### PR TITLE
golangci updates for speed

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -38,7 +38,7 @@ steps:
         plugins:
           - docker#v5.12.0:
               image: "ghcr.io/theopenlane/build-image:latest"
-              command: ["task", "go:lint"]
+              command: ["task", "go:lint:ci"]
               always_pull: true
               environment:
                 - "GOTOOLCHAIN=auto"

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,6 +2,7 @@ run:
   timeout: 15m
   allow-serial-runners: true
   concurrency: 0
+  tests: false
 linters-settings:
   goimports:
     local-prefixes: github.com/theopenlane/core
@@ -13,29 +14,30 @@ linters-settings:
     ignore-generated-header: true
 linters:
   enable:
+    # default linters
+    - errcheck 
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    # additional linters
     - bodyclose
-    - errcheck
     - gocritic
     - gocyclo
     - err113
     - gofmt
     - goimports
     - mnd
-    - gosimple
-    - govet
     - gosec
-    - ineffassign
     - misspell
     - noctx
     - revive
-    - staticcheck
     - stylecheck
     - typecheck
-    - unused
     - whitespace
     - wsl
 issues:
-  fix: true
   exclude-use-default: true
   exclude-dirs:
     - pkg/testutils/*
@@ -55,3 +57,5 @@ issues:
     - internal/graphapi/gen_models.go
     - internal/openlaneclient/graphclient.go
     - pkg/openlaneclient/graphclient.go
+output:
+  show-stats: true

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -43,6 +43,12 @@ tasks:
     desc: runs golangci-lint, the most annoying opinionated linter ever
     cmds:
       - golangci-lint run --config=.golangci.yaml --verbose --fast --fix
+  
+  go:lint:ci:
+    desc: runs golangci-lint, the most annoying opinionated linter ever, for CI
+    ## do not use --fast or --fix in CI
+    cmds:
+      - golangci-lint run --config=.golangci.yaml --verbose
 
   go:test:
     desc: runs and outputs results of created go tests

--- a/pkg/middleware/ratelimiter/ratelimiter.go
+++ b/pkg/middleware/ratelimiter/ratelimiter.go
@@ -77,7 +77,7 @@ func (r *RateLimiter) Check(key string) (limitStatus *LimitStatus, err error) {
 }
 
 // calcRate calculates current rate based on previous and current values
-func (r *RateLimiter) calcRate(timeFromCurrWindow time.Duration, prevValue int64, currentValue int64) float64 {
+func (r *RateLimiter) calcRate(timeFromCurrWindow time.Duration, prevValue int64, currentValue int64) float64 { // nolint: unused
 	return float64((float64(r.windowSize)-float64(timeFromCurrWindow))/float64(r.windowSize))*float64(prevValue) + float64(currentValue)
 }
 


### PR DESCRIPTION
This now locally takes:

```
INFO Execution took 2m42.106713042s  
```

vs. before the changes:

```
INFO Execution took 4m54.794890834s
```

CI is passing in about 7-8 minutes. 

Changes: 
- `test: false` will now include all tests files from the linter.
- No linters were removed, I just re-orded so I could see the default vs. what additional ones we have added are. Removing some didn't really speed up the process. 
- removed `fast` and `fix` from the ci run. The first run of `fast` is always slower, its not recommended to run in ci. And `fix` should never be run in CI because the changes need to be pushed to the branch. 