### PR TITLE
fixes from pre-commit run: typos and graphql formatting

### DIFF
--- a/docker/docker-compose-riverboat.yml
+++ b/docker/docker-compose-riverboat.yml
@@ -6,7 +6,7 @@ services:
     image: ghcr.io/theopenlane/riverboat:arm64-78-90832455
     container_name: riverboat
     environment:
-      # this needs to use host.docker.internal since it is a seperate docker-compose file
+      # this needs to use host.docker.internal since it is a separate docker-compose file
       - RIVERBOAT_JOBQUEUE_DATABASEHOST=postgres://postgres:password@host.docker.internal:5432/jobs?sslmode=disable
       - RIVERBOAT_RUNMIGRATIONS=true
     command:

--- a/pkg/objects/objects.go
+++ b/pkg/objects/objects.go
@@ -140,7 +140,7 @@ type File struct {
 	ContentType string `json:"content_type,omitempty"`
 	// Size in bytes of the uploaded file
 	Size int64 `json:"size,omitempty"`
-	// Metdata is a map of key value pairs that can be used to store additional information about the file
+	// Metadata is a map of key value pairs that can be used to store additional information about the file
 	Metadata map[string]string `json:"metadata,omitempty"`
 	// Bucket is the bucket that the file is stored in
 	Bucket string `json:"bucket,omitempty"`

--- a/pkg/objects/options.go
+++ b/pkg/objects/options.go
@@ -95,7 +95,7 @@ func WithDownloadFileOptions(opts *DownloadFileOptions) Option {
 	}
 }
 
-func WithMetdata(mp map[string]interface{}) Option {
+func WithMetadata(mp map[string]interface{}) Option {
 	return func(o *Objects) {
 		if o.UploadFileOptions.Metadata == nil {
 			o.UploadFileOptions.Metadata = map[string]string{}

--- a/query/feature.graphql
+++ b/query/feature.graphql
@@ -1,4 +1,3 @@
-
 mutation CreateBulkCSVFeature($input: Upload!) {
   createBulkCSVFeature(input: $input) {
     features {
@@ -86,6 +85,7 @@ query GetAllFeatures {
     }
   }
 }
+
 query GetFeatureByID($featureId: ID!) {
   feature(id: $featureId) {
     createdAt
@@ -125,6 +125,7 @@ query GetFeatures($where: FeatureWhereInput) {
     }
   }
 }
+
 mutation UpdateFeature($updateFeatureId: ID!, $input: UpdateFeatureInput!) {
   updateFeature(id: $updateFeatureId, input: $input) {
     feature {

--- a/query/internalpolicyhistory.graphql
+++ b/query/internalpolicyhistory.graphql
@@ -1,5 +1,3 @@
-
-
 query GetAllInternalPolicyHistories {
   internalPolicyHistories {
     edges {

--- a/query/organizationhistory.graphql
+++ b/query/organizationhistory.graphql
@@ -1,5 +1,3 @@
-
-
 query GetAllOrganizationHistories {
   organizationHistories {
     edges {

--- a/query/standard.graphql
+++ b/query/standard.graphql
@@ -1,4 +1,3 @@
-
 mutation CreateBulkCSVStandard($input: Upload!) {
   createBulkCSVStandard(input: $input) {
     standards {
@@ -98,6 +97,7 @@ query GetAllStandards {
     }
   }
 }
+
 query GetStandardByID($standardId: ID!) {
   standard(id: $standardId) {
     background
@@ -143,6 +143,7 @@ query GetStandards($where: StandardWhereInput) {
     }
   }
 }
+
 mutation UpdateStandard($updateStandardId: ID!, $input: UpdateStandardInput!) {
   updateStandard(id: $updateStandardId, input: $input) {
     standard {

--- a/query/usersettinghistory.graphql
+++ b/query/usersettinghistory.graphql
@@ -1,5 +1,3 @@
-
-
 query GetAllUserSettingHistories {
   userSettingHistories {
     edges {


### PR DESCRIPTION
these fixes came from running the command `pre-commit run --show-diff-on-failure --color=always --all-files`. 

Note: I had to run the command multiple times to get to a final passing state. Seems like the typos ran first, stages changes then killed the pre-commit, running it again fixes the graphql formatting. 