### PR TITLE
remove libsql and sqlite support

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -42,35 +42,20 @@ steps:
               always_pull: true
               environment:
                 - "GOTOOLCHAIN=auto"
-      - label: ":golang: go test - libsql"
-        key: "go_test_libsql"
-        retry:
-          automatic:
-            - exit_status: "*"
-              limit: 2
-        cancel_on_build_failing: true
-        env:
-          TEST_DB_URL: "libsql://file::memory:?cache=shared"
-        plugins:
-          - docker#v5.11.0:
-              image: ghcr.io/theopenlane/build-image:latest
-              always_pull: true
-              command: ["task", "go:test:cover"]
-              environment:
-                - "TEST_DB_URL"
         artifact_paths: ["coverage.out"]
-      - label: ":golang: go test - {{matrix}}"
+      - label: ":golang: go test - {{matrix.version}}"
         key: "go_test"
         retry:
           automatic:
             - exit_status: "*"
               limit: 2
         env:
-          TEST_DB_URL: "{{matrix}}"
+          TEST_DB_URL: "docker://postgres:{{matrix.version}}"
         matrix:
-          - "docker://postgres:16-alpine"
-          - "docker://postgres:15-alpine"
-          - "sqlite://file:ent?mode=memory&cache=shared"
+          setup:
+            version:
+              - 16-alpine
+              - 15-alpine
         plugins:
           - docker#v5.11.0:
               image: ghcr.io/theopenlane/build-image:latest
@@ -90,7 +75,6 @@ steps:
               image: openfga/cli:v0.5.1
               command: ["model", "test", "--tests", "fga/tests/tests.yaml"]
   - group: ":closed_lock_with_key: Security Checks"
-    depends_on: "go_test_libsql"
     key: "security"
     steps:
       - label: ":closed_lock_with_key: gosec"
@@ -105,13 +89,13 @@ steps:
       - label: ":github: upload PR reports"
         key: "scan-upload-pr"
         if: build.pull_request.id != null
-        depends_on: ["gosec", "go_test_libsql"]
+        depends_on: ["gosec", "go_test"]
         plugins:
           - artifacts#v1.9.4:
               download: "results.txt"
           - artifacts#v1.9.4:
               download: "coverage.out"
-              step: "go_test_libsql"
+              step: "go_test"
           - docker#v5.11.0:
               image: "sonarsource/sonar-scanner-cli:11.0"
               environment:
@@ -121,13 +105,13 @@ steps:
       - label: ":github: upload reports"
         key: "scan-upload"
         if: build.branch == "main"
-        depends_on: ["gosec", "go_test_libsql"]
+        depends_on: ["gosec", "go_test"]
         plugins:
           - artifacts#v1.9.4:
               download: results.txt
           - artifacts#v1.9.4:
               download: coverage.out
-              step: "go_test_libsql"
+              step: "go_test"
           - docker#v5.11.0:
               image: "sonarsource/sonar-scanner-cli:11.0"
               environment:

--- a/README.md
+++ b/README.md
@@ -10,11 +10,14 @@
 
 # openlane
 
-This repository houses the core server and orchestration elements which are at the heart of the [openlane](https://theopenlane.io) cloud service.
+This repository houses the core server and orchestration elements which are at
+the heart of the [openlane](https://theopenlane.io) cloud service.
 
 ## Features
 
-At it's core, this repo is a collection of services built on top of an entity framework which allows us to:
+At it's core, this repo is a collection of services built on top of an entity
+framework which allows us to:
+
 - Model database schemas as graph structures
 - Define schemas as programmatic go code
 - Execute complex database queries and graph traversals easily
@@ -22,27 +25,43 @@ At it's core, this repo is a collection of services built on top of an entity fr
 - Type-safe resolvers and GraphQL schema stitching
 - Code generated audit / history tables for defined schemas
 
-On top of this powerful core we also have an incredible amount of pluggable, extensible services:
+On top of this powerful core we also have an incredible amount of pluggable,
+extensible services:
 
-- Authentication: we today support password, OAuth2 / Social login providers (Github, Google), Passkeys as well as standard OIDC Discovery flows
+- Authentication: we today support password, OAuth2 / Social login providers
+  (Github, Google), Passkeys as well as standard OIDC Discovery flows
 - Multi-factor: built-in 2FA mechanisms, TOTP
-- Authorization: extensible and flexible permissions constructs via openFGA based on Google Zanzibar
-- Session Management: built-in session management with JWKS key validation, encrypted cookies and sessions
-- Robust Middleware: cache control, CORS, Rate Limiting, transaction rollbacks, and more
+- Authorization: extensible and flexible permissions constructs via openFGA
+  based on Google Zanzibar
+- Session Management: built-in session management with JWKS key validation,
+  encrypted cookies and sessions
+- Robust Middleware: cache control, CORS, Rate Limiting, transaction rollbacks,
+  and more
 - Queuing and Scheduling: Task management and scheduling with Marionette
 - External Storage Providers: store data in AWS S3, Google GCS, or locally
-- External Database Providers: Leverage Turso, or other PostgreSQL / SQLite compatible vendors and libraries
-- Data Isolation and Management: Hierarchal organizations and granular permissions controls
+- External Database Providers: Leverage NeonDB, or other PostgreSQL compatible
+  vendors and libraries
+- Data Isolation and Management: Hierarchal organizations and granular
+  permissions controls
 
 ## Development
 
 ### Dependencies
 
-The vast majority of behaviors of the system can be turned on or off by updating the configuration parameters found in `config`; in some instances, we've made features or integrations with third party systems which are "always on", but we're happy to receive PR's wrapping those dependencies if you are interested in running the software without them!
+The vast majority of behaviors of the system can be turned on or off by updating
+the configuration parameters found in `config`; in some instances, we've made
+features or integrations with third party systems which are "always on", but
+we're happy to receive PR's wrapping those dependencies if you are interested in
+running the software without them!
 
 ### Installing Dependencies
 
-Setup [Taskfile](https://taskfile.dev/installation/) by following the instructions and using one of the various convenient package managers or installation scripts. After installation, you can then simply run `task install` to load the associated dependencies. Nearly everything in this repository assumes you already have a local golang environment setup so this is not included. Please see the associated documentation.
+Setup [Taskfile](https://taskfile.dev/installation/) by following the
+instructions and using one of the various convenient package managers or
+installation scripts. After installation, you can then simply run `task install`
+to load the associated dependencies. Nearly everything in this repository
+assumes you already have a local golang environment setup so this is not
+included. Please see the associated documentation.
 
 ### Updating Configuration Settings
 
@@ -50,13 +69,15 @@ See the [README](/config/README.md) in the `config` directory.
 
 ### Starting the Server
 
-1. Copy the config, this is in .gitignore so you do not have to worry about accidentally committing secrets
+1. Copy the config, this is in .gitignore so you do not have to worry about
+   accidentally committing secrets
 
    ```bash
    cp ./config/config-dev.example.yaml ./config/.config.yaml
    ```
 
-1. Update the configuration with whatever respective settings you desire; the defaults inside should allow you to run the server without a problem
+1. Update the configuration with whatever respective settings you desire; the
+   defaults inside should allow you to run the server without a problem
 
 1. Use the task commands to start the server
 
@@ -72,19 +93,25 @@ See the [README](/config/README.md) in the `config` directory.
    task docker:all:up
    ```
 
-1. In a separate terminal, with the server running, you can create a verified test user by running:
+1. In a separate terminal, with the server running, you can create a verified
+   test user by running:
 
    ```bash
    task cli:user:all
    ```
 
-1. Once this command has finished ^, you can login and perform actions as user `mitb@theopenlane.io` with password `mattisthebest1234`
+1. Once this command has finished ^, you can login and perform actions as user
+   `mitb@theopenlane.io` with password `mattisthebest1234`
 
 ### Creating Queries in GraphQL
 
-The best method of forming / testing queries against the server is to run `task docker:rover` which will launch an interactive query UI.
+The best method of forming / testing queries against the server is to run
+`task docker:rover` which will launch an interactive query UI.
 
-If you are running the queries against your local repo, you will have CORS issues using the local running apollo. Instead, its recommended to use the [apollo sandbox](https://studio.apollographql.com/sandbox/explorer) and ensure the following origin is allowed in your `config/.config.yaml`
+If you are running the queries against your local repo, you will have CORS
+issues using the local running apollo. Instead, its recommended to use the
+[apollo sandbox](https://studio.apollographql.com/sandbox/explorer) and ensure
+the following origin is allowed in your `config/.config.yaml`
 
 ```
 server:
@@ -95,23 +122,41 @@ server:
 
 ### OpenFGA Playground
 
-You can load up a local openFGA environment with the compose setup in this repository; `task fga:up` - this will launch an interactive playground where you can model permissions model(s) or changes to the models
+You can load up a local openFGA environment with the compose setup in this
+repository; `task fga:up` - this will launch an interactive playground where you
+can model permissions model(s) or changes to the models
 
 ### Creating a new Schema
 
-To ease the effort required to add additional schemas into the system a template + task function has been created. This isn't doing anything terribly complex, but it's attempting to ensure you have the _minimum_ set of required things needed to create a schema - most notably: you need to ensure the IDMixin is present (otherwise you will get ID type conflicts) and a standard set of schema annotations.
+To ease the effort required to add additional schemas into the system a
+template + task function has been created. This isn't doing anything terribly
+complex, but it's attempting to ensure you have the _minimum_ set of required
+things needed to create a schema - most notably: you need to ensure the IDMixin
+is present (otherwise you will get ID type conflicts) and a standard set of
+schema annotations.
 
-NOTE: you still have to make intelligent decisions around things like the presence / integration of hooks, interceptors, policies, etc. This is saving you about 10 seconds of copy-paste, so don't over estimate the automation, here.
+NOTE: you still have to make intelligent decisions around things like the
+presence / integration of hooks, interceptors, policies, etc. This is saving you
+about 10 seconds of copy-paste, so don't over estimate the automation, here.
 
-To generate a new schema, you can run `task newschema -- [yourschemaname]` where you replace the name within `[]`. Please be sure to note that this isn't a command line flag so there's a space between `--` and the name.
+To generate a new schema, you can run `task newschema -- [yourschemaname]` where
+you replace the name within `[]`. Please be sure to note that this isn't a
+command line flag so there's a space between `--` and the name.
 
 ### Migrations
 
-We use [atlas](https://atlasgo.io/) and [goose](https://github.com/pressly/goose) to create and manage our DB migrations - you can trigger one via `task atlas:create` and that will generate the necessary migrations. There should be a new migration file created in `db/migrations`, `db/migrations-goose-postgre` and `db/migrations-goose-sqlite`. On every PR, the Atlas integration also creates comments with any issues related to the schema changes / migrations.
+We use [atlas](https://atlasgo.io/) and
+[goose](https://github.com/pressly/goose) to create and manage our DB
+migrations - you can trigger one via `task atlas:create` and that will generate
+the necessary migrations. There should be a new migration file created in
+`db/migrations` and `db/migrations-goose-postgres`. On every PR, the Atlas
+integration also creates comments with any issues related to the schema changes
+/ migrations.
 
 ## Deploying
 
-The only "supported" method of deploying today is locally, but we have a WIP Helm chart which can be found [here](https://github.com/theopenlane/helm-charts)
+The only "supported" method of deploying today is locally, but we have a WIP
+Helm chart which can be found [here](https://github.com/theopenlane/helm-charts)
 
 ## Contributing
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -19,7 +19,6 @@ includes:
     taskfile: ./jsonschema/Taskfile.yaml
 
 env:
-  ATLAS_SQLITE_DB_URI: "sqlite://file?mode=memory&_fk=1"
   ATLAS_POSTGRES_DB_URI: "postgres:16-alpine"
   TEST_DB_URL: "docker://postgres:16-alpine"
   TEST_DB_CONTAINER_EXPIRY: "2" # in minutes
@@ -50,14 +49,6 @@ tasks:
     aliases: ['go:test:psql', 'test:psql']
     env:
       TEST_DB_URL: "docker://postgres:16-alpine"
-    cmds:
-      - go test -v ./...
-
-  go:test:libsql:
-    desc: runs and outputs results of created go tests
-    aliases: ['test:libsql']
-    env:
-      TEST_DB_URL: "libsql://file::memory:?cache=shared"
     cmds:
       - go test -v ./...
 

--- a/db/README.md
+++ b/db/README.md
@@ -2,47 +2,26 @@
 
 ## Dependencies
 
-1. [ent](https://entgo.io/) - insane entity mapping tool, definitely not an ORM but kind of an ORM
+1. [ent](https://entgo.io/) - insane entity mapping tool, definitely not an ORM
+   but kind of an ORM
 1. [atlas](https://atlasgo.io/) - Schema generation and migration
-1. [entx](https://github.com/theopenlane/entx) - Wrapper to interact with the ent
+1. [entx](https://github.com/theopenlane/entx) - Wrapper to interact with the
+   ent
 
 ## Supported Drivers
 
-1. [libsql](https://github.com/tursodatabase/libsql)
-1. [sqlite](https://gitlab.com/cznic/sqlite)
 1. [postgres](https://github.com/lib/pq)
+1. [pgx](https://github.com/jackc/pgx)
 
 ## Local Development
 
 ### Config Examples
 
-#### Libsql
-
-1. This will write to a local file `core.db`, already included in `.gitignore`
-
-```yaml
-db:
-  debug: true
-  driver_name: "libsql"
-  primary_db_source: "file:core.db"
-  run_migrations: true
-```
-
-#### Sqlite
-
-1. This will write to a local file `core.db`, already included in `.gitignore`
-
-```yaml
-db:
-  debug: true
-  driver_name: sqlite3
-  primary_db_source: "core.db"
-  run_migrations: true
-```
-
 #### Postgres
 
-1. Postgres is included in `docker/docker-compose-fga.yml` and the same instance can be used for development. The following connection string should work when using `task docker:all:up`
+1. Postgres is included in `docker/docker-compose-fga.yml` and the same instance
+   can be used for development. The following connection string should work when
+   using `task docker:all:up`
 
 ```yaml
 db:
@@ -50,16 +29,4 @@ db:
   driver_name: postgres
   primary_db_source: "postgres://postgres:password@postgres:5432?sslmode=disable"
   run_migrations: true
-```
-
-#### Turso
-
-1. Replace the url with your turso database url and token
-
-```yaml
-db:
-  debug: true
-  driver_name: libsql
-  primary_db_source: "https://core-theopenlane.turso.io?authToken=$TURSO_TOKEN"  # set TURSO_TOKEN to value
-  run_migrations: false
 ```

--- a/db/Taskfile.yaml
+++ b/db/Taskfile.yaml
@@ -25,13 +25,7 @@ tasks:
     desc: re-sets the checksum created by the atlas package so that a complete migration can be re-created if deleted
     cmds:
       - atlas migrate hash --dir="file://migrations"
-      - atlas migrate hash --dir="file://migrations-goose-sqlite"
       - atlas migrate hash --dir="file://migrations-goose-postgres"
-
-  console:
-    desc: launches an interactive terminal to the local core db with some tasty options
-    cmds:
-      - sqlite3 -column -header -box ../core.db
 
   newschema:
     desc: generate a new ent schema from template

--- a/db/migrate.go
+++ b/db/migrate.go
@@ -10,11 +10,6 @@ import (
 //go:embed migrations/*.sql
 var Migrations embed.FS
 
-// GooseMigrationsSQLite contain an embedded filesystem with all the goose migration files for sqlite
-//
-//go:embed migrations-goose-sqlite/*.sql
-var GooseMigrationsSQLite embed.FS
-
 // GooseMigrationsPG contain an embedded filesystem with all the goose migration files for postgres
 //
 //go:embed migrations-goose-postgres/*.sql

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,25 +1,42 @@
 # Tools
 
-Developing against this repo involves a few mandatory tools; please read up on these and familiarize yourself if you're interested in making additions or changes!
+Developing against this repo involves a few mandatory tools; please read up on
+these and familiarize yourself if you're interested in making additions or
+changes!
 
-1. [ent](https://entgo.io/) - insane entity mapping tool, definitely not an ORM but kind of an ORM (handles our relational data storage, mappings, codegen processes)
-1. [atlas](https://atlasgo.io/) - Schema generation and migrations (can be disabled in lieu of migrations on disk)
-1. [goose](https://github.com/pressly/goose) - Secondary database migration utility we also use for seeding data
-1. [gqlgen](https://gqlgen.com/) - Code generation + GraphQL server building from from `ent` schema definitions
-1. [gqlgenc](https://github.com/Yamashou/gqlgenc) - Client building utilities with GraphQL
-1. [openfga](https://openfga.dev/) - Flexible authorization/permission engine inspired by Google Zanzibar
-1. [echo](https://echo.labstack.com/) - High performance, extensible, minimalist Go web framework
-1. [koanf](https://github.com/knadh/koanf) - Configuration management library which parses command line arguments, Go structs + creates our main configuration files
+1. [ent](https://entgo.io/) - insane entity mapping tool, definitely not an ORM
+   but kind of an ORM (handles our relational data storage, mappings, codegen
+   processes)
+1. [atlas](https://atlasgo.io/) - Schema generation and migrations (can be
+   disabled in lieu of migrations on disk)
+1. [goose](https://github.com/pressly/goose) - Secondary database migration
+   utility we also use for seeding data
+1. [gqlgen](https://gqlgen.com/) - Code generation + GraphQL server building
+   from from `ent` schema definitions
+1. [gqlgenc](https://github.com/Yamashou/gqlgenc) - Client building utilities
+   with GraphQL
+1. [openfga](https://openfga.dev/) - Flexible authorization/permission engine
+   inspired by Google Zanzibar
+1. [echo](https://echo.labstack.com/) - High performance, extensible, minimalist
+   Go web framework
+1. [koanf](https://github.com/knadh/koanf) - Configuration management library
+   which parses command line arguments, Go structs + creates our main
+   configuration files
 
-We also leverage many secondary technologies in use, including (but not limited to!):
+We also leverage many secondary technologies in use, including (but not limited
+to!):
 
 1. [taskfile](https://taskfile.dev/usage/) - So much better than Make zomg
 1. [redis](https://redis.io/) - in-memory datastore used for sessions, caching
-1. databases:
-    * [postgres](https://www.postgresql.org/)
-    * [libsql](https://turso.tech/libsql)
-    * [sqlite](https://www.sqlite.org/)
-1. [golangci-lint](https://github.com/golangci/golangci-lint) - an annoyingly opinionated linter
-1. [buildkite](https://buildkite.com/theopenlane) - our CI system of choice (with github actions providing some intermediary support)
+1. [postgres](https://www.postgresql.org/)
+1. [golangci-lint](https://github.com/golangci/golangci-lint) - an annoyingly
+   opinionated linter
+1. [buildkite](https://buildkite.com/theopenlane) - our CI system of choice
+   (with github actions providing some intermediary support)
 
-All of these components are bundled into our respective Docker images; for additional information / instructions, see the [contributing guide](.github/CONTRIBUTING.md) in this repository. We're constantly adding and changing things, but have tried to list all the great open source tools and projects we rely on; if you see your project (or one you use) in here and wish to list it, feel free to open a PR!
+All of these components are bundled into our respective Docker images; for
+additional information / instructions, see the
+[contributing guide](.github/CONTRIBUTING.md) in this repository. We're
+constantly adding and changing things, but have tried to list all the great open
+source tools and projects we rely on; if you see your project (or one you use)
+in here and wish to list it, feel free to open a PR!

--- a/internal/entdb/client.go
+++ b/internal/entdb/client.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"ariga.io/entcache"
-	"entgo.io/ent/dialect"
 	entsql "entgo.io/ent/dialect/sql"
 	"github.com/pressly/goose/v3"
 	"github.com/rs/zerolog/log"
@@ -145,15 +144,6 @@ func (c *client) runGooseMigrations() error {
 	defer drv.Close()
 
 	migrations := migratedb.GooseMigrationsPG
-	if driver == dialect.SQLite {
-		migrations = migratedb.GooseMigrationsSQLite
-
-		if _, err := drv.Exec("PRAGMA foreign_keys = off;", nil); err != nil {
-			drv.Close()
-
-			return fmt.Errorf("failed to disable foreign keys: %w", err)
-		}
-	}
 
 	goose.SetBaseFS(migrations)
 
@@ -162,20 +152,9 @@ func (c *client) runGooseMigrations() error {
 	}
 
 	migrationsDir := "migrations-goose-postgres"
-	if driver == dialect.SQLite {
-		migrationsDir = "migrations-goose-sqlite"
-	}
 
 	if err := goose.Up(drv, migrationsDir); err != nil {
 		return err
-	}
-
-	if driver == dialect.SQLite {
-		if _, err := drv.Exec("PRAGMA foreign_keys = on;", nil); err != nil {
-			drv.Close()
-
-			return fmt.Errorf("failed to enable foreign keys: %w", err)
-		}
 	}
 
 	return nil

--- a/internal/graphapi/errors.go
+++ b/internal/graphapi/errors.go
@@ -120,7 +120,7 @@ func parseRequestError(err error, a action) error {
 
 		log.Debug().Err(constraintError).Msg("constraint error")
 
-		// Check for unique (or UNIQUE in sqlite) constraint error
+		// Check for unique constraint error
 		if strings.Contains(strings.ToLower(constraintError.Error()), "unique") {
 			return newAlreadyExistsError(a.object)
 		}


### PR DESCRIPTION
- Removes support for sqlite and libsql, with the addition of `riverqueue` which requires `postgres` it does not seem worth it to support sqlite variants. However, making this it's own PR outside of the river integration so if we ever want to add it back we have a simple reference point to do so. 