### PR TITLE
fix aio image from running with sslmode psql

### DIFF
--- a/docker/all-in-one/Dockerfile.all-in-one
+++ b/docker/all-in-one/Dockerfile.all-in-one
@@ -5,7 +5,7 @@ COPY . .
 
 RUN go mod download
 
-RUN CGO_ENABLED=1 GOOS=linux go build -o /go/bin/core -a -ldflags '-linkmode external -extldflags "-static"' .
+RUN CGO_ENABLED=1 GOOS=linux go build -o /go/bin/core -a -tags osusergo -ldflags '-linkmode external -extldflags "-static"' .
 
 FROM cgr.dev/chainguard/bash:latest
 


### PR DESCRIPTION
Segfault specific to connection to sslmode=require psql connection. _Something_ that is upgraded since the last time this was attempted changed causing this segfault. I confirmed this is not related to go1.23.0 and a few other libraries, but added the `-tags osusergo` to the go build fixes this and this tag will force all os/user calls to use the native Go implementations instead of c implementations. 

Prior stacktrace: 

```
SIGSEGV: segmentation violation
PC=0x0 m=0 sigcode=1 addr=0x0
signal arrived during cgo execution

goroutine 1 gp=0x40000021c0 m=0 mp=0x7918ba0 [syscall]:
runtime.cgocall(0x3a19794, 0x400127d7e8)
	/usr/local/go/src/runtime/cgocall.go:157 +0x44 fp=0x400127d7b0 sp=0x400127d770 pc=0x407284
os/user._Cfunc_mygetpwuid_r(0xfffc, 0x4000125c00, 0x400, 0x4000d01d1c, 0x4000d01d30)
	_cgo_gotypes.go:163 +0x3c fp=0x400127d7e0 sp=0x400127d7b0 pc=0xf6574c
os/user._C_getpwuid_r(0xfffc, 0x4000125c00, 0x400)
	/usr/local/go/src/os/user/cgo_lookup_cgo.go:91 +0x7c fp=0x400127d890 sp=0x400127d7e0 pc=0xf658bc
os/user.lookupUnixUid.func1({0x4000125c00?, 0x409248?, 0x0?})
	/usr/local/go/src/os/user/cgo_lookup_unix.go:57 +0x4c fp=0x400127d940 sp=0x400127d890 pc=0xf64c6c
os/user.retryWithBuffer(0x0?, 0x400127da38)
	/usr/local/go/src/os/user/cgo_lookup_unix.go:171 +0x6c fp=0x400127d9a0 sp=0x400127d940 pc=0xf6532c
os/user.lookupUnixUid(0xfffc)
	/usr/local/go/src/os/user/cgo_lookup_unix.go:55 +0x6c fp=0x400127da60 sp=0x400127d9a0 pc=0xf64b4c
os/user.current()
	/usr/local/go/src/os/user/cgo_lookup_unix.go:19 +0x34 fp=0x400127daa0 sp=0x400127da60 pc=0xf64a64
os/user.Current.func1()
	/usr/local/go/src/os/user/lookup.go:22 +0x1c fp=0x400127dab0 sp=0x400127daa0 pc=0xf65a2c
sync.(*Once).doSlow(0x4001270000?, 0x400127da90?)
	/usr/local/go/src/sync/once.go:74 +0x100 fp=0x400127db10 sp=0x400127dab0 pc=0x496af0
sync.(*Once).Do(...)
	/usr/local/go/src/sync/once.go:65
os/user.Current()
	/usr/local/go/src/os/user/lookup.go:22 +0x40 fp=0x400127db50 sp=0x400127db10 pc=0xf65420
github.com/lib/pq.sslClientCertificates(0x40000d4340, 0x40012d2de0)
	/go/pkg/mod/github.com/lib/pq@v1.10.9/ssl.go:110 +0x208 fp=0x400127de90 sp=0x400127db50 pc=0x3712fc8
github.com/lib/pq.ssl(0x40012d2de0)
	/go/pkg/mod/github.com/lib/pq@v1.10.9/ssl.go:64 +0x2bc fp=0x400127def0 sp=0x400127de90 pc=0x3712b5c
github.com/lib/pq.(*conn).ssl(0x40003d4f08, 0x7986280?)
	/go/pkg/mod/github.com/lib/pq@v1.10.9/conn.go:1105 +0x28 fp=0x400127df80 sp=0x400127def0 pc=0x3703dc8
github.com/lib/pq.(*Connector).open(0x400030ce28, {0x53a54a0, 0x7986280})
	/go/pkg/mod/github.com/lib/pq@v1.10.9/conn.go:373 +0x20c fp=0x400127e100 sp=0x400127df80 pc=0x36ffb5c
github.com/lib/pq.DialOpen({0x539b4c8, 0x40009dabd0}, {0x4000058018?, 0x418ad4?})
	/go/pkg/mod/github.com/lib/pq@v1.10.9/conn.go:340 +0x80 fp=0x400127e130 sp=0x400127e100 pc=0x36ff8e0
github.com/lib/pq.Open(...)
	/go/pkg/mod/github.com/lib/pq@v1.10.9/conn.go:330
github.com/lib/pq.Driver.Open({}, {0x4000058018, 0x70})
	/go/pkg/mod/github.com/lib/pq@v1.10.9/conn.go:57 +0x64 fp=0x400127e1d0 sp=0x400127e130 pc=0x36fe244
github.com/lib/pq.(*Driver).Open(0x400127e228?, {0x4000058018?, 0xffff4409fb58?})
	<autogenerated>:1 +0x34 fp=0x400127e1f0 sp=0x400127e1d0 pc=0x3714bd4
github.com/XSAM/otelsql.(*otDriver).Open(0x40005b2210, {0x4000058018?, 0x400127e318?})
	/go/pkg/mod/github.com/!x!s!a!m/otelsql@v0.32.0/driver.go:42 +0x38 fp=0x400127e2e0 sp=0x400127e1f0 pc=0x1287888
github.com/XSAM/otelsql.dsnConnector.Connect(...)
	/go/pkg/mod/github.com/!x!s!a!m/otelsql@v0.32.0/connector.go:83
github.com/XSAM/otelsql.(*dsnConnector).Connect(0x400127e368?, {0x40d64c?, 0x400127e338?})
	<autogenerated>:1 +0x3c fp=0x400127e310 sp=0x400127e2e0 pc=0x128f98c
database/sql.(*DB).conn(0x40012c7450, {0x53a54a0, 0x7986280}, 0x1)
	/usr/local/go/src/database/sql/sql.go:1415 +0x824 fp=0x400127e4a0 sp=0x400127e310 pc=0xea5e64
database/sql.(*DB).PingContext.func1(0x7?)
	/usr/local/go/src/database/sql/sql.go:883 +0x40 fp=0x400127e4e0 sp=0x400127e4a0 pc=0xea3940
database/sql.(*DB).retry(0x1?, 0x400127e588)
	/usr/local/go/src/database/sql/sql.go:1566 +0x4c fp=0x400127e530 sp=0x400127e4e0 pc=0xea6dbc
database/sql.(*DB).PingContext(0x40012c7450, {0x53a54a0, 0x7986280})
	/usr/local/go/src/database/sql/sql.go:882 +0x6c fp=0x400127e5c0 sp=0x400127e530 pc=0xea387c
database/sql.(*DB).Ping(...)
	/usr/local/go/src/database/sql/sql.go:900
github.com/theopenlane/entx.(*EntClientConfig).NewEntDB(0x40009eecf0, {0x4000058018, 0x70})
	/go/src/entx/client.go:148 +0x4bc fp=0x400127e7e0 sp=0x400127e5c0 pc=0x14ef8cc
github.com/theopenlane/entx.NewDBConfig({0x1, {0x3faabef, 0x8}, {0x4000052073, 0x8}, 0x0, {0x4000058018, 0x70}, {0x4083d6b, 0xe}, ...}, ...)
	/go/src/entx/client.go:76 +0x26c fp=0x400127e930 sp=0x400127e7e0 pc=0x14ef1ec
github.com/theopenlane/core/internal/entdb.NewMultiDriverDBClient({0x53a54a0, 0x7986280}, {0x1, {0x3faabef, 0x8}, {0x4000052073, 0x8}, 0x0, {0x4000058018, 0x70}, ...}, ...)
	/go/src/app/internal/entdb/client.go:56 +0x1bc fp=0x400127ec10 sp=0x400127e930 pc=0x37219cc
github.com/theopenlane/core/cmd.serve({0x53a54a0, 0x7986280})
	/go/src/app/cmd/serve.go:126 +0xd04 fp=0x400127fc80 sp=0x400127ec10 pc=0x3a16c14
github.com/theopenlane/core/cmd.init.func2(0x4000df8200?, {0x4382230?, 0x4?, 0x4382218?})
	/go/src/app/cmd/serve.go:26 +0x28 fp=0x400127fca0 sp=0x400127fc80 pc=0x3a15708
github.com/spf13/cobra.(*Command).execute(0x77cb100, {0x4000aab880, 0x2, 0x2})
	/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:989 +0x828 fp=0x400127fe30 sp=0x400127fca0 pc=0x620d18
github.com/spf13/cobra.(*Command).ExecuteC(0x77cae20)
	/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x344 fp=0x400127ff10 sp=0x400127fe30 pc=0x6214f4
github.com/spf13/cobra.(*Command).Execute(...)
	/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041
github.com/theopenlane/core/cmd.Execute()
	/go/src/app/cmd/root.go:32 +0x24 fp=0x400127ff30 sp=0x400127ff10 pc=0x3a15774
main.main()
	/go/src/app/main.go:10 +0x1c fp=0x400127ff40 sp=0x400127ff30 pc=0x3a1929c
runtime.main()
	/usr/local/go/src/runtime/proc.go:271 +0x28c fp=0x400127ffd0 sp=0x400127ff40 pc=0x440bcc
runtime.goexit({})
	/usr/local/go/src/runtime/asm_arm64.s:1222 +0x4 fp=0x400127ffd0 sp=0x400127ffd0 pc=0x4766b4
```

Now the app starts up and connects to an `sslmode=require` psql.

After we are done porting, I'll confirm if we still even need the CGO sqlite driver, but for now want to do less changes as possible. 