### PR TITLE
Remove mod=mod from go run commands in generate

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -1,13 +1,13 @@
 package main
 
 //go:generate echo "------> Generating code - running entc.go... <------"
-//go:generate go run -mod=mod ./internal/ent/entc.go
+//go:generate go run ./internal/ent/entc.go
 //go:generate echo "------> Generating code - running gqlgen... <------"
 //go:generate go run ./internal/graphapi/generate/generate.go
 //go:generate echo "------> Generating code - running gen_schema.go... <------"
-//go:generate go run -mod=mod ./gen_schema.go
+//go:generate go run ./gen_schema.go
 //go:generate echo "------> Generating code - running gqlgenc... <------"
-//go:generate go run -mod=mod github.com/Yamashou/gqlgenc generate --configdir schema
+//go:generate go run github.com/Yamashou/gqlgenc generate --configdir schema
 //go:generate echo "------> Tidying up... <------"
 //go:generate go mod tidy
 //go:generate echo "------> Code generation process completed! <------"


### PR DESCRIPTION
I think we should be okay without this flag because our deps are in our go.mod file that we need here and this is possibly causing issues with pulling the wrong modules 

```
The -mod=mod flag instructs the go command to attempt to find new modules providing missing packages and to update go.mod and go.sum.
```
