### PR TITLE
feat: test support for pg 17, remove pg 15

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -54,8 +54,8 @@ steps:
         matrix:
           setup:
             version:
+              - 17-alpine
               - 16-alpine
-              - 15-alpine
         plugins:
           - docker#v5.11.0:
               image: ghcr.io/theopenlane/build-image:latest


### PR DESCRIPTION
I'd like to start testing postgres 17, but at least locally our tests take 3x as long due to CPU throttling so keeping 16 as the default for now. 