### PR TITLE
update goreleaser and cli name

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,7 +43,7 @@ brews:
     directory: Formula
     license: 'Apache-2.0'
     commit_author:
-      name: bender-core
+      name: theopenlane-bender
       email: bender@theopenlane.io
     repository:
       owner: theopenlane

--- a/cmd/cli/cmd/client.go
+++ b/cmd/cli/cmd/client.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	serviceName     = "core"
+	serviceName     = "openlane"
 	accessTokenKey  = "open_lane_token"
 	refreshTokenKey = "open_lane_refresh_token" // nolint:gosec
 	sessionKey      = "open_lane_session"

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	appName         = "core"
+	appName         = "openlane"
 	defaultRootHost = "http://localhost:17608"
 	TableOutput     = "table"
 	JSONOutput      = "json"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,7 +9,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const appName = "core"
+const appName = "openlane"
 
 var (
 	logger *zap.SugaredLogger
@@ -19,7 +19,7 @@ var (
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   appName,
-	Short: "A cli for interacting with the core server",
+	Short: "A cli for interacting with the openlane core server",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		err := initCmdFlags(cmd)
 		cobra.CheckErr(err)


### PR DESCRIPTION
Listing the CLI on brew as "core" would likely be confusing so adjusted the service name in `/cmd` being used as well as some minor tweaks to the goreleaser config to publish the artifacts as "openlane" vs. "core"