### PR TITLE
add dependabot + renovate to deps labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,7 +9,7 @@ breaking-change:
   - head-branch: ["^breaking-change", "breaking-change"]
 # Add 'dependencies' label to any PR where the head branch name starts with `dependencies` or has a `dependencies` section in the name
 dependencies:
-  - head-branch: ["^dependencies", "dependencies", "^deps", "deps"]
+  - head-branch: ["^dependencies", "dependencies", "^deps", "deps", "renovate", "dependabot"]
 ci:
   - changed-files:
       - any-glob-to-any-file: .github/**


### PR DESCRIPTION
the current labeler is removing the dependencies label because the conditions are not met 

<img width="551" alt="image" src="https://github.com/user-attachments/assets/0f03be96-5526-47f9-b27c-27989c5ae613">
