### PR TITLE
deps: upgrade trivy version to 0.55.2

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -184,7 +184,7 @@ steps:
               push: false
               build-args:
                 - NAME=${APP_NAME}
-          - equinixmetal-buildkite/trivy#v1.18.5:
+          - equinixmetal-buildkite/trivy#v1.19.0:
               severity: CRITICAL,HIGH
               ignore-unfixed: true
               scanners: misconfig,secret,vuln
@@ -212,7 +212,7 @@ steps:
               push: true
               build-args:
                 - NAME=${APP_NAME}
-          - equinixmetal-buildkite/trivy#v1.18.5:
+          - equinixmetal-buildkite/trivy#v1.19.0:
               severity: CRITICAL,HIGH
               ignore-unfixed: true
               scanners: misconfig,secret,vuln
@@ -240,7 +240,7 @@ steps:
               push: true
               build-args:
                 - NAME=${APP_NAME}
-          - equinixmetal-buildkite/trivy#v1.18.5:
+          - equinixmetal-buildkite/trivy#v1.19.0:
               severity: CRITICAL,HIGH
               ignore-unfixed: true
               security-checks: config,secret,vuln
@@ -266,7 +266,7 @@ steps:
               push: true
               build-args:
                 - NAME=${APP_NAME}
-          - equinixmetal-buildkite/trivy#v1.18.5:
+          - equinixmetal-buildkite/trivy#v1.19.0:
               severity: CRITICAL,HIGH
               ignore-unfixed: true
               scanners: misconfig,secret,vuln
@@ -294,7 +294,7 @@ steps:
               push: true
               build-args:
                 - NAME=${APP_NAME}
-          - equinixmetal-buildkite/trivy#v1.18.5:
+          - equinixmetal-buildkite/trivy#v1.19.0:
               severity: CRITICAL,HIGH
               ignore-unfixed: true
               scanners: misconfig,secret,vuln

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -189,6 +189,7 @@ steps:
               ignore-unfixed: true
               security-checks: config,secret,vuln
               skip-files: "cosign.key,Dockerfile.dev"
+              trivy-version: "0.55.2"
       - label: ":docker: docker build and publish"
         key: "docker-build"
         cancel_on_build_failing: true
@@ -216,6 +217,7 @@ steps:
               ignore-unfixed: true
               security-checks: config,secret,vuln
               skip-files: "cosign.key,Dockerfile.dev"
+              trivy-version: "0.55.2"
       - label: ":docker: docker build and publish all in one"
         key: "docker-build-aio"
         if: build.branch == "main"
@@ -243,6 +245,7 @@ steps:
               ignore-unfixed: true
               security-checks: config,secret,vuln
               skip-files: "cosign.key,Dockerfile.dev"
+              trivy-version: "0.55.2"
       - label: ":docker: docker build and publish"
         key: "docker-build-and-tag"
         if: build.tag != null
@@ -268,6 +271,7 @@ steps:
               ignore-unfixed: true
               security-checks: config,secret,vuln
               skip-files: "cosign.key,Dockerfile.dev"
+              trivy-version: "0.55.2"
       - label: ":docker: docker build and publish all in one"
         key: "docker-build-aio-and-tag"
         if: build.tag != null
@@ -295,3 +299,4 @@ steps:
               ignore-unfixed: true
               security-checks: config,secret,vuln
               skip-files: "cosign.key,Dockerfile.dev"
+              trivy-version: "0.55.2"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -187,7 +187,7 @@ steps:
           - equinixmetal-buildkite/trivy#v1.18.5:
               severity: CRITICAL,HIGH
               ignore-unfixed: true
-              security-checks: config,secret,vuln
+              scanners: misconfig,secret,vuln
               skip-files: "cosign.key,Dockerfile.dev"
               trivy-version: "0.55.2"
       - label: ":docker: docker build and publish"
@@ -215,7 +215,7 @@ steps:
           - equinixmetal-buildkite/trivy#v1.18.5:
               severity: CRITICAL,HIGH
               ignore-unfixed: true
-              security-checks: config,secret,vuln
+              scanners: misconfig,secret,vuln
               skip-files: "cosign.key,Dockerfile.dev"
               trivy-version: "0.55.2"
       - label: ":docker: docker build and publish all in one"
@@ -269,7 +269,7 @@ steps:
           - equinixmetal-buildkite/trivy#v1.18.5:
               severity: CRITICAL,HIGH
               ignore-unfixed: true
-              security-checks: config,secret,vuln
+              scanners: misconfig,secret,vuln
               skip-files: "cosign.key,Dockerfile.dev"
               trivy-version: "0.55.2"
       - label: ":docker: docker build and publish all in one"
@@ -297,6 +297,6 @@ steps:
           - equinixmetal-buildkite/trivy#v1.18.5:
               severity: CRITICAL,HIGH
               ignore-unfixed: true
-              security-checks: config,secret,vuln
+              scanners: misconfig,secret,vuln
               skip-files: "cosign.key,Dockerfile.dev"
               trivy-version: "0.55.2"


### PR DESCRIPTION
- The default version in the plugin is 6+ months old (v0.49.1), current version is `v0.55.2`
- Updates deprecated config options
