### PR TITLE
Document adding openlane.fga

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ See the [README](/config/README.md) in the `config` directory.
 1. Update the configuration with whatever respective settings you desire; the
    defaults inside should allow you to run the server without a problem
 
+1. Create the openlane.fga
+
+    ```bash
+    cp fga/model/model.fga fga/model/openlane.fga
+    ```
+
 1. Use the task commands to start the server
 
    Run the core server in development mode with dependencies in docker


### PR DESCRIPTION
`task run-dev` failed with

```
Error: open fga/model/openlane.fga: no such file or directory
exit status 1
task: Failed to run task "run-dev": exit status 1
```

I fixed this by running `cp config/config-dev.example.yaml .config/.config.yaml`. 