### PR TITLE
feat: control objectives and their permissions, group permissions mixin

### DIFF
--- a/cmd/cli/cmd/controlobjective/create.go
+++ b/cmd/cli/cmd/controlobjective/create.go
@@ -1,0 +1,111 @@
+package controlobjective
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/theopenlane/core/cmd/cli/cmd"
+	"github.com/theopenlane/core/pkg/openlaneclient"
+)
+
+var createCmd = &cobra.Command{
+	Use:   "create",
+	Short: "create a new controlObjective",
+	Run: func(cmd *cobra.Command, args []string) {
+		err := create(cmd.Context())
+		cobra.CheckErr(err)
+	},
+}
+
+func init() {
+	command.AddCommand(createCmd)
+
+	// command line flags for the create command
+	createCmd.Flags().StringP("name", "n", "", "name of the control objective")
+	createCmd.Flags().StringP("description", "d", "", "description of the control objective")
+	createCmd.Flags().StringP("status", "s", "", "status of the control objective")
+	createCmd.Flags().StringP("type", "t", "", "type of the control objective")
+	createCmd.Flags().StringP("version", "v", "", "version of the control objective")
+	createCmd.Flags().StringP("control-number", "c", "", "number of the control objective")
+	createCmd.Flags().StringP("family", "f", "", "family of the control objective")
+	createCmd.Flags().StringP("class", "l", "", "class associated with the control objective")
+	createCmd.Flags().StringP("source", "o", "", "source of the control objective")
+	createCmd.Flags().StringP("mapped-frameworks", "m", "", "mapped frameworks")
+	createCmd.Flags().StringSliceP("programs", "p", []string{}, "program ID(s) associated with the control objective")
+}
+
+// createValidation validates the required fields for the command
+func createValidation() (input openlaneclient.CreateControlObjectiveInput, err error) {
+	// validation of required fields for the create command
+	// output the input struct with the required fields and optional fields based on the command line flags
+	input.Name = cmd.Config.String("name")
+	if input.Name == "" {
+		return input, cmd.NewRequiredFieldMissingError("name")
+	}
+
+	input.ProgramIDs = cmd.Config.Strings("programs")
+
+	description := cmd.Config.String("description")
+	if description != "" {
+		input.Description = &description
+	}
+
+	status := cmd.Config.String("status")
+	if status != "" {
+		input.Status = &status
+	}
+
+	controlObjectiveType := cmd.Config.String("type")
+	if controlObjectiveType != "" {
+		input.ControlObjectiveType = &controlObjectiveType
+	}
+
+	version := cmd.Config.String("version")
+	if version != "" {
+		input.Version = &version
+	}
+
+	controlNumber := cmd.Config.String("control-number")
+	if controlNumber != "" {
+		input.ControlNumber = &controlNumber
+	}
+
+	family := cmd.Config.String("family")
+	if family != "" {
+		input.Family = &family
+	}
+
+	class := cmd.Config.String("class")
+	if class != "" {
+		input.Class = &class
+	}
+
+	source := cmd.Config.String("source")
+	if source != "" {
+		input.Source = &source
+	}
+
+	mappedFrameworks := cmd.Config.String("mapped-frameworks")
+	if mappedFrameworks != "" {
+		input.MappedFrameworks = &mappedFrameworks
+	}
+
+	return input, nil
+}
+
+// create a new controlObjective
+func create(ctx context.Context) error {
+	// setup http client
+	client, err := cmd.SetupClientWithAuth(ctx)
+	cobra.CheckErr(err)
+	defer cmd.StoreSessionCookies(client)
+
+	input, err := createValidation()
+	cobra.CheckErr(err)
+
+	o, err := client.CreateControlObjective(ctx, input)
+	cobra.CheckErr(err)
+
+	return consoleOutput(o)
+}

--- a/cmd/cli/cmd/controlobjective/delete.go
+++ b/cmd/cli/cmd/controlobjective/delete.go
@@ -1,0 +1,50 @@
+package controlobjective
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/theopenlane/core/cmd/cli/cmd"
+)
+
+var deleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "delete an existing controlobjective",
+	Run: func(cmd *cobra.Command, args []string) {
+		err := delete(cmd.Context())
+		cobra.CheckErr(err)
+	},
+}
+
+func init() {
+	command.AddCommand(deleteCmd)
+
+	deleteCmd.Flags().StringP("id", "i", "", "controlobjective id to delete")
+}
+
+// deleteValidation validates the required fields for the command
+func deleteValidation() (string, error) {
+	id := cmd.Config.String("id")
+	if id == "" {
+		return "", cmd.NewRequiredFieldMissingError("controlobjective id")
+	}
+
+	return id, nil
+}
+
+// delete an existing controlObjective in the platform
+func delete(ctx context.Context) error {
+	// setup http client
+	client, err := cmd.SetupClientWithAuth(ctx)
+	cobra.CheckErr(err)
+	defer cmd.StoreSessionCookies(client)
+
+	id, err := deleteValidation()
+	cobra.CheckErr(err)
+
+	o, err := client.DeleteControlObjective(ctx, id)
+	cobra.CheckErr(err)
+
+	return consoleOutput(o)
+}

--- a/cmd/cli/cmd/controlobjective/doc.go
+++ b/cmd/cli/cmd/controlobjective/doc.go
@@ -1,0 +1,2 @@
+// Package controlobjective is our cobra cli for controlObjective endpoints
+package controlobjective

--- a/cmd/cli/cmd/controlobjective/get.go
+++ b/cmd/cli/cmd/controlobjective/get.go
@@ -1,0 +1,48 @@
+package controlobjective
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/theopenlane/core/cmd/cli/cmd"
+)
+
+var getCmd = &cobra.Command{
+	Use:   "get",
+	Short: "get an existing controlObjective",
+	Run: func(cmd *cobra.Command, args []string) {
+		err := get(cmd.Context())
+		cobra.CheckErr(err)
+	},
+}
+
+func init() {
+	command.AddCommand(getCmd)
+	getCmd.Flags().StringP("id", "i", "", "controlObjective id to query")
+
+}
+
+// get an existing controlObjective in the platform
+func get(ctx context.Context) error {
+	// setup http client
+	client, err := cmd.SetupClientWithAuth(ctx)
+	cobra.CheckErr(err)
+	defer cmd.StoreSessionCookies(client)
+	// filter options
+	id := cmd.Config.String("id")
+
+	// if an controlObjective ID is provided, filter on that controlObjective, otherwise get all
+	if id != "" {
+		o, err := client.GetControlObjectiveByID(ctx, id)
+		cobra.CheckErr(err)
+
+		return consoleOutput(o)
+	}
+
+	// get all will be filtered for the authorized organization(s)
+	o, err := client.GetAllControlObjectives(ctx)
+	cobra.CheckErr(err)
+
+	return consoleOutput(o)
+}

--- a/cmd/cli/cmd/controlobjective/get.go
+++ b/cmd/cli/cmd/controlobjective/get.go
@@ -20,7 +20,6 @@ var getCmd = &cobra.Command{
 func init() {
 	command.AddCommand(getCmd)
 	getCmd.Flags().StringP("id", "i", "", "controlObjective id to query")
-
 }
 
 // get an existing controlObjective in the platform

--- a/cmd/cli/cmd/controlobjective/get.go
+++ b/cmd/cli/cmd/controlobjective/get.go
@@ -28,6 +28,7 @@ func get(ctx context.Context) error {
 	client, err := cmd.SetupClientWithAuth(ctx)
 	cobra.CheckErr(err)
 	defer cmd.StoreSessionCookies(client)
+
 	// filter options
 	id := cmd.Config.String("id")
 

--- a/cmd/cli/cmd/controlobjective/root.go
+++ b/cmd/cli/cmd/controlobjective/root.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/theopenlane/utils/cli/tables"
+
 	"github.com/theopenlane/core/cmd/cli/cmd"
 	"github.com/theopenlane/core/pkg/openlaneclient"
-	"github.com/theopenlane/utils/cli/tables"
 )
 
 // command represents the base controlObjective command when called without any subcommands

--- a/cmd/cli/cmd/controlobjective/root.go
+++ b/cmd/cli/cmd/controlobjective/root.go
@@ -1,0 +1,111 @@
+package controlobjective
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/theopenlane/core/cmd/cli/cmd"
+	"github.com/theopenlane/core/pkg/openlaneclient"
+	"github.com/theopenlane/utils/cli/tables"
+)
+
+// command represents the base controlObjective command when called without any subcommands
+var command = &cobra.Command{
+	Use:   "control-objective",
+	Short: "the subcommands for working with controlObjectives",
+}
+
+func init() {
+	cmd.RootCmd.AddCommand(command)
+}
+
+// consoleOutput prints the output in the console
+func consoleOutput(e any) error {
+	// check if the output format is JSON and print the controlObjectives in JSON format
+	if strings.EqualFold(cmd.OutputFormat, cmd.JSONOutput) {
+		return jsonOutput(e)
+	}
+
+	// check the type of the controlObjectives and print them in a table format
+	switch v := e.(type) {
+	case *openlaneclient.GetAllControlObjectives:
+		var nodes []*openlaneclient.GetAllControlObjectives_ControlObjectives_Edges_Node
+
+		for _, i := range v.ControlObjectives.Edges {
+			nodes = append(nodes, i.Node)
+		}
+
+		e = nodes
+	case *openlaneclient.GetControlObjectives:
+		var nodes []*openlaneclient.GetControlObjectives_ControlObjectives_Edges_Node
+
+		for _, i := range v.ControlObjectives.Edges {
+			nodes = append(nodes, i.Node)
+		}
+
+		e = nodes
+	case *openlaneclient.GetControlObjectiveByID:
+		e = v.ControlObjective
+	case *openlaneclient.CreateControlObjective:
+		e = v.CreateControlObjective.ControlObjective
+	case *openlaneclient.UpdateControlObjective:
+		e = v.UpdateControlObjective.ControlObjective
+	case *openlaneclient.DeleteControlObjective:
+		deletedTableOutput(v)
+		return nil
+	}
+
+	s, err := json.Marshal(e)
+	cobra.CheckErr(err)
+
+	var list []openlaneclient.ControlObjective
+
+	err = json.Unmarshal(s, &list)
+	if err != nil {
+		var in openlaneclient.ControlObjective
+		err = json.Unmarshal(s, &in)
+		cobra.CheckErr(err)
+
+		list = append(list, in)
+	}
+
+	tableOutput(list)
+
+	return nil
+}
+
+// jsonOutput prints the output in a JSON format
+func jsonOutput(out any) error {
+	s, err := json.Marshal(out)
+	cobra.CheckErr(err)
+
+	return cmd.JSONPrint(s)
+}
+
+// tableOutput prints the output in a table format
+func tableOutput(out []openlaneclient.ControlObjective) {
+	// create a table writer
+	writer := tables.NewTableWriter(command.OutOrStdout(), "ID", "Name", "Program(s)", "Description", "Status", "Type", "Version", "ControlNumber", "Family", "Class", "Source", "MappedFrameworks")
+	for _, i := range out {
+		programs := []string{}
+
+		for _, p := range i.Programs {
+			programs = append(programs, p.Name)
+		}
+
+		writer.AddRow(i.ID, i.Name, strings.Join(programs, ","), *i.Description, *i.Status, *i.ControlObjectiveType, *i.Version, *i.ControlNumber, *i.Family, *i.Class, *i.Source, *i.MappedFrameworks)
+	}
+
+	writer.Render()
+}
+
+// deleteTableOutput prints the deleted id in a table format
+func deletedTableOutput(e *openlaneclient.DeleteControlObjective) {
+	writer := tables.NewTableWriter(command.OutOrStdout(), "DeletedID")
+
+	writer.AddRow(e.DeleteControlObjective.DeletedID)
+
+	writer.Render()
+}

--- a/cmd/cli/cmd/controlobjective/root.go
+++ b/cmd/cli/cmd/controlobjective/root.go
@@ -89,6 +89,7 @@ func jsonOutput(out any) error {
 func tableOutput(out []openlaneclient.ControlObjective) {
 	// create a table writer
 	writer := tables.NewTableWriter(command.OutOrStdout(), "ID", "Name", "Program(s)", "Description", "Status", "Type", "Version", "ControlNumber", "Family", "Class", "Source", "MappedFrameworks")
+
 	for _, i := range out {
 		programs := []string{}
 

--- a/cmd/cli/cmd/controlobjective/update.go
+++ b/cmd/cli/cmd/controlobjective/update.go
@@ -1,0 +1,127 @@
+package controlobjective
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/theopenlane/core/cmd/cli/cmd"
+	"github.com/theopenlane/core/pkg/openlaneclient"
+)
+
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "update an existing controlObjective",
+	Run: func(cmd *cobra.Command, args []string) {
+		err := update(cmd.Context())
+		cobra.CheckErr(err)
+	},
+}
+
+func init() {
+	command.AddCommand(updateCmd)
+
+	updateCmd.Flags().StringP("id", "i", "", "controlObjective id to update")
+
+	// command line flags for the update command
+	updateCmd.Flags().StringP("name", "n", "", "name of the control objective")
+	updateCmd.Flags().StringP("description", "d", "", "description of the control objective")
+	updateCmd.Flags().StringP("status", "s", "", "status of the control objective")
+	updateCmd.Flags().StringP("type", "t", "", "type of the control objective")
+	updateCmd.Flags().StringP("version", "v", "", "version of the control objective")
+	updateCmd.Flags().StringP("control-number", "c", "", "number of the control objective")
+	updateCmd.Flags().StringP("family", "f", "", "family of the control objective")
+	updateCmd.Flags().StringP("class", "l", "", "class associated with the control objective")
+	updateCmd.Flags().StringP("source", "o", "", "source of the control objective")
+	updateCmd.Flags().StringP("mapped-frameworks", "m", "", "mapped frameworks")
+	updateCmd.Flags().StringSlice("add-programs", []string{}, "add program(s) to the risk")
+	updateCmd.Flags().StringSlice("remove-programs", []string{}, "remove program(s) from the risk")
+}
+
+// updateValidation validates the required fields for the command
+func updateValidation() (id string, input openlaneclient.UpdateControlObjectiveInput, err error) {
+	id = cmd.Config.String("id")
+	if id == "" {
+		return id, input, cmd.NewRequiredFieldMissingError("controlObjective id")
+	}
+
+	// validation of required fields for the update command
+	// output the input struct with the required fields and optional fields based on the command line flags
+	name := cmd.Config.String("name")
+	if name != "" {
+		input.Name = &name
+	}
+
+	addPrograms := cmd.Config.Strings("add-programs")
+	if len(addPrograms) > 0 {
+		input.AddProgramIDs = addPrograms
+	}
+
+	removePrograms := cmd.Config.Strings("remove-programs")
+	if len(removePrograms) > 0 {
+		input.RemoveProgramIDs = removePrograms
+	}
+
+	description := cmd.Config.String("description")
+	if description != "" {
+		input.Description = &description
+	}
+
+	status := cmd.Config.String("status")
+	if status != "" {
+		input.Status = &status
+	}
+
+	controlObjectiveType := cmd.Config.String("type")
+	if controlObjectiveType != "" {
+		input.ControlObjectiveType = &controlObjectiveType
+	}
+
+	version := cmd.Config.String("version")
+	if version != "" {
+		input.Version = &version
+	}
+
+	controlNumber := cmd.Config.String("control-number")
+	if controlNumber != "" {
+		input.ControlNumber = &controlNumber
+	}
+
+	family := cmd.Config.String("family")
+	if family != "" {
+		input.Family = &family
+	}
+
+	class := cmd.Config.String("class")
+	if class != "" {
+		input.Class = &class
+	}
+
+	source := cmd.Config.String("source")
+	if source != "" {
+		input.Source = &source
+	}
+
+	mappedFrameworks := cmd.Config.String("mapped-frameworks")
+	if mappedFrameworks != "" {
+		input.MappedFrameworks = &mappedFrameworks
+	}
+
+	return id, input, nil
+}
+
+// update an existing controlObjective in the platform
+func update(ctx context.Context) error {
+	// setup http client
+	client, err := cmd.SetupClientWithAuth(ctx)
+	cobra.CheckErr(err)
+	defer cmd.StoreSessionCookies(client)
+
+	id, input, err := updateValidation()
+	cobra.CheckErr(err)
+
+	o, err := client.UpdateControlObjective(ctx, id, input)
+	cobra.CheckErr(err)
+
+	return consoleOutput(o)
+}

--- a/cmd/cli/cmd/controlobjectivehistory/doc.go
+++ b/cmd/cli/cmd/controlobjectivehistory/doc.go
@@ -1,0 +1,2 @@
+// Package controlobjectivehistory is our cobra cli for controlObjectiveHistory endpoints
+package controlobjectivehistory

--- a/cmd/cli/cmd/controlobjectivehistory/get.go
+++ b/cmd/cli/cmd/controlobjectivehistory/get.go
@@ -1,0 +1,49 @@
+package controlobjectivehistory
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/theopenlane/core/cmd/cli/cmd"
+	"github.com/theopenlane/core/pkg/openlaneclient"
+)
+
+var getCmd = &cobra.Command{
+	Use:   "get",
+	Short: "get an existing controlObjectiveHistory",
+	Run: func(cmd *cobra.Command, args []string) {
+		err := get(cmd.Context())
+		cobra.CheckErr(err)
+	},
+}
+
+func init() {
+	command.AddCommand(getCmd)
+	getCmd.Flags().StringP("id", "i", "", "id to query")
+}
+
+// get an existing controlObjectiveHistory in the platform
+func get(ctx context.Context) error {
+	// setup http client
+	client, err := cmd.SetupClientWithAuth(ctx)
+	cobra.CheckErr(err)
+	defer cmd.StoreSessionCookies(client)
+
+	// filter options
+	id := cmd.Config.String("id")
+	if id != "" {
+		o, err := client.GetControlObjectiveHistories(ctx, &openlaneclient.ControlObjectiveHistoryWhereInput{
+			Ref: &id,
+		})
+		cobra.CheckErr(err)
+
+		return consoleOutput(o)
+	}
+
+	// get all will be filtered for the authorized organization(s)
+	o, err := client.GetAllControlObjectiveHistories(ctx)
+	cobra.CheckErr(err)
+
+	return consoleOutput(o)
+}

--- a/cmd/cli/cmd/controlobjectivehistory/root.go
+++ b/cmd/cli/cmd/controlobjectivehistory/root.go
@@ -1,0 +1,87 @@
+package controlobjectivehistory
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/theopenlane/core/cmd/cli/cmd"
+	"github.com/theopenlane/core/pkg/openlaneclient"
+	"github.com/theopenlane/utils/cli/tables"
+)
+
+// command represents the base controlObjectiveHistory command when called without any subcommands
+var command = &cobra.Command{
+	Use:   "control-objective-history",
+	Short: "the subcommands for working with controlObjectiveHistories",
+}
+
+func init() {
+	cmd.RootCmd.AddCommand(command)
+}
+
+// consoleOutput prints the output in the console
+func consoleOutput(e any) error {
+	// check if the output format is JSON and print the controlObjectiveHistories in JSON format
+	if strings.EqualFold(cmd.OutputFormat, cmd.JSONOutput) {
+		return jsonOutput(e)
+	}
+
+	// check the type of the controlObjectiveHistories and print them in a table format
+	switch v := e.(type) {
+	case *openlaneclient.GetAllControlObjectiveHistories:
+		var nodes []*openlaneclient.GetAllControlObjectiveHistories_ControlObjectiveHistories_Edges_Node
+
+		for _, i := range v.ControlObjectiveHistories.Edges {
+			nodes = append(nodes, i.Node)
+		}
+
+		e = nodes
+	case *openlaneclient.GetControlObjectiveHistories:
+		var nodes []*openlaneclient.GetControlObjectiveHistories_ControlObjectiveHistories_Edges_Node
+
+		for _, i := range v.ControlObjectiveHistories.Edges {
+			nodes = append(nodes, i.Node)
+		}
+
+		e = nodes
+	}
+
+	s, err := json.Marshal(e)
+	cobra.CheckErr(err)
+
+	var list []openlaneclient.ControlObjectiveHistory
+
+	err = json.Unmarshal(s, &list)
+	if err != nil {
+		var in openlaneclient.ControlObjectiveHistory
+		err = json.Unmarshal(s, &in)
+		cobra.CheckErr(err)
+
+		list = append(list, in)
+	}
+
+	tableOutput(list)
+
+	return nil
+}
+
+// jsonOutput prints the output in a JSON format
+func jsonOutput(out any) error {
+	s, err := json.Marshal(out)
+	cobra.CheckErr(err)
+
+	return cmd.JSONPrint(s)
+}
+
+// tableOutput prints the output in a table format
+func tableOutput(out []openlaneclient.ControlObjectiveHistory) {
+	// create a table writer
+	writer := tables.NewTableWriter(command.OutOrStdout(), "ID", "Ref", "Operation", "UpdatedAt", "UpdatedBy")
+	for _, i := range out {
+		writer.AddRow(i.ID, *i.Ref, i.Operation, *i.UpdatedAt, *i.UpdatedBy)
+	}
+
+	writer.Render()
+}

--- a/cmd/cli/cmd/controlobjectivehistory/root.go
+++ b/cmd/cli/cmd/controlobjectivehistory/root.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/theopenlane/utils/cli/tables"
+
 	"github.com/theopenlane/core/cmd/cli/cmd"
 	"github.com/theopenlane/core/pkg/openlaneclient"
-	"github.com/theopenlane/utils/cli/tables"
 )
 
 // command represents the base controlObjectiveHistory command when called without any subcommands

--- a/cmd/cli/cmd/risk/create.go
+++ b/cmd/cli/cmd/risk/create.go
@@ -2,7 +2,6 @@ package risk
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -46,7 +45,6 @@ func createValidation() (input openlaneclient.CreateRiskInput, err error) {
 	}
 
 	input.ProgramIDs = cmd.Config.Strings("programs")
-	fmt.Println(input.ProgramIDs)
 
 	riskType := cmd.Config.String("type")
 	if riskType != "" {

--- a/cmd/cli/cmd/risk/root.go
+++ b/cmd/cli/cmd/risk/root.go
@@ -88,13 +88,12 @@ func jsonOutput(out any) error {
 // tableOutput prints the output in a table format
 func tableOutput(out []openlaneclient.Risk) {
 	// create a table writer
-	// TODO: add additional columns to the table writer
 	writer := tables.NewTableWriter(command.OutOrStdout(), "ID", "Name", "Program(s)", "RiskType", "BusinessCosts", "Impact", "Likelihood", "Mitigation", "Satisfies")
 
 	for _, i := range out {
 		programs := []string{}
 
-		for _, p := range i.Program {
+		for _, p := range i.Programs {
 			programs = append(programs, p.Name)
 		}
 

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -7,6 +7,7 @@ import (
 	// they must all be imported in main
 	_ "github.com/theopenlane/core/cmd/cli/cmd/apitokens"
 	_ "github.com/theopenlane/core/cmd/cli/cmd/contact"
+	_ "github.com/theopenlane/core/cmd/cli/cmd/controlobjective"
 	_ "github.com/theopenlane/core/cmd/cli/cmd/entitlementplan"
 	_ "github.com/theopenlane/core/cmd/cli/cmd/entitlementplanfeatures"
 	_ "github.com/theopenlane/core/cmd/cli/cmd/entitlements"
@@ -43,6 +44,7 @@ import (
 	_ "github.com/theopenlane/core/cmd/cli/cmd/webhook"
 
 	// history commands
+	_ "github.com/theopenlane/core/cmd/cli/cmd/controlobjectivehistory"
 	_ "github.com/theopenlane/core/cmd/cli/cmd/documentdatahistory"
 	_ "github.com/theopenlane/core/cmd/cli/cmd/entitlementhistory"
 	_ "github.com/theopenlane/core/cmd/cli/cmd/entityhistory"

--- a/db/migrations-goose-postgres/20241126203309_control_objectives.sql
+++ b/db/migrations-goose-postgres/20241126203309_control_objectives.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+-- modify "control_objective_history" table
+ALTER TABLE "control_objective_history" ADD COLUMN "owner_id" character varying NOT NULL;
+-- modify "control_objectives" table
+ALTER TABLE "control_objectives" ADD COLUMN "owner_id" character varying NOT NULL, ADD CONSTRAINT "control_objectives_organizations_controlobjectives" FOREIGN KEY ("owner_id") REFERENCES "organizations" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+-- create "control_objective_blocked_groups" table
+CREATE TABLE "control_objective_blocked_groups" ("control_objective_id" character varying NOT NULL, "group_id" character varying NOT NULL, PRIMARY KEY ("control_objective_id", "group_id"), CONSTRAINT "control_objective_blocked_groups_control_objective_id" FOREIGN KEY ("control_objective_id") REFERENCES "control_objectives" ("id") ON UPDATE NO ACTION ON DELETE CASCADE, CONSTRAINT "control_objective_blocked_groups_group_id" FOREIGN KEY ("group_id") REFERENCES "groups" ("id") ON UPDATE NO ACTION ON DELETE CASCADE);
+-- create "control_objective_editors" table
+CREATE TABLE "control_objective_editors" ("control_objective_id" character varying NOT NULL, "group_id" character varying NOT NULL, PRIMARY KEY ("control_objective_id", "group_id"), CONSTRAINT "control_objective_editors_control_objective_id" FOREIGN KEY ("control_objective_id") REFERENCES "control_objectives" ("id") ON UPDATE NO ACTION ON DELETE CASCADE, CONSTRAINT "control_objective_editors_group_id" FOREIGN KEY ("group_id") REFERENCES "groups" ("id") ON UPDATE NO ACTION ON DELETE CASCADE);
+-- create "control_objective_viewers" table
+CREATE TABLE "control_objective_viewers" ("control_objective_id" character varying NOT NULL, "group_id" character varying NOT NULL, PRIMARY KEY ("control_objective_id", "group_id"), CONSTRAINT "control_objective_viewers_control_objective_id" FOREIGN KEY ("control_objective_id") REFERENCES "control_objectives" ("id") ON UPDATE NO ACTION ON DELETE CASCADE, CONSTRAINT "control_objective_viewers_group_id" FOREIGN KEY ("group_id") REFERENCES "groups" ("id") ON UPDATE NO ACTION ON DELETE CASCADE);
+
+-- +goose Down
+-- reverse: create "control_objective_viewers" table
+DROP TABLE "control_objective_viewers";
+-- reverse: create "control_objective_editors" table
+DROP TABLE "control_objective_editors";
+-- reverse: create "control_objective_blocked_groups" table
+DROP TABLE "control_objective_blocked_groups";
+-- reverse: modify "control_objectives" table
+ALTER TABLE "control_objectives" DROP CONSTRAINT "control_objectives_organizations_controlobjectives", DROP COLUMN "owner_id";
+-- reverse: modify "control_objective_history" table
+ALTER TABLE "control_objective_history" DROP COLUMN "owner_id";

--- a/db/migrations-goose-postgres/atlas.sum
+++ b/db/migrations-goose-postgres/atlas.sum
@@ -1,4 +1,4 @@
-h1:rzUf8uHfxJmvsMnnD6DOoVfjI3Max1RTNy+EMmgwijY=
+h1:Kv4cfafrF3KiaMXj/G5497zbzimq4JN+17zJlF3+oX0=
 20240827061503_init.sql h1:D0Ce7h0FSKpjtQOHZK5gXOpaPvlNAFHHzqfQQ8re0T4=
 20241014185634_object_upload.sql h1:xeeCqYCpQ3RFWgNjnKV1GMHgTEoZK2aWv5a2EvU4DP8=
 20241030173034_base.sql h1:+eJ3JGD5lzsP16mz7q+yD78Jvs7sTX8nBZQmS68hjoA=
@@ -8,3 +8,4 @@ h1:rzUf8uHfxJmvsMnnD6DOoVfjI3Max1RTNy+EMmgwijY=
 20241113002817_stripeintegration.sql h1:WtXDYl0bpas44WEMc7+/njlvdgxrKUa7weQdHPdkr8E=
 20241121200815_policy_procedure_program_edges.sql h1:/7c7pj5XlsNPOKE7CK2n6EFbW8KdSbxmua05V9IWAWg=
 20241125224128_risks.sql h1:Zu3O/C4g+GA3hvq7VXsEFf+AfybQdWygAU98fUd/wLM=
+20241126203309_control_objectives.sql h1:wo56TBIY22BZwoGMetReVarOQKyEyiOCeLJolOJew38=

--- a/db/migrations/20241126203308_control_objectives.sql
+++ b/db/migrations/20241126203308_control_objectives.sql
@@ -1,0 +1,10 @@
+-- Modify "control_objective_history" table
+ALTER TABLE "control_objective_history" ADD COLUMN "owner_id" character varying NOT NULL;
+-- Modify "control_objectives" table
+ALTER TABLE "control_objectives" ADD COLUMN "owner_id" character varying NOT NULL, ADD CONSTRAINT "control_objectives_organizations_controlobjectives" FOREIGN KEY ("owner_id") REFERENCES "organizations" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+-- Create "control_objective_blocked_groups" table
+CREATE TABLE "control_objective_blocked_groups" ("control_objective_id" character varying NOT NULL, "group_id" character varying NOT NULL, PRIMARY KEY ("control_objective_id", "group_id"), CONSTRAINT "control_objective_blocked_groups_control_objective_id" FOREIGN KEY ("control_objective_id") REFERENCES "control_objectives" ("id") ON UPDATE NO ACTION ON DELETE CASCADE, CONSTRAINT "control_objective_blocked_groups_group_id" FOREIGN KEY ("group_id") REFERENCES "groups" ("id") ON UPDATE NO ACTION ON DELETE CASCADE);
+-- Create "control_objective_editors" table
+CREATE TABLE "control_objective_editors" ("control_objective_id" character varying NOT NULL, "group_id" character varying NOT NULL, PRIMARY KEY ("control_objective_id", "group_id"), CONSTRAINT "control_objective_editors_control_objective_id" FOREIGN KEY ("control_objective_id") REFERENCES "control_objectives" ("id") ON UPDATE NO ACTION ON DELETE CASCADE, CONSTRAINT "control_objective_editors_group_id" FOREIGN KEY ("group_id") REFERENCES "groups" ("id") ON UPDATE NO ACTION ON DELETE CASCADE);
+-- Create "control_objective_viewers" table
+CREATE TABLE "control_objective_viewers" ("control_objective_id" character varying NOT NULL, "group_id" character varying NOT NULL, PRIMARY KEY ("control_objective_id", "group_id"), CONSTRAINT "control_objective_viewers_control_objective_id" FOREIGN KEY ("control_objective_id") REFERENCES "control_objectives" ("id") ON UPDATE NO ACTION ON DELETE CASCADE, CONSTRAINT "control_objective_viewers_group_id" FOREIGN KEY ("group_id") REFERENCES "groups" ("id") ON UPDATE NO ACTION ON DELETE CASCADE);

--- a/db/migrations/atlas.sum
+++ b/db/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:72FLJlD316S3WavcWpuSGu4/cpgZywrRBEMn+MTDOy8=
+h1:0huuGW7N64WUhLrY2A3WasuT6fmhrcNwh34rzNYr5R4=
 20240827061437_init.sql h1:9pQTZIsiDF3hW0HraVTzaU3M25iiy3MdxvhsZosxgvo=
 20241014185633_object_upload.sql h1:0lzY0vj0gav3gMHGc8gm793zPeSQSMMHjt4c2V+7Eok=
 20241108062010_compliance.sql h1:vmJyf1VhoKSRw9zRQKXsRtWJEEUYDbqZmpkyp89O/Tc=
@@ -7,3 +7,4 @@ h1:72FLJlD316S3WavcWpuSGu4/cpgZywrRBEMn+MTDOy8=
 20241113002815_stripeintegration.sql h1:ESFTpELtjz/4wJPR5p2oEqQgUfFJe2PRYHPHV9JIn3A=
 20241121200811_policy_procedure_program_edges.sql h1:K5HuAgBqYM2CMYpb8Gc9rgQrOxdLeD8BwXtRkti9Ud0=
 20241125224127_risks.sql h1:zqgRud+GNfsz9niYb3u1VSzhpeMW+ghGzJXwhVytuXk=
+20241126203308_control_objectives.sql h1:e2DUn9RTWOR8fJl3PGdQ/YgzLfj585nNTeTiuvkAh+A=

--- a/fga/model/model.fga
+++ b/fga/model/model.fga
@@ -101,27 +101,27 @@ type program
     define user_in_context: [user]
 type control
   relations
-    define can_view: [user] or can_view from parent
-    define can_edit: [user] or can_edit from parent
-    define can_delete: [user] or can_delete from parent
+    define can_view: [user] or ((can_view from parent or viewer) but not blocked)
+    define can_edit: [user] or ((can_edit from parent or editor) but not blocked)
+    define can_delete: [user] or ((can_delete from parent or editor) but not blocked)
     define parent: [user, service, program]
     define viewer: [group#member]
     define editor: [group#member]
     define blocked: [user, group#member]
 type subcontrol
   relations
-    define can_view: [user] or can_view from parent
-    define can_edit: [user] or can_edit from parent
-    define can_delete: [user] or can_delete from parent
+    define can_view: [user] or ((can_view from parent or viewer) but not blocked)
+    define can_edit: [user] or ((can_edit from parent or editor) but not blocked)
+    define can_delete: [user] or ((can_delete from parent or editor) but not blocked)
     define parent: [user, service, program]
     define viewer: [group#member]
     define editor: [group#member]
     define blocked: [user, group#member]
-type control_objective
+type controlobjective
   relations
-    define can_view: [user] or can_view from parent
-    define can_edit: [user] or can_edit from parent
-    define can_delete: [user] or can_delete from parent
+    define can_view: [user] or ((can_view from parent or viewer) but not blocked)
+    define can_edit: [user] or ((can_edit from parent or editor) but not blocked)
+    define can_delete: [user] or ((can_delete from parent or editor) but not blocked)
     define parent: [user, service, program]
     define viewer: [group#member]
     define editor: [group#member]
@@ -139,7 +139,7 @@ type risk
     define editor: [group#member]
     define blocked: [user, group#member]
 # policies are always assigned to an organization and by default all org members can view
-# groups can be used to exclude users from being able to view a internalpolicy
+# groups can be used to exclude users from being able to view a internal policy
 # groups can be used to give edit (or delete) access to users
 type internalpolicy
   relations
@@ -213,7 +213,7 @@ type contact
     # allow users or groups to be blocked from view + edit access
     define blocked: [user, group#member]
     define parent: [organization]
-# tasks can be created by any user and permissioned are assigned to the creator (assinger) and the assignee
+# tasks can be created by any user and permissions are assigned to the creator (assigner) and the assignee
 # tasks can also be associated with a parent object (like a control or a procedure) and inherit access from that object
 type task
   relations
@@ -221,4 +221,4 @@ type task
     define can_edit: [user, service] or assignee or can_delete or can_edit from parent
     define can_delete: [user, service] or can_delete from parent
     define assignee: [user]
-    define parent: [user, service, program, organization, control, procedure, group, internalpolicy, subcontrol, control_objective]
+    define parent: [user, service, program, organization, control, procedure, group, internalpolicy, subcontrol, controlobjective]

--- a/internal/ent/generated/auditing.go
+++ b/internal/ent/generated/auditing.go
@@ -333,6 +333,9 @@ func (coh *ControlObjectiveHistory) changes(new *ControlObjectiveHistory) []Chan
 	if !reflect.DeepEqual(coh.Tags, new.Tags) {
 		changes = append(changes, NewChange(controlobjectivehistory.FieldTags, coh.Tags, new.Tags))
 	}
+	if !reflect.DeepEqual(coh.OwnerID, new.OwnerID) {
+		changes = append(changes, NewChange(controlobjectivehistory.FieldOwnerID, coh.OwnerID, new.OwnerID))
+	}
 	if !reflect.DeepEqual(coh.Name, new.Name) {
 		changes = append(changes, NewChange(controlobjectivehistory.FieldName, coh.Name, new.Name))
 	}
@@ -2076,6 +2079,9 @@ func (rh *RiskHistory) changes(new *RiskHistory) []Change {
 	if !reflect.DeepEqual(rh.Tags, new.Tags) {
 		changes = append(changes, NewChange(riskhistory.FieldTags, rh.Tags, new.Tags))
 	}
+	if !reflect.DeepEqual(rh.OwnerID, new.OwnerID) {
+		changes = append(changes, NewChange(riskhistory.FieldOwnerID, rh.OwnerID, new.OwnerID))
+	}
 	if !reflect.DeepEqual(rh.Name, new.Name) {
 		changes = append(changes, NewChange(riskhistory.FieldName, rh.Name, new.Name))
 	}
@@ -2105,9 +2111,6 @@ func (rh *RiskHistory) changes(new *RiskHistory) []Change {
 	}
 	if !reflect.DeepEqual(rh.Details, new.Details) {
 		changes = append(changes, NewChange(riskhistory.FieldDetails, rh.Details, new.Details))
-	}
-	if !reflect.DeepEqual(rh.OwnerID, new.OwnerID) {
-		changes = append(changes, NewChange(riskhistory.FieldOwnerID, rh.OwnerID, new.OwnerID))
 	}
 	return changes
 }

--- a/internal/ent/generated/authz_checks.go
+++ b/internal/ent/generated/authz_checks.go
@@ -9,6 +9,7 @@ import (
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/rs/zerolog/log"
 
+	"github.com/theopenlane/core/internal/ent/generated/controlobjective"
 	"github.com/theopenlane/core/internal/ent/generated/file"
 	"github.com/theopenlane/core/internal/ent/generated/group"
 	"github.com/theopenlane/core/internal/ent/generated/groupmembership"
@@ -397,6 +398,234 @@ func (q *ContactHistoryQuery) CheckAccess(ctx context.Context) error {
 				return privacy.Allowf("nil request, bypassing auth check")
 			}
 			ac.ObjectID = ob.OwnerID
+		}
+
+		// request is for a list objects, will get filtered in interceptors
+		if ac.ObjectID == "" {
+			return privacy.Allowf("nil request, bypassing auth check")
+		}
+
+		var err error
+		ac.SubjectID, err = auth.GetUserIDFromContext(ctx)
+		if err != nil {
+			return err
+		}
+
+		access, err := q.Authz.CheckAccess(ctx, ac)
+		if err != nil {
+			return privacy.Skipf("unable to check access, %s", err.Error())
+		}
+
+		if access {
+			return privacy.Allow
+		}
+	}
+
+	// Skip to the next privacy rule (equivalent to return nil)
+	return privacy.Skip
+}
+
+func (q *ControlObjectiveQuery) CheckAccess(ctx context.Context) error {
+	gCtx := graphql.GetFieldContext(ctx)
+
+	if gCtx != nil {
+		ac := fgax.AccessCheck{
+			Relation:    fgax.CanView,
+			ObjectType:  "controlobjective",
+			SubjectType: auth.GetAuthzSubjectType(ctx),
+		}
+
+		// check id from graphql arg context
+		// when all objects are requested, the interceptor will check object access
+		// check the where input first
+		whereArg := gCtx.Args["where"]
+		if whereArg != nil {
+			where, ok := whereArg.(*ControlObjectiveWhereInput)
+			if ok && where != nil && where.ID != nil {
+				ac.ObjectID = *where.ID
+			}
+		}
+
+		// if that doesn't work, check for the id in the args
+		if ac.ObjectID == "" {
+			ac.ObjectID, _ = gCtx.Args["id"].(string)
+		}
+
+		// if we still don't have an object id, run the query and grab the object ID
+		// from the result
+		// this happens on join tables where we have the join ID (for updates and deletes)
+		// and not the actual object id
+		if ac.ObjectID == "" && "id" != "id" {
+			// allow this query to run
+			reqCtx := privacy.DecisionContext(ctx, privacy.Allow)
+			ob, err := q.Clone().Only(reqCtx)
+			if err != nil {
+				return privacy.Allowf("nil request, bypassing auth check")
+			}
+			ac.ObjectID = ob.ID
+		}
+
+		// request is for a list objects, will get filtered in interceptors
+		if ac.ObjectID == "" {
+			return privacy.Allowf("nil request, bypassing auth check")
+		}
+
+		var err error
+		ac.SubjectID, err = auth.GetUserIDFromContext(ctx)
+		if err != nil {
+			return err
+		}
+
+		access, err := q.Authz.CheckAccess(ctx, ac)
+		if err != nil {
+			return privacy.Skipf("unable to check access, %s", err.Error())
+		}
+
+		if access {
+			return privacy.Allow
+		}
+	}
+
+	// Skip to the next privacy rule (equivalent to return nil)
+	return privacy.Skip
+}
+func (m *ControlObjectiveMutation) CheckAccessForEdit(ctx context.Context) error {
+	ac := fgax.AccessCheck{
+		Relation:    fgax.CanEdit,
+		ObjectType:  "controlobjective",
+		SubjectType: auth.GetAuthzSubjectType(ctx),
+	}
+
+	gCtx := graphql.GetFieldContext(ctx)
+
+	// check the id from the args
+	if ac.ObjectID == "" {
+		ac.ObjectID, _ = gCtx.Args["id"].(string)
+	}
+
+	// if this is still empty, we need to query the object to get the object id
+	// this happens on join tables where we have the join ID (for updates and deletes)
+	if ac.ObjectID == "" && "id" != "id" {
+		id, ok := gCtx.Args["id"].(string)
+		if ok {
+			// allow this query to run
+			reqCtx := privacy.DecisionContext(ctx, privacy.Allow)
+			ob, err := m.Client().ControlObjective.Query().Where(controlobjective.ID(id)).Only(reqCtx)
+			if err != nil {
+				return privacy.Skipf("nil request, skipping auth check")
+			}
+			ac.ObjectID = ob.ID
+		}
+	}
+
+	// request is for a list objects, will get filtered in interceptors
+	if ac.ObjectID == "" {
+		return privacy.Allowf("nil request, bypassing auth check")
+	}
+
+	log.Debug().Msg("checking mutation access")
+
+	var err error
+	ac.SubjectID, err = auth.GetUserIDFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	log.Info().Str("relation", ac.Relation).Str("object_id", ac.ObjectID).Msg("checking relationship tuples")
+
+	access, err := m.Authz.CheckAccess(ctx, ac)
+	if err != nil {
+		return privacy.Skipf("unable to check access, %s", err.Error())
+	}
+
+	if access {
+		log.Debug().Str("relation", ac.Relation).Str("object_id", ac.ObjectID).Msg("access allowed")
+
+		return privacy.Allow
+	}
+
+	// return error if the action is not allowed
+	return ErrPermissionDenied
+}
+
+func (m *ControlObjectiveMutation) CheckAccessForDelete(ctx context.Context) error {
+	ac := fgax.AccessCheck{
+		Relation:    fgax.CanDelete,
+		ObjectType:  "controlobjective",
+		SubjectType: auth.GetAuthzSubjectType(ctx),
+	}
+
+	gCtx := graphql.GetFieldContext(ctx)
+
+	var ok bool
+	ac.ObjectID, ok = gCtx.Args["id"].(string)
+	if !ok {
+		return privacy.Allowf("nil request, bypassing auth check")
+	}
+
+	log.Debug().Msg("checking mutation access")
+
+	var err error
+	ac.SubjectID, err = auth.GetUserIDFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	log.Info().Str("relation", ac.Relation).Str("object_id", ac.ObjectID).Msg("checking relationship tuples")
+
+	access, err := m.Authz.CheckAccess(ctx, ac)
+	if err != nil {
+		return privacy.Skipf("unable to check access, %s", err.Error())
+	}
+
+	if access {
+		log.Debug().Str("relation", ac.Relation).Str("object_id", ac.ObjectID).Msg("access allowed")
+
+		return privacy.Allow
+	}
+
+	// return error if the action is not allowed
+	return ErrPermissionDenied
+}
+
+func (q *ControlObjectiveHistoryQuery) CheckAccess(ctx context.Context) error {
+	gCtx := graphql.GetFieldContext(ctx)
+
+	if gCtx != nil {
+		ac := fgax.AccessCheck{
+			Relation:    fgax.CanView,
+			ObjectType:  "controlobjective",
+			SubjectType: auth.GetAuthzSubjectType(ctx),
+		}
+
+		// check id from graphql arg context
+		// when all objects are requested, the interceptor will check object access
+		// check the where input first
+		whereArg := gCtx.Args["where"]
+		if whereArg != nil {
+			where, ok := whereArg.(*ControlObjectiveHistoryWhereInput)
+			if ok && where != nil && where.Ref != nil {
+				ac.ObjectID = *where.Ref
+			}
+		}
+
+		// if that doesn't work, check for the id in the args
+		if ac.ObjectID == "" {
+			ac.ObjectID, _ = gCtx.Args["ref"].(string)
+		}
+
+		// if we still don't have an object id, run the query and grab the object ID
+		// from the result
+		// this happens on join tables where we have the join ID (for updates and deletes)
+		// and not the actual object id
+		if ac.ObjectID == "" && "id" != "ref" {
+			// allow this query to run
+			reqCtx := privacy.DecisionContext(ctx, privacy.Allow)
+			ob, err := q.Clone().Only(reqCtx)
+			if err != nil {
+				return privacy.Allowf("nil request, bypassing auth check")
+			}
+			ac.ObjectID = ob.Ref
 		}
 
 		// request is for a list objects, will get filtered in interceptors

--- a/internal/ent/generated/client.go
+++ b/internal/ent/generated/client.go
@@ -2441,6 +2441,82 @@ func (c *ControlObjectiveClient) GetX(ctx context.Context, id string) *ControlOb
 	return obj
 }
 
+// QueryOwner queries the owner edge of a ControlObjective.
+func (c *ControlObjectiveClient) QueryOwner(co *ControlObjective) *OrganizationQuery {
+	query := (&OrganizationClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := co.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(controlobjective.Table, controlobjective.FieldID, id),
+			sqlgraph.To(organization.Table, organization.FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, controlobjective.OwnerTable, controlobjective.OwnerColumn),
+		)
+		schemaConfig := co.schemaConfig
+		step.To.Schema = schemaConfig.Organization
+		step.Edge.Schema = schemaConfig.ControlObjective
+		fromV = sqlgraph.Neighbors(co.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryBlockedGroups queries the blocked_groups edge of a ControlObjective.
+func (c *ControlObjectiveClient) QueryBlockedGroups(co *ControlObjective) *GroupQuery {
+	query := (&GroupClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := co.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(controlobjective.Table, controlobjective.FieldID, id),
+			sqlgraph.To(group.Table, group.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, controlobjective.BlockedGroupsTable, controlobjective.BlockedGroupsPrimaryKey...),
+		)
+		schemaConfig := co.schemaConfig
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.ControlObjectiveBlockedGroups
+		fromV = sqlgraph.Neighbors(co.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryEditors queries the editors edge of a ControlObjective.
+func (c *ControlObjectiveClient) QueryEditors(co *ControlObjective) *GroupQuery {
+	query := (&GroupClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := co.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(controlobjective.Table, controlobjective.FieldID, id),
+			sqlgraph.To(group.Table, group.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, controlobjective.EditorsTable, controlobjective.EditorsPrimaryKey...),
+		)
+		schemaConfig := co.schemaConfig
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.ControlObjectiveEditors
+		fromV = sqlgraph.Neighbors(co.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryViewers queries the viewers edge of a ControlObjective.
+func (c *ControlObjectiveClient) QueryViewers(co *ControlObjective) *GroupQuery {
+	query := (&GroupClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := co.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(controlobjective.Table, controlobjective.FieldID, id),
+			sqlgraph.To(group.Table, group.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, controlobjective.ViewersTable, controlobjective.ViewersPrimaryKey...),
+		)
+		schemaConfig := co.schemaConfig
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.ControlObjectiveViewers
+		fromV = sqlgraph.Neighbors(co.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
 // QueryPolicy queries the policy edge of a ControlObjective.
 func (c *ControlObjectiveClient) QueryPolicy(co *ControlObjective) *InternalPolicyQuery {
 	query := (&InternalPolicyClient{config: c.config}).Query()
@@ -2749,12 +2825,14 @@ func (c *ControlObjectiveHistoryClient) GetX(ctx context.Context, id string) *Co
 
 // Hooks returns the client hooks.
 func (c *ControlObjectiveHistoryClient) Hooks() []Hook {
-	return c.hooks.ControlObjectiveHistory
+	hooks := c.hooks.ControlObjectiveHistory
+	return append(hooks[:len(hooks):len(hooks)], controlobjectivehistory.Hooks[:]...)
 }
 
 // Interceptors returns the client interceptors.
 func (c *ControlObjectiveHistoryClient) Interceptors() []Interceptor {
-	return c.inters.ControlObjectiveHistory
+	inters := c.inters.ControlObjectiveHistory
+	return append(inters[:len(inters):len(inters)], controlobjectivehistory.Interceptors[:]...)
 }
 
 func (c *ControlObjectiveHistoryClient) mutate(ctx context.Context, m *ControlObjectiveHistoryMutation) (Value, error) {
@@ -6867,6 +6945,63 @@ func (c *GroupClient) QueryRiskBlockedGroups(gr *Group) *RiskQuery {
 	return query
 }
 
+// QueryControlobjectiveViewers queries the controlobjective_viewers edge of a Group.
+func (c *GroupClient) QueryControlobjectiveViewers(gr *Group) *ControlObjectiveQuery {
+	query := (&ControlObjectiveClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := gr.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(group.Table, group.FieldID, id),
+			sqlgraph.To(controlobjective.Table, controlobjective.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, group.ControlobjectiveViewersTable, group.ControlobjectiveViewersPrimaryKey...),
+		)
+		schemaConfig := gr.schemaConfig
+		step.To.Schema = schemaConfig.ControlObjective
+		step.Edge.Schema = schemaConfig.ControlObjectiveViewers
+		fromV = sqlgraph.Neighbors(gr.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryControlobjectiveEditors queries the controlobjective_editors edge of a Group.
+func (c *GroupClient) QueryControlobjectiveEditors(gr *Group) *ControlObjectiveQuery {
+	query := (&ControlObjectiveClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := gr.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(group.Table, group.FieldID, id),
+			sqlgraph.To(controlobjective.Table, controlobjective.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, group.ControlobjectiveEditorsTable, group.ControlobjectiveEditorsPrimaryKey...),
+		)
+		schemaConfig := gr.schemaConfig
+		step.To.Schema = schemaConfig.ControlObjective
+		step.Edge.Schema = schemaConfig.ControlObjectiveEditors
+		fromV = sqlgraph.Neighbors(gr.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryControlobjectiveBlockedGroups queries the controlobjective_blocked_groups edge of a Group.
+func (c *GroupClient) QueryControlobjectiveBlockedGroups(gr *Group) *ControlObjectiveQuery {
+	query := (&ControlObjectiveClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := gr.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(group.Table, group.FieldID, id),
+			sqlgraph.To(controlobjective.Table, controlobjective.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, group.ControlobjectiveBlockedGroupsTable, group.ControlobjectiveBlockedGroupsPrimaryKey...),
+		)
+		schemaConfig := gr.schemaConfig
+		step.To.Schema = schemaConfig.ControlObjective
+		step.Edge.Schema = schemaConfig.ControlObjectiveBlockedGroups
+		fromV = sqlgraph.Neighbors(gr.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
 // QueryMembers queries the members edge of a Group.
 func (c *GroupClient) QueryMembers(gr *Group) *GroupMembershipQuery {
 	query := (&GroupMembershipClient{config: c.config}).Query()
@@ -8481,6 +8616,44 @@ func (c *InternalPolicyClient) QueryOwner(ip *InternalPolicy) *OrganizationQuery
 	return query
 }
 
+// QueryBlockedGroups queries the blocked_groups edge of a InternalPolicy.
+func (c *InternalPolicyClient) QueryBlockedGroups(ip *InternalPolicy) *GroupQuery {
+	query := (&GroupClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := ip.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(internalpolicy.Table, internalpolicy.FieldID, id),
+			sqlgraph.To(group.Table, group.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, internalpolicy.BlockedGroupsTable, internalpolicy.BlockedGroupsPrimaryKey...),
+		)
+		schemaConfig := ip.schemaConfig
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.InternalPolicyBlockedGroups
+		fromV = sqlgraph.Neighbors(ip.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryEditors queries the editors edge of a InternalPolicy.
+func (c *InternalPolicyClient) QueryEditors(ip *InternalPolicy) *GroupQuery {
+	query := (&GroupClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := ip.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(internalpolicy.Table, internalpolicy.FieldID, id),
+			sqlgraph.To(group.Table, group.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, internalpolicy.EditorsTable, internalpolicy.EditorsPrimaryKey...),
+		)
+		schemaConfig := ip.schemaConfig
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.InternalPolicyEditors
+		fromV = sqlgraph.Neighbors(ip.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
 // QueryControlobjectives queries the controlobjectives edge of a InternalPolicy.
 func (c *InternalPolicyClient) QueryControlobjectives(ip *InternalPolicy) *ControlObjectiveQuery {
 	query := (&ControlObjectiveClient{config: c.config}).Query()
@@ -8589,44 +8762,6 @@ func (c *InternalPolicyClient) QueryPrograms(ip *InternalPolicy) *ProgramQuery {
 		schemaConfig := ip.schemaConfig
 		step.To.Schema = schemaConfig.Program
 		step.Edge.Schema = schemaConfig.ProgramPolicies
-		fromV = sqlgraph.Neighbors(ip.driver.Dialect(), step)
-		return fromV, nil
-	}
-	return query
-}
-
-// QueryEditors queries the editors edge of a InternalPolicy.
-func (c *InternalPolicyClient) QueryEditors(ip *InternalPolicy) *GroupQuery {
-	query := (&GroupClient{config: c.config}).Query()
-	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
-		id := ip.ID
-		step := sqlgraph.NewStep(
-			sqlgraph.From(internalpolicy.Table, internalpolicy.FieldID, id),
-			sqlgraph.To(group.Table, group.FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, internalpolicy.EditorsTable, internalpolicy.EditorsPrimaryKey...),
-		)
-		schemaConfig := ip.schemaConfig
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.InternalPolicyEditors
-		fromV = sqlgraph.Neighbors(ip.driver.Dialect(), step)
-		return fromV, nil
-	}
-	return query
-}
-
-// QueryBlockedGroups queries the blocked_groups edge of a InternalPolicy.
-func (c *InternalPolicyClient) QueryBlockedGroups(ip *InternalPolicy) *GroupQuery {
-	query := (&GroupClient{config: c.config}).Query()
-	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
-		id := ip.ID
-		step := sqlgraph.NewStep(
-			sqlgraph.From(internalpolicy.Table, internalpolicy.FieldID, id),
-			sqlgraph.To(group.Table, group.FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, internalpolicy.BlockedGroupsTable, internalpolicy.BlockedGroupsPrimaryKey...),
-		)
-		schemaConfig := ip.schemaConfig
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.InternalPolicyBlockedGroups
 		fromV = sqlgraph.Neighbors(ip.driver.Dialect(), step)
 		return fromV, nil
 	}
@@ -11161,6 +11296,25 @@ func (c *OrganizationClient) QueryRisks(o *Organization) *RiskQuery {
 	return query
 }
 
+// QueryControlobjectives queries the controlobjectives edge of a Organization.
+func (c *OrganizationClient) QueryControlobjectives(o *Organization) *ControlObjectiveQuery {
+	query := (&ControlObjectiveClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := o.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(organization.Table, organization.FieldID, id),
+			sqlgraph.To(controlobjective.Table, controlobjective.FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, organization.ControlobjectivesTable, organization.ControlobjectivesColumn),
+		)
+		schemaConfig := o.schemaConfig
+		step.To.Schema = schemaConfig.ControlObjective
+		step.Edge.Schema = schemaConfig.ControlObjective
+		fromV = sqlgraph.Neighbors(o.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
 // QueryMembers queries the members edge of a Organization.
 func (c *OrganizationClient) QueryMembers(o *Organization) *OrgMembershipQuery {
 	query := (&OrgMembershipClient{config: c.config}).Query()
@@ -12123,6 +12277,44 @@ func (c *ProcedureClient) QueryOwner(pr *Procedure) *OrganizationQuery {
 	return query
 }
 
+// QueryBlockedGroups queries the blocked_groups edge of a Procedure.
+func (c *ProcedureClient) QueryBlockedGroups(pr *Procedure) *GroupQuery {
+	query := (&GroupClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := pr.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(procedure.Table, procedure.FieldID, id),
+			sqlgraph.To(group.Table, group.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, procedure.BlockedGroupsTable, procedure.BlockedGroupsPrimaryKey...),
+		)
+		schemaConfig := pr.schemaConfig
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.ProcedureBlockedGroups
+		fromV = sqlgraph.Neighbors(pr.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryEditors queries the editors edge of a Procedure.
+func (c *ProcedureClient) QueryEditors(pr *Procedure) *GroupQuery {
+	query := (&GroupClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := pr.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(procedure.Table, procedure.FieldID, id),
+			sqlgraph.To(group.Table, group.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, procedure.EditorsTable, procedure.EditorsPrimaryKey...),
+		)
+		schemaConfig := pr.schemaConfig
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.ProcedureEditors
+		fromV = sqlgraph.Neighbors(pr.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
 // QueryControl queries the control edge of a Procedure.
 func (c *ProcedureClient) QueryControl(pr *Procedure) *ControlQuery {
 	query := (&ControlClient{config: c.config}).Query()
@@ -12231,44 +12423,6 @@ func (c *ProcedureClient) QueryPrograms(pr *Procedure) *ProgramQuery {
 		schemaConfig := pr.schemaConfig
 		step.To.Schema = schemaConfig.Program
 		step.Edge.Schema = schemaConfig.ProgramProcedures
-		fromV = sqlgraph.Neighbors(pr.driver.Dialect(), step)
-		return fromV, nil
-	}
-	return query
-}
-
-// QueryEditors queries the editors edge of a Procedure.
-func (c *ProcedureClient) QueryEditors(pr *Procedure) *GroupQuery {
-	query := (&GroupClient{config: c.config}).Query()
-	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
-		id := pr.ID
-		step := sqlgraph.NewStep(
-			sqlgraph.From(procedure.Table, procedure.FieldID, id),
-			sqlgraph.To(group.Table, group.FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, procedure.EditorsTable, procedure.EditorsPrimaryKey...),
-		)
-		schemaConfig := pr.schemaConfig
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.ProcedureEditors
-		fromV = sqlgraph.Neighbors(pr.driver.Dialect(), step)
-		return fromV, nil
-	}
-	return query
-}
-
-// QueryBlockedGroups queries the blocked_groups edge of a Procedure.
-func (c *ProcedureClient) QueryBlockedGroups(pr *Procedure) *GroupQuery {
-	query := (&GroupClient{config: c.config}).Query()
-	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
-		id := pr.ID
-		step := sqlgraph.NewStep(
-			sqlgraph.From(procedure.Table, procedure.FieldID, id),
-			sqlgraph.To(group.Table, group.FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, procedure.BlockedGroupsTable, procedure.BlockedGroupsPrimaryKey...),
-		)
-		schemaConfig := pr.schemaConfig
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.ProcedureBlockedGroups
 		fromV = sqlgraph.Neighbors(pr.driver.Dialect(), step)
 		return fromV, nil
 	}
@@ -12564,6 +12718,63 @@ func (c *ProgramClient) QueryOwner(pr *Program) *OrganizationQuery {
 	return query
 }
 
+// QueryBlockedGroups queries the blocked_groups edge of a Program.
+func (c *ProgramClient) QueryBlockedGroups(pr *Program) *GroupQuery {
+	query := (&GroupClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := pr.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(program.Table, program.FieldID, id),
+			sqlgraph.To(group.Table, group.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, program.BlockedGroupsTable, program.BlockedGroupsPrimaryKey...),
+		)
+		schemaConfig := pr.schemaConfig
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.ProgramBlockedGroups
+		fromV = sqlgraph.Neighbors(pr.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryEditors queries the editors edge of a Program.
+func (c *ProgramClient) QueryEditors(pr *Program) *GroupQuery {
+	query := (&GroupClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := pr.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(program.Table, program.FieldID, id),
+			sqlgraph.To(group.Table, group.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, program.EditorsTable, program.EditorsPrimaryKey...),
+		)
+		schemaConfig := pr.schemaConfig
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.ProgramEditors
+		fromV = sqlgraph.Neighbors(pr.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryViewers queries the viewers edge of a Program.
+func (c *ProgramClient) QueryViewers(pr *Program) *GroupQuery {
+	query := (&GroupClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := pr.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(program.Table, program.FieldID, id),
+			sqlgraph.To(group.Table, group.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, program.ViewersTable, program.ViewersPrimaryKey...),
+		)
+		schemaConfig := pr.schemaConfig
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.ProgramViewers
+		fromV = sqlgraph.Neighbors(pr.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
 // QueryControls queries the controls edge of a Program.
 func (c *ProgramClient) QueryControls(pr *Program) *ControlQuery {
 	query := (&ControlClient{config: c.config}).Query()
@@ -12805,63 +13016,6 @@ func (c *ProgramClient) QueryUsers(pr *Program) *UserQuery {
 		schemaConfig := pr.schemaConfig
 		step.To.Schema = schemaConfig.User
 		step.Edge.Schema = schemaConfig.ProgramMembership
-		fromV = sqlgraph.Neighbors(pr.driver.Dialect(), step)
-		return fromV, nil
-	}
-	return query
-}
-
-// QueryViewers queries the viewers edge of a Program.
-func (c *ProgramClient) QueryViewers(pr *Program) *GroupQuery {
-	query := (&GroupClient{config: c.config}).Query()
-	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
-		id := pr.ID
-		step := sqlgraph.NewStep(
-			sqlgraph.From(program.Table, program.FieldID, id),
-			sqlgraph.To(group.Table, group.FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, program.ViewersTable, program.ViewersPrimaryKey...),
-		)
-		schemaConfig := pr.schemaConfig
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.ProgramViewers
-		fromV = sqlgraph.Neighbors(pr.driver.Dialect(), step)
-		return fromV, nil
-	}
-	return query
-}
-
-// QueryEditors queries the editors edge of a Program.
-func (c *ProgramClient) QueryEditors(pr *Program) *GroupQuery {
-	query := (&GroupClient{config: c.config}).Query()
-	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
-		id := pr.ID
-		step := sqlgraph.NewStep(
-			sqlgraph.From(program.Table, program.FieldID, id),
-			sqlgraph.To(group.Table, group.FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, program.EditorsTable, program.EditorsPrimaryKey...),
-		)
-		schemaConfig := pr.schemaConfig
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.ProgramEditors
-		fromV = sqlgraph.Neighbors(pr.driver.Dialect(), step)
-		return fromV, nil
-	}
-	return query
-}
-
-// QueryBlockedGroups queries the blocked_groups edge of a Program.
-func (c *ProgramClient) QueryBlockedGroups(pr *Program) *GroupQuery {
-	query := (&GroupClient{config: c.config}).Query()
-	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
-		id := pr.ID
-		step := sqlgraph.NewStep(
-			sqlgraph.From(program.Table, program.FieldID, id),
-			sqlgraph.To(group.Table, group.FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, program.BlockedGroupsTable, program.BlockedGroupsPrimaryKey...),
-		)
-		schemaConfig := pr.schemaConfig
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.ProgramBlockedGroups
 		fromV = sqlgraph.Neighbors(pr.driver.Dialect(), step)
 		return fromV, nil
 	}
@@ -13465,6 +13619,82 @@ func (c *RiskClient) GetX(ctx context.Context, id string) *Risk {
 	return obj
 }
 
+// QueryOwner queries the owner edge of a Risk.
+func (c *RiskClient) QueryOwner(r *Risk) *OrganizationQuery {
+	query := (&OrganizationClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := r.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(risk.Table, risk.FieldID, id),
+			sqlgraph.To(organization.Table, organization.FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, risk.OwnerTable, risk.OwnerColumn),
+		)
+		schemaConfig := r.schemaConfig
+		step.To.Schema = schemaConfig.Organization
+		step.Edge.Schema = schemaConfig.Risk
+		fromV = sqlgraph.Neighbors(r.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryBlockedGroups queries the blocked_groups edge of a Risk.
+func (c *RiskClient) QueryBlockedGroups(r *Risk) *GroupQuery {
+	query := (&GroupClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := r.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(risk.Table, risk.FieldID, id),
+			sqlgraph.To(group.Table, group.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, risk.BlockedGroupsTable, risk.BlockedGroupsPrimaryKey...),
+		)
+		schemaConfig := r.schemaConfig
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.RiskBlockedGroups
+		fromV = sqlgraph.Neighbors(r.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryEditors queries the editors edge of a Risk.
+func (c *RiskClient) QueryEditors(r *Risk) *GroupQuery {
+	query := (&GroupClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := r.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(risk.Table, risk.FieldID, id),
+			sqlgraph.To(group.Table, group.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, risk.EditorsTable, risk.EditorsPrimaryKey...),
+		)
+		schemaConfig := r.schemaConfig
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.RiskEditors
+		fromV = sqlgraph.Neighbors(r.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryViewers queries the viewers edge of a Risk.
+func (c *RiskClient) QueryViewers(r *Risk) *GroupQuery {
+	query := (&GroupClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := r.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(risk.Table, risk.FieldID, id),
+			sqlgraph.To(group.Table, group.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, risk.ViewersTable, risk.ViewersPrimaryKey...),
+		)
+		schemaConfig := r.schemaConfig
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.RiskViewers
+		fromV = sqlgraph.Neighbors(r.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
 // QueryControl queries the control edge of a Risk.
 func (c *RiskClient) QueryControl(r *Risk) *ControlQuery {
 	query := (&ControlClient{config: c.config}).Query()
@@ -13522,95 +13752,19 @@ func (c *RiskClient) QueryActionplans(r *Risk) *ActionPlanQuery {
 	return query
 }
 
-// QueryOwner queries the owner edge of a Risk.
-func (c *RiskClient) QueryOwner(r *Risk) *OrganizationQuery {
-	query := (&OrganizationClient{config: c.config}).Query()
-	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
-		id := r.ID
-		step := sqlgraph.NewStep(
-			sqlgraph.From(risk.Table, risk.FieldID, id),
-			sqlgraph.To(organization.Table, organization.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, risk.OwnerTable, risk.OwnerColumn),
-		)
-		schemaConfig := r.schemaConfig
-		step.To.Schema = schemaConfig.Organization
-		step.Edge.Schema = schemaConfig.Risk
-		fromV = sqlgraph.Neighbors(r.driver.Dialect(), step)
-		return fromV, nil
-	}
-	return query
-}
-
-// QueryProgram queries the program edge of a Risk.
-func (c *RiskClient) QueryProgram(r *Risk) *ProgramQuery {
+// QueryPrograms queries the programs edge of a Risk.
+func (c *RiskClient) QueryPrograms(r *Risk) *ProgramQuery {
 	query := (&ProgramClient{config: c.config}).Query()
 	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := r.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(risk.Table, risk.FieldID, id),
 			sqlgraph.To(program.Table, program.FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, true, risk.ProgramTable, risk.ProgramPrimaryKey...),
+			sqlgraph.Edge(sqlgraph.M2M, true, risk.ProgramsTable, risk.ProgramsPrimaryKey...),
 		)
 		schemaConfig := r.schemaConfig
 		step.To.Schema = schemaConfig.Program
 		step.Edge.Schema = schemaConfig.ProgramRisks
-		fromV = sqlgraph.Neighbors(r.driver.Dialect(), step)
-		return fromV, nil
-	}
-	return query
-}
-
-// QueryViewers queries the viewers edge of a Risk.
-func (c *RiskClient) QueryViewers(r *Risk) *GroupQuery {
-	query := (&GroupClient{config: c.config}).Query()
-	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
-		id := r.ID
-		step := sqlgraph.NewStep(
-			sqlgraph.From(risk.Table, risk.FieldID, id),
-			sqlgraph.To(group.Table, group.FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, risk.ViewersTable, risk.ViewersPrimaryKey...),
-		)
-		schemaConfig := r.schemaConfig
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.RiskViewers
-		fromV = sqlgraph.Neighbors(r.driver.Dialect(), step)
-		return fromV, nil
-	}
-	return query
-}
-
-// QueryEditors queries the editors edge of a Risk.
-func (c *RiskClient) QueryEditors(r *Risk) *GroupQuery {
-	query := (&GroupClient{config: c.config}).Query()
-	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
-		id := r.ID
-		step := sqlgraph.NewStep(
-			sqlgraph.From(risk.Table, risk.FieldID, id),
-			sqlgraph.To(group.Table, group.FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, risk.EditorsTable, risk.EditorsPrimaryKey...),
-		)
-		schemaConfig := r.schemaConfig
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.RiskEditors
-		fromV = sqlgraph.Neighbors(r.driver.Dialect(), step)
-		return fromV, nil
-	}
-	return query
-}
-
-// QueryBlockedGroups queries the blocked_groups edge of a Risk.
-func (c *RiskClient) QueryBlockedGroups(r *Risk) *GroupQuery {
-	query := (&GroupClient{config: c.config}).Query()
-	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
-		id := r.ID
-		step := sqlgraph.NewStep(
-			sqlgraph.From(risk.Table, risk.FieldID, id),
-			sqlgraph.To(group.Table, group.FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, risk.BlockedGroupsTable, risk.BlockedGroupsPrimaryKey...),
-		)
-		schemaConfig := r.schemaConfig
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.RiskBlockedGroups
 		fromV = sqlgraph.Neighbors(r.driver.Dialect(), step)
 		return fromV, nil
 	}

--- a/internal/ent/generated/controlobjective.go
+++ b/internal/ent/generated/controlobjective.go
@@ -11,6 +11,7 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"github.com/theopenlane/core/internal/ent/generated/controlobjective"
+	"github.com/theopenlane/core/internal/ent/generated/organization"
 )
 
 // ControlObjective is the model entity for the ControlObjective schema.
@@ -34,6 +35,8 @@ type ControlObjective struct {
 	MappingID string `json:"mapping_id,omitempty"`
 	// tags associated with the object
 	Tags []string `json:"tags,omitempty"`
+	// the ID of the organization owner of the object
+	OwnerID string `json:"owner_id,omitempty"`
 	// the name of the control objective
 	Name string `json:"name,omitempty"`
 	// description of the control objective
@@ -65,6 +68,14 @@ type ControlObjective struct {
 
 // ControlObjectiveEdges holds the relations/edges for other nodes in the graph.
 type ControlObjectiveEdges struct {
+	// Owner holds the value of the owner edge.
+	Owner *Organization `json:"owner,omitempty"`
+	// groups that are blocked from viewing or editing the risk
+	BlockedGroups []*Group `json:"blocked_groups,omitempty"`
+	// provides edit access to the risk to members of the group
+	Editors []*Group `json:"editors,omitempty"`
+	// provides view access to the risk to members of the group
+	Viewers []*Group `json:"viewers,omitempty"`
 	// Policy holds the value of the policy edge.
 	Policy []*InternalPolicy `json:"policy,omitempty"`
 	// Controls holds the value of the controls edge.
@@ -85,25 +96,66 @@ type ControlObjectiveEdges struct {
 	Programs []*Program `json:"programs,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [9]bool
+	loadedTypes [13]bool
 	// totalCount holds the count of the edges above.
-	totalCount [9]map[string]int
+	totalCount [13]map[string]int
 
-	namedPolicy      map[string][]*InternalPolicy
-	namedControls    map[string][]*Control
-	namedProcedures  map[string][]*Procedure
-	namedRisks       map[string][]*Risk
-	namedSubcontrols map[string][]*Subcontrol
-	namedStandard    map[string][]*Standard
-	namedNarratives  map[string][]*Narrative
-	namedTasks       map[string][]*Task
-	namedPrograms    map[string][]*Program
+	namedBlockedGroups map[string][]*Group
+	namedEditors       map[string][]*Group
+	namedViewers       map[string][]*Group
+	namedPolicy        map[string][]*InternalPolicy
+	namedControls      map[string][]*Control
+	namedProcedures    map[string][]*Procedure
+	namedRisks         map[string][]*Risk
+	namedSubcontrols   map[string][]*Subcontrol
+	namedStandard      map[string][]*Standard
+	namedNarratives    map[string][]*Narrative
+	namedTasks         map[string][]*Task
+	namedPrograms      map[string][]*Program
+}
+
+// OwnerOrErr returns the Owner value or an error if the edge
+// was not loaded in eager-loading, or loaded but was not found.
+func (e ControlObjectiveEdges) OwnerOrErr() (*Organization, error) {
+	if e.Owner != nil {
+		return e.Owner, nil
+	} else if e.loadedTypes[0] {
+		return nil, &NotFoundError{label: organization.Label}
+	}
+	return nil, &NotLoadedError{edge: "owner"}
+}
+
+// BlockedGroupsOrErr returns the BlockedGroups value or an error if the edge
+// was not loaded in eager-loading.
+func (e ControlObjectiveEdges) BlockedGroupsOrErr() ([]*Group, error) {
+	if e.loadedTypes[1] {
+		return e.BlockedGroups, nil
+	}
+	return nil, &NotLoadedError{edge: "blocked_groups"}
+}
+
+// EditorsOrErr returns the Editors value or an error if the edge
+// was not loaded in eager-loading.
+func (e ControlObjectiveEdges) EditorsOrErr() ([]*Group, error) {
+	if e.loadedTypes[2] {
+		return e.Editors, nil
+	}
+	return nil, &NotLoadedError{edge: "editors"}
+}
+
+// ViewersOrErr returns the Viewers value or an error if the edge
+// was not loaded in eager-loading.
+func (e ControlObjectiveEdges) ViewersOrErr() ([]*Group, error) {
+	if e.loadedTypes[3] {
+		return e.Viewers, nil
+	}
+	return nil, &NotLoadedError{edge: "viewers"}
 }
 
 // PolicyOrErr returns the Policy value or an error if the edge
 // was not loaded in eager-loading.
 func (e ControlObjectiveEdges) PolicyOrErr() ([]*InternalPolicy, error) {
-	if e.loadedTypes[0] {
+	if e.loadedTypes[4] {
 		return e.Policy, nil
 	}
 	return nil, &NotLoadedError{edge: "policy"}
@@ -112,7 +164,7 @@ func (e ControlObjectiveEdges) PolicyOrErr() ([]*InternalPolicy, error) {
 // ControlsOrErr returns the Controls value or an error if the edge
 // was not loaded in eager-loading.
 func (e ControlObjectiveEdges) ControlsOrErr() ([]*Control, error) {
-	if e.loadedTypes[1] {
+	if e.loadedTypes[5] {
 		return e.Controls, nil
 	}
 	return nil, &NotLoadedError{edge: "controls"}
@@ -121,7 +173,7 @@ func (e ControlObjectiveEdges) ControlsOrErr() ([]*Control, error) {
 // ProceduresOrErr returns the Procedures value or an error if the edge
 // was not loaded in eager-loading.
 func (e ControlObjectiveEdges) ProceduresOrErr() ([]*Procedure, error) {
-	if e.loadedTypes[2] {
+	if e.loadedTypes[6] {
 		return e.Procedures, nil
 	}
 	return nil, &NotLoadedError{edge: "procedures"}
@@ -130,7 +182,7 @@ func (e ControlObjectiveEdges) ProceduresOrErr() ([]*Procedure, error) {
 // RisksOrErr returns the Risks value or an error if the edge
 // was not loaded in eager-loading.
 func (e ControlObjectiveEdges) RisksOrErr() ([]*Risk, error) {
-	if e.loadedTypes[3] {
+	if e.loadedTypes[7] {
 		return e.Risks, nil
 	}
 	return nil, &NotLoadedError{edge: "risks"}
@@ -139,7 +191,7 @@ func (e ControlObjectiveEdges) RisksOrErr() ([]*Risk, error) {
 // SubcontrolsOrErr returns the Subcontrols value or an error if the edge
 // was not loaded in eager-loading.
 func (e ControlObjectiveEdges) SubcontrolsOrErr() ([]*Subcontrol, error) {
-	if e.loadedTypes[4] {
+	if e.loadedTypes[8] {
 		return e.Subcontrols, nil
 	}
 	return nil, &NotLoadedError{edge: "subcontrols"}
@@ -148,7 +200,7 @@ func (e ControlObjectiveEdges) SubcontrolsOrErr() ([]*Subcontrol, error) {
 // StandardOrErr returns the Standard value or an error if the edge
 // was not loaded in eager-loading.
 func (e ControlObjectiveEdges) StandardOrErr() ([]*Standard, error) {
-	if e.loadedTypes[5] {
+	if e.loadedTypes[9] {
 		return e.Standard, nil
 	}
 	return nil, &NotLoadedError{edge: "standard"}
@@ -157,7 +209,7 @@ func (e ControlObjectiveEdges) StandardOrErr() ([]*Standard, error) {
 // NarrativesOrErr returns the Narratives value or an error if the edge
 // was not loaded in eager-loading.
 func (e ControlObjectiveEdges) NarrativesOrErr() ([]*Narrative, error) {
-	if e.loadedTypes[6] {
+	if e.loadedTypes[10] {
 		return e.Narratives, nil
 	}
 	return nil, &NotLoadedError{edge: "narratives"}
@@ -166,7 +218,7 @@ func (e ControlObjectiveEdges) NarrativesOrErr() ([]*Narrative, error) {
 // TasksOrErr returns the Tasks value or an error if the edge
 // was not loaded in eager-loading.
 func (e ControlObjectiveEdges) TasksOrErr() ([]*Task, error) {
-	if e.loadedTypes[7] {
+	if e.loadedTypes[11] {
 		return e.Tasks, nil
 	}
 	return nil, &NotLoadedError{edge: "tasks"}
@@ -175,7 +227,7 @@ func (e ControlObjectiveEdges) TasksOrErr() ([]*Task, error) {
 // ProgramsOrErr returns the Programs value or an error if the edge
 // was not loaded in eager-loading.
 func (e ControlObjectiveEdges) ProgramsOrErr() ([]*Program, error) {
-	if e.loadedTypes[8] {
+	if e.loadedTypes[12] {
 		return e.Programs, nil
 	}
 	return nil, &NotLoadedError{edge: "programs"}
@@ -188,7 +240,7 @@ func (*ControlObjective) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case controlobjective.FieldTags, controlobjective.FieldDetails:
 			values[i] = new([]byte)
-		case controlobjective.FieldID, controlobjective.FieldCreatedBy, controlobjective.FieldUpdatedBy, controlobjective.FieldDeletedBy, controlobjective.FieldMappingID, controlobjective.FieldName, controlobjective.FieldDescription, controlobjective.FieldStatus, controlobjective.FieldControlObjectiveType, controlobjective.FieldVersion, controlobjective.FieldControlNumber, controlobjective.FieldFamily, controlobjective.FieldClass, controlobjective.FieldSource, controlobjective.FieldMappedFrameworks:
+		case controlobjective.FieldID, controlobjective.FieldCreatedBy, controlobjective.FieldUpdatedBy, controlobjective.FieldDeletedBy, controlobjective.FieldMappingID, controlobjective.FieldOwnerID, controlobjective.FieldName, controlobjective.FieldDescription, controlobjective.FieldStatus, controlobjective.FieldControlObjectiveType, controlobjective.FieldVersion, controlobjective.FieldControlNumber, controlobjective.FieldFamily, controlobjective.FieldClass, controlobjective.FieldSource, controlobjective.FieldMappedFrameworks:
 			values[i] = new(sql.NullString)
 		case controlobjective.FieldCreatedAt, controlobjective.FieldUpdatedAt, controlobjective.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
@@ -264,6 +316,12 @@ func (co *ControlObjective) assignValues(columns []string, values []any) error {
 				if err := json.Unmarshal(*value, &co.Tags); err != nil {
 					return fmt.Errorf("unmarshal field tags: %w", err)
 				}
+			}
+		case controlobjective.FieldOwnerID:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field owner_id", values[i])
+			} else if value.Valid {
+				co.OwnerID = value.String
 			}
 		case controlobjective.FieldName:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -351,6 +409,26 @@ func (co *ControlObjective) assignValues(columns []string, values []any) error {
 // This includes values selected through modifiers, order, etc.
 func (co *ControlObjective) Value(name string) (ent.Value, error) {
 	return co.selectValues.Get(name)
+}
+
+// QueryOwner queries the "owner" edge of the ControlObjective entity.
+func (co *ControlObjective) QueryOwner() *OrganizationQuery {
+	return NewControlObjectiveClient(co.config).QueryOwner(co)
+}
+
+// QueryBlockedGroups queries the "blocked_groups" edge of the ControlObjective entity.
+func (co *ControlObjective) QueryBlockedGroups() *GroupQuery {
+	return NewControlObjectiveClient(co.config).QueryBlockedGroups(co)
+}
+
+// QueryEditors queries the "editors" edge of the ControlObjective entity.
+func (co *ControlObjective) QueryEditors() *GroupQuery {
+	return NewControlObjectiveClient(co.config).QueryEditors(co)
+}
+
+// QueryViewers queries the "viewers" edge of the ControlObjective entity.
+func (co *ControlObjective) QueryViewers() *GroupQuery {
+	return NewControlObjectiveClient(co.config).QueryViewers(co)
 }
 
 // QueryPolicy queries the "policy" edge of the ControlObjective entity.
@@ -445,6 +523,9 @@ func (co *ControlObjective) String() string {
 	builder.WriteString("tags=")
 	builder.WriteString(fmt.Sprintf("%v", co.Tags))
 	builder.WriteString(", ")
+	builder.WriteString("owner_id=")
+	builder.WriteString(co.OwnerID)
+	builder.WriteString(", ")
 	builder.WriteString("name=")
 	builder.WriteString(co.Name)
 	builder.WriteString(", ")
@@ -479,6 +560,78 @@ func (co *ControlObjective) String() string {
 	builder.WriteString(fmt.Sprintf("%v", co.Details))
 	builder.WriteByte(')')
 	return builder.String()
+}
+
+// NamedBlockedGroups returns the BlockedGroups named value or an error if the edge was not
+// loaded in eager-loading with this name.
+func (co *ControlObjective) NamedBlockedGroups(name string) ([]*Group, error) {
+	if co.Edges.namedBlockedGroups == nil {
+		return nil, &NotLoadedError{edge: name}
+	}
+	nodes, ok := co.Edges.namedBlockedGroups[name]
+	if !ok {
+		return nil, &NotLoadedError{edge: name}
+	}
+	return nodes, nil
+}
+
+func (co *ControlObjective) appendNamedBlockedGroups(name string, edges ...*Group) {
+	if co.Edges.namedBlockedGroups == nil {
+		co.Edges.namedBlockedGroups = make(map[string][]*Group)
+	}
+	if len(edges) == 0 {
+		co.Edges.namedBlockedGroups[name] = []*Group{}
+	} else {
+		co.Edges.namedBlockedGroups[name] = append(co.Edges.namedBlockedGroups[name], edges...)
+	}
+}
+
+// NamedEditors returns the Editors named value or an error if the edge was not
+// loaded in eager-loading with this name.
+func (co *ControlObjective) NamedEditors(name string) ([]*Group, error) {
+	if co.Edges.namedEditors == nil {
+		return nil, &NotLoadedError{edge: name}
+	}
+	nodes, ok := co.Edges.namedEditors[name]
+	if !ok {
+		return nil, &NotLoadedError{edge: name}
+	}
+	return nodes, nil
+}
+
+func (co *ControlObjective) appendNamedEditors(name string, edges ...*Group) {
+	if co.Edges.namedEditors == nil {
+		co.Edges.namedEditors = make(map[string][]*Group)
+	}
+	if len(edges) == 0 {
+		co.Edges.namedEditors[name] = []*Group{}
+	} else {
+		co.Edges.namedEditors[name] = append(co.Edges.namedEditors[name], edges...)
+	}
+}
+
+// NamedViewers returns the Viewers named value or an error if the edge was not
+// loaded in eager-loading with this name.
+func (co *ControlObjective) NamedViewers(name string) ([]*Group, error) {
+	if co.Edges.namedViewers == nil {
+		return nil, &NotLoadedError{edge: name}
+	}
+	nodes, ok := co.Edges.namedViewers[name]
+	if !ok {
+		return nil, &NotLoadedError{edge: name}
+	}
+	return nodes, nil
+}
+
+func (co *ControlObjective) appendNamedViewers(name string, edges ...*Group) {
+	if co.Edges.namedViewers == nil {
+		co.Edges.namedViewers = make(map[string][]*Group)
+	}
+	if len(edges) == 0 {
+		co.Edges.namedViewers[name] = []*Group{}
+	} else {
+		co.Edges.namedViewers[name] = append(co.Edges.namedViewers[name], edges...)
+	}
 }
 
 // NamedPolicy returns the Policy named value or an error if the edge was not

--- a/internal/ent/generated/controlobjective/controlobjective.go
+++ b/internal/ent/generated/controlobjective/controlobjective.go
@@ -31,6 +31,8 @@ const (
 	FieldMappingID = "mapping_id"
 	// FieldTags holds the string denoting the tags field in the database.
 	FieldTags = "tags"
+	// FieldOwnerID holds the string denoting the owner_id field in the database.
+	FieldOwnerID = "owner_id"
 	// FieldName holds the string denoting the name field in the database.
 	FieldName = "name"
 	// FieldDescription holds the string denoting the description field in the database.
@@ -53,6 +55,14 @@ const (
 	FieldMappedFrameworks = "mapped_frameworks"
 	// FieldDetails holds the string denoting the details field in the database.
 	FieldDetails = "details"
+	// EdgeOwner holds the string denoting the owner edge name in mutations.
+	EdgeOwner = "owner"
+	// EdgeBlockedGroups holds the string denoting the blocked_groups edge name in mutations.
+	EdgeBlockedGroups = "blocked_groups"
+	// EdgeEditors holds the string denoting the editors edge name in mutations.
+	EdgeEditors = "editors"
+	// EdgeViewers holds the string denoting the viewers edge name in mutations.
+	EdgeViewers = "viewers"
 	// EdgePolicy holds the string denoting the policy edge name in mutations.
 	EdgePolicy = "policy"
 	// EdgeControls holds the string denoting the controls edge name in mutations.
@@ -73,6 +83,28 @@ const (
 	EdgePrograms = "programs"
 	// Table holds the table name of the controlobjective in the database.
 	Table = "control_objectives"
+	// OwnerTable is the table that holds the owner relation/edge.
+	OwnerTable = "control_objectives"
+	// OwnerInverseTable is the table name for the Organization entity.
+	// It exists in this package in order to avoid circular dependency with the "organization" package.
+	OwnerInverseTable = "organizations"
+	// OwnerColumn is the table column denoting the owner relation/edge.
+	OwnerColumn = "owner_id"
+	// BlockedGroupsTable is the table that holds the blocked_groups relation/edge. The primary key declared below.
+	BlockedGroupsTable = "control_objective_blocked_groups"
+	// BlockedGroupsInverseTable is the table name for the Group entity.
+	// It exists in this package in order to avoid circular dependency with the "group" package.
+	BlockedGroupsInverseTable = "groups"
+	// EditorsTable is the table that holds the editors relation/edge. The primary key declared below.
+	EditorsTable = "control_objective_editors"
+	// EditorsInverseTable is the table name for the Group entity.
+	// It exists in this package in order to avoid circular dependency with the "group" package.
+	EditorsInverseTable = "groups"
+	// ViewersTable is the table that holds the viewers relation/edge. The primary key declared below.
+	ViewersTable = "control_objective_viewers"
+	// ViewersInverseTable is the table name for the Group entity.
+	// It exists in this package in order to avoid circular dependency with the "group" package.
+	ViewersInverseTable = "groups"
 	// PolicyTable is the table that holds the policy relation/edge. The primary key declared below.
 	PolicyTable = "internal_policy_controlobjectives"
 	// PolicyInverseTable is the table name for the InternalPolicy entity.
@@ -139,6 +171,7 @@ var Columns = []string{
 	FieldDeletedBy,
 	FieldMappingID,
 	FieldTags,
+	FieldOwnerID,
 	FieldName,
 	FieldDescription,
 	FieldStatus,
@@ -159,6 +192,15 @@ var ForeignKeys = []string{
 }
 
 var (
+	// BlockedGroupsPrimaryKey and BlockedGroupsColumn2 are the table columns denoting the
+	// primary key for the blocked_groups relation (M2M).
+	BlockedGroupsPrimaryKey = []string{"control_objective_id", "group_id"}
+	// EditorsPrimaryKey and EditorsColumn2 are the table columns denoting the
+	// primary key for the editors relation (M2M).
+	EditorsPrimaryKey = []string{"control_objective_id", "group_id"}
+	// ViewersPrimaryKey and ViewersColumn2 are the table columns denoting the
+	// primary key for the viewers relation (M2M).
+	ViewersPrimaryKey = []string{"control_objective_id", "group_id"}
 	// PolicyPrimaryKey and PolicyColumn2 are the table columns denoting the
 	// primary key for the policy relation (M2M).
 	PolicyPrimaryKey = []string{"internal_policy_id", "control_objective_id"}
@@ -197,8 +239,9 @@ func ValidColumn(column string) bool {
 //
 //	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
-	Hooks        [2]ent.Hook
-	Interceptors [1]ent.Interceptor
+	Hooks        [9]ent.Hook
+	Interceptors [2]ent.Interceptor
+	Policy       ent.Policy
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
 	// DefaultUpdatedAt holds the default value on creation for the "updated_at" field.
@@ -209,6 +252,10 @@ var (
 	DefaultMappingID func() string
 	// DefaultTags holds the default value on creation for the "tags" field.
 	DefaultTags []string
+	// OwnerIDValidator is a validator for the "owner_id" field. It is called by the builders before save.
+	OwnerIDValidator func(string) error
+	// NameValidator is a validator for the "name" field. It is called by the builders before save.
+	NameValidator func(string) error
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() string
 )
@@ -254,6 +301,11 @@ func ByDeletedBy(opts ...sql.OrderTermOption) OrderOption {
 // ByMappingID orders the results by the mapping_id field.
 func ByMappingID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldMappingID, opts...).ToFunc()
+}
+
+// ByOwnerID orders the results by the owner_id field.
+func ByOwnerID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldOwnerID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.
@@ -304,6 +356,55 @@ func BySource(opts ...sql.OrderTermOption) OrderOption {
 // ByMappedFrameworks orders the results by the mapped_frameworks field.
 func ByMappedFrameworks(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldMappedFrameworks, opts...).ToFunc()
+}
+
+// ByOwnerField orders the results by owner field.
+func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByBlockedGroupsCount orders the results by blocked_groups count.
+func ByBlockedGroupsCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newBlockedGroupsStep(), opts...)
+	}
+}
+
+// ByBlockedGroups orders the results by blocked_groups terms.
+func ByBlockedGroups(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newBlockedGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByEditorsCount orders the results by editors count.
+func ByEditorsCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newEditorsStep(), opts...)
+	}
+}
+
+// ByEditors orders the results by editors terms.
+func ByEditors(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newEditorsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByViewersCount orders the results by viewers count.
+func ByViewersCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newViewersStep(), opts...)
+	}
+}
+
+// ByViewers orders the results by viewers terms.
+func ByViewers(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newViewersStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
 }
 
 // ByPolicyCount orders the results by policy count.
@@ -430,6 +531,34 @@ func ByPrograms(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newProgramsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
+}
+func newOwnerStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(OwnerInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
+	)
+}
+func newBlockedGroupsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(BlockedGroupsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, BlockedGroupsTable, BlockedGroupsPrimaryKey...),
+	)
+}
+func newEditorsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(EditorsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, EditorsTable, EditorsPrimaryKey...),
+	)
+}
+func newViewersStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(ViewersInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, ViewersTable, ViewersPrimaryKey...),
+	)
 }
 func newPolicyStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(

--- a/internal/ent/generated/controlobjective/where.go
+++ b/internal/ent/generated/controlobjective/where.go
@@ -102,6 +102,11 @@ func MappingID(v string) predicate.ControlObjective {
 	return predicate.ControlObjective(sql.FieldEQ(FieldMappingID, v))
 }
 
+// OwnerID applies equality check predicate on the "owner_id" field. It's identical to OwnerIDEQ.
+func OwnerID(v string) predicate.ControlObjective {
+	return predicate.ControlObjective(sql.FieldEQ(FieldOwnerID, v))
+}
+
 // Name applies equality check predicate on the "name" field. It's identical to NameEQ.
 func Name(v string) predicate.ControlObjective {
 	return predicate.ControlObjective(sql.FieldEQ(FieldName, v))
@@ -600,6 +605,71 @@ func TagsIsNil() predicate.ControlObjective {
 // TagsNotNil applies the NotNil predicate on the "tags" field.
 func TagsNotNil() predicate.ControlObjective {
 	return predicate.ControlObjective(sql.FieldNotNull(FieldTags))
+}
+
+// OwnerIDEQ applies the EQ predicate on the "owner_id" field.
+func OwnerIDEQ(v string) predicate.ControlObjective {
+	return predicate.ControlObjective(sql.FieldEQ(FieldOwnerID, v))
+}
+
+// OwnerIDNEQ applies the NEQ predicate on the "owner_id" field.
+func OwnerIDNEQ(v string) predicate.ControlObjective {
+	return predicate.ControlObjective(sql.FieldNEQ(FieldOwnerID, v))
+}
+
+// OwnerIDIn applies the In predicate on the "owner_id" field.
+func OwnerIDIn(vs ...string) predicate.ControlObjective {
+	return predicate.ControlObjective(sql.FieldIn(FieldOwnerID, vs...))
+}
+
+// OwnerIDNotIn applies the NotIn predicate on the "owner_id" field.
+func OwnerIDNotIn(vs ...string) predicate.ControlObjective {
+	return predicate.ControlObjective(sql.FieldNotIn(FieldOwnerID, vs...))
+}
+
+// OwnerIDGT applies the GT predicate on the "owner_id" field.
+func OwnerIDGT(v string) predicate.ControlObjective {
+	return predicate.ControlObjective(sql.FieldGT(FieldOwnerID, v))
+}
+
+// OwnerIDGTE applies the GTE predicate on the "owner_id" field.
+func OwnerIDGTE(v string) predicate.ControlObjective {
+	return predicate.ControlObjective(sql.FieldGTE(FieldOwnerID, v))
+}
+
+// OwnerIDLT applies the LT predicate on the "owner_id" field.
+func OwnerIDLT(v string) predicate.ControlObjective {
+	return predicate.ControlObjective(sql.FieldLT(FieldOwnerID, v))
+}
+
+// OwnerIDLTE applies the LTE predicate on the "owner_id" field.
+func OwnerIDLTE(v string) predicate.ControlObjective {
+	return predicate.ControlObjective(sql.FieldLTE(FieldOwnerID, v))
+}
+
+// OwnerIDContains applies the Contains predicate on the "owner_id" field.
+func OwnerIDContains(v string) predicate.ControlObjective {
+	return predicate.ControlObjective(sql.FieldContains(FieldOwnerID, v))
+}
+
+// OwnerIDHasPrefix applies the HasPrefix predicate on the "owner_id" field.
+func OwnerIDHasPrefix(v string) predicate.ControlObjective {
+	return predicate.ControlObjective(sql.FieldHasPrefix(FieldOwnerID, v))
+}
+
+// OwnerIDHasSuffix applies the HasSuffix predicate on the "owner_id" field.
+func OwnerIDHasSuffix(v string) predicate.ControlObjective {
+	return predicate.ControlObjective(sql.FieldHasSuffix(FieldOwnerID, v))
+}
+
+// OwnerIDEqualFold applies the EqualFold predicate on the "owner_id" field.
+func OwnerIDEqualFold(v string) predicate.ControlObjective {
+	return predicate.ControlObjective(sql.FieldEqualFold(FieldOwnerID, v))
+}
+
+// OwnerIDContainsFold applies the ContainsFold predicate on the "owner_id" field.
+func OwnerIDContainsFold(v string) predicate.ControlObjective {
+	return predicate.ControlObjective(sql.FieldContainsFold(FieldOwnerID, v))
 }
 
 // NameEQ applies the EQ predicate on the "name" field.
@@ -1350,6 +1420,122 @@ func DetailsIsNil() predicate.ControlObjective {
 // DetailsNotNil applies the NotNil predicate on the "details" field.
 func DetailsNotNil() predicate.ControlObjective {
 	return predicate.ControlObjective(sql.FieldNotNull(FieldDetails))
+}
+
+// HasOwner applies the HasEdge predicate on the "owner" edge.
+func HasOwner() predicate.ControlObjective {
+	return predicate.ControlObjective(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
+		)
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Organization
+		step.Edge.Schema = schemaConfig.ControlObjective
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasOwnerWith applies the HasEdge predicate on the "owner" edge with a given conditions (other predicates).
+func HasOwnerWith(preds ...predicate.Organization) predicate.ControlObjective {
+	return predicate.ControlObjective(func(s *sql.Selector) {
+		step := newOwnerStep()
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Organization
+		step.Edge.Schema = schemaConfig.ControlObjective
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasBlockedGroups applies the HasEdge predicate on the "blocked_groups" edge.
+func HasBlockedGroups() predicate.ControlObjective {
+	return predicate.ControlObjective(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, BlockedGroupsTable, BlockedGroupsPrimaryKey...),
+		)
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.ControlObjectiveBlockedGroups
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasBlockedGroupsWith applies the HasEdge predicate on the "blocked_groups" edge with a given conditions (other predicates).
+func HasBlockedGroupsWith(preds ...predicate.Group) predicate.ControlObjective {
+	return predicate.ControlObjective(func(s *sql.Selector) {
+		step := newBlockedGroupsStep()
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.ControlObjectiveBlockedGroups
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasEditors applies the HasEdge predicate on the "editors" edge.
+func HasEditors() predicate.ControlObjective {
+	return predicate.ControlObjective(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, EditorsTable, EditorsPrimaryKey...),
+		)
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.ControlObjectiveEditors
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasEditorsWith applies the HasEdge predicate on the "editors" edge with a given conditions (other predicates).
+func HasEditorsWith(preds ...predicate.Group) predicate.ControlObjective {
+	return predicate.ControlObjective(func(s *sql.Selector) {
+		step := newEditorsStep()
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.ControlObjectiveEditors
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasViewers applies the HasEdge predicate on the "viewers" edge.
+func HasViewers() predicate.ControlObjective {
+	return predicate.ControlObjective(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, ViewersTable, ViewersPrimaryKey...),
+		)
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.ControlObjectiveViewers
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasViewersWith applies the HasEdge predicate on the "viewers" edge with a given conditions (other predicates).
+func HasViewersWith(preds ...predicate.Group) predicate.ControlObjective {
+	return predicate.ControlObjective(func(s *sql.Selector) {
+		step := newViewersStep()
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.ControlObjectiveViewers
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
 }
 
 // HasPolicy applies the HasEdge predicate on the "policy" edge.

--- a/internal/ent/generated/controlobjective_create.go
+++ b/internal/ent/generated/controlobjective_create.go
@@ -12,8 +12,10 @@ import (
 	"entgo.io/ent/schema/field"
 	"github.com/theopenlane/core/internal/ent/generated/control"
 	"github.com/theopenlane/core/internal/ent/generated/controlobjective"
+	"github.com/theopenlane/core/internal/ent/generated/group"
 	"github.com/theopenlane/core/internal/ent/generated/internalpolicy"
 	"github.com/theopenlane/core/internal/ent/generated/narrative"
+	"github.com/theopenlane/core/internal/ent/generated/organization"
 	"github.com/theopenlane/core/internal/ent/generated/procedure"
 	"github.com/theopenlane/core/internal/ent/generated/program"
 	"github.com/theopenlane/core/internal/ent/generated/risk"
@@ -130,6 +132,12 @@ func (coc *ControlObjectiveCreate) SetNillableMappingID(s *string) *ControlObjec
 // SetTags sets the "tags" field.
 func (coc *ControlObjectiveCreate) SetTags(s []string) *ControlObjectiveCreate {
 	coc.mutation.SetTags(s)
+	return coc
+}
+
+// SetOwnerID sets the "owner_id" field.
+func (coc *ControlObjectiveCreate) SetOwnerID(s string) *ControlObjectiveCreate {
+	coc.mutation.SetOwnerID(s)
 	return coc
 }
 
@@ -283,6 +291,56 @@ func (coc *ControlObjectiveCreate) SetNillableID(s *string) *ControlObjectiveCre
 		coc.SetID(*s)
 	}
 	return coc
+}
+
+// SetOwner sets the "owner" edge to the Organization entity.
+func (coc *ControlObjectiveCreate) SetOwner(o *Organization) *ControlObjectiveCreate {
+	return coc.SetOwnerID(o.ID)
+}
+
+// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
+func (coc *ControlObjectiveCreate) AddBlockedGroupIDs(ids ...string) *ControlObjectiveCreate {
+	coc.mutation.AddBlockedGroupIDs(ids...)
+	return coc
+}
+
+// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
+func (coc *ControlObjectiveCreate) AddBlockedGroups(g ...*Group) *ControlObjectiveCreate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return coc.AddBlockedGroupIDs(ids...)
+}
+
+// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
+func (coc *ControlObjectiveCreate) AddEditorIDs(ids ...string) *ControlObjectiveCreate {
+	coc.mutation.AddEditorIDs(ids...)
+	return coc
+}
+
+// AddEditors adds the "editors" edges to the Group entity.
+func (coc *ControlObjectiveCreate) AddEditors(g ...*Group) *ControlObjectiveCreate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return coc.AddEditorIDs(ids...)
+}
+
+// AddViewerIDs adds the "viewers" edge to the Group entity by IDs.
+func (coc *ControlObjectiveCreate) AddViewerIDs(ids ...string) *ControlObjectiveCreate {
+	coc.mutation.AddViewerIDs(ids...)
+	return coc
+}
+
+// AddViewers adds the "viewers" edges to the Group entity.
+func (coc *ControlObjectiveCreate) AddViewers(g ...*Group) *ControlObjectiveCreate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return coc.AddViewerIDs(ids...)
 }
 
 // AddPolicyIDs adds the "policy" edge to the InternalPolicy entity by IDs.
@@ -497,8 +555,24 @@ func (coc *ControlObjectiveCreate) check() error {
 	if _, ok := coc.mutation.MappingID(); !ok {
 		return &ValidationError{Name: "mapping_id", err: errors.New(`generated: missing required field "ControlObjective.mapping_id"`)}
 	}
+	if _, ok := coc.mutation.OwnerID(); !ok {
+		return &ValidationError{Name: "owner_id", err: errors.New(`generated: missing required field "ControlObjective.owner_id"`)}
+	}
+	if v, ok := coc.mutation.OwnerID(); ok {
+		if err := controlobjective.OwnerIDValidator(v); err != nil {
+			return &ValidationError{Name: "owner_id", err: fmt.Errorf(`generated: validator failed for field "ControlObjective.owner_id": %w`, err)}
+		}
+	}
 	if _, ok := coc.mutation.Name(); !ok {
 		return &ValidationError{Name: "name", err: errors.New(`generated: missing required field "ControlObjective.name"`)}
+	}
+	if v, ok := coc.mutation.Name(); ok {
+		if err := controlobjective.NameValidator(v); err != nil {
+			return &ValidationError{Name: "name", err: fmt.Errorf(`generated: validator failed for field "ControlObjective.name": %w`, err)}
+		}
+	}
+	if len(coc.mutation.OwnerIDs()) == 0 {
+		return &ValidationError{Name: "owner", err: errors.New(`generated: missing required edge "ControlObjective.owner"`)}
 	}
 	return nil
 }
@@ -611,6 +685,75 @@ func (coc *ControlObjectiveCreate) createSpec() (*ControlObjective, *sqlgraph.Cr
 	if value, ok := coc.mutation.Details(); ok {
 		_spec.SetField(controlobjective.FieldDetails, field.TypeJSON, value)
 		_node.Details = value
+	}
+	if nodes := coc.mutation.OwnerIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   controlobjective.OwnerTable,
+			Columns: []string{controlobjective.OwnerColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(organization.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = coc.schemaConfig.ControlObjective
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_node.OwnerID = nodes[0]
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := coc.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   controlobjective.BlockedGroupsTable,
+			Columns: controlobjective.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = coc.schemaConfig.ControlObjectiveBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := coc.mutation.EditorsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   controlobjective.EditorsTable,
+			Columns: controlobjective.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = coc.schemaConfig.ControlObjectiveEditors
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := coc.mutation.ViewersIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   controlobjective.ViewersTable,
+			Columns: controlobjective.ViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = coc.schemaConfig.ControlObjectiveViewers
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := coc.mutation.PolicyIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/internal/ent/generated/controlobjective_update.go
+++ b/internal/ent/generated/controlobjective_update.go
@@ -14,8 +14,10 @@ import (
 	"entgo.io/ent/schema/field"
 	"github.com/theopenlane/core/internal/ent/generated/control"
 	"github.com/theopenlane/core/internal/ent/generated/controlobjective"
+	"github.com/theopenlane/core/internal/ent/generated/group"
 	"github.com/theopenlane/core/internal/ent/generated/internalpolicy"
 	"github.com/theopenlane/core/internal/ent/generated/narrative"
+	"github.com/theopenlane/core/internal/ent/generated/organization"
 	"github.com/theopenlane/core/internal/ent/generated/predicate"
 	"github.com/theopenlane/core/internal/ent/generated/procedure"
 	"github.com/theopenlane/core/internal/ent/generated/program"
@@ -128,6 +130,20 @@ func (cou *ControlObjectiveUpdate) AppendTags(s []string) *ControlObjectiveUpdat
 // ClearTags clears the value of the "tags" field.
 func (cou *ControlObjectiveUpdate) ClearTags() *ControlObjectiveUpdate {
 	cou.mutation.ClearTags()
+	return cou
+}
+
+// SetOwnerID sets the "owner_id" field.
+func (cou *ControlObjectiveUpdate) SetOwnerID(s string) *ControlObjectiveUpdate {
+	cou.mutation.SetOwnerID(s)
+	return cou
+}
+
+// SetNillableOwnerID sets the "owner_id" field if the given value is not nil.
+func (cou *ControlObjectiveUpdate) SetNillableOwnerID(s *string) *ControlObjectiveUpdate {
+	if s != nil {
+		cou.SetOwnerID(*s)
+	}
 	return cou
 }
 
@@ -337,6 +353,56 @@ func (cou *ControlObjectiveUpdate) ClearDetails() *ControlObjectiveUpdate {
 	return cou
 }
 
+// SetOwner sets the "owner" edge to the Organization entity.
+func (cou *ControlObjectiveUpdate) SetOwner(o *Organization) *ControlObjectiveUpdate {
+	return cou.SetOwnerID(o.ID)
+}
+
+// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
+func (cou *ControlObjectiveUpdate) AddBlockedGroupIDs(ids ...string) *ControlObjectiveUpdate {
+	cou.mutation.AddBlockedGroupIDs(ids...)
+	return cou
+}
+
+// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
+func (cou *ControlObjectiveUpdate) AddBlockedGroups(g ...*Group) *ControlObjectiveUpdate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return cou.AddBlockedGroupIDs(ids...)
+}
+
+// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
+func (cou *ControlObjectiveUpdate) AddEditorIDs(ids ...string) *ControlObjectiveUpdate {
+	cou.mutation.AddEditorIDs(ids...)
+	return cou
+}
+
+// AddEditors adds the "editors" edges to the Group entity.
+func (cou *ControlObjectiveUpdate) AddEditors(g ...*Group) *ControlObjectiveUpdate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return cou.AddEditorIDs(ids...)
+}
+
+// AddViewerIDs adds the "viewers" edge to the Group entity by IDs.
+func (cou *ControlObjectiveUpdate) AddViewerIDs(ids ...string) *ControlObjectiveUpdate {
+	cou.mutation.AddViewerIDs(ids...)
+	return cou
+}
+
+// AddViewers adds the "viewers" edges to the Group entity.
+func (cou *ControlObjectiveUpdate) AddViewers(g ...*Group) *ControlObjectiveUpdate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return cou.AddViewerIDs(ids...)
+}
+
 // AddPolicyIDs adds the "policy" edge to the InternalPolicy entity by IDs.
 func (cou *ControlObjectiveUpdate) AddPolicyIDs(ids ...string) *ControlObjectiveUpdate {
 	cou.mutation.AddPolicyIDs(ids...)
@@ -475,6 +541,75 @@ func (cou *ControlObjectiveUpdate) AddPrograms(p ...*Program) *ControlObjectiveU
 // Mutation returns the ControlObjectiveMutation object of the builder.
 func (cou *ControlObjectiveUpdate) Mutation() *ControlObjectiveMutation {
 	return cou.mutation
+}
+
+// ClearOwner clears the "owner" edge to the Organization entity.
+func (cou *ControlObjectiveUpdate) ClearOwner() *ControlObjectiveUpdate {
+	cou.mutation.ClearOwner()
+	return cou
+}
+
+// ClearBlockedGroups clears all "blocked_groups" edges to the Group entity.
+func (cou *ControlObjectiveUpdate) ClearBlockedGroups() *ControlObjectiveUpdate {
+	cou.mutation.ClearBlockedGroups()
+	return cou
+}
+
+// RemoveBlockedGroupIDs removes the "blocked_groups" edge to Group entities by IDs.
+func (cou *ControlObjectiveUpdate) RemoveBlockedGroupIDs(ids ...string) *ControlObjectiveUpdate {
+	cou.mutation.RemoveBlockedGroupIDs(ids...)
+	return cou
+}
+
+// RemoveBlockedGroups removes "blocked_groups" edges to Group entities.
+func (cou *ControlObjectiveUpdate) RemoveBlockedGroups(g ...*Group) *ControlObjectiveUpdate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return cou.RemoveBlockedGroupIDs(ids...)
+}
+
+// ClearEditors clears all "editors" edges to the Group entity.
+func (cou *ControlObjectiveUpdate) ClearEditors() *ControlObjectiveUpdate {
+	cou.mutation.ClearEditors()
+	return cou
+}
+
+// RemoveEditorIDs removes the "editors" edge to Group entities by IDs.
+func (cou *ControlObjectiveUpdate) RemoveEditorIDs(ids ...string) *ControlObjectiveUpdate {
+	cou.mutation.RemoveEditorIDs(ids...)
+	return cou
+}
+
+// RemoveEditors removes "editors" edges to Group entities.
+func (cou *ControlObjectiveUpdate) RemoveEditors(g ...*Group) *ControlObjectiveUpdate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return cou.RemoveEditorIDs(ids...)
+}
+
+// ClearViewers clears all "viewers" edges to the Group entity.
+func (cou *ControlObjectiveUpdate) ClearViewers() *ControlObjectiveUpdate {
+	cou.mutation.ClearViewers()
+	return cou
+}
+
+// RemoveViewerIDs removes the "viewers" edge to Group entities by IDs.
+func (cou *ControlObjectiveUpdate) RemoveViewerIDs(ids ...string) *ControlObjectiveUpdate {
+	cou.mutation.RemoveViewerIDs(ids...)
+	return cou
+}
+
+// RemoveViewers removes "viewers" edges to Group entities.
+func (cou *ControlObjectiveUpdate) RemoveViewers(g ...*Group) *ControlObjectiveUpdate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return cou.RemoveViewerIDs(ids...)
 }
 
 // ClearPolicy clears all "policy" edges to the InternalPolicy entity.
@@ -708,6 +843,24 @@ func (cou *ControlObjectiveUpdate) defaults() error {
 	return nil
 }
 
+// check runs all checks and user-defined validators on the builder.
+func (cou *ControlObjectiveUpdate) check() error {
+	if v, ok := cou.mutation.OwnerID(); ok {
+		if err := controlobjective.OwnerIDValidator(v); err != nil {
+			return &ValidationError{Name: "owner_id", err: fmt.Errorf(`generated: validator failed for field "ControlObjective.owner_id": %w`, err)}
+		}
+	}
+	if v, ok := cou.mutation.Name(); ok {
+		if err := controlobjective.NameValidator(v); err != nil {
+			return &ValidationError{Name: "name", err: fmt.Errorf(`generated: validator failed for field "ControlObjective.name": %w`, err)}
+		}
+	}
+	if cou.mutation.OwnerCleared() && len(cou.mutation.OwnerIDs()) > 0 {
+		return errors.New(`generated: clearing a required unique edge "ControlObjective.owner"`)
+	}
+	return nil
+}
+
 // Modify adds a statement modifier for attaching custom logic to the UPDATE statement.
 func (cou *ControlObjectiveUpdate) Modify(modifiers ...func(u *sql.UpdateBuilder)) *ControlObjectiveUpdate {
 	cou.modifiers = append(cou.modifiers, modifiers...)
@@ -715,6 +868,9 @@ func (cou *ControlObjectiveUpdate) Modify(modifiers ...func(u *sql.UpdateBuilder
 }
 
 func (cou *ControlObjectiveUpdate) sqlSave(ctx context.Context) (n int, err error) {
+	if err := cou.check(); err != nil {
+		return n, err
+	}
 	_spec := sqlgraph.NewUpdateSpec(controlobjective.Table, controlobjective.Columns, sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString))
 	if ps := cou.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
@@ -826,6 +982,181 @@ func (cou *ControlObjectiveUpdate) sqlSave(ctx context.Context) (n int, err erro
 	}
 	if cou.mutation.DetailsCleared() {
 		_spec.ClearField(controlobjective.FieldDetails, field.TypeJSON)
+	}
+	if cou.mutation.OwnerCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   controlobjective.OwnerTable,
+			Columns: []string{controlobjective.OwnerColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(organization.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = cou.schemaConfig.ControlObjective
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := cou.mutation.OwnerIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   controlobjective.OwnerTable,
+			Columns: []string{controlobjective.OwnerColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(organization.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = cou.schemaConfig.ControlObjective
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if cou.mutation.BlockedGroupsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   controlobjective.BlockedGroupsTable,
+			Columns: controlobjective.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = cou.schemaConfig.ControlObjectiveBlockedGroups
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := cou.mutation.RemovedBlockedGroupsIDs(); len(nodes) > 0 && !cou.mutation.BlockedGroupsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   controlobjective.BlockedGroupsTable,
+			Columns: controlobjective.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = cou.schemaConfig.ControlObjectiveBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := cou.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   controlobjective.BlockedGroupsTable,
+			Columns: controlobjective.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = cou.schemaConfig.ControlObjectiveBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if cou.mutation.EditorsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   controlobjective.EditorsTable,
+			Columns: controlobjective.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = cou.schemaConfig.ControlObjectiveEditors
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := cou.mutation.RemovedEditorsIDs(); len(nodes) > 0 && !cou.mutation.EditorsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   controlobjective.EditorsTable,
+			Columns: controlobjective.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = cou.schemaConfig.ControlObjectiveEditors
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := cou.mutation.EditorsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   controlobjective.EditorsTable,
+			Columns: controlobjective.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = cou.schemaConfig.ControlObjectiveEditors
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if cou.mutation.ViewersCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   controlobjective.ViewersTable,
+			Columns: controlobjective.ViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = cou.schemaConfig.ControlObjectiveViewers
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := cou.mutation.RemovedViewersIDs(); len(nodes) > 0 && !cou.mutation.ViewersCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   controlobjective.ViewersTable,
+			Columns: controlobjective.ViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = cou.schemaConfig.ControlObjectiveViewers
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := cou.mutation.ViewersIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   controlobjective.ViewersTable,
+			Columns: controlobjective.ViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = cou.schemaConfig.ControlObjectiveViewers
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if cou.mutation.PolicyCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -1373,6 +1704,20 @@ func (couo *ControlObjectiveUpdateOne) ClearTags() *ControlObjectiveUpdateOne {
 	return couo
 }
 
+// SetOwnerID sets the "owner_id" field.
+func (couo *ControlObjectiveUpdateOne) SetOwnerID(s string) *ControlObjectiveUpdateOne {
+	couo.mutation.SetOwnerID(s)
+	return couo
+}
+
+// SetNillableOwnerID sets the "owner_id" field if the given value is not nil.
+func (couo *ControlObjectiveUpdateOne) SetNillableOwnerID(s *string) *ControlObjectiveUpdateOne {
+	if s != nil {
+		couo.SetOwnerID(*s)
+	}
+	return couo
+}
+
 // SetName sets the "name" field.
 func (couo *ControlObjectiveUpdateOne) SetName(s string) *ControlObjectiveUpdateOne {
 	couo.mutation.SetName(s)
@@ -1579,6 +1924,56 @@ func (couo *ControlObjectiveUpdateOne) ClearDetails() *ControlObjectiveUpdateOne
 	return couo
 }
 
+// SetOwner sets the "owner" edge to the Organization entity.
+func (couo *ControlObjectiveUpdateOne) SetOwner(o *Organization) *ControlObjectiveUpdateOne {
+	return couo.SetOwnerID(o.ID)
+}
+
+// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
+func (couo *ControlObjectiveUpdateOne) AddBlockedGroupIDs(ids ...string) *ControlObjectiveUpdateOne {
+	couo.mutation.AddBlockedGroupIDs(ids...)
+	return couo
+}
+
+// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
+func (couo *ControlObjectiveUpdateOne) AddBlockedGroups(g ...*Group) *ControlObjectiveUpdateOne {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return couo.AddBlockedGroupIDs(ids...)
+}
+
+// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
+func (couo *ControlObjectiveUpdateOne) AddEditorIDs(ids ...string) *ControlObjectiveUpdateOne {
+	couo.mutation.AddEditorIDs(ids...)
+	return couo
+}
+
+// AddEditors adds the "editors" edges to the Group entity.
+func (couo *ControlObjectiveUpdateOne) AddEditors(g ...*Group) *ControlObjectiveUpdateOne {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return couo.AddEditorIDs(ids...)
+}
+
+// AddViewerIDs adds the "viewers" edge to the Group entity by IDs.
+func (couo *ControlObjectiveUpdateOne) AddViewerIDs(ids ...string) *ControlObjectiveUpdateOne {
+	couo.mutation.AddViewerIDs(ids...)
+	return couo
+}
+
+// AddViewers adds the "viewers" edges to the Group entity.
+func (couo *ControlObjectiveUpdateOne) AddViewers(g ...*Group) *ControlObjectiveUpdateOne {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return couo.AddViewerIDs(ids...)
+}
+
 // AddPolicyIDs adds the "policy" edge to the InternalPolicy entity by IDs.
 func (couo *ControlObjectiveUpdateOne) AddPolicyIDs(ids ...string) *ControlObjectiveUpdateOne {
 	couo.mutation.AddPolicyIDs(ids...)
@@ -1717,6 +2112,75 @@ func (couo *ControlObjectiveUpdateOne) AddPrograms(p ...*Program) *ControlObject
 // Mutation returns the ControlObjectiveMutation object of the builder.
 func (couo *ControlObjectiveUpdateOne) Mutation() *ControlObjectiveMutation {
 	return couo.mutation
+}
+
+// ClearOwner clears the "owner" edge to the Organization entity.
+func (couo *ControlObjectiveUpdateOne) ClearOwner() *ControlObjectiveUpdateOne {
+	couo.mutation.ClearOwner()
+	return couo
+}
+
+// ClearBlockedGroups clears all "blocked_groups" edges to the Group entity.
+func (couo *ControlObjectiveUpdateOne) ClearBlockedGroups() *ControlObjectiveUpdateOne {
+	couo.mutation.ClearBlockedGroups()
+	return couo
+}
+
+// RemoveBlockedGroupIDs removes the "blocked_groups" edge to Group entities by IDs.
+func (couo *ControlObjectiveUpdateOne) RemoveBlockedGroupIDs(ids ...string) *ControlObjectiveUpdateOne {
+	couo.mutation.RemoveBlockedGroupIDs(ids...)
+	return couo
+}
+
+// RemoveBlockedGroups removes "blocked_groups" edges to Group entities.
+func (couo *ControlObjectiveUpdateOne) RemoveBlockedGroups(g ...*Group) *ControlObjectiveUpdateOne {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return couo.RemoveBlockedGroupIDs(ids...)
+}
+
+// ClearEditors clears all "editors" edges to the Group entity.
+func (couo *ControlObjectiveUpdateOne) ClearEditors() *ControlObjectiveUpdateOne {
+	couo.mutation.ClearEditors()
+	return couo
+}
+
+// RemoveEditorIDs removes the "editors" edge to Group entities by IDs.
+func (couo *ControlObjectiveUpdateOne) RemoveEditorIDs(ids ...string) *ControlObjectiveUpdateOne {
+	couo.mutation.RemoveEditorIDs(ids...)
+	return couo
+}
+
+// RemoveEditors removes "editors" edges to Group entities.
+func (couo *ControlObjectiveUpdateOne) RemoveEditors(g ...*Group) *ControlObjectiveUpdateOne {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return couo.RemoveEditorIDs(ids...)
+}
+
+// ClearViewers clears all "viewers" edges to the Group entity.
+func (couo *ControlObjectiveUpdateOne) ClearViewers() *ControlObjectiveUpdateOne {
+	couo.mutation.ClearViewers()
+	return couo
+}
+
+// RemoveViewerIDs removes the "viewers" edge to Group entities by IDs.
+func (couo *ControlObjectiveUpdateOne) RemoveViewerIDs(ids ...string) *ControlObjectiveUpdateOne {
+	couo.mutation.RemoveViewerIDs(ids...)
+	return couo
+}
+
+// RemoveViewers removes "viewers" edges to Group entities.
+func (couo *ControlObjectiveUpdateOne) RemoveViewers(g ...*Group) *ControlObjectiveUpdateOne {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return couo.RemoveViewerIDs(ids...)
 }
 
 // ClearPolicy clears all "policy" edges to the InternalPolicy entity.
@@ -1963,6 +2427,24 @@ func (couo *ControlObjectiveUpdateOne) defaults() error {
 	return nil
 }
 
+// check runs all checks and user-defined validators on the builder.
+func (couo *ControlObjectiveUpdateOne) check() error {
+	if v, ok := couo.mutation.OwnerID(); ok {
+		if err := controlobjective.OwnerIDValidator(v); err != nil {
+			return &ValidationError{Name: "owner_id", err: fmt.Errorf(`generated: validator failed for field "ControlObjective.owner_id": %w`, err)}
+		}
+	}
+	if v, ok := couo.mutation.Name(); ok {
+		if err := controlobjective.NameValidator(v); err != nil {
+			return &ValidationError{Name: "name", err: fmt.Errorf(`generated: validator failed for field "ControlObjective.name": %w`, err)}
+		}
+	}
+	if couo.mutation.OwnerCleared() && len(couo.mutation.OwnerIDs()) > 0 {
+		return errors.New(`generated: clearing a required unique edge "ControlObjective.owner"`)
+	}
+	return nil
+}
+
 // Modify adds a statement modifier for attaching custom logic to the UPDATE statement.
 func (couo *ControlObjectiveUpdateOne) Modify(modifiers ...func(u *sql.UpdateBuilder)) *ControlObjectiveUpdateOne {
 	couo.modifiers = append(couo.modifiers, modifiers...)
@@ -1970,6 +2452,9 @@ func (couo *ControlObjectiveUpdateOne) Modify(modifiers ...func(u *sql.UpdateBui
 }
 
 func (couo *ControlObjectiveUpdateOne) sqlSave(ctx context.Context) (_node *ControlObjective, err error) {
+	if err := couo.check(); err != nil {
+		return _node, err
+	}
 	_spec := sqlgraph.NewUpdateSpec(controlobjective.Table, controlobjective.Columns, sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString))
 	id, ok := couo.mutation.ID()
 	if !ok {
@@ -2098,6 +2583,181 @@ func (couo *ControlObjectiveUpdateOne) sqlSave(ctx context.Context) (_node *Cont
 	}
 	if couo.mutation.DetailsCleared() {
 		_spec.ClearField(controlobjective.FieldDetails, field.TypeJSON)
+	}
+	if couo.mutation.OwnerCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   controlobjective.OwnerTable,
+			Columns: []string{controlobjective.OwnerColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(organization.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = couo.schemaConfig.ControlObjective
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := couo.mutation.OwnerIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   controlobjective.OwnerTable,
+			Columns: []string{controlobjective.OwnerColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(organization.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = couo.schemaConfig.ControlObjective
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if couo.mutation.BlockedGroupsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   controlobjective.BlockedGroupsTable,
+			Columns: controlobjective.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = couo.schemaConfig.ControlObjectiveBlockedGroups
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := couo.mutation.RemovedBlockedGroupsIDs(); len(nodes) > 0 && !couo.mutation.BlockedGroupsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   controlobjective.BlockedGroupsTable,
+			Columns: controlobjective.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = couo.schemaConfig.ControlObjectiveBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := couo.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   controlobjective.BlockedGroupsTable,
+			Columns: controlobjective.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = couo.schemaConfig.ControlObjectiveBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if couo.mutation.EditorsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   controlobjective.EditorsTable,
+			Columns: controlobjective.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = couo.schemaConfig.ControlObjectiveEditors
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := couo.mutation.RemovedEditorsIDs(); len(nodes) > 0 && !couo.mutation.EditorsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   controlobjective.EditorsTable,
+			Columns: controlobjective.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = couo.schemaConfig.ControlObjectiveEditors
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := couo.mutation.EditorsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   controlobjective.EditorsTable,
+			Columns: controlobjective.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = couo.schemaConfig.ControlObjectiveEditors
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if couo.mutation.ViewersCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   controlobjective.ViewersTable,
+			Columns: controlobjective.ViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = couo.schemaConfig.ControlObjectiveViewers
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := couo.mutation.RemovedViewersIDs(); len(nodes) > 0 && !couo.mutation.ViewersCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   controlobjective.ViewersTable,
+			Columns: controlobjective.ViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = couo.schemaConfig.ControlObjectiveViewers
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := couo.mutation.ViewersIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   controlobjective.ViewersTable,
+			Columns: controlobjective.ViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = couo.schemaConfig.ControlObjectiveViewers
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if couo.mutation.PolicyCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/internal/ent/generated/controlobjectivehistory.go
+++ b/internal/ent/generated/controlobjectivehistory.go
@@ -41,6 +41,8 @@ type ControlObjectiveHistory struct {
 	MappingID string `json:"mapping_id,omitempty"`
 	// tags associated with the object
 	Tags []string `json:"tags,omitempty"`
+	// the ID of the organization owner of the object
+	OwnerID string `json:"owner_id,omitempty"`
 	// the name of the control objective
 	Name string `json:"name,omitempty"`
 	// description of the control objective
@@ -75,7 +77,7 @@ func (*ControlObjectiveHistory) scanValues(columns []string) ([]any, error) {
 			values[i] = new([]byte)
 		case controlobjectivehistory.FieldOperation:
 			values[i] = new(history.OpType)
-		case controlobjectivehistory.FieldID, controlobjectivehistory.FieldRef, controlobjectivehistory.FieldCreatedBy, controlobjectivehistory.FieldUpdatedBy, controlobjectivehistory.FieldDeletedBy, controlobjectivehistory.FieldMappingID, controlobjectivehistory.FieldName, controlobjectivehistory.FieldDescription, controlobjectivehistory.FieldStatus, controlobjectivehistory.FieldControlObjectiveType, controlobjectivehistory.FieldVersion, controlobjectivehistory.FieldControlNumber, controlobjectivehistory.FieldFamily, controlobjectivehistory.FieldClass, controlobjectivehistory.FieldSource, controlobjectivehistory.FieldMappedFrameworks:
+		case controlobjectivehistory.FieldID, controlobjectivehistory.FieldRef, controlobjectivehistory.FieldCreatedBy, controlobjectivehistory.FieldUpdatedBy, controlobjectivehistory.FieldDeletedBy, controlobjectivehistory.FieldMappingID, controlobjectivehistory.FieldOwnerID, controlobjectivehistory.FieldName, controlobjectivehistory.FieldDescription, controlobjectivehistory.FieldStatus, controlobjectivehistory.FieldControlObjectiveType, controlobjectivehistory.FieldVersion, controlobjectivehistory.FieldControlNumber, controlobjectivehistory.FieldFamily, controlobjectivehistory.FieldClass, controlobjectivehistory.FieldSource, controlobjectivehistory.FieldMappedFrameworks:
 			values[i] = new(sql.NullString)
 		case controlobjectivehistory.FieldHistoryTime, controlobjectivehistory.FieldCreatedAt, controlobjectivehistory.FieldUpdatedAt, controlobjectivehistory.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
@@ -167,6 +169,12 @@ func (coh *ControlObjectiveHistory) assignValues(columns []string, values []any)
 				if err := json.Unmarshal(*value, &coh.Tags); err != nil {
 					return fmt.Errorf("unmarshal field tags: %w", err)
 				}
+			}
+		case controlobjectivehistory.FieldOwnerID:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field owner_id", values[i])
+			} else if value.Valid {
+				coh.OwnerID = value.String
 			}
 		case controlobjectivehistory.FieldName:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -304,6 +312,9 @@ func (coh *ControlObjectiveHistory) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("tags=")
 	builder.WriteString(fmt.Sprintf("%v", coh.Tags))
+	builder.WriteString(", ")
+	builder.WriteString("owner_id=")
+	builder.WriteString(coh.OwnerID)
 	builder.WriteString(", ")
 	builder.WriteString("name=")
 	builder.WriteString(coh.Name)

--- a/internal/ent/generated/controlobjectivehistory/controlobjectivehistory.go
+++ b/internal/ent/generated/controlobjectivehistory/controlobjectivehistory.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/theopenlane/entx/history"
@@ -38,6 +39,8 @@ const (
 	FieldMappingID = "mapping_id"
 	// FieldTags holds the string denoting the tags field in the database.
 	FieldTags = "tags"
+	// FieldOwnerID holds the string denoting the owner_id field in the database.
+	FieldOwnerID = "owner_id"
 	// FieldName holds the string denoting the name field in the database.
 	FieldName = "name"
 	// FieldDescription holds the string denoting the description field in the database.
@@ -78,6 +81,7 @@ var Columns = []string{
 	FieldDeletedBy,
 	FieldMappingID,
 	FieldTags,
+	FieldOwnerID,
 	FieldName,
 	FieldDescription,
 	FieldStatus,
@@ -101,7 +105,15 @@ func ValidColumn(column string) bool {
 	return false
 }
 
+// Note that the variables below are initialized by the runtime
+// package on the initialization of the application. Therefore,
+// it should be imported in the main as follows:
+//
+//	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
+	Hooks        [1]ent.Hook
+	Interceptors [1]ent.Interceptor
+	Policy       ent.Policy
 	// DefaultHistoryTime holds the default value on creation for the "history_time" field.
 	DefaultHistoryTime func() time.Time
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
@@ -184,6 +196,11 @@ func ByDeletedBy(opts ...sql.OrderTermOption) OrderOption {
 // ByMappingID orders the results by the mapping_id field.
 func ByMappingID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldMappingID, opts...).ToFunc()
+}
+
+// ByOwnerID orders the results by the owner_id field.
+func ByOwnerID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldOwnerID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.

--- a/internal/ent/generated/controlobjectivehistory/where.go
+++ b/internal/ent/generated/controlobjectivehistory/where.go
@@ -110,6 +110,11 @@ func MappingID(v string) predicate.ControlObjectiveHistory {
 	return predicate.ControlObjectiveHistory(sql.FieldEQ(FieldMappingID, v))
 }
 
+// OwnerID applies equality check predicate on the "owner_id" field. It's identical to OwnerIDEQ.
+func OwnerID(v string) predicate.ControlObjectiveHistory {
+	return predicate.ControlObjectiveHistory(sql.FieldEQ(FieldOwnerID, v))
+}
+
 // Name applies equality check predicate on the "name" field. It's identical to NameEQ.
 func Name(v string) predicate.ControlObjectiveHistory {
 	return predicate.ControlObjectiveHistory(sql.FieldEQ(FieldName, v))
@@ -743,6 +748,71 @@ func TagsIsNil() predicate.ControlObjectiveHistory {
 // TagsNotNil applies the NotNil predicate on the "tags" field.
 func TagsNotNil() predicate.ControlObjectiveHistory {
 	return predicate.ControlObjectiveHistory(sql.FieldNotNull(FieldTags))
+}
+
+// OwnerIDEQ applies the EQ predicate on the "owner_id" field.
+func OwnerIDEQ(v string) predicate.ControlObjectiveHistory {
+	return predicate.ControlObjectiveHistory(sql.FieldEQ(FieldOwnerID, v))
+}
+
+// OwnerIDNEQ applies the NEQ predicate on the "owner_id" field.
+func OwnerIDNEQ(v string) predicate.ControlObjectiveHistory {
+	return predicate.ControlObjectiveHistory(sql.FieldNEQ(FieldOwnerID, v))
+}
+
+// OwnerIDIn applies the In predicate on the "owner_id" field.
+func OwnerIDIn(vs ...string) predicate.ControlObjectiveHistory {
+	return predicate.ControlObjectiveHistory(sql.FieldIn(FieldOwnerID, vs...))
+}
+
+// OwnerIDNotIn applies the NotIn predicate on the "owner_id" field.
+func OwnerIDNotIn(vs ...string) predicate.ControlObjectiveHistory {
+	return predicate.ControlObjectiveHistory(sql.FieldNotIn(FieldOwnerID, vs...))
+}
+
+// OwnerIDGT applies the GT predicate on the "owner_id" field.
+func OwnerIDGT(v string) predicate.ControlObjectiveHistory {
+	return predicate.ControlObjectiveHistory(sql.FieldGT(FieldOwnerID, v))
+}
+
+// OwnerIDGTE applies the GTE predicate on the "owner_id" field.
+func OwnerIDGTE(v string) predicate.ControlObjectiveHistory {
+	return predicate.ControlObjectiveHistory(sql.FieldGTE(FieldOwnerID, v))
+}
+
+// OwnerIDLT applies the LT predicate on the "owner_id" field.
+func OwnerIDLT(v string) predicate.ControlObjectiveHistory {
+	return predicate.ControlObjectiveHistory(sql.FieldLT(FieldOwnerID, v))
+}
+
+// OwnerIDLTE applies the LTE predicate on the "owner_id" field.
+func OwnerIDLTE(v string) predicate.ControlObjectiveHistory {
+	return predicate.ControlObjectiveHistory(sql.FieldLTE(FieldOwnerID, v))
+}
+
+// OwnerIDContains applies the Contains predicate on the "owner_id" field.
+func OwnerIDContains(v string) predicate.ControlObjectiveHistory {
+	return predicate.ControlObjectiveHistory(sql.FieldContains(FieldOwnerID, v))
+}
+
+// OwnerIDHasPrefix applies the HasPrefix predicate on the "owner_id" field.
+func OwnerIDHasPrefix(v string) predicate.ControlObjectiveHistory {
+	return predicate.ControlObjectiveHistory(sql.FieldHasPrefix(FieldOwnerID, v))
+}
+
+// OwnerIDHasSuffix applies the HasSuffix predicate on the "owner_id" field.
+func OwnerIDHasSuffix(v string) predicate.ControlObjectiveHistory {
+	return predicate.ControlObjectiveHistory(sql.FieldHasSuffix(FieldOwnerID, v))
+}
+
+// OwnerIDEqualFold applies the EqualFold predicate on the "owner_id" field.
+func OwnerIDEqualFold(v string) predicate.ControlObjectiveHistory {
+	return predicate.ControlObjectiveHistory(sql.FieldEqualFold(FieldOwnerID, v))
+}
+
+// OwnerIDContainsFold applies the ContainsFold predicate on the "owner_id" field.
+func OwnerIDContainsFold(v string) predicate.ControlObjectiveHistory {
+	return predicate.ControlObjectiveHistory(sql.FieldContainsFold(FieldOwnerID, v))
 }
 
 // NameEQ applies the EQ predicate on the "name" field.

--- a/internal/ent/generated/controlobjectivehistory_create.go
+++ b/internal/ent/generated/controlobjectivehistory_create.go
@@ -159,6 +159,12 @@ func (cohc *ControlObjectiveHistoryCreate) SetTags(s []string) *ControlObjective
 	return cohc
 }
 
+// SetOwnerID sets the "owner_id" field.
+func (cohc *ControlObjectiveHistoryCreate) SetOwnerID(s string) *ControlObjectiveHistoryCreate {
+	cohc.mutation.SetOwnerID(s)
+	return cohc
+}
+
 // SetName sets the "name" field.
 func (cohc *ControlObjectiveHistoryCreate) SetName(s string) *ControlObjectiveHistoryCreate {
 	cohc.mutation.SetName(s)
@@ -318,7 +324,9 @@ func (cohc *ControlObjectiveHistoryCreate) Mutation() *ControlObjectiveHistoryMu
 
 // Save creates the ControlObjectiveHistory in the database.
 func (cohc *ControlObjectiveHistoryCreate) Save(ctx context.Context) (*ControlObjectiveHistory, error) {
-	cohc.defaults()
+	if err := cohc.defaults(); err != nil {
+		return nil, err
+	}
 	return withHooks(ctx, cohc.sqlSave, cohc.mutation, cohc.hooks)
 }
 
@@ -345,20 +353,32 @@ func (cohc *ControlObjectiveHistoryCreate) ExecX(ctx context.Context) {
 }
 
 // defaults sets the default values of the builder before save.
-func (cohc *ControlObjectiveHistoryCreate) defaults() {
+func (cohc *ControlObjectiveHistoryCreate) defaults() error {
 	if _, ok := cohc.mutation.HistoryTime(); !ok {
+		if controlobjectivehistory.DefaultHistoryTime == nil {
+			return fmt.Errorf("generated: uninitialized controlobjectivehistory.DefaultHistoryTime (forgotten import generated/runtime?)")
+		}
 		v := controlobjectivehistory.DefaultHistoryTime()
 		cohc.mutation.SetHistoryTime(v)
 	}
 	if _, ok := cohc.mutation.CreatedAt(); !ok {
+		if controlobjectivehistory.DefaultCreatedAt == nil {
+			return fmt.Errorf("generated: uninitialized controlobjectivehistory.DefaultCreatedAt (forgotten import generated/runtime?)")
+		}
 		v := controlobjectivehistory.DefaultCreatedAt()
 		cohc.mutation.SetCreatedAt(v)
 	}
 	if _, ok := cohc.mutation.UpdatedAt(); !ok {
+		if controlobjectivehistory.DefaultUpdatedAt == nil {
+			return fmt.Errorf("generated: uninitialized controlobjectivehistory.DefaultUpdatedAt (forgotten import generated/runtime?)")
+		}
 		v := controlobjectivehistory.DefaultUpdatedAt()
 		cohc.mutation.SetUpdatedAt(v)
 	}
 	if _, ok := cohc.mutation.MappingID(); !ok {
+		if controlobjectivehistory.DefaultMappingID == nil {
+			return fmt.Errorf("generated: uninitialized controlobjectivehistory.DefaultMappingID (forgotten import generated/runtime?)")
+		}
 		v := controlobjectivehistory.DefaultMappingID()
 		cohc.mutation.SetMappingID(v)
 	}
@@ -367,9 +387,13 @@ func (cohc *ControlObjectiveHistoryCreate) defaults() {
 		cohc.mutation.SetTags(v)
 	}
 	if _, ok := cohc.mutation.ID(); !ok {
+		if controlobjectivehistory.DefaultID == nil {
+			return fmt.Errorf("generated: uninitialized controlobjectivehistory.DefaultID (forgotten import generated/runtime?)")
+		}
 		v := controlobjectivehistory.DefaultID()
 		cohc.mutation.SetID(v)
 	}
+	return nil
 }
 
 // check runs all checks and user-defined validators on the builder.
@@ -387,6 +411,9 @@ func (cohc *ControlObjectiveHistoryCreate) check() error {
 	}
 	if _, ok := cohc.mutation.MappingID(); !ok {
 		return &ValidationError{Name: "mapping_id", err: errors.New(`generated: missing required field "ControlObjectiveHistory.mapping_id"`)}
+	}
+	if _, ok := cohc.mutation.OwnerID(); !ok {
+		return &ValidationError{Name: "owner_id", err: errors.New(`generated: missing required field "ControlObjectiveHistory.owner_id"`)}
 	}
 	if _, ok := cohc.mutation.Name(); !ok {
 		return &ValidationError{Name: "name", err: errors.New(`generated: missing required field "ControlObjectiveHistory.name"`)}
@@ -470,6 +497,10 @@ func (cohc *ControlObjectiveHistoryCreate) createSpec() (*ControlObjectiveHistor
 	if value, ok := cohc.mutation.Tags(); ok {
 		_spec.SetField(controlobjectivehistory.FieldTags, field.TypeJSON, value)
 		_node.Tags = value
+	}
+	if value, ok := cohc.mutation.OwnerID(); ok {
+		_spec.SetField(controlobjectivehistory.FieldOwnerID, field.TypeString, value)
+		_node.OwnerID = value
 	}
 	if value, ok := cohc.mutation.Name(); ok {
 		_spec.SetField(controlobjectivehistory.FieldName, field.TypeString, value)

--- a/internal/ent/generated/controlobjectivehistory_query.go
+++ b/internal/ent/generated/controlobjectivehistory_query.go
@@ -4,6 +4,7 @@ package generated
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 
@@ -331,6 +332,12 @@ func (cohq *ControlObjectiveHistoryQuery) prepareQuery(ctx context.Context) erro
 			return err
 		}
 		cohq.sql = prev
+	}
+	if controlobjectivehistory.Policy == nil {
+		return errors.New("generated: uninitialized controlobjectivehistory.Policy (forgotten import generated/runtime?)")
+	}
+	if err := controlobjectivehistory.Policy.EvalQuery(ctx, cohq); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/ent/generated/controlobjectivehistory_update.go
+++ b/internal/ent/generated/controlobjectivehistory_update.go
@@ -122,6 +122,20 @@ func (cohu *ControlObjectiveHistoryUpdate) ClearTags() *ControlObjectiveHistoryU
 	return cohu
 }
 
+// SetOwnerID sets the "owner_id" field.
+func (cohu *ControlObjectiveHistoryUpdate) SetOwnerID(s string) *ControlObjectiveHistoryUpdate {
+	cohu.mutation.SetOwnerID(s)
+	return cohu
+}
+
+// SetNillableOwnerID sets the "owner_id" field if the given value is not nil.
+func (cohu *ControlObjectiveHistoryUpdate) SetNillableOwnerID(s *string) *ControlObjectiveHistoryUpdate {
+	if s != nil {
+		cohu.SetOwnerID(*s)
+	}
+	return cohu
+}
+
 // SetName sets the "name" field.
 func (cohu *ControlObjectiveHistoryUpdate) SetName(s string) *ControlObjectiveHistoryUpdate {
 	cohu.mutation.SetName(s)
@@ -335,7 +349,9 @@ func (cohu *ControlObjectiveHistoryUpdate) Mutation() *ControlObjectiveHistoryMu
 
 // Save executes the query and returns the number of nodes affected by the update operation.
 func (cohu *ControlObjectiveHistoryUpdate) Save(ctx context.Context) (int, error) {
-	cohu.defaults()
+	if err := cohu.defaults(); err != nil {
+		return 0, err
+	}
 	return withHooks(ctx, cohu.sqlSave, cohu.mutation, cohu.hooks)
 }
 
@@ -362,11 +378,15 @@ func (cohu *ControlObjectiveHistoryUpdate) ExecX(ctx context.Context) {
 }
 
 // defaults sets the default values of the builder before save.
-func (cohu *ControlObjectiveHistoryUpdate) defaults() {
+func (cohu *ControlObjectiveHistoryUpdate) defaults() error {
 	if _, ok := cohu.mutation.UpdatedAt(); !ok && !cohu.mutation.UpdatedAtCleared() {
+		if controlobjectivehistory.UpdateDefaultUpdatedAt == nil {
+			return fmt.Errorf("generated: uninitialized controlobjectivehistory.UpdateDefaultUpdatedAt (forgotten import generated/runtime?)")
+		}
 		v := controlobjectivehistory.UpdateDefaultUpdatedAt()
 		cohu.mutation.SetUpdatedAt(v)
 	}
+	return nil
 }
 
 // Modify adds a statement modifier for attaching custom logic to the UPDATE statement.
@@ -427,6 +447,9 @@ func (cohu *ControlObjectiveHistoryUpdate) sqlSave(ctx context.Context) (n int, 
 	}
 	if cohu.mutation.TagsCleared() {
 		_spec.ClearField(controlobjectivehistory.FieldTags, field.TypeJSON)
+	}
+	if value, ok := cohu.mutation.OwnerID(); ok {
+		_spec.SetField(controlobjectivehistory.FieldOwnerID, field.TypeString, value)
 	}
 	if value, ok := cohu.mutation.Name(); ok {
 		_spec.SetField(controlobjectivehistory.FieldName, field.TypeString, value)
@@ -602,6 +625,20 @@ func (cohuo *ControlObjectiveHistoryUpdateOne) AppendTags(s []string) *ControlOb
 // ClearTags clears the value of the "tags" field.
 func (cohuo *ControlObjectiveHistoryUpdateOne) ClearTags() *ControlObjectiveHistoryUpdateOne {
 	cohuo.mutation.ClearTags()
+	return cohuo
+}
+
+// SetOwnerID sets the "owner_id" field.
+func (cohuo *ControlObjectiveHistoryUpdateOne) SetOwnerID(s string) *ControlObjectiveHistoryUpdateOne {
+	cohuo.mutation.SetOwnerID(s)
+	return cohuo
+}
+
+// SetNillableOwnerID sets the "owner_id" field if the given value is not nil.
+func (cohuo *ControlObjectiveHistoryUpdateOne) SetNillableOwnerID(s *string) *ControlObjectiveHistoryUpdateOne {
+	if s != nil {
+		cohuo.SetOwnerID(*s)
+	}
 	return cohuo
 }
 
@@ -831,7 +868,9 @@ func (cohuo *ControlObjectiveHistoryUpdateOne) Select(field string, fields ...st
 
 // Save executes the query and returns the updated ControlObjectiveHistory entity.
 func (cohuo *ControlObjectiveHistoryUpdateOne) Save(ctx context.Context) (*ControlObjectiveHistory, error) {
-	cohuo.defaults()
+	if err := cohuo.defaults(); err != nil {
+		return nil, err
+	}
 	return withHooks(ctx, cohuo.sqlSave, cohuo.mutation, cohuo.hooks)
 }
 
@@ -858,11 +897,15 @@ func (cohuo *ControlObjectiveHistoryUpdateOne) ExecX(ctx context.Context) {
 }
 
 // defaults sets the default values of the builder before save.
-func (cohuo *ControlObjectiveHistoryUpdateOne) defaults() {
+func (cohuo *ControlObjectiveHistoryUpdateOne) defaults() error {
 	if _, ok := cohuo.mutation.UpdatedAt(); !ok && !cohuo.mutation.UpdatedAtCleared() {
+		if controlobjectivehistory.UpdateDefaultUpdatedAt == nil {
+			return fmt.Errorf("generated: uninitialized controlobjectivehistory.UpdateDefaultUpdatedAt (forgotten import generated/runtime?)")
+		}
 		v := controlobjectivehistory.UpdateDefaultUpdatedAt()
 		cohuo.mutation.SetUpdatedAt(v)
 	}
+	return nil
 }
 
 // Modify adds a statement modifier for attaching custom logic to the UPDATE statement.
@@ -940,6 +983,9 @@ func (cohuo *ControlObjectiveHistoryUpdateOne) sqlSave(ctx context.Context) (_no
 	}
 	if cohuo.mutation.TagsCleared() {
 		_spec.ClearField(controlobjectivehistory.FieldTags, field.TypeJSON)
+	}
+	if value, ok := cohuo.mutation.OwnerID(); ok {
+		_spec.SetField(controlobjectivehistory.FieldOwnerID, field.TypeString, value)
 	}
 	if value, ok := cohuo.mutation.Name(); ok {
 		_spec.SetField(controlobjectivehistory.FieldName, field.TypeString, value)

--- a/internal/ent/generated/edge_cleanup.go
+++ b/internal/ent/generated/edge_cleanup.go
@@ -8,6 +8,7 @@ import (
 	"entgo.io/ent/privacy"
 	"github.com/rs/zerolog/log"
 	"github.com/theopenlane/core/internal/ent/generated/contact"
+	"github.com/theopenlane/core/internal/ent/generated/controlobjective"
 	"github.com/theopenlane/core/internal/ent/generated/documentdata"
 	"github.com/theopenlane/core/internal/ent/generated/emailverificationtoken"
 	"github.com/theopenlane/core/internal/ent/generated/entitlement"
@@ -552,6 +553,13 @@ func OrganizationEdgeCleanup(ctx context.Context, id string) error {
 	if exists, err := FromContext(ctx).Risk.Query().Where((risk.HasOwnerWith(organization.ID(id)))).Exist(ctx); err == nil && exists {
 		if riskCount, err := FromContext(ctx).Risk.Delete().Where(risk.HasOwnerWith(organization.ID(id))).Exec(ctx); err != nil {
 			log.Debug().Err(err).Int("count", riskCount).Msg("deleting risk")
+			return err
+		}
+	}
+
+	if exists, err := FromContext(ctx).ControlObjective.Query().Where((controlobjective.HasOwnerWith(organization.ID(id)))).Exist(ctx); err == nil && exists {
+		if controlobjectiveCount, err := FromContext(ctx).ControlObjective.Delete().Where(controlobjective.HasOwnerWith(organization.ID(id))).Exec(ctx); err != nil {
+			log.Debug().Err(err).Int("count", controlobjectiveCount).Msg("deleting controlobjective")
 			return err
 		}
 	}

--- a/internal/ent/generated/entql.go
+++ b/internal/ent/generated/entql.go
@@ -331,6 +331,7 @@ var schemaGraph = func() *sqlgraph.Schema {
 			controlobjective.FieldDeletedBy:            {Type: field.TypeString, Column: controlobjective.FieldDeletedBy},
 			controlobjective.FieldMappingID:            {Type: field.TypeString, Column: controlobjective.FieldMappingID},
 			controlobjective.FieldTags:                 {Type: field.TypeJSON, Column: controlobjective.FieldTags},
+			controlobjective.FieldOwnerID:              {Type: field.TypeString, Column: controlobjective.FieldOwnerID},
 			controlobjective.FieldName:                 {Type: field.TypeString, Column: controlobjective.FieldName},
 			controlobjective.FieldDescription:          {Type: field.TypeString, Column: controlobjective.FieldDescription},
 			controlobjective.FieldStatus:               {Type: field.TypeString, Column: controlobjective.FieldStatus},
@@ -366,6 +367,7 @@ var schemaGraph = func() *sqlgraph.Schema {
 			controlobjectivehistory.FieldDeletedBy:            {Type: field.TypeString, Column: controlobjectivehistory.FieldDeletedBy},
 			controlobjectivehistory.FieldMappingID:            {Type: field.TypeString, Column: controlobjectivehistory.FieldMappingID},
 			controlobjectivehistory.FieldTags:                 {Type: field.TypeJSON, Column: controlobjectivehistory.FieldTags},
+			controlobjectivehistory.FieldOwnerID:              {Type: field.TypeString, Column: controlobjectivehistory.FieldOwnerID},
 			controlobjectivehistory.FieldName:                 {Type: field.TypeString, Column: controlobjectivehistory.FieldName},
 			controlobjectivehistory.FieldDescription:          {Type: field.TypeString, Column: controlobjectivehistory.FieldDescription},
 			controlobjectivehistory.FieldStatus:               {Type: field.TypeString, Column: controlobjectivehistory.FieldStatus},
@@ -1902,6 +1904,7 @@ var schemaGraph = func() *sqlgraph.Schema {
 			risk.FieldDeletedBy:     {Type: field.TypeString, Column: risk.FieldDeletedBy},
 			risk.FieldMappingID:     {Type: field.TypeString, Column: risk.FieldMappingID},
 			risk.FieldTags:          {Type: field.TypeJSON, Column: risk.FieldTags},
+			risk.FieldOwnerID:       {Type: field.TypeString, Column: risk.FieldOwnerID},
 			risk.FieldName:          {Type: field.TypeString, Column: risk.FieldName},
 			risk.FieldDescription:   {Type: field.TypeString, Column: risk.FieldDescription},
 			risk.FieldStatus:        {Type: field.TypeString, Column: risk.FieldStatus},
@@ -1912,7 +1915,6 @@ var schemaGraph = func() *sqlgraph.Schema {
 			risk.FieldMitigation:    {Type: field.TypeString, Column: risk.FieldMitigation},
 			risk.FieldSatisfies:     {Type: field.TypeString, Column: risk.FieldSatisfies},
 			risk.FieldDetails:       {Type: field.TypeJSON, Column: risk.FieldDetails},
-			risk.FieldOwnerID:       {Type: field.TypeString, Column: risk.FieldOwnerID},
 		},
 	}
 	graph.Nodes[63] = &sqlgraph.Node{
@@ -1937,6 +1939,7 @@ var schemaGraph = func() *sqlgraph.Schema {
 			riskhistory.FieldDeletedBy:     {Type: field.TypeString, Column: riskhistory.FieldDeletedBy},
 			riskhistory.FieldMappingID:     {Type: field.TypeString, Column: riskhistory.FieldMappingID},
 			riskhistory.FieldTags:          {Type: field.TypeJSON, Column: riskhistory.FieldTags},
+			riskhistory.FieldOwnerID:       {Type: field.TypeString, Column: riskhistory.FieldOwnerID},
 			riskhistory.FieldName:          {Type: field.TypeString, Column: riskhistory.FieldName},
 			riskhistory.FieldDescription:   {Type: field.TypeString, Column: riskhistory.FieldDescription},
 			riskhistory.FieldStatus:        {Type: field.TypeString, Column: riskhistory.FieldStatus},
@@ -1947,7 +1950,6 @@ var schemaGraph = func() *sqlgraph.Schema {
 			riskhistory.FieldMitigation:    {Type: field.TypeString, Column: riskhistory.FieldMitigation},
 			riskhistory.FieldSatisfies:     {Type: field.TypeString, Column: riskhistory.FieldSatisfies},
 			riskhistory.FieldDetails:       {Type: field.TypeJSON, Column: riskhistory.FieldDetails},
-			riskhistory.FieldOwnerID:       {Type: field.TypeString, Column: riskhistory.FieldOwnerID},
 		},
 	}
 	graph.Nodes[64] = &sqlgraph.Node{
@@ -2710,6 +2712,54 @@ var schemaGraph = func() *sqlgraph.Schema {
 		},
 		"Control",
 		"Program",
+	)
+	graph.MustAddE(
+		"owner",
+		&sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   controlobjective.OwnerTable,
+			Columns: []string{controlobjective.OwnerColumn},
+			Bidi:    false,
+		},
+		"ControlObjective",
+		"Organization",
+	)
+	graph.MustAddE(
+		"blocked_groups",
+		&sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   controlobjective.BlockedGroupsTable,
+			Columns: controlobjective.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+		},
+		"ControlObjective",
+		"Group",
+	)
+	graph.MustAddE(
+		"editors",
+		&sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   controlobjective.EditorsTable,
+			Columns: controlobjective.EditorsPrimaryKey,
+			Bidi:    false,
+		},
+		"ControlObjective",
+		"Group",
+	)
+	graph.MustAddE(
+		"viewers",
+		&sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   controlobjective.ViewersTable,
+			Columns: controlobjective.ViewersPrimaryKey,
+			Bidi:    false,
+		},
+		"ControlObjective",
+		"Group",
 	)
 	graph.MustAddE(
 		"policy",
@@ -3720,6 +3770,42 @@ var schemaGraph = func() *sqlgraph.Schema {
 		"Risk",
 	)
 	graph.MustAddE(
+		"controlobjective_viewers",
+		&sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   group.ControlobjectiveViewersTable,
+			Columns: group.ControlobjectiveViewersPrimaryKey,
+			Bidi:    false,
+		},
+		"Group",
+		"ControlObjective",
+	)
+	graph.MustAddE(
+		"controlobjective_editors",
+		&sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   group.ControlobjectiveEditorsTable,
+			Columns: group.ControlobjectiveEditorsPrimaryKey,
+			Bidi:    false,
+		},
+		"Group",
+		"ControlObjective",
+	)
+	graph.MustAddE(
+		"controlobjective_blocked_groups",
+		&sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   group.ControlobjectiveBlockedGroupsTable,
+			Columns: group.ControlobjectiveBlockedGroupsPrimaryKey,
+			Bidi:    false,
+		},
+		"Group",
+		"ControlObjective",
+	)
+	graph.MustAddE(
 		"members",
 		&sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.O2M,
@@ -3888,6 +3974,30 @@ var schemaGraph = func() *sqlgraph.Schema {
 		"Organization",
 	)
 	graph.MustAddE(
+		"blocked_groups",
+		&sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   internalpolicy.BlockedGroupsTable,
+			Columns: internalpolicy.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+		},
+		"InternalPolicy",
+		"Group",
+	)
+	graph.MustAddE(
+		"editors",
+		&sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   internalpolicy.EditorsTable,
+			Columns: internalpolicy.EditorsPrimaryKey,
+			Bidi:    false,
+		},
+		"InternalPolicy",
+		"Group",
+	)
+	graph.MustAddE(
 		"controlobjectives",
 		&sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2M,
@@ -3958,30 +4068,6 @@ var schemaGraph = func() *sqlgraph.Schema {
 		},
 		"InternalPolicy",
 		"Program",
-	)
-	graph.MustAddE(
-		"editors",
-		&sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   internalpolicy.EditorsTable,
-			Columns: internalpolicy.EditorsPrimaryKey,
-			Bidi:    false,
-		},
-		"InternalPolicy",
-		"Group",
-	)
-	graph.MustAddE(
-		"blocked_groups",
-		&sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   internalpolicy.BlockedGroupsTable,
-			Columns: internalpolicy.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-		},
-		"InternalPolicy",
-		"Group",
 	)
 	graph.MustAddE(
 		"owner",
@@ -4560,6 +4646,18 @@ var schemaGraph = func() *sqlgraph.Schema {
 		"Risk",
 	)
 	graph.MustAddE(
+		"controlobjectives",
+		&sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   organization.ControlobjectivesTable,
+			Columns: []string{organization.ControlobjectivesColumn},
+			Bidi:    false,
+		},
+		"Organization",
+		"ControlObjective",
+	)
+	graph.MustAddE(
 		"members",
 		&sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.O2M,
@@ -4656,6 +4754,30 @@ var schemaGraph = func() *sqlgraph.Schema {
 		"Organization",
 	)
 	graph.MustAddE(
+		"blocked_groups",
+		&sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   procedure.BlockedGroupsTable,
+			Columns: procedure.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+		},
+		"Procedure",
+		"Group",
+	)
+	graph.MustAddE(
+		"editors",
+		&sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   procedure.EditorsTable,
+			Columns: procedure.EditorsPrimaryKey,
+			Bidi:    false,
+		},
+		"Procedure",
+		"Group",
+	)
+	graph.MustAddE(
 		"control",
 		&sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2M,
@@ -4728,30 +4850,6 @@ var schemaGraph = func() *sqlgraph.Schema {
 		"Program",
 	)
 	graph.MustAddE(
-		"editors",
-		&sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   procedure.EditorsTable,
-			Columns: procedure.EditorsPrimaryKey,
-			Bidi:    false,
-		},
-		"Procedure",
-		"Group",
-	)
-	graph.MustAddE(
-		"blocked_groups",
-		&sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   procedure.BlockedGroupsTable,
-			Columns: procedure.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-		},
-		"Procedure",
-		"Group",
-	)
-	graph.MustAddE(
 		"owner",
 		&sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
@@ -4762,6 +4860,42 @@ var schemaGraph = func() *sqlgraph.Schema {
 		},
 		"Program",
 		"Organization",
+	)
+	graph.MustAddE(
+		"blocked_groups",
+		&sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   program.BlockedGroupsTable,
+			Columns: program.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+		},
+		"Program",
+		"Group",
+	)
+	graph.MustAddE(
+		"editors",
+		&sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   program.EditorsTable,
+			Columns: program.EditorsPrimaryKey,
+			Bidi:    false,
+		},
+		"Program",
+		"Group",
+	)
+	graph.MustAddE(
+		"viewers",
+		&sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   program.ViewersTable,
+			Columns: program.ViewersPrimaryKey,
+			Bidi:    false,
+		},
+		"Program",
+		"Group",
 	)
 	graph.MustAddE(
 		"controls",
@@ -4920,42 +5054,6 @@ var schemaGraph = func() *sqlgraph.Schema {
 		"User",
 	)
 	graph.MustAddE(
-		"viewers",
-		&sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   program.ViewersTable,
-			Columns: program.ViewersPrimaryKey,
-			Bidi:    false,
-		},
-		"Program",
-		"Group",
-	)
-	graph.MustAddE(
-		"editors",
-		&sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   program.EditorsTable,
-			Columns: program.EditorsPrimaryKey,
-			Bidi:    false,
-		},
-		"Program",
-		"Group",
-	)
-	graph.MustAddE(
-		"blocked_groups",
-		&sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   program.BlockedGroupsTable,
-			Columns: program.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-		},
-		"Program",
-		"Group",
-	)
-	graph.MustAddE(
 		"members",
 		&sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.O2M,
@@ -4990,6 +5088,54 @@ var schemaGraph = func() *sqlgraph.Schema {
 		},
 		"ProgramMembership",
 		"User",
+	)
+	graph.MustAddE(
+		"owner",
+		&sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   risk.OwnerTable,
+			Columns: []string{risk.OwnerColumn},
+			Bidi:    false,
+		},
+		"Risk",
+		"Organization",
+	)
+	graph.MustAddE(
+		"blocked_groups",
+		&sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   risk.BlockedGroupsTable,
+			Columns: risk.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+		},
+		"Risk",
+		"Group",
+	)
+	graph.MustAddE(
+		"editors",
+		&sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   risk.EditorsTable,
+			Columns: risk.EditorsPrimaryKey,
+			Bidi:    false,
+		},
+		"Risk",
+		"Group",
+	)
+	graph.MustAddE(
+		"viewers",
+		&sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   risk.ViewersTable,
+			Columns: risk.ViewersPrimaryKey,
+			Bidi:    false,
+		},
+		"Risk",
+		"Group",
 	)
 	graph.MustAddE(
 		"control",
@@ -5028,64 +5174,16 @@ var schemaGraph = func() *sqlgraph.Schema {
 		"ActionPlan",
 	)
 	graph.MustAddE(
-		"owner",
-		&sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: true,
-			Table:   risk.OwnerTable,
-			Columns: []string{risk.OwnerColumn},
-			Bidi:    false,
-		},
-		"Risk",
-		"Organization",
-	)
-	graph.MustAddE(
-		"program",
+		"programs",
 		&sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2M,
 			Inverse: true,
-			Table:   risk.ProgramTable,
-			Columns: risk.ProgramPrimaryKey,
+			Table:   risk.ProgramsTable,
+			Columns: risk.ProgramsPrimaryKey,
 			Bidi:    false,
 		},
 		"Risk",
 		"Program",
-	)
-	graph.MustAddE(
-		"viewers",
-		&sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   risk.ViewersTable,
-			Columns: risk.ViewersPrimaryKey,
-			Bidi:    false,
-		},
-		"Risk",
-		"Group",
-	)
-	graph.MustAddE(
-		"editors",
-		&sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   risk.EditorsTable,
-			Columns: risk.EditorsPrimaryKey,
-			Bidi:    false,
-		},
-		"Risk",
-		"Group",
-	)
-	graph.MustAddE(
-		"blocked_groups",
-		&sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   risk.BlockedGroupsTable,
-			Columns: risk.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-		},
-		"Risk",
-		"Group",
 	)
 	graph.MustAddE(
 		"controlobjectives",
@@ -6962,6 +7060,11 @@ func (f *ControlObjectiveFilter) WhereTags(p entql.BytesP) {
 	f.Where(p.Field(controlobjective.FieldTags))
 }
 
+// WhereOwnerID applies the entql string predicate on the owner_id field.
+func (f *ControlObjectiveFilter) WhereOwnerID(p entql.StringP) {
+	f.Where(p.Field(controlobjective.FieldOwnerID))
+}
+
 // WhereName applies the entql string predicate on the name field.
 func (f *ControlObjectiveFilter) WhereName(p entql.StringP) {
 	f.Where(p.Field(controlobjective.FieldName))
@@ -7015,6 +7118,62 @@ func (f *ControlObjectiveFilter) WhereMappedFrameworks(p entql.StringP) {
 // WhereDetails applies the entql json.RawMessage predicate on the details field.
 func (f *ControlObjectiveFilter) WhereDetails(p entql.BytesP) {
 	f.Where(p.Field(controlobjective.FieldDetails))
+}
+
+// WhereHasOwner applies a predicate to check if query has an edge owner.
+func (f *ControlObjectiveFilter) WhereHasOwner() {
+	f.Where(entql.HasEdge("owner"))
+}
+
+// WhereHasOwnerWith applies a predicate to check if query has an edge owner with a given conditions (other predicates).
+func (f *ControlObjectiveFilter) WhereHasOwnerWith(preds ...predicate.Organization) {
+	f.Where(entql.HasEdgeWith("owner", sqlgraph.WrapFunc(func(s *sql.Selector) {
+		for _, p := range preds {
+			p(s)
+		}
+	})))
+}
+
+// WhereHasBlockedGroups applies a predicate to check if query has an edge blocked_groups.
+func (f *ControlObjectiveFilter) WhereHasBlockedGroups() {
+	f.Where(entql.HasEdge("blocked_groups"))
+}
+
+// WhereHasBlockedGroupsWith applies a predicate to check if query has an edge blocked_groups with a given conditions (other predicates).
+func (f *ControlObjectiveFilter) WhereHasBlockedGroupsWith(preds ...predicate.Group) {
+	f.Where(entql.HasEdgeWith("blocked_groups", sqlgraph.WrapFunc(func(s *sql.Selector) {
+		for _, p := range preds {
+			p(s)
+		}
+	})))
+}
+
+// WhereHasEditors applies a predicate to check if query has an edge editors.
+func (f *ControlObjectiveFilter) WhereHasEditors() {
+	f.Where(entql.HasEdge("editors"))
+}
+
+// WhereHasEditorsWith applies a predicate to check if query has an edge editors with a given conditions (other predicates).
+func (f *ControlObjectiveFilter) WhereHasEditorsWith(preds ...predicate.Group) {
+	f.Where(entql.HasEdgeWith("editors", sqlgraph.WrapFunc(func(s *sql.Selector) {
+		for _, p := range preds {
+			p(s)
+		}
+	})))
+}
+
+// WhereHasViewers applies a predicate to check if query has an edge viewers.
+func (f *ControlObjectiveFilter) WhereHasViewers() {
+	f.Where(entql.HasEdge("viewers"))
+}
+
+// WhereHasViewersWith applies a predicate to check if query has an edge viewers with a given conditions (other predicates).
+func (f *ControlObjectiveFilter) WhereHasViewersWith(preds ...predicate.Group) {
+	f.Where(entql.HasEdgeWith("viewers", sqlgraph.WrapFunc(func(s *sql.Selector) {
+		for _, p := range preds {
+			p(s)
+		}
+	})))
 }
 
 // WhereHasPolicy applies a predicate to check if query has an edge policy.
@@ -7236,6 +7395,11 @@ func (f *ControlObjectiveHistoryFilter) WhereMappingID(p entql.StringP) {
 // WhereTags applies the entql json.RawMessage predicate on the tags field.
 func (f *ControlObjectiveHistoryFilter) WhereTags(p entql.BytesP) {
 	f.Where(p.Field(controlobjectivehistory.FieldTags))
+}
+
+// WhereOwnerID applies the entql string predicate on the owner_id field.
+func (f *ControlObjectiveHistoryFilter) WhereOwnerID(p entql.StringP) {
+	f.Where(p.Field(controlobjectivehistory.FieldOwnerID))
 }
 
 // WhereName applies the entql string predicate on the name field.
@@ -10728,6 +10892,48 @@ func (f *GroupFilter) WhereHasRiskBlockedGroupsWith(preds ...predicate.Risk) {
 	})))
 }
 
+// WhereHasControlobjectiveViewers applies a predicate to check if query has an edge controlobjective_viewers.
+func (f *GroupFilter) WhereHasControlobjectiveViewers() {
+	f.Where(entql.HasEdge("controlobjective_viewers"))
+}
+
+// WhereHasControlobjectiveViewersWith applies a predicate to check if query has an edge controlobjective_viewers with a given conditions (other predicates).
+func (f *GroupFilter) WhereHasControlobjectiveViewersWith(preds ...predicate.ControlObjective) {
+	f.Where(entql.HasEdgeWith("controlobjective_viewers", sqlgraph.WrapFunc(func(s *sql.Selector) {
+		for _, p := range preds {
+			p(s)
+		}
+	})))
+}
+
+// WhereHasControlobjectiveEditors applies a predicate to check if query has an edge controlobjective_editors.
+func (f *GroupFilter) WhereHasControlobjectiveEditors() {
+	f.Where(entql.HasEdge("controlobjective_editors"))
+}
+
+// WhereHasControlobjectiveEditorsWith applies a predicate to check if query has an edge controlobjective_editors with a given conditions (other predicates).
+func (f *GroupFilter) WhereHasControlobjectiveEditorsWith(preds ...predicate.ControlObjective) {
+	f.Where(entql.HasEdgeWith("controlobjective_editors", sqlgraph.WrapFunc(func(s *sql.Selector) {
+		for _, p := range preds {
+			p(s)
+		}
+	})))
+}
+
+// WhereHasControlobjectiveBlockedGroups applies a predicate to check if query has an edge controlobjective_blocked_groups.
+func (f *GroupFilter) WhereHasControlobjectiveBlockedGroups() {
+	f.Where(entql.HasEdge("controlobjective_blocked_groups"))
+}
+
+// WhereHasControlobjectiveBlockedGroupsWith applies a predicate to check if query has an edge controlobjective_blocked_groups with a given conditions (other predicates).
+func (f *GroupFilter) WhereHasControlobjectiveBlockedGroupsWith(preds ...predicate.ControlObjective) {
+	f.Where(entql.HasEdgeWith("controlobjective_blocked_groups", sqlgraph.WrapFunc(func(s *sql.Selector) {
+		for _, p := range preds {
+			p(s)
+		}
+	})))
+}
+
 // WhereHasMembers applies a predicate to check if query has an edge members.
 func (f *GroupFilter) WhereHasMembers() {
 	f.Where(entql.HasEdge("members"))
@@ -12024,6 +12230,34 @@ func (f *InternalPolicyFilter) WhereHasOwnerWith(preds ...predicate.Organization
 	})))
 }
 
+// WhereHasBlockedGroups applies a predicate to check if query has an edge blocked_groups.
+func (f *InternalPolicyFilter) WhereHasBlockedGroups() {
+	f.Where(entql.HasEdge("blocked_groups"))
+}
+
+// WhereHasBlockedGroupsWith applies a predicate to check if query has an edge blocked_groups with a given conditions (other predicates).
+func (f *InternalPolicyFilter) WhereHasBlockedGroupsWith(preds ...predicate.Group) {
+	f.Where(entql.HasEdgeWith("blocked_groups", sqlgraph.WrapFunc(func(s *sql.Selector) {
+		for _, p := range preds {
+			p(s)
+		}
+	})))
+}
+
+// WhereHasEditors applies a predicate to check if query has an edge editors.
+func (f *InternalPolicyFilter) WhereHasEditors() {
+	f.Where(entql.HasEdge("editors"))
+}
+
+// WhereHasEditorsWith applies a predicate to check if query has an edge editors with a given conditions (other predicates).
+func (f *InternalPolicyFilter) WhereHasEditorsWith(preds ...predicate.Group) {
+	f.Where(entql.HasEdgeWith("editors", sqlgraph.WrapFunc(func(s *sql.Selector) {
+		for _, p := range preds {
+			p(s)
+		}
+	})))
+}
+
 // WhereHasControlobjectives applies a predicate to check if query has an edge controlobjectives.
 func (f *InternalPolicyFilter) WhereHasControlobjectives() {
 	f.Where(entql.HasEdge("controlobjectives"))
@@ -12102,34 +12336,6 @@ func (f *InternalPolicyFilter) WhereHasPrograms() {
 // WhereHasProgramsWith applies a predicate to check if query has an edge programs with a given conditions (other predicates).
 func (f *InternalPolicyFilter) WhereHasProgramsWith(preds ...predicate.Program) {
 	f.Where(entql.HasEdgeWith("programs", sqlgraph.WrapFunc(func(s *sql.Selector) {
-		for _, p := range preds {
-			p(s)
-		}
-	})))
-}
-
-// WhereHasEditors applies a predicate to check if query has an edge editors.
-func (f *InternalPolicyFilter) WhereHasEditors() {
-	f.Where(entql.HasEdge("editors"))
-}
-
-// WhereHasEditorsWith applies a predicate to check if query has an edge editors with a given conditions (other predicates).
-func (f *InternalPolicyFilter) WhereHasEditorsWith(preds ...predicate.Group) {
-	f.Where(entql.HasEdgeWith("editors", sqlgraph.WrapFunc(func(s *sql.Selector) {
-		for _, p := range preds {
-			p(s)
-		}
-	})))
-}
-
-// WhereHasBlockedGroups applies a predicate to check if query has an edge blocked_groups.
-func (f *InternalPolicyFilter) WhereHasBlockedGroups() {
-	f.Where(entql.HasEdge("blocked_groups"))
-}
-
-// WhereHasBlockedGroupsWith applies a predicate to check if query has an edge blocked_groups with a given conditions (other predicates).
-func (f *InternalPolicyFilter) WhereHasBlockedGroupsWith(preds ...predicate.Group) {
-	f.Where(entql.HasEdgeWith("blocked_groups", sqlgraph.WrapFunc(func(s *sql.Selector) {
 		for _, p := range preds {
 			p(s)
 		}
@@ -14173,6 +14379,20 @@ func (f *OrganizationFilter) WhereHasRisksWith(preds ...predicate.Risk) {
 	})))
 }
 
+// WhereHasControlobjectives applies a predicate to check if query has an edge controlobjectives.
+func (f *OrganizationFilter) WhereHasControlobjectives() {
+	f.Where(entql.HasEdge("controlobjectives"))
+}
+
+// WhereHasControlobjectivesWith applies a predicate to check if query has an edge controlobjectives with a given conditions (other predicates).
+func (f *OrganizationFilter) WhereHasControlobjectivesWith(preds ...predicate.ControlObjective) {
+	f.Where(entql.HasEdgeWith("controlobjectives", sqlgraph.WrapFunc(func(s *sql.Selector) {
+		for _, p := range preds {
+			p(s)
+		}
+	})))
+}
+
 // WhereHasMembers applies a predicate to check if query has an edge members.
 func (f *OrganizationFilter) WhereHasMembers() {
 	f.Where(entql.HasEdge("members"))
@@ -15025,6 +15245,34 @@ func (f *ProcedureFilter) WhereHasOwnerWith(preds ...predicate.Organization) {
 	})))
 }
 
+// WhereHasBlockedGroups applies a predicate to check if query has an edge blocked_groups.
+func (f *ProcedureFilter) WhereHasBlockedGroups() {
+	f.Where(entql.HasEdge("blocked_groups"))
+}
+
+// WhereHasBlockedGroupsWith applies a predicate to check if query has an edge blocked_groups with a given conditions (other predicates).
+func (f *ProcedureFilter) WhereHasBlockedGroupsWith(preds ...predicate.Group) {
+	f.Where(entql.HasEdgeWith("blocked_groups", sqlgraph.WrapFunc(func(s *sql.Selector) {
+		for _, p := range preds {
+			p(s)
+		}
+	})))
+}
+
+// WhereHasEditors applies a predicate to check if query has an edge editors.
+func (f *ProcedureFilter) WhereHasEditors() {
+	f.Where(entql.HasEdge("editors"))
+}
+
+// WhereHasEditorsWith applies a predicate to check if query has an edge editors with a given conditions (other predicates).
+func (f *ProcedureFilter) WhereHasEditorsWith(preds ...predicate.Group) {
+	f.Where(entql.HasEdgeWith("editors", sqlgraph.WrapFunc(func(s *sql.Selector) {
+		for _, p := range preds {
+			p(s)
+		}
+	})))
+}
+
 // WhereHasControl applies a predicate to check if query has an edge control.
 func (f *ProcedureFilter) WhereHasControl() {
 	f.Where(entql.HasEdge("control"))
@@ -15103,34 +15351,6 @@ func (f *ProcedureFilter) WhereHasPrograms() {
 // WhereHasProgramsWith applies a predicate to check if query has an edge programs with a given conditions (other predicates).
 func (f *ProcedureFilter) WhereHasProgramsWith(preds ...predicate.Program) {
 	f.Where(entql.HasEdgeWith("programs", sqlgraph.WrapFunc(func(s *sql.Selector) {
-		for _, p := range preds {
-			p(s)
-		}
-	})))
-}
-
-// WhereHasEditors applies a predicate to check if query has an edge editors.
-func (f *ProcedureFilter) WhereHasEditors() {
-	f.Where(entql.HasEdge("editors"))
-}
-
-// WhereHasEditorsWith applies a predicate to check if query has an edge editors with a given conditions (other predicates).
-func (f *ProcedureFilter) WhereHasEditorsWith(preds ...predicate.Group) {
-	f.Where(entql.HasEdgeWith("editors", sqlgraph.WrapFunc(func(s *sql.Selector) {
-		for _, p := range preds {
-			p(s)
-		}
-	})))
-}
-
-// WhereHasBlockedGroups applies a predicate to check if query has an edge blocked_groups.
-func (f *ProcedureFilter) WhereHasBlockedGroups() {
-	f.Where(entql.HasEdge("blocked_groups"))
-}
-
-// WhereHasBlockedGroupsWith applies a predicate to check if query has an edge blocked_groups with a given conditions (other predicates).
-func (f *ProcedureFilter) WhereHasBlockedGroupsWith(preds ...predicate.Group) {
-	f.Where(entql.HasEdgeWith("blocked_groups", sqlgraph.WrapFunc(func(s *sql.Selector) {
 		for _, p := range preds {
 			p(s)
 		}
@@ -15421,6 +15641,48 @@ func (f *ProgramFilter) WhereHasOwnerWith(preds ...predicate.Organization) {
 	})))
 }
 
+// WhereHasBlockedGroups applies a predicate to check if query has an edge blocked_groups.
+func (f *ProgramFilter) WhereHasBlockedGroups() {
+	f.Where(entql.HasEdge("blocked_groups"))
+}
+
+// WhereHasBlockedGroupsWith applies a predicate to check if query has an edge blocked_groups with a given conditions (other predicates).
+func (f *ProgramFilter) WhereHasBlockedGroupsWith(preds ...predicate.Group) {
+	f.Where(entql.HasEdgeWith("blocked_groups", sqlgraph.WrapFunc(func(s *sql.Selector) {
+		for _, p := range preds {
+			p(s)
+		}
+	})))
+}
+
+// WhereHasEditors applies a predicate to check if query has an edge editors.
+func (f *ProgramFilter) WhereHasEditors() {
+	f.Where(entql.HasEdge("editors"))
+}
+
+// WhereHasEditorsWith applies a predicate to check if query has an edge editors with a given conditions (other predicates).
+func (f *ProgramFilter) WhereHasEditorsWith(preds ...predicate.Group) {
+	f.Where(entql.HasEdgeWith("editors", sqlgraph.WrapFunc(func(s *sql.Selector) {
+		for _, p := range preds {
+			p(s)
+		}
+	})))
+}
+
+// WhereHasViewers applies a predicate to check if query has an edge viewers.
+func (f *ProgramFilter) WhereHasViewers() {
+	f.Where(entql.HasEdge("viewers"))
+}
+
+// WhereHasViewersWith applies a predicate to check if query has an edge viewers with a given conditions (other predicates).
+func (f *ProgramFilter) WhereHasViewersWith(preds ...predicate.Group) {
+	f.Where(entql.HasEdgeWith("viewers", sqlgraph.WrapFunc(func(s *sql.Selector) {
+		for _, p := range preds {
+			p(s)
+		}
+	})))
+}
+
 // WhereHasControls applies a predicate to check if query has an edge controls.
 func (f *ProgramFilter) WhereHasControls() {
 	f.Where(entql.HasEdge("controls"))
@@ -15597,48 +15859,6 @@ func (f *ProgramFilter) WhereHasUsers() {
 // WhereHasUsersWith applies a predicate to check if query has an edge users with a given conditions (other predicates).
 func (f *ProgramFilter) WhereHasUsersWith(preds ...predicate.User) {
 	f.Where(entql.HasEdgeWith("users", sqlgraph.WrapFunc(func(s *sql.Selector) {
-		for _, p := range preds {
-			p(s)
-		}
-	})))
-}
-
-// WhereHasViewers applies a predicate to check if query has an edge viewers.
-func (f *ProgramFilter) WhereHasViewers() {
-	f.Where(entql.HasEdge("viewers"))
-}
-
-// WhereHasViewersWith applies a predicate to check if query has an edge viewers with a given conditions (other predicates).
-func (f *ProgramFilter) WhereHasViewersWith(preds ...predicate.Group) {
-	f.Where(entql.HasEdgeWith("viewers", sqlgraph.WrapFunc(func(s *sql.Selector) {
-		for _, p := range preds {
-			p(s)
-		}
-	})))
-}
-
-// WhereHasEditors applies a predicate to check if query has an edge editors.
-func (f *ProgramFilter) WhereHasEditors() {
-	f.Where(entql.HasEdge("editors"))
-}
-
-// WhereHasEditorsWith applies a predicate to check if query has an edge editors with a given conditions (other predicates).
-func (f *ProgramFilter) WhereHasEditorsWith(preds ...predicate.Group) {
-	f.Where(entql.HasEdgeWith("editors", sqlgraph.WrapFunc(func(s *sql.Selector) {
-		for _, p := range preds {
-			p(s)
-		}
-	})))
-}
-
-// WhereHasBlockedGroups applies a predicate to check if query has an edge blocked_groups.
-func (f *ProgramFilter) WhereHasBlockedGroups() {
-	f.Where(entql.HasEdge("blocked_groups"))
-}
-
-// WhereHasBlockedGroupsWith applies a predicate to check if query has an edge blocked_groups with a given conditions (other predicates).
-func (f *ProgramFilter) WhereHasBlockedGroupsWith(preds ...predicate.Group) {
-	f.Where(entql.HasEdgeWith("blocked_groups", sqlgraph.WrapFunc(func(s *sql.Selector) {
 		for _, p := range preds {
 			p(s)
 		}
@@ -16102,6 +16322,11 @@ func (f *RiskFilter) WhereTags(p entql.BytesP) {
 	f.Where(p.Field(risk.FieldTags))
 }
 
+// WhereOwnerID applies the entql string predicate on the owner_id field.
+func (f *RiskFilter) WhereOwnerID(p entql.StringP) {
+	f.Where(p.Field(risk.FieldOwnerID))
+}
+
 // WhereName applies the entql string predicate on the name field.
 func (f *RiskFilter) WhereName(p entql.StringP) {
 	f.Where(p.Field(risk.FieldName))
@@ -16152,9 +16377,60 @@ func (f *RiskFilter) WhereDetails(p entql.BytesP) {
 	f.Where(p.Field(risk.FieldDetails))
 }
 
-// WhereOwnerID applies the entql string predicate on the owner_id field.
-func (f *RiskFilter) WhereOwnerID(p entql.StringP) {
-	f.Where(p.Field(risk.FieldOwnerID))
+// WhereHasOwner applies a predicate to check if query has an edge owner.
+func (f *RiskFilter) WhereHasOwner() {
+	f.Where(entql.HasEdge("owner"))
+}
+
+// WhereHasOwnerWith applies a predicate to check if query has an edge owner with a given conditions (other predicates).
+func (f *RiskFilter) WhereHasOwnerWith(preds ...predicate.Organization) {
+	f.Where(entql.HasEdgeWith("owner", sqlgraph.WrapFunc(func(s *sql.Selector) {
+		for _, p := range preds {
+			p(s)
+		}
+	})))
+}
+
+// WhereHasBlockedGroups applies a predicate to check if query has an edge blocked_groups.
+func (f *RiskFilter) WhereHasBlockedGroups() {
+	f.Where(entql.HasEdge("blocked_groups"))
+}
+
+// WhereHasBlockedGroupsWith applies a predicate to check if query has an edge blocked_groups with a given conditions (other predicates).
+func (f *RiskFilter) WhereHasBlockedGroupsWith(preds ...predicate.Group) {
+	f.Where(entql.HasEdgeWith("blocked_groups", sqlgraph.WrapFunc(func(s *sql.Selector) {
+		for _, p := range preds {
+			p(s)
+		}
+	})))
+}
+
+// WhereHasEditors applies a predicate to check if query has an edge editors.
+func (f *RiskFilter) WhereHasEditors() {
+	f.Where(entql.HasEdge("editors"))
+}
+
+// WhereHasEditorsWith applies a predicate to check if query has an edge editors with a given conditions (other predicates).
+func (f *RiskFilter) WhereHasEditorsWith(preds ...predicate.Group) {
+	f.Where(entql.HasEdgeWith("editors", sqlgraph.WrapFunc(func(s *sql.Selector) {
+		for _, p := range preds {
+			p(s)
+		}
+	})))
+}
+
+// WhereHasViewers applies a predicate to check if query has an edge viewers.
+func (f *RiskFilter) WhereHasViewers() {
+	f.Where(entql.HasEdge("viewers"))
+}
+
+// WhereHasViewersWith applies a predicate to check if query has an edge viewers with a given conditions (other predicates).
+func (f *RiskFilter) WhereHasViewersWith(preds ...predicate.Group) {
+	f.Where(entql.HasEdgeWith("viewers", sqlgraph.WrapFunc(func(s *sql.Selector) {
+		for _, p := range preds {
+			p(s)
+		}
+	})))
 }
 
 // WhereHasControl applies a predicate to check if query has an edge control.
@@ -16199,70 +16475,14 @@ func (f *RiskFilter) WhereHasActionplansWith(preds ...predicate.ActionPlan) {
 	})))
 }
 
-// WhereHasOwner applies a predicate to check if query has an edge owner.
-func (f *RiskFilter) WhereHasOwner() {
-	f.Where(entql.HasEdge("owner"))
+// WhereHasPrograms applies a predicate to check if query has an edge programs.
+func (f *RiskFilter) WhereHasPrograms() {
+	f.Where(entql.HasEdge("programs"))
 }
 
-// WhereHasOwnerWith applies a predicate to check if query has an edge owner with a given conditions (other predicates).
-func (f *RiskFilter) WhereHasOwnerWith(preds ...predicate.Organization) {
-	f.Where(entql.HasEdgeWith("owner", sqlgraph.WrapFunc(func(s *sql.Selector) {
-		for _, p := range preds {
-			p(s)
-		}
-	})))
-}
-
-// WhereHasProgram applies a predicate to check if query has an edge program.
-func (f *RiskFilter) WhereHasProgram() {
-	f.Where(entql.HasEdge("program"))
-}
-
-// WhereHasProgramWith applies a predicate to check if query has an edge program with a given conditions (other predicates).
-func (f *RiskFilter) WhereHasProgramWith(preds ...predicate.Program) {
-	f.Where(entql.HasEdgeWith("program", sqlgraph.WrapFunc(func(s *sql.Selector) {
-		for _, p := range preds {
-			p(s)
-		}
-	})))
-}
-
-// WhereHasViewers applies a predicate to check if query has an edge viewers.
-func (f *RiskFilter) WhereHasViewers() {
-	f.Where(entql.HasEdge("viewers"))
-}
-
-// WhereHasViewersWith applies a predicate to check if query has an edge viewers with a given conditions (other predicates).
-func (f *RiskFilter) WhereHasViewersWith(preds ...predicate.Group) {
-	f.Where(entql.HasEdgeWith("viewers", sqlgraph.WrapFunc(func(s *sql.Selector) {
-		for _, p := range preds {
-			p(s)
-		}
-	})))
-}
-
-// WhereHasEditors applies a predicate to check if query has an edge editors.
-func (f *RiskFilter) WhereHasEditors() {
-	f.Where(entql.HasEdge("editors"))
-}
-
-// WhereHasEditorsWith applies a predicate to check if query has an edge editors with a given conditions (other predicates).
-func (f *RiskFilter) WhereHasEditorsWith(preds ...predicate.Group) {
-	f.Where(entql.HasEdgeWith("editors", sqlgraph.WrapFunc(func(s *sql.Selector) {
-		for _, p := range preds {
-			p(s)
-		}
-	})))
-}
-
-// WhereHasBlockedGroups applies a predicate to check if query has an edge blocked_groups.
-func (f *RiskFilter) WhereHasBlockedGroups() {
-	f.Where(entql.HasEdge("blocked_groups"))
-}
-
-// WhereHasBlockedGroupsWith applies a predicate to check if query has an edge blocked_groups with a given conditions (other predicates).
-func (f *RiskFilter) WhereHasBlockedGroupsWith(preds ...predicate.Group) {
-	f.Where(entql.HasEdgeWith("blocked_groups", sqlgraph.WrapFunc(func(s *sql.Selector) {
+// WhereHasProgramsWith applies a predicate to check if query has an edge programs with a given conditions (other predicates).
+func (f *RiskFilter) WhereHasProgramsWith(preds ...predicate.Program) {
+	f.Where(entql.HasEdgeWith("programs", sqlgraph.WrapFunc(func(s *sql.Selector) {
 		for _, p := range preds {
 			p(s)
 		}
@@ -16364,6 +16584,11 @@ func (f *RiskHistoryFilter) WhereTags(p entql.BytesP) {
 	f.Where(p.Field(riskhistory.FieldTags))
 }
 
+// WhereOwnerID applies the entql string predicate on the owner_id field.
+func (f *RiskHistoryFilter) WhereOwnerID(p entql.StringP) {
+	f.Where(p.Field(riskhistory.FieldOwnerID))
+}
+
 // WhereName applies the entql string predicate on the name field.
 func (f *RiskHistoryFilter) WhereName(p entql.StringP) {
 	f.Where(p.Field(riskhistory.FieldName))
@@ -16412,11 +16637,6 @@ func (f *RiskHistoryFilter) WhereSatisfies(p entql.StringP) {
 // WhereDetails applies the entql json.RawMessage predicate on the details field.
 func (f *RiskHistoryFilter) WhereDetails(p entql.BytesP) {
 	f.Where(p.Field(riskhistory.FieldDetails))
-}
-
-// WhereOwnerID applies the entql string predicate on the owner_id field.
-func (f *RiskHistoryFilter) WhereOwnerID(p entql.StringP) {
-	f.Where(p.Field(riskhistory.FieldOwnerID))
 }
 
 // addPredicate implements the predicateAdder interface.

--- a/internal/ent/generated/gql_collection.go
+++ b/internal/ent/generated/gql_collection.go
@@ -1379,6 +1379,60 @@ func (co *ControlObjectiveQuery) collectField(ctx context.Context, oneNode bool,
 	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
 		switch field.Name {
 
+		case "owner":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&OrganizationClient{config: co.config}).Query()
+			)
+			if err := query.collectField(ctx, oneNode, opCtx, field, path, mayAddCondition(satisfies, organizationImplementors)...); err != nil {
+				return err
+			}
+			co.withOwner = query
+			if _, ok := fieldSeen[controlobjective.FieldOwnerID]; !ok {
+				selectedFields = append(selectedFields, controlobjective.FieldOwnerID)
+				fieldSeen[controlobjective.FieldOwnerID] = struct{}{}
+			}
+
+		case "blockedGroups":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&GroupClient{config: co.config}).Query()
+			)
+			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, groupImplementors)...); err != nil {
+				return err
+			}
+			co.WithNamedBlockedGroups(alias, func(wq *GroupQuery) {
+				*wq = *query
+			})
+
+		case "editors":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&GroupClient{config: co.config}).Query()
+			)
+			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, groupImplementors)...); err != nil {
+				return err
+			}
+			co.WithNamedEditors(alias, func(wq *GroupQuery) {
+				*wq = *query
+			})
+
+		case "viewers":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&GroupClient{config: co.config}).Query()
+			)
+			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, groupImplementors)...); err != nil {
+				return err
+			}
+			co.WithNamedViewers(alias, func(wq *GroupQuery) {
+				*wq = *query
+			})
+
 		case "policy":
 			var (
 				alias = field.Alias
@@ -1529,6 +1583,11 @@ func (co *ControlObjectiveQuery) collectField(ctx context.Context, oneNode bool,
 			if _, ok := fieldSeen[controlobjective.FieldTags]; !ok {
 				selectedFields = append(selectedFields, controlobjective.FieldTags)
 				fieldSeen[controlobjective.FieldTags] = struct{}{}
+			}
+		case "ownerID":
+			if _, ok := fieldSeen[controlobjective.FieldOwnerID]; !ok {
+				selectedFields = append(selectedFields, controlobjective.FieldOwnerID)
+				fieldSeen[controlobjective.FieldOwnerID] = struct{}{}
 			}
 		case "name":
 			if _, ok := fieldSeen[controlobjective.FieldName]; !ok {
@@ -1696,6 +1755,11 @@ func (coh *ControlObjectiveHistoryQuery) collectField(ctx context.Context, oneNo
 			if _, ok := fieldSeen[controlobjectivehistory.FieldTags]; !ok {
 				selectedFields = append(selectedFields, controlobjectivehistory.FieldTags)
 				fieldSeen[controlobjectivehistory.FieldTags] = struct{}{}
+			}
+		case "ownerID":
+			if _, ok := fieldSeen[controlobjectivehistory.FieldOwnerID]; !ok {
+				selectedFields = append(selectedFields, controlobjectivehistory.FieldOwnerID)
+				fieldSeen[controlobjectivehistory.FieldOwnerID] = struct{}{}
 			}
 		case "name":
 			if _, ok := fieldSeen[controlobjectivehistory.FieldName]; !ok {
@@ -5362,6 +5426,45 @@ func (gr *GroupQuery) collectField(ctx context.Context, oneNode bool, opCtx *gra
 				*wq = *query
 			})
 
+		case "controlobjectiveViewers":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&ControlObjectiveClient{config: gr.config}).Query()
+			)
+			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, controlobjectiveImplementors)...); err != nil {
+				return err
+			}
+			gr.WithNamedControlobjectiveViewers(alias, func(wq *ControlObjectiveQuery) {
+				*wq = *query
+			})
+
+		case "controlobjectiveEditors":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&ControlObjectiveClient{config: gr.config}).Query()
+			)
+			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, controlobjectiveImplementors)...); err != nil {
+				return err
+			}
+			gr.WithNamedControlobjectiveEditors(alias, func(wq *ControlObjectiveQuery) {
+				*wq = *query
+			})
+
+		case "controlobjectiveBlockedGroups":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&ControlObjectiveClient{config: gr.config}).Query()
+			)
+			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, controlobjectiveImplementors)...); err != nil {
+				return err
+			}
+			gr.WithNamedControlobjectiveBlockedGroups(alias, func(wq *ControlObjectiveQuery) {
+				*wq = *query
+			})
+
 		case "members":
 			var (
 				alias = field.Alias
@@ -6931,6 +7034,32 @@ func (ip *InternalPolicyQuery) collectField(ctx context.Context, oneNode bool, o
 				fieldSeen[internalpolicy.FieldOwnerID] = struct{}{}
 			}
 
+		case "blockedGroups":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&GroupClient{config: ip.config}).Query()
+			)
+			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, groupImplementors)...); err != nil {
+				return err
+			}
+			ip.WithNamedBlockedGroups(alias, func(wq *GroupQuery) {
+				*wq = *query
+			})
+
+		case "editors":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&GroupClient{config: ip.config}).Query()
+			)
+			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, groupImplementors)...); err != nil {
+				return err
+			}
+			ip.WithNamedEditors(alias, func(wq *GroupQuery) {
+				*wq = *query
+			})
+
 		case "controlobjectives":
 			var (
 				alias = field.Alias
@@ -7006,32 +7135,6 @@ func (ip *InternalPolicyQuery) collectField(ctx context.Context, oneNode bool, o
 				return err
 			}
 			ip.WithNamedPrograms(alias, func(wq *ProgramQuery) {
-				*wq = *query
-			})
-
-		case "editors":
-			var (
-				alias = field.Alias
-				path  = append(path, alias)
-				query = (&GroupClient{config: ip.config}).Query()
-			)
-			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, groupImplementors)...); err != nil {
-				return err
-			}
-			ip.WithNamedEditors(alias, func(wq *GroupQuery) {
-				*wq = *query
-			})
-
-		case "blockedGroups":
-			var (
-				alias = field.Alias
-				path  = append(path, alias)
-				query = (&GroupClient{config: ip.config}).Query()
-			)
-			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, groupImplementors)...); err != nil {
-				return err
-			}
-			ip.WithNamedBlockedGroups(alias, func(wq *GroupQuery) {
 				*wq = *query
 			})
 		case "createdAt":
@@ -9312,6 +9415,19 @@ func (o *OrganizationQuery) collectField(ctx context.Context, oneNode bool, opCt
 				*wq = *query
 			})
 
+		case "controlobjectives":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&ControlObjectiveClient{config: o.config}).Query()
+			)
+			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, controlobjectiveImplementors)...); err != nil {
+				return err
+			}
+			o.WithNamedControlobjectives(alias, func(wq *ControlObjectiveQuery) {
+				*wq = *query
+			})
+
 		case "members":
 			var (
 				alias = field.Alias
@@ -10148,6 +10264,32 @@ func (pr *ProcedureQuery) collectField(ctx context.Context, oneNode bool, opCtx 
 				fieldSeen[procedure.FieldOwnerID] = struct{}{}
 			}
 
+		case "blockedGroups":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&GroupClient{config: pr.config}).Query()
+			)
+			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, groupImplementors)...); err != nil {
+				return err
+			}
+			pr.WithNamedBlockedGroups(alias, func(wq *GroupQuery) {
+				*wq = *query
+			})
+
+		case "editors":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&GroupClient{config: pr.config}).Query()
+			)
+			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, groupImplementors)...); err != nil {
+				return err
+			}
+			pr.WithNamedEditors(alias, func(wq *GroupQuery) {
+				*wq = *query
+			})
+
 		case "control":
 			var (
 				alias = field.Alias
@@ -10223,32 +10365,6 @@ func (pr *ProcedureQuery) collectField(ctx context.Context, oneNode bool, opCtx 
 				return err
 			}
 			pr.WithNamedPrograms(alias, func(wq *ProgramQuery) {
-				*wq = *query
-			})
-
-		case "editors":
-			var (
-				alias = field.Alias
-				path  = append(path, alias)
-				query = (&GroupClient{config: pr.config}).Query()
-			)
-			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, groupImplementors)...); err != nil {
-				return err
-			}
-			pr.WithNamedEditors(alias, func(wq *GroupQuery) {
-				*wq = *query
-			})
-
-		case "blockedGroups":
-			var (
-				alias = field.Alias
-				path  = append(path, alias)
-				query = (&GroupClient{config: pr.config}).Query()
-			)
-			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, groupImplementors)...); err != nil {
-				return err
-			}
-			pr.WithNamedBlockedGroups(alias, func(wq *GroupQuery) {
 				*wq = *query
 			})
 		case "createdAt":
@@ -10576,6 +10692,45 @@ func (pr *ProgramQuery) collectField(ctx context.Context, oneNode bool, opCtx *g
 				fieldSeen[program.FieldOwnerID] = struct{}{}
 			}
 
+		case "blockedGroups":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&GroupClient{config: pr.config}).Query()
+			)
+			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, groupImplementors)...); err != nil {
+				return err
+			}
+			pr.WithNamedBlockedGroups(alias, func(wq *GroupQuery) {
+				*wq = *query
+			})
+
+		case "editors":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&GroupClient{config: pr.config}).Query()
+			)
+			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, groupImplementors)...); err != nil {
+				return err
+			}
+			pr.WithNamedEditors(alias, func(wq *GroupQuery) {
+				*wq = *query
+			})
+
+		case "viewers":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&GroupClient{config: pr.config}).Query()
+			)
+			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, groupImplementors)...); err != nil {
+				return err
+			}
+			pr.WithNamedViewers(alias, func(wq *GroupQuery) {
+				*wq = *query
+			})
+
 		case "controls":
 			var (
 				alias = field.Alias
@@ -10742,45 +10897,6 @@ func (pr *ProgramQuery) collectField(ctx context.Context, oneNode bool, opCtx *g
 				return err
 			}
 			pr.WithNamedUsers(alias, func(wq *UserQuery) {
-				*wq = *query
-			})
-
-		case "viewers":
-			var (
-				alias = field.Alias
-				path  = append(path, alias)
-				query = (&GroupClient{config: pr.config}).Query()
-			)
-			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, groupImplementors)...); err != nil {
-				return err
-			}
-			pr.WithNamedViewers(alias, func(wq *GroupQuery) {
-				*wq = *query
-			})
-
-		case "editors":
-			var (
-				alias = field.Alias
-				path  = append(path, alias)
-				query = (&GroupClient{config: pr.config}).Query()
-			)
-			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, groupImplementors)...); err != nil {
-				return err
-			}
-			pr.WithNamedEditors(alias, func(wq *GroupQuery) {
-				*wq = *query
-			})
-
-		case "blockedGroups":
-			var (
-				alias = field.Alias
-				path  = append(path, alias)
-				query = (&GroupClient{config: pr.config}).Query()
-			)
-			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, groupImplementors)...); err != nil {
-				return err
-			}
-			pr.WithNamedBlockedGroups(alias, func(wq *GroupQuery) {
 				*wq = *query
 			})
 
@@ -11355,6 +11471,60 @@ func (r *RiskQuery) collectField(ctx context.Context, oneNode bool, opCtx *graph
 	for _, field := range graphql.CollectFields(opCtx, collected.Selections, satisfies) {
 		switch field.Name {
 
+		case "owner":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&OrganizationClient{config: r.config}).Query()
+			)
+			if err := query.collectField(ctx, oneNode, opCtx, field, path, mayAddCondition(satisfies, organizationImplementors)...); err != nil {
+				return err
+			}
+			r.withOwner = query
+			if _, ok := fieldSeen[risk.FieldOwnerID]; !ok {
+				selectedFields = append(selectedFields, risk.FieldOwnerID)
+				fieldSeen[risk.FieldOwnerID] = struct{}{}
+			}
+
+		case "blockedGroups":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&GroupClient{config: r.config}).Query()
+			)
+			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, groupImplementors)...); err != nil {
+				return err
+			}
+			r.WithNamedBlockedGroups(alias, func(wq *GroupQuery) {
+				*wq = *query
+			})
+
+		case "editors":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&GroupClient{config: r.config}).Query()
+			)
+			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, groupImplementors)...); err != nil {
+				return err
+			}
+			r.WithNamedEditors(alias, func(wq *GroupQuery) {
+				*wq = *query
+			})
+
+		case "viewers":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&GroupClient{config: r.config}).Query()
+			)
+			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, groupImplementors)...); err != nil {
+				return err
+			}
+			r.WithNamedViewers(alias, func(wq *GroupQuery) {
+				*wq = *query
+			})
+
 		case "control":
 			var (
 				alias = field.Alias
@@ -11394,22 +11564,7 @@ func (r *RiskQuery) collectField(ctx context.Context, oneNode bool, opCtx *graph
 				*wq = *query
 			})
 
-		case "owner":
-			var (
-				alias = field.Alias
-				path  = append(path, alias)
-				query = (&OrganizationClient{config: r.config}).Query()
-			)
-			if err := query.collectField(ctx, oneNode, opCtx, field, path, mayAddCondition(satisfies, organizationImplementors)...); err != nil {
-				return err
-			}
-			r.withOwner = query
-			if _, ok := fieldSeen[risk.FieldOwnerID]; !ok {
-				selectedFields = append(selectedFields, risk.FieldOwnerID)
-				fieldSeen[risk.FieldOwnerID] = struct{}{}
-			}
-
-		case "program":
+		case "programs":
 			var (
 				alias = field.Alias
 				path  = append(path, alias)
@@ -11418,46 +11573,7 @@ func (r *RiskQuery) collectField(ctx context.Context, oneNode bool, opCtx *graph
 			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, programImplementors)...); err != nil {
 				return err
 			}
-			r.WithNamedProgram(alias, func(wq *ProgramQuery) {
-				*wq = *query
-			})
-
-		case "viewers":
-			var (
-				alias = field.Alias
-				path  = append(path, alias)
-				query = (&GroupClient{config: r.config}).Query()
-			)
-			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, groupImplementors)...); err != nil {
-				return err
-			}
-			r.WithNamedViewers(alias, func(wq *GroupQuery) {
-				*wq = *query
-			})
-
-		case "editors":
-			var (
-				alias = field.Alias
-				path  = append(path, alias)
-				query = (&GroupClient{config: r.config}).Query()
-			)
-			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, groupImplementors)...); err != nil {
-				return err
-			}
-			r.WithNamedEditors(alias, func(wq *GroupQuery) {
-				*wq = *query
-			})
-
-		case "blockedGroups":
-			var (
-				alias = field.Alias
-				path  = append(path, alias)
-				query = (&GroupClient{config: r.config}).Query()
-			)
-			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, groupImplementors)...); err != nil {
-				return err
-			}
-			r.WithNamedBlockedGroups(alias, func(wq *GroupQuery) {
+			r.WithNamedPrograms(alias, func(wq *ProgramQuery) {
 				*wq = *query
 			})
 		case "createdAt":
@@ -11494,6 +11610,11 @@ func (r *RiskQuery) collectField(ctx context.Context, oneNode bool, opCtx *graph
 			if _, ok := fieldSeen[risk.FieldTags]; !ok {
 				selectedFields = append(selectedFields, risk.FieldTags)
 				fieldSeen[risk.FieldTags] = struct{}{}
+			}
+		case "ownerID":
+			if _, ok := fieldSeen[risk.FieldOwnerID]; !ok {
+				selectedFields = append(selectedFields, risk.FieldOwnerID)
+				fieldSeen[risk.FieldOwnerID] = struct{}{}
 			}
 		case "name":
 			if _, ok := fieldSeen[risk.FieldName]; !ok {
@@ -11544,11 +11665,6 @@ func (r *RiskQuery) collectField(ctx context.Context, oneNode bool, opCtx *graph
 			if _, ok := fieldSeen[risk.FieldDetails]; !ok {
 				selectedFields = append(selectedFields, risk.FieldDetails)
 				fieldSeen[risk.FieldDetails] = struct{}{}
-			}
-		case "ownerID":
-			if _, ok := fieldSeen[risk.FieldOwnerID]; !ok {
-				selectedFields = append(selectedFields, risk.FieldOwnerID)
-				fieldSeen[risk.FieldOwnerID] = struct{}{}
 			}
 		case "id":
 		case "__typename":
@@ -11662,6 +11778,11 @@ func (rh *RiskHistoryQuery) collectField(ctx context.Context, oneNode bool, opCt
 				selectedFields = append(selectedFields, riskhistory.FieldTags)
 				fieldSeen[riskhistory.FieldTags] = struct{}{}
 			}
+		case "ownerID":
+			if _, ok := fieldSeen[riskhistory.FieldOwnerID]; !ok {
+				selectedFields = append(selectedFields, riskhistory.FieldOwnerID)
+				fieldSeen[riskhistory.FieldOwnerID] = struct{}{}
+			}
 		case "name":
 			if _, ok := fieldSeen[riskhistory.FieldName]; !ok {
 				selectedFields = append(selectedFields, riskhistory.FieldName)
@@ -11711,11 +11832,6 @@ func (rh *RiskHistoryQuery) collectField(ctx context.Context, oneNode bool, opCt
 			if _, ok := fieldSeen[riskhistory.FieldDetails]; !ok {
 				selectedFields = append(selectedFields, riskhistory.FieldDetails)
 				fieldSeen[riskhistory.FieldDetails] = struct{}{}
-			}
-		case "ownerID":
-			if _, ok := fieldSeen[riskhistory.FieldOwnerID]; !ok {
-				selectedFields = append(selectedFields, riskhistory.FieldOwnerID)
-				fieldSeen[riskhistory.FieldOwnerID] = struct{}{}
 			}
 		case "id":
 		case "__typename":

--- a/internal/ent/generated/gql_edge.go
+++ b/internal/ent/generated/gql_edge.go
@@ -216,6 +216,50 @@ func (c *Control) Programs(ctx context.Context) (result []*Program, err error) {
 	return result, err
 }
 
+func (co *ControlObjective) Owner(ctx context.Context) (*Organization, error) {
+	result, err := co.Edges.OwnerOrErr()
+	if IsNotLoaded(err) {
+		result, err = co.QueryOwner().Only(ctx)
+	}
+	return result, err
+}
+
+func (co *ControlObjective) BlockedGroups(ctx context.Context) (result []*Group, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = co.NamedBlockedGroups(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = co.Edges.BlockedGroupsOrErr()
+	}
+	if IsNotLoaded(err) {
+		result, err = co.QueryBlockedGroups().All(ctx)
+	}
+	return result, err
+}
+
+func (co *ControlObjective) Editors(ctx context.Context) (result []*Group, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = co.NamedEditors(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = co.Edges.EditorsOrErr()
+	}
+	if IsNotLoaded(err) {
+		result, err = co.QueryEditors().All(ctx)
+	}
+	return result, err
+}
+
+func (co *ControlObjective) Viewers(ctx context.Context) (result []*Group, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = co.NamedViewers(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = co.Edges.ViewersOrErr()
+	}
+	if IsNotLoaded(err) {
+		result, err = co.QueryViewers().All(ctx)
+	}
+	return result, err
+}
+
 func (co *ControlObjective) Policy(ctx context.Context) (result []*InternalPolicy, err error) {
 	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
 		result, err = co.NamedPolicy(graphql.GetFieldContext(ctx).Field.Alias)
@@ -1152,6 +1196,42 @@ func (gr *Group) RiskBlockedGroups(ctx context.Context) (result []*Risk, err err
 	return result, err
 }
 
+func (gr *Group) ControlobjectiveViewers(ctx context.Context) (result []*ControlObjective, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = gr.NamedControlobjectiveViewers(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = gr.Edges.ControlobjectiveViewersOrErr()
+	}
+	if IsNotLoaded(err) {
+		result, err = gr.QueryControlobjectiveViewers().All(ctx)
+	}
+	return result, err
+}
+
+func (gr *Group) ControlobjectiveEditors(ctx context.Context) (result []*ControlObjective, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = gr.NamedControlobjectiveEditors(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = gr.Edges.ControlobjectiveEditorsOrErr()
+	}
+	if IsNotLoaded(err) {
+		result, err = gr.QueryControlobjectiveEditors().All(ctx)
+	}
+	return result, err
+}
+
+func (gr *Group) ControlobjectiveBlockedGroups(ctx context.Context) (result []*ControlObjective, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = gr.NamedControlobjectiveBlockedGroups(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = gr.Edges.ControlobjectiveBlockedGroupsOrErr()
+	}
+	if IsNotLoaded(err) {
+		result, err = gr.QueryControlobjectiveBlockedGroups().All(ctx)
+	}
+	return result, err
+}
+
 func (gr *Group) Members(ctx context.Context) (result []*GroupMembership, err error) {
 	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
 		result, err = gr.NamedMembers(graphql.GetFieldContext(ctx).Field.Alias)
@@ -1300,6 +1380,30 @@ func (ip *InternalPolicy) Owner(ctx context.Context) (*Organization, error) {
 	return result, MaskNotFound(err)
 }
 
+func (ip *InternalPolicy) BlockedGroups(ctx context.Context) (result []*Group, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = ip.NamedBlockedGroups(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = ip.Edges.BlockedGroupsOrErr()
+	}
+	if IsNotLoaded(err) {
+		result, err = ip.QueryBlockedGroups().All(ctx)
+	}
+	return result, err
+}
+
+func (ip *InternalPolicy) Editors(ctx context.Context) (result []*Group, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = ip.NamedEditors(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = ip.Edges.EditorsOrErr()
+	}
+	if IsNotLoaded(err) {
+		result, err = ip.QueryEditors().All(ctx)
+	}
+	return result, err
+}
+
 func (ip *InternalPolicy) Controlobjectives(ctx context.Context) (result []*ControlObjective, err error) {
 	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
 		result, err = ip.NamedControlobjectives(graphql.GetFieldContext(ctx).Field.Alias)
@@ -1368,30 +1472,6 @@ func (ip *InternalPolicy) Programs(ctx context.Context) (result []*Program, err 
 	}
 	if IsNotLoaded(err) {
 		result, err = ip.QueryPrograms().All(ctx)
-	}
-	return result, err
-}
-
-func (ip *InternalPolicy) Editors(ctx context.Context) (result []*Group, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = ip.NamedEditors(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = ip.Edges.EditorsOrErr()
-	}
-	if IsNotLoaded(err) {
-		result, err = ip.QueryEditors().All(ctx)
-	}
-	return result, err
-}
-
-func (ip *InternalPolicy) BlockedGroups(ctx context.Context) (result []*Group, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = ip.NamedBlockedGroups(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = ip.Edges.BlockedGroupsOrErr()
-	}
-	if IsNotLoaded(err) {
-		result, err = ip.QueryBlockedGroups().All(ctx)
 	}
 	return result, err
 }
@@ -1949,6 +2029,18 @@ func (o *Organization) Risks(ctx context.Context) (result []*Risk, err error) {
 	return result, err
 }
 
+func (o *Organization) Controlobjectives(ctx context.Context) (result []*ControlObjective, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = o.NamedControlobjectives(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = o.Edges.ControlobjectivesOrErr()
+	}
+	if IsNotLoaded(err) {
+		result, err = o.QueryControlobjectives().All(ctx)
+	}
+	return result, err
+}
+
 func (o *Organization) Members(ctx context.Context) (result []*OrgMembership, err error) {
 	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
 		result, err = o.NamedMembers(graphql.GetFieldContext(ctx).Field.Alias)
@@ -2019,6 +2111,30 @@ func (pr *Procedure) Owner(ctx context.Context) (*Organization, error) {
 		result, err = pr.QueryOwner().Only(ctx)
 	}
 	return result, MaskNotFound(err)
+}
+
+func (pr *Procedure) BlockedGroups(ctx context.Context) (result []*Group, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = pr.NamedBlockedGroups(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = pr.Edges.BlockedGroupsOrErr()
+	}
+	if IsNotLoaded(err) {
+		result, err = pr.QueryBlockedGroups().All(ctx)
+	}
+	return result, err
+}
+
+func (pr *Procedure) Editors(ctx context.Context) (result []*Group, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = pr.NamedEditors(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = pr.Edges.EditorsOrErr()
+	}
+	if IsNotLoaded(err) {
+		result, err = pr.QueryEditors().All(ctx)
+	}
+	return result, err
 }
 
 func (pr *Procedure) Control(ctx context.Context) (result []*Control, err error) {
@@ -2093,19 +2209,15 @@ func (pr *Procedure) Programs(ctx context.Context) (result []*Program, err error
 	return result, err
 }
 
-func (pr *Procedure) Editors(ctx context.Context) (result []*Group, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = pr.NamedEditors(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = pr.Edges.EditorsOrErr()
-	}
+func (pr *Program) Owner(ctx context.Context) (*Organization, error) {
+	result, err := pr.Edges.OwnerOrErr()
 	if IsNotLoaded(err) {
-		result, err = pr.QueryEditors().All(ctx)
+		result, err = pr.QueryOwner().Only(ctx)
 	}
-	return result, err
+	return result, MaskNotFound(err)
 }
 
-func (pr *Procedure) BlockedGroups(ctx context.Context) (result []*Group, err error) {
+func (pr *Program) BlockedGroups(ctx context.Context) (result []*Group, err error) {
 	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
 		result, err = pr.NamedBlockedGroups(graphql.GetFieldContext(ctx).Field.Alias)
 	} else {
@@ -2117,12 +2229,28 @@ func (pr *Procedure) BlockedGroups(ctx context.Context) (result []*Group, err er
 	return result, err
 }
 
-func (pr *Program) Owner(ctx context.Context) (*Organization, error) {
-	result, err := pr.Edges.OwnerOrErr()
-	if IsNotLoaded(err) {
-		result, err = pr.QueryOwner().Only(ctx)
+func (pr *Program) Editors(ctx context.Context) (result []*Group, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = pr.NamedEditors(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = pr.Edges.EditorsOrErr()
 	}
-	return result, MaskNotFound(err)
+	if IsNotLoaded(err) {
+		result, err = pr.QueryEditors().All(ctx)
+	}
+	return result, err
+}
+
+func (pr *Program) Viewers(ctx context.Context) (result []*Group, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = pr.NamedViewers(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = pr.Edges.ViewersOrErr()
+	}
+	if IsNotLoaded(err) {
+		result, err = pr.QueryViewers().All(ctx)
+	}
+	return result, err
 }
 
 func (pr *Program) Controls(ctx context.Context) (result []*Control, err error) {
@@ -2281,42 +2409,6 @@ func (pr *Program) Users(ctx context.Context) (result []*User, err error) {
 	return result, err
 }
 
-func (pr *Program) Viewers(ctx context.Context) (result []*Group, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = pr.NamedViewers(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = pr.Edges.ViewersOrErr()
-	}
-	if IsNotLoaded(err) {
-		result, err = pr.QueryViewers().All(ctx)
-	}
-	return result, err
-}
-
-func (pr *Program) Editors(ctx context.Context) (result []*Group, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = pr.NamedEditors(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = pr.Edges.EditorsOrErr()
-	}
-	if IsNotLoaded(err) {
-		result, err = pr.QueryEditors().All(ctx)
-	}
-	return result, err
-}
-
-func (pr *Program) BlockedGroups(ctx context.Context) (result []*Group, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = pr.NamedBlockedGroups(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = pr.Edges.BlockedGroupsOrErr()
-	}
-	if IsNotLoaded(err) {
-		result, err = pr.QueryBlockedGroups().All(ctx)
-	}
-	return result, err
-}
-
 func (pr *Program) Members(ctx context.Context) (result []*ProgramMembership, err error) {
 	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
 		result, err = pr.NamedMembers(graphql.GetFieldContext(ctx).Field.Alias)
@@ -2341,6 +2433,50 @@ func (pm *ProgramMembership) User(ctx context.Context) (*User, error) {
 	result, err := pm.Edges.UserOrErr()
 	if IsNotLoaded(err) {
 		result, err = pm.QueryUser().Only(ctx)
+	}
+	return result, err
+}
+
+func (r *Risk) Owner(ctx context.Context) (*Organization, error) {
+	result, err := r.Edges.OwnerOrErr()
+	if IsNotLoaded(err) {
+		result, err = r.QueryOwner().Only(ctx)
+	}
+	return result, err
+}
+
+func (r *Risk) BlockedGroups(ctx context.Context) (result []*Group, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = r.NamedBlockedGroups(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = r.Edges.BlockedGroupsOrErr()
+	}
+	if IsNotLoaded(err) {
+		result, err = r.QueryBlockedGroups().All(ctx)
+	}
+	return result, err
+}
+
+func (r *Risk) Editors(ctx context.Context) (result []*Group, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = r.NamedEditors(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = r.Edges.EditorsOrErr()
+	}
+	if IsNotLoaded(err) {
+		result, err = r.QueryEditors().All(ctx)
+	}
+	return result, err
+}
+
+func (r *Risk) Viewers(ctx context.Context) (result []*Group, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = r.NamedViewers(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = r.Edges.ViewersOrErr()
+	}
+	if IsNotLoaded(err) {
+		result, err = r.QueryViewers().All(ctx)
 	}
 	return result, err
 }
@@ -2381,58 +2517,14 @@ func (r *Risk) Actionplans(ctx context.Context) (result []*ActionPlan, err error
 	return result, err
 }
 
-func (r *Risk) Owner(ctx context.Context) (*Organization, error) {
-	result, err := r.Edges.OwnerOrErr()
-	if IsNotLoaded(err) {
-		result, err = r.QueryOwner().Only(ctx)
-	}
-	return result, err
-}
-
-func (r *Risk) Program(ctx context.Context) (result []*Program, err error) {
+func (r *Risk) Programs(ctx context.Context) (result []*Program, err error) {
 	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = r.NamedProgram(graphql.GetFieldContext(ctx).Field.Alias)
+		result, err = r.NamedPrograms(graphql.GetFieldContext(ctx).Field.Alias)
 	} else {
-		result, err = r.Edges.ProgramOrErr()
+		result, err = r.Edges.ProgramsOrErr()
 	}
 	if IsNotLoaded(err) {
-		result, err = r.QueryProgram().All(ctx)
-	}
-	return result, err
-}
-
-func (r *Risk) Viewers(ctx context.Context) (result []*Group, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = r.NamedViewers(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = r.Edges.ViewersOrErr()
-	}
-	if IsNotLoaded(err) {
-		result, err = r.QueryViewers().All(ctx)
-	}
-	return result, err
-}
-
-func (r *Risk) Editors(ctx context.Context) (result []*Group, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = r.NamedEditors(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = r.Edges.EditorsOrErr()
-	}
-	if IsNotLoaded(err) {
-		result, err = r.QueryEditors().All(ctx)
-	}
-	return result, err
-}
-
-func (r *Risk) BlockedGroups(ctx context.Context) (result []*Group, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = r.NamedBlockedGroups(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = r.Edges.BlockedGroupsOrErr()
-	}
-	if IsNotLoaded(err) {
-		result, err = r.QueryBlockedGroups().All(ctx)
+		result, err = r.QueryPrograms().All(ctx)
 	}
 	return result, err
 }

--- a/internal/ent/generated/gql_mutation_input.go
+++ b/internal/ent/generated/gql_mutation_input.go
@@ -843,6 +843,10 @@ type CreateControlObjectiveInput struct {
 	Source               *string
 	MappedFrameworks     *string
 	Details              map[string]interface{}
+	OwnerID              string
+	BlockedGroupIDs      []string
+	EditorIDs            []string
+	ViewerIDs            []string
 	PolicyIDs            []string
 	ControlIDs           []string
 	ProcedureIDs         []string
@@ -889,6 +893,16 @@ func (i *CreateControlObjectiveInput) Mutate(m *ControlObjectiveMutation) {
 	}
 	if v := i.Details; v != nil {
 		m.SetDetails(v)
+	}
+	m.SetOwnerID(i.OwnerID)
+	if v := i.BlockedGroupIDs; len(v) > 0 {
+		m.AddBlockedGroupIDs(v...)
+	}
+	if v := i.EditorIDs; len(v) > 0 {
+		m.AddEditorIDs(v...)
+	}
+	if v := i.ViewerIDs; len(v) > 0 {
+		m.AddViewerIDs(v...)
 	}
 	if v := i.PolicyIDs; len(v) > 0 {
 		m.AddPolicyIDs(v...)
@@ -951,6 +965,16 @@ type UpdateControlObjectiveInput struct {
 	MappedFrameworks          *string
 	ClearDetails              bool
 	Details                   map[string]interface{}
+	OwnerID                   *string
+	ClearBlockedGroups        bool
+	AddBlockedGroupIDs        []string
+	RemoveBlockedGroupIDs     []string
+	ClearEditors              bool
+	AddEditorIDs              []string
+	RemoveEditorIDs           []string
+	ClearViewers              bool
+	AddViewerIDs              []string
+	RemoveViewerIDs           []string
 	ClearPolicy               bool
 	AddPolicyIDs              []string
 	RemovePolicyIDs           []string
@@ -1053,6 +1077,36 @@ func (i *UpdateControlObjectiveInput) Mutate(m *ControlObjectiveMutation) {
 	}
 	if v := i.Details; v != nil {
 		m.SetDetails(v)
+	}
+	if v := i.OwnerID; v != nil {
+		m.SetOwnerID(*v)
+	}
+	if i.ClearBlockedGroups {
+		m.ClearBlockedGroups()
+	}
+	if v := i.AddBlockedGroupIDs; len(v) > 0 {
+		m.AddBlockedGroupIDs(v...)
+	}
+	if v := i.RemoveBlockedGroupIDs; len(v) > 0 {
+		m.RemoveBlockedGroupIDs(v...)
+	}
+	if i.ClearEditors {
+		m.ClearEditors()
+	}
+	if v := i.AddEditorIDs; len(v) > 0 {
+		m.AddEditorIDs(v...)
+	}
+	if v := i.RemoveEditorIDs; len(v) > 0 {
+		m.RemoveEditorIDs(v...)
+	}
+	if i.ClearViewers {
+		m.ClearViewers()
+	}
+	if v := i.AddViewerIDs; len(v) > 0 {
+		m.AddViewerIDs(v...)
+	}
+	if v := i.RemoveViewerIDs; len(v) > 0 {
+		m.RemoveViewerIDs(v...)
 	}
 	if i.ClearPolicy {
 		m.ClearPolicy()
@@ -2823,29 +2877,32 @@ func (c *FileUpdateOne) SetInput(i UpdateFileInput) *FileUpdateOne {
 
 // CreateGroupInput represents a mutation input for creating groups.
 type CreateGroupInput struct {
-	Tags                          []string
-	Name                          string
-	Description                   *string
-	GravatarLogoURL               *string
-	LogoURL                       *string
-	DisplayName                   *string
-	OwnerID                       *string
-	SettingID                     string
-	UserIDs                       []string
-	EventIDs                      []string
-	IntegrationIDs                []string
-	FileIDs                       []string
-	TaskIDs                       []string
-	ProcedureEditorIDs            []string
-	ProcedureBlockedGroupIDs      []string
-	InternalpolicyEditorIDs       []string
-	InternalpolicyBlockedGroupIDs []string
-	ProgramViewerIDs              []string
-	ProgramEditorIDs              []string
-	ProgramBlockedGroupIDs        []string
-	RiskViewerIDs                 []string
-	RiskEditorIDs                 []string
-	RiskBlockedGroupIDs           []string
+	Tags                            []string
+	Name                            string
+	Description                     *string
+	GravatarLogoURL                 *string
+	LogoURL                         *string
+	DisplayName                     *string
+	OwnerID                         *string
+	SettingID                       string
+	UserIDs                         []string
+	EventIDs                        []string
+	IntegrationIDs                  []string
+	FileIDs                         []string
+	TaskIDs                         []string
+	ProcedureEditorIDs              []string
+	ProcedureBlockedGroupIDs        []string
+	InternalpolicyEditorIDs         []string
+	InternalpolicyBlockedGroupIDs   []string
+	ProgramViewerIDs                []string
+	ProgramEditorIDs                []string
+	ProgramBlockedGroupIDs          []string
+	RiskViewerIDs                   []string
+	RiskEditorIDs                   []string
+	RiskBlockedGroupIDs             []string
+	ControlobjectiveViewerIDs       []string
+	ControlobjectiveEditorIDs       []string
+	ControlobjectiveBlockedGroupIDs []string
 }
 
 // Mutate applies the CreateGroupInput on the GroupMutation builder.
@@ -2915,6 +2972,15 @@ func (i *CreateGroupInput) Mutate(m *GroupMutation) {
 	if v := i.RiskBlockedGroupIDs; len(v) > 0 {
 		m.AddRiskBlockedGroupIDs(v...)
 	}
+	if v := i.ControlobjectiveViewerIDs; len(v) > 0 {
+		m.AddControlobjectiveViewerIDs(v...)
+	}
+	if v := i.ControlobjectiveEditorIDs; len(v) > 0 {
+		m.AddControlobjectiveEditorIDs(v...)
+	}
+	if v := i.ControlobjectiveBlockedGroupIDs; len(v) > 0 {
+		m.AddControlobjectiveBlockedGroupIDs(v...)
+	}
 }
 
 // SetInput applies the change-set in the CreateGroupInput on the GroupCreate builder.
@@ -2925,65 +2991,74 @@ func (c *GroupCreate) SetInput(i CreateGroupInput) *GroupCreate {
 
 // UpdateGroupInput represents a mutation input for updating groups.
 type UpdateGroupInput struct {
-	ClearTags                           bool
-	Tags                                []string
-	AppendTags                          []string
-	Name                                *string
-	ClearDescription                    bool
-	Description                         *string
-	ClearGravatarLogoURL                bool
-	GravatarLogoURL                     *string
-	ClearLogoURL                        bool
-	LogoURL                             *string
-	DisplayName                         *string
-	ClearOwner                          bool
-	OwnerID                             *string
-	SettingID                           *string
-	ClearUsers                          bool
-	AddUserIDs                          []string
-	RemoveUserIDs                       []string
-	ClearEvents                         bool
-	AddEventIDs                         []string
-	RemoveEventIDs                      []string
-	ClearIntegrations                   bool
-	AddIntegrationIDs                   []string
-	RemoveIntegrationIDs                []string
-	ClearFiles                          bool
-	AddFileIDs                          []string
-	RemoveFileIDs                       []string
-	ClearTasks                          bool
-	AddTaskIDs                          []string
-	RemoveTaskIDs                       []string
-	ClearProcedureEditors               bool
-	AddProcedureEditorIDs               []string
-	RemoveProcedureEditorIDs            []string
-	ClearProcedureBlockedGroups         bool
-	AddProcedureBlockedGroupIDs         []string
-	RemoveProcedureBlockedGroupIDs      []string
-	ClearInternalpolicyEditors          bool
-	AddInternalpolicyEditorIDs          []string
-	RemoveInternalpolicyEditorIDs       []string
-	ClearInternalpolicyBlockedGroups    bool
-	AddInternalpolicyBlockedGroupIDs    []string
-	RemoveInternalpolicyBlockedGroupIDs []string
-	ClearProgramViewers                 bool
-	AddProgramViewerIDs                 []string
-	RemoveProgramViewerIDs              []string
-	ClearProgramEditors                 bool
-	AddProgramEditorIDs                 []string
-	RemoveProgramEditorIDs              []string
-	ClearProgramBlockedGroups           bool
-	AddProgramBlockedGroupIDs           []string
-	RemoveProgramBlockedGroupIDs        []string
-	ClearRiskViewers                    bool
-	AddRiskViewerIDs                    []string
-	RemoveRiskViewerIDs                 []string
-	ClearRiskEditors                    bool
-	AddRiskEditorIDs                    []string
-	RemoveRiskEditorIDs                 []string
-	ClearRiskBlockedGroups              bool
-	AddRiskBlockedGroupIDs              []string
-	RemoveRiskBlockedGroupIDs           []string
+	ClearTags                             bool
+	Tags                                  []string
+	AppendTags                            []string
+	Name                                  *string
+	ClearDescription                      bool
+	Description                           *string
+	ClearGravatarLogoURL                  bool
+	GravatarLogoURL                       *string
+	ClearLogoURL                          bool
+	LogoURL                               *string
+	DisplayName                           *string
+	ClearOwner                            bool
+	OwnerID                               *string
+	SettingID                             *string
+	ClearUsers                            bool
+	AddUserIDs                            []string
+	RemoveUserIDs                         []string
+	ClearEvents                           bool
+	AddEventIDs                           []string
+	RemoveEventIDs                        []string
+	ClearIntegrations                     bool
+	AddIntegrationIDs                     []string
+	RemoveIntegrationIDs                  []string
+	ClearFiles                            bool
+	AddFileIDs                            []string
+	RemoveFileIDs                         []string
+	ClearTasks                            bool
+	AddTaskIDs                            []string
+	RemoveTaskIDs                         []string
+	ClearProcedureEditors                 bool
+	AddProcedureEditorIDs                 []string
+	RemoveProcedureEditorIDs              []string
+	ClearProcedureBlockedGroups           bool
+	AddProcedureBlockedGroupIDs           []string
+	RemoveProcedureBlockedGroupIDs        []string
+	ClearInternalpolicyEditors            bool
+	AddInternalpolicyEditorIDs            []string
+	RemoveInternalpolicyEditorIDs         []string
+	ClearInternalpolicyBlockedGroups      bool
+	AddInternalpolicyBlockedGroupIDs      []string
+	RemoveInternalpolicyBlockedGroupIDs   []string
+	ClearProgramViewers                   bool
+	AddProgramViewerIDs                   []string
+	RemoveProgramViewerIDs                []string
+	ClearProgramEditors                   bool
+	AddProgramEditorIDs                   []string
+	RemoveProgramEditorIDs                []string
+	ClearProgramBlockedGroups             bool
+	AddProgramBlockedGroupIDs             []string
+	RemoveProgramBlockedGroupIDs          []string
+	ClearRiskViewers                      bool
+	AddRiskViewerIDs                      []string
+	RemoveRiskViewerIDs                   []string
+	ClearRiskEditors                      bool
+	AddRiskEditorIDs                      []string
+	RemoveRiskEditorIDs                   []string
+	ClearRiskBlockedGroups                bool
+	AddRiskBlockedGroupIDs                []string
+	RemoveRiskBlockedGroupIDs             []string
+	ClearControlobjectiveViewers          bool
+	AddControlobjectiveViewerIDs          []string
+	RemoveControlobjectiveViewerIDs       []string
+	ClearControlobjectiveEditors          bool
+	AddControlobjectiveEditorIDs          []string
+	RemoveControlobjectiveEditorIDs       []string
+	ClearControlobjectiveBlockedGroups    bool
+	AddControlobjectiveBlockedGroupIDs    []string
+	RemoveControlobjectiveBlockedGroupIDs []string
 }
 
 // Mutate applies the UpdateGroupInput on the GroupMutation builder.
@@ -3164,6 +3239,33 @@ func (i *UpdateGroupInput) Mutate(m *GroupMutation) {
 	}
 	if v := i.RemoveRiskBlockedGroupIDs; len(v) > 0 {
 		m.RemoveRiskBlockedGroupIDs(v...)
+	}
+	if i.ClearControlobjectiveViewers {
+		m.ClearControlobjectiveViewers()
+	}
+	if v := i.AddControlobjectiveViewerIDs; len(v) > 0 {
+		m.AddControlobjectiveViewerIDs(v...)
+	}
+	if v := i.RemoveControlobjectiveViewerIDs; len(v) > 0 {
+		m.RemoveControlobjectiveViewerIDs(v...)
+	}
+	if i.ClearControlobjectiveEditors {
+		m.ClearControlobjectiveEditors()
+	}
+	if v := i.AddControlobjectiveEditorIDs; len(v) > 0 {
+		m.AddControlobjectiveEditorIDs(v...)
+	}
+	if v := i.RemoveControlobjectiveEditorIDs; len(v) > 0 {
+		m.RemoveControlobjectiveEditorIDs(v...)
+	}
+	if i.ClearControlobjectiveBlockedGroups {
+		m.ClearControlobjectiveBlockedGroups()
+	}
+	if v := i.AddControlobjectiveBlockedGroupIDs; len(v) > 0 {
+		m.AddControlobjectiveBlockedGroupIDs(v...)
+	}
+	if v := i.RemoveControlobjectiveBlockedGroupIDs; len(v) > 0 {
+		m.RemoveControlobjectiveBlockedGroupIDs(v...)
 	}
 }
 
@@ -3631,14 +3733,14 @@ type CreateInternalPolicyInput struct {
 	Background          *string
 	Details             map[string]interface{}
 	OwnerID             *string
+	BlockedGroupIDs     []string
+	EditorIDs           []string
 	ControlobjectiveIDs []string
 	ControlIDs          []string
 	ProcedureIDs        []string
 	NarrativeIDs        []string
 	TaskIDs             []string
 	ProgramIDs          []string
-	EditorIDs           []string
-	BlockedGroupIDs     []string
 }
 
 // Mutate applies the CreateInternalPolicyInput on the InternalPolicyMutation builder.
@@ -3671,6 +3773,12 @@ func (i *CreateInternalPolicyInput) Mutate(m *InternalPolicyMutation) {
 	if v := i.OwnerID; v != nil {
 		m.SetOwnerID(*v)
 	}
+	if v := i.BlockedGroupIDs; len(v) > 0 {
+		m.AddBlockedGroupIDs(v...)
+	}
+	if v := i.EditorIDs; len(v) > 0 {
+		m.AddEditorIDs(v...)
+	}
 	if v := i.ControlobjectiveIDs; len(v) > 0 {
 		m.AddControlobjectiveIDs(v...)
 	}
@@ -3688,12 +3796,6 @@ func (i *CreateInternalPolicyInput) Mutate(m *InternalPolicyMutation) {
 	}
 	if v := i.ProgramIDs; len(v) > 0 {
 		m.AddProgramIDs(v...)
-	}
-	if v := i.EditorIDs; len(v) > 0 {
-		m.AddEditorIDs(v...)
-	}
-	if v := i.BlockedGroupIDs; len(v) > 0 {
-		m.AddBlockedGroupIDs(v...)
 	}
 }
 
@@ -3725,6 +3827,12 @@ type UpdateInternalPolicyInput struct {
 	Details                   map[string]interface{}
 	ClearOwner                bool
 	OwnerID                   *string
+	ClearBlockedGroups        bool
+	AddBlockedGroupIDs        []string
+	RemoveBlockedGroupIDs     []string
+	ClearEditors              bool
+	AddEditorIDs              []string
+	RemoveEditorIDs           []string
 	ClearControlobjectives    bool
 	AddControlobjectiveIDs    []string
 	RemoveControlobjectiveIDs []string
@@ -3743,12 +3851,6 @@ type UpdateInternalPolicyInput struct {
 	ClearPrograms             bool
 	AddProgramIDs             []string
 	RemoveProgramIDs          []string
-	ClearEditors              bool
-	AddEditorIDs              []string
-	RemoveEditorIDs           []string
-	ClearBlockedGroups        bool
-	AddBlockedGroupIDs        []string
-	RemoveBlockedGroupIDs     []string
 }
 
 // Mutate applies the UpdateInternalPolicyInput on the InternalPolicyMutation builder.
@@ -3813,6 +3915,24 @@ func (i *UpdateInternalPolicyInput) Mutate(m *InternalPolicyMutation) {
 	if v := i.OwnerID; v != nil {
 		m.SetOwnerID(*v)
 	}
+	if i.ClearBlockedGroups {
+		m.ClearBlockedGroups()
+	}
+	if v := i.AddBlockedGroupIDs; len(v) > 0 {
+		m.AddBlockedGroupIDs(v...)
+	}
+	if v := i.RemoveBlockedGroupIDs; len(v) > 0 {
+		m.RemoveBlockedGroupIDs(v...)
+	}
+	if i.ClearEditors {
+		m.ClearEditors()
+	}
+	if v := i.AddEditorIDs; len(v) > 0 {
+		m.AddEditorIDs(v...)
+	}
+	if v := i.RemoveEditorIDs; len(v) > 0 {
+		m.RemoveEditorIDs(v...)
+	}
 	if i.ClearControlobjectives {
 		m.ClearControlobjectives()
 	}
@@ -3866,24 +3986,6 @@ func (i *UpdateInternalPolicyInput) Mutate(m *InternalPolicyMutation) {
 	}
 	if v := i.RemoveProgramIDs; len(v) > 0 {
 		m.RemoveProgramIDs(v...)
-	}
-	if i.ClearEditors {
-		m.ClearEditors()
-	}
-	if v := i.AddEditorIDs; len(v) > 0 {
-		m.AddEditorIDs(v...)
-	}
-	if v := i.RemoveEditorIDs; len(v) > 0 {
-		m.RemoveEditorIDs(v...)
-	}
-	if i.ClearBlockedGroups {
-		m.ClearBlockedGroups()
-	}
-	if v := i.AddBlockedGroupIDs; len(v) > 0 {
-		m.AddBlockedGroupIDs(v...)
-	}
-	if v := i.RemoveBlockedGroupIDs; len(v) > 0 {
-		m.RemoveBlockedGroupIDs(v...)
 	}
 }
 
@@ -4689,6 +4791,7 @@ type CreateOrganizationInput struct {
 	ProcedureIDs               []string
 	InternalpolicyIDs          []string
 	RiskIDs                    []string
+	ControlobjectiveIDs        []string
 }
 
 // Mutate applies the CreateOrganizationInput on the OrganizationMutation builder.
@@ -4799,6 +4902,9 @@ func (i *CreateOrganizationInput) Mutate(m *OrganizationMutation) {
 	if v := i.RiskIDs; len(v) > 0 {
 		m.AddRiskIDs(v...)
 	}
+	if v := i.ControlobjectiveIDs; len(v) > 0 {
+		m.AddControlobjectiveIDs(v...)
+	}
 }
 
 // SetInput applies the change-set in the CreateOrganizationInput on the OrganizationCreate builder.
@@ -4901,6 +5007,9 @@ type UpdateOrganizationInput struct {
 	ClearRisks                       bool
 	AddRiskIDs                       []string
 	RemoveRiskIDs                    []string
+	ClearControlobjectives           bool
+	AddControlobjectiveIDs           []string
+	RemoveControlobjectiveIDs        []string
 }
 
 // Mutate applies the UpdateOrganizationInput on the OrganizationMutation builder.
@@ -5180,6 +5289,15 @@ func (i *UpdateOrganizationInput) Mutate(m *OrganizationMutation) {
 	}
 	if v := i.RemoveRiskIDs; len(v) > 0 {
 		m.RemoveRiskIDs(v...)
+	}
+	if i.ClearControlobjectives {
+		m.ClearControlobjectives()
+	}
+	if v := i.AddControlobjectiveIDs; len(v) > 0 {
+		m.AddControlobjectiveIDs(v...)
+	}
+	if v := i.RemoveControlobjectiveIDs; len(v) > 0 {
+		m.RemoveControlobjectiveIDs(v...)
 	}
 }
 
@@ -5520,14 +5638,14 @@ type CreateProcedureInput struct {
 	Satisfies         *string
 	Details           map[string]interface{}
 	OwnerID           *string
+	BlockedGroupIDs   []string
+	EditorIDs         []string
 	ControlIDs        []string
 	InternalpolicyIDs []string
 	NarrativeIDs      []string
 	RiskIDs           []string
 	TaskIDs           []string
 	ProgramIDs        []string
-	EditorIDs         []string
-	BlockedGroupIDs   []string
 }
 
 // Mutate applies the CreateProcedureInput on the ProcedureMutation builder.
@@ -5563,6 +5681,12 @@ func (i *CreateProcedureInput) Mutate(m *ProcedureMutation) {
 	if v := i.OwnerID; v != nil {
 		m.SetOwnerID(*v)
 	}
+	if v := i.BlockedGroupIDs; len(v) > 0 {
+		m.AddBlockedGroupIDs(v...)
+	}
+	if v := i.EditorIDs; len(v) > 0 {
+		m.AddEditorIDs(v...)
+	}
 	if v := i.ControlIDs; len(v) > 0 {
 		m.AddControlIDs(v...)
 	}
@@ -5580,12 +5704,6 @@ func (i *CreateProcedureInput) Mutate(m *ProcedureMutation) {
 	}
 	if v := i.ProgramIDs; len(v) > 0 {
 		m.AddProgramIDs(v...)
-	}
-	if v := i.EditorIDs; len(v) > 0 {
-		m.AddEditorIDs(v...)
-	}
-	if v := i.BlockedGroupIDs; len(v) > 0 {
-		m.AddBlockedGroupIDs(v...)
 	}
 }
 
@@ -5619,6 +5737,12 @@ type UpdateProcedureInput struct {
 	Details                 map[string]interface{}
 	ClearOwner              bool
 	OwnerID                 *string
+	ClearBlockedGroups      bool
+	AddBlockedGroupIDs      []string
+	RemoveBlockedGroupIDs   []string
+	ClearEditors            bool
+	AddEditorIDs            []string
+	RemoveEditorIDs         []string
 	ClearControl            bool
 	AddControlIDs           []string
 	RemoveControlIDs        []string
@@ -5637,12 +5761,6 @@ type UpdateProcedureInput struct {
 	ClearPrograms           bool
 	AddProgramIDs           []string
 	RemoveProgramIDs        []string
-	ClearEditors            bool
-	AddEditorIDs            []string
-	RemoveEditorIDs         []string
-	ClearBlockedGroups      bool
-	AddBlockedGroupIDs      []string
-	RemoveBlockedGroupIDs   []string
 }
 
 // Mutate applies the UpdateProcedureInput on the ProcedureMutation builder.
@@ -5713,6 +5831,24 @@ func (i *UpdateProcedureInput) Mutate(m *ProcedureMutation) {
 	if v := i.OwnerID; v != nil {
 		m.SetOwnerID(*v)
 	}
+	if i.ClearBlockedGroups {
+		m.ClearBlockedGroups()
+	}
+	if v := i.AddBlockedGroupIDs; len(v) > 0 {
+		m.AddBlockedGroupIDs(v...)
+	}
+	if v := i.RemoveBlockedGroupIDs; len(v) > 0 {
+		m.RemoveBlockedGroupIDs(v...)
+	}
+	if i.ClearEditors {
+		m.ClearEditors()
+	}
+	if v := i.AddEditorIDs; len(v) > 0 {
+		m.AddEditorIDs(v...)
+	}
+	if v := i.RemoveEditorIDs; len(v) > 0 {
+		m.RemoveEditorIDs(v...)
+	}
 	if i.ClearControl {
 		m.ClearControl()
 	}
@@ -5767,24 +5903,6 @@ func (i *UpdateProcedureInput) Mutate(m *ProcedureMutation) {
 	if v := i.RemoveProgramIDs; len(v) > 0 {
 		m.RemoveProgramIDs(v...)
 	}
-	if i.ClearEditors {
-		m.ClearEditors()
-	}
-	if v := i.AddEditorIDs; len(v) > 0 {
-		m.AddEditorIDs(v...)
-	}
-	if v := i.RemoveEditorIDs; len(v) > 0 {
-		m.RemoveEditorIDs(v...)
-	}
-	if i.ClearBlockedGroups {
-		m.ClearBlockedGroups()
-	}
-	if v := i.AddBlockedGroupIDs; len(v) > 0 {
-		m.AddBlockedGroupIDs(v...)
-	}
-	if v := i.RemoveBlockedGroupIDs; len(v) > 0 {
-		m.RemoveBlockedGroupIDs(v...)
-	}
 }
 
 // SetInput applies the change-set in the UpdateProcedureInput on the ProcedureUpdate builder.
@@ -5811,6 +5929,9 @@ type CreateProgramInput struct {
 	AuditorWriteComments *bool
 	AuditorReadComments  *bool
 	OwnerID              *string
+	BlockedGroupIDs      []string
+	EditorIDs            []string
+	ViewerIDs            []string
 	ControlIDs           []string
 	SubcontrolIDs        []string
 	ControlobjectiveIDs  []string
@@ -5824,9 +5945,6 @@ type CreateProgramInput struct {
 	ActionplanIDs        []string
 	StandardIDs          []string
 	UserIDs              []string
-	ViewerIDs            []string
-	EditorIDs            []string
-	BlockedGroupIDs      []string
 }
 
 // Mutate applies the CreateProgramInput on the ProgramMutation builder.
@@ -5858,6 +5976,15 @@ func (i *CreateProgramInput) Mutate(m *ProgramMutation) {
 	}
 	if v := i.OwnerID; v != nil {
 		m.SetOwnerID(*v)
+	}
+	if v := i.BlockedGroupIDs; len(v) > 0 {
+		m.AddBlockedGroupIDs(v...)
+	}
+	if v := i.EditorIDs; len(v) > 0 {
+		m.AddEditorIDs(v...)
+	}
+	if v := i.ViewerIDs; len(v) > 0 {
+		m.AddViewerIDs(v...)
 	}
 	if v := i.ControlIDs; len(v) > 0 {
 		m.AddControlIDs(v...)
@@ -5898,15 +6025,6 @@ func (i *CreateProgramInput) Mutate(m *ProgramMutation) {
 	if v := i.UserIDs; len(v) > 0 {
 		m.AddUserIDs(v...)
 	}
-	if v := i.ViewerIDs; len(v) > 0 {
-		m.AddViewerIDs(v...)
-	}
-	if v := i.EditorIDs; len(v) > 0 {
-		m.AddEditorIDs(v...)
-	}
-	if v := i.BlockedGroupIDs; len(v) > 0 {
-		m.AddBlockedGroupIDs(v...)
-	}
 }
 
 // SetInput applies the change-set in the CreateProgramInput on the ProgramCreate builder.
@@ -5933,6 +6051,15 @@ type UpdateProgramInput struct {
 	AuditorReadComments       *bool
 	ClearOwner                bool
 	OwnerID                   *string
+	ClearBlockedGroups        bool
+	AddBlockedGroupIDs        []string
+	RemoveBlockedGroupIDs     []string
+	ClearEditors              bool
+	AddEditorIDs              []string
+	RemoveEditorIDs           []string
+	ClearViewers              bool
+	AddViewerIDs              []string
+	RemoveViewerIDs           []string
 	ClearControls             bool
 	AddControlIDs             []string
 	RemoveControlIDs          []string
@@ -5972,15 +6099,6 @@ type UpdateProgramInput struct {
 	ClearUsers                bool
 	AddUserIDs                []string
 	RemoveUserIDs             []string
-	ClearViewers              bool
-	AddViewerIDs              []string
-	RemoveViewerIDs           []string
-	ClearEditors              bool
-	AddEditorIDs              []string
-	RemoveEditorIDs           []string
-	ClearBlockedGroups        bool
-	AddBlockedGroupIDs        []string
-	RemoveBlockedGroupIDs     []string
 }
 
 // Mutate applies the UpdateProgramInput on the ProgramMutation builder.
@@ -6032,6 +6150,33 @@ func (i *UpdateProgramInput) Mutate(m *ProgramMutation) {
 	}
 	if v := i.OwnerID; v != nil {
 		m.SetOwnerID(*v)
+	}
+	if i.ClearBlockedGroups {
+		m.ClearBlockedGroups()
+	}
+	if v := i.AddBlockedGroupIDs; len(v) > 0 {
+		m.AddBlockedGroupIDs(v...)
+	}
+	if v := i.RemoveBlockedGroupIDs; len(v) > 0 {
+		m.RemoveBlockedGroupIDs(v...)
+	}
+	if i.ClearEditors {
+		m.ClearEditors()
+	}
+	if v := i.AddEditorIDs; len(v) > 0 {
+		m.AddEditorIDs(v...)
+	}
+	if v := i.RemoveEditorIDs; len(v) > 0 {
+		m.RemoveEditorIDs(v...)
+	}
+	if i.ClearViewers {
+		m.ClearViewers()
+	}
+	if v := i.AddViewerIDs; len(v) > 0 {
+		m.AddViewerIDs(v...)
+	}
+	if v := i.RemoveViewerIDs; len(v) > 0 {
+		m.RemoveViewerIDs(v...)
 	}
 	if i.ClearControls {
 		m.ClearControls()
@@ -6150,33 +6295,6 @@ func (i *UpdateProgramInput) Mutate(m *ProgramMutation) {
 	if v := i.RemoveUserIDs; len(v) > 0 {
 		m.RemoveUserIDs(v...)
 	}
-	if i.ClearViewers {
-		m.ClearViewers()
-	}
-	if v := i.AddViewerIDs; len(v) > 0 {
-		m.AddViewerIDs(v...)
-	}
-	if v := i.RemoveViewerIDs; len(v) > 0 {
-		m.RemoveViewerIDs(v...)
-	}
-	if i.ClearEditors {
-		m.ClearEditors()
-	}
-	if v := i.AddEditorIDs; len(v) > 0 {
-		m.AddEditorIDs(v...)
-	}
-	if v := i.RemoveEditorIDs; len(v) > 0 {
-		m.RemoveEditorIDs(v...)
-	}
-	if i.ClearBlockedGroups {
-		m.ClearBlockedGroups()
-	}
-	if v := i.AddBlockedGroupIDs; len(v) > 0 {
-		m.AddBlockedGroupIDs(v...)
-	}
-	if v := i.RemoveBlockedGroupIDs; len(v) > 0 {
-		m.RemoveBlockedGroupIDs(v...)
-	}
 }
 
 // SetInput applies the change-set in the UpdateProgramInput on the ProgramUpdate builder.
@@ -6250,14 +6368,14 @@ type CreateRiskInput struct {
 	Mitigation      *string
 	Satisfies       *string
 	Details         map[string]interface{}
+	OwnerID         string
+	BlockedGroupIDs []string
+	EditorIDs       []string
+	ViewerIDs       []string
 	ControlIDs      []string
 	ProcedureIDs    []string
 	ActionplanIDs   []string
-	OwnerID         string
 	ProgramIDs      []string
-	ViewerIDs       []string
-	EditorIDs       []string
-	BlockedGroupIDs []string
 }
 
 // Mutate applies the CreateRiskInput on the RiskMutation builder.
@@ -6293,6 +6411,16 @@ func (i *CreateRiskInput) Mutate(m *RiskMutation) {
 	if v := i.Details; v != nil {
 		m.SetDetails(v)
 	}
+	m.SetOwnerID(i.OwnerID)
+	if v := i.BlockedGroupIDs; len(v) > 0 {
+		m.AddBlockedGroupIDs(v...)
+	}
+	if v := i.EditorIDs; len(v) > 0 {
+		m.AddEditorIDs(v...)
+	}
+	if v := i.ViewerIDs; len(v) > 0 {
+		m.AddViewerIDs(v...)
+	}
 	if v := i.ControlIDs; len(v) > 0 {
 		m.AddControlIDs(v...)
 	}
@@ -6302,18 +6430,8 @@ func (i *CreateRiskInput) Mutate(m *RiskMutation) {
 	if v := i.ActionplanIDs; len(v) > 0 {
 		m.AddActionplanIDs(v...)
 	}
-	m.SetOwnerID(i.OwnerID)
 	if v := i.ProgramIDs; len(v) > 0 {
 		m.AddProgramIDs(v...)
-	}
-	if v := i.ViewerIDs; len(v) > 0 {
-		m.AddViewerIDs(v...)
-	}
-	if v := i.EditorIDs; len(v) > 0 {
-		m.AddEditorIDs(v...)
-	}
-	if v := i.BlockedGroupIDs; len(v) > 0 {
-		m.AddBlockedGroupIDs(v...)
 	}
 }
 
@@ -6347,6 +6465,16 @@ type UpdateRiskInput struct {
 	Satisfies             *string
 	ClearDetails          bool
 	Details               map[string]interface{}
+	OwnerID               *string
+	ClearBlockedGroups    bool
+	AddBlockedGroupIDs    []string
+	RemoveBlockedGroupIDs []string
+	ClearEditors          bool
+	AddEditorIDs          []string
+	RemoveEditorIDs       []string
+	ClearViewers          bool
+	AddViewerIDs          []string
+	RemoveViewerIDs       []string
 	ClearControl          bool
 	AddControlIDs         []string
 	RemoveControlIDs      []string
@@ -6356,19 +6484,9 @@ type UpdateRiskInput struct {
 	ClearActionplans      bool
 	AddActionplanIDs      []string
 	RemoveActionplanIDs   []string
-	OwnerID               *string
-	ClearProgram          bool
+	ClearPrograms         bool
 	AddProgramIDs         []string
 	RemoveProgramIDs      []string
-	ClearViewers          bool
-	AddViewerIDs          []string
-	RemoveViewerIDs       []string
-	ClearEditors          bool
-	AddEditorIDs          []string
-	RemoveEditorIDs       []string
-	ClearBlockedGroups    bool
-	AddBlockedGroupIDs    []string
-	RemoveBlockedGroupIDs []string
 }
 
 // Mutate applies the UpdateRiskInput on the RiskMutation builder.
@@ -6439,6 +6557,36 @@ func (i *UpdateRiskInput) Mutate(m *RiskMutation) {
 	if v := i.Details; v != nil {
 		m.SetDetails(v)
 	}
+	if v := i.OwnerID; v != nil {
+		m.SetOwnerID(*v)
+	}
+	if i.ClearBlockedGroups {
+		m.ClearBlockedGroups()
+	}
+	if v := i.AddBlockedGroupIDs; len(v) > 0 {
+		m.AddBlockedGroupIDs(v...)
+	}
+	if v := i.RemoveBlockedGroupIDs; len(v) > 0 {
+		m.RemoveBlockedGroupIDs(v...)
+	}
+	if i.ClearEditors {
+		m.ClearEditors()
+	}
+	if v := i.AddEditorIDs; len(v) > 0 {
+		m.AddEditorIDs(v...)
+	}
+	if v := i.RemoveEditorIDs; len(v) > 0 {
+		m.RemoveEditorIDs(v...)
+	}
+	if i.ClearViewers {
+		m.ClearViewers()
+	}
+	if v := i.AddViewerIDs; len(v) > 0 {
+		m.AddViewerIDs(v...)
+	}
+	if v := i.RemoveViewerIDs; len(v) > 0 {
+		m.RemoveViewerIDs(v...)
+	}
 	if i.ClearControl {
 		m.ClearControl()
 	}
@@ -6466,44 +6614,14 @@ func (i *UpdateRiskInput) Mutate(m *RiskMutation) {
 	if v := i.RemoveActionplanIDs; len(v) > 0 {
 		m.RemoveActionplanIDs(v...)
 	}
-	if v := i.OwnerID; v != nil {
-		m.SetOwnerID(*v)
-	}
-	if i.ClearProgram {
-		m.ClearProgram()
+	if i.ClearPrograms {
+		m.ClearPrograms()
 	}
 	if v := i.AddProgramIDs; len(v) > 0 {
 		m.AddProgramIDs(v...)
 	}
 	if v := i.RemoveProgramIDs; len(v) > 0 {
 		m.RemoveProgramIDs(v...)
-	}
-	if i.ClearViewers {
-		m.ClearViewers()
-	}
-	if v := i.AddViewerIDs; len(v) > 0 {
-		m.AddViewerIDs(v...)
-	}
-	if v := i.RemoveViewerIDs; len(v) > 0 {
-		m.RemoveViewerIDs(v...)
-	}
-	if i.ClearEditors {
-		m.ClearEditors()
-	}
-	if v := i.AddEditorIDs; len(v) > 0 {
-		m.AddEditorIDs(v...)
-	}
-	if v := i.RemoveEditorIDs; len(v) > 0 {
-		m.RemoveEditorIDs(v...)
-	}
-	if i.ClearBlockedGroups {
-		m.ClearBlockedGroups()
-	}
-	if v := i.AddBlockedGroupIDs; len(v) > 0 {
-		m.AddBlockedGroupIDs(v...)
-	}
-	if v := i.RemoveBlockedGroupIDs; len(v) > 0 {
-		m.RemoveBlockedGroupIDs(v...)
 	}
 }
 

--- a/internal/ent/generated/gql_where_input.go
+++ b/internal/ent/generated/gql_where_input.go
@@ -7167,6 +7167,21 @@ type ControlObjectiveWhereInput struct {
 	DeletedByEqualFold    *string  `json:"deletedByEqualFold,omitempty"`
 	DeletedByContainsFold *string  `json:"deletedByContainsFold,omitempty"`
 
+	// "owner_id" field predicates.
+	OwnerID             *string  `json:"ownerID,omitempty"`
+	OwnerIDNEQ          *string  `json:"ownerIDNEQ,omitempty"`
+	OwnerIDIn           []string `json:"ownerIDIn,omitempty"`
+	OwnerIDNotIn        []string `json:"ownerIDNotIn,omitempty"`
+	OwnerIDGT           *string  `json:"ownerIDGT,omitempty"`
+	OwnerIDGTE          *string  `json:"ownerIDGTE,omitempty"`
+	OwnerIDLT           *string  `json:"ownerIDLT,omitempty"`
+	OwnerIDLTE          *string  `json:"ownerIDLTE,omitempty"`
+	OwnerIDContains     *string  `json:"ownerIDContains,omitempty"`
+	OwnerIDHasPrefix    *string  `json:"ownerIDHasPrefix,omitempty"`
+	OwnerIDHasSuffix    *string  `json:"ownerIDHasSuffix,omitempty"`
+	OwnerIDEqualFold    *string  `json:"ownerIDEqualFold,omitempty"`
+	OwnerIDContainsFold *string  `json:"ownerIDContainsFold,omitempty"`
+
 	// "name" field predicates.
 	Name             *string  `json:"name,omitempty"`
 	NameNEQ          *string  `json:"nameNEQ,omitempty"`
@@ -7334,6 +7349,22 @@ type ControlObjectiveWhereInput struct {
 	MappedFrameworksNotNil       bool     `json:"mappedFrameworksNotNil,omitempty"`
 	MappedFrameworksEqualFold    *string  `json:"mappedFrameworksEqualFold,omitempty"`
 	MappedFrameworksContainsFold *string  `json:"mappedFrameworksContainsFold,omitempty"`
+
+	// "owner" edge predicates.
+	HasOwner     *bool                     `json:"hasOwner,omitempty"`
+	HasOwnerWith []*OrganizationWhereInput `json:"hasOwnerWith,omitempty"`
+
+	// "blocked_groups" edge predicates.
+	HasBlockedGroups     *bool              `json:"hasBlockedGroups,omitempty"`
+	HasBlockedGroupsWith []*GroupWhereInput `json:"hasBlockedGroupsWith,omitempty"`
+
+	// "editors" edge predicates.
+	HasEditors     *bool              `json:"hasEditors,omitempty"`
+	HasEditorsWith []*GroupWhereInput `json:"hasEditorsWith,omitempty"`
+
+	// "viewers" edge predicates.
+	HasViewers     *bool              `json:"hasViewers,omitempty"`
+	HasViewersWith []*GroupWhereInput `json:"hasViewersWith,omitempty"`
 
 	// "policy" edge predicates.
 	HasPolicy     *bool                       `json:"hasPolicy,omitempty"`
@@ -7697,6 +7728,45 @@ func (i *ControlObjectiveWhereInput) P() (predicate.ControlObjective, error) {
 	}
 	if i.DeletedByContainsFold != nil {
 		predicates = append(predicates, controlobjective.DeletedByContainsFold(*i.DeletedByContainsFold))
+	}
+	if i.OwnerID != nil {
+		predicates = append(predicates, controlobjective.OwnerIDEQ(*i.OwnerID))
+	}
+	if i.OwnerIDNEQ != nil {
+		predicates = append(predicates, controlobjective.OwnerIDNEQ(*i.OwnerIDNEQ))
+	}
+	if len(i.OwnerIDIn) > 0 {
+		predicates = append(predicates, controlobjective.OwnerIDIn(i.OwnerIDIn...))
+	}
+	if len(i.OwnerIDNotIn) > 0 {
+		predicates = append(predicates, controlobjective.OwnerIDNotIn(i.OwnerIDNotIn...))
+	}
+	if i.OwnerIDGT != nil {
+		predicates = append(predicates, controlobjective.OwnerIDGT(*i.OwnerIDGT))
+	}
+	if i.OwnerIDGTE != nil {
+		predicates = append(predicates, controlobjective.OwnerIDGTE(*i.OwnerIDGTE))
+	}
+	if i.OwnerIDLT != nil {
+		predicates = append(predicates, controlobjective.OwnerIDLT(*i.OwnerIDLT))
+	}
+	if i.OwnerIDLTE != nil {
+		predicates = append(predicates, controlobjective.OwnerIDLTE(*i.OwnerIDLTE))
+	}
+	if i.OwnerIDContains != nil {
+		predicates = append(predicates, controlobjective.OwnerIDContains(*i.OwnerIDContains))
+	}
+	if i.OwnerIDHasPrefix != nil {
+		predicates = append(predicates, controlobjective.OwnerIDHasPrefix(*i.OwnerIDHasPrefix))
+	}
+	if i.OwnerIDHasSuffix != nil {
+		predicates = append(predicates, controlobjective.OwnerIDHasSuffix(*i.OwnerIDHasSuffix))
+	}
+	if i.OwnerIDEqualFold != nil {
+		predicates = append(predicates, controlobjective.OwnerIDEqualFold(*i.OwnerIDEqualFold))
+	}
+	if i.OwnerIDContainsFold != nil {
+		predicates = append(predicates, controlobjective.OwnerIDContainsFold(*i.OwnerIDContainsFold))
 	}
 	if i.Name != nil {
 		predicates = append(predicates, controlobjective.NameEQ(*i.Name))
@@ -8143,6 +8213,78 @@ func (i *ControlObjectiveWhereInput) P() (predicate.ControlObjective, error) {
 		predicates = append(predicates, controlobjective.MappedFrameworksContainsFold(*i.MappedFrameworksContainsFold))
 	}
 
+	if i.HasOwner != nil {
+		p := controlobjective.HasOwner()
+		if !*i.HasOwner {
+			p = controlobjective.Not(p)
+		}
+		predicates = append(predicates, p)
+	}
+	if len(i.HasOwnerWith) > 0 {
+		with := make([]predicate.Organization, 0, len(i.HasOwnerWith))
+		for _, w := range i.HasOwnerWith {
+			p, err := w.P()
+			if err != nil {
+				return nil, fmt.Errorf("%w: field 'HasOwnerWith'", err)
+			}
+			with = append(with, p)
+		}
+		predicates = append(predicates, controlobjective.HasOwnerWith(with...))
+	}
+	if i.HasBlockedGroups != nil {
+		p := controlobjective.HasBlockedGroups()
+		if !*i.HasBlockedGroups {
+			p = controlobjective.Not(p)
+		}
+		predicates = append(predicates, p)
+	}
+	if len(i.HasBlockedGroupsWith) > 0 {
+		with := make([]predicate.Group, 0, len(i.HasBlockedGroupsWith))
+		for _, w := range i.HasBlockedGroupsWith {
+			p, err := w.P()
+			if err != nil {
+				return nil, fmt.Errorf("%w: field 'HasBlockedGroupsWith'", err)
+			}
+			with = append(with, p)
+		}
+		predicates = append(predicates, controlobjective.HasBlockedGroupsWith(with...))
+	}
+	if i.HasEditors != nil {
+		p := controlobjective.HasEditors()
+		if !*i.HasEditors {
+			p = controlobjective.Not(p)
+		}
+		predicates = append(predicates, p)
+	}
+	if len(i.HasEditorsWith) > 0 {
+		with := make([]predicate.Group, 0, len(i.HasEditorsWith))
+		for _, w := range i.HasEditorsWith {
+			p, err := w.P()
+			if err != nil {
+				return nil, fmt.Errorf("%w: field 'HasEditorsWith'", err)
+			}
+			with = append(with, p)
+		}
+		predicates = append(predicates, controlobjective.HasEditorsWith(with...))
+	}
+	if i.HasViewers != nil {
+		p := controlobjective.HasViewers()
+		if !*i.HasViewers {
+			p = controlobjective.Not(p)
+		}
+		predicates = append(predicates, p)
+	}
+	if len(i.HasViewersWith) > 0 {
+		with := make([]predicate.Group, 0, len(i.HasViewersWith))
+		for _, w := range i.HasViewersWith {
+			p, err := w.P()
+			if err != nil {
+				return nil, fmt.Errorf("%w: field 'HasViewersWith'", err)
+			}
+			with = append(with, p)
+		}
+		predicates = append(predicates, controlobjective.HasViewersWith(with...))
+	}
 	if i.HasPolicy != nil {
 		p := controlobjective.HasPolicy()
 		if !*i.HasPolicy {
@@ -8453,6 +8595,21 @@ type ControlObjectiveHistoryWhereInput struct {
 	DeletedByNotNil       bool     `json:"deletedByNotNil,omitempty"`
 	DeletedByEqualFold    *string  `json:"deletedByEqualFold,omitempty"`
 	DeletedByContainsFold *string  `json:"deletedByContainsFold,omitempty"`
+
+	// "owner_id" field predicates.
+	OwnerID             *string  `json:"ownerID,omitempty"`
+	OwnerIDNEQ          *string  `json:"ownerIDNEQ,omitempty"`
+	OwnerIDIn           []string `json:"ownerIDIn,omitempty"`
+	OwnerIDNotIn        []string `json:"ownerIDNotIn,omitempty"`
+	OwnerIDGT           *string  `json:"ownerIDGT,omitempty"`
+	OwnerIDGTE          *string  `json:"ownerIDGTE,omitempty"`
+	OwnerIDLT           *string  `json:"ownerIDLT,omitempty"`
+	OwnerIDLTE          *string  `json:"ownerIDLTE,omitempty"`
+	OwnerIDContains     *string  `json:"ownerIDContains,omitempty"`
+	OwnerIDHasPrefix    *string  `json:"ownerIDHasPrefix,omitempty"`
+	OwnerIDHasSuffix    *string  `json:"ownerIDHasSuffix,omitempty"`
+	OwnerIDEqualFold    *string  `json:"ownerIDEqualFold,omitempty"`
+	OwnerIDContainsFold *string  `json:"ownerIDContainsFold,omitempty"`
 
 	// "name" field predicates.
 	Name             *string  `json:"name,omitempty"`
@@ -9029,6 +9186,45 @@ func (i *ControlObjectiveHistoryWhereInput) P() (predicate.ControlObjectiveHisto
 	}
 	if i.DeletedByContainsFold != nil {
 		predicates = append(predicates, controlobjectivehistory.DeletedByContainsFold(*i.DeletedByContainsFold))
+	}
+	if i.OwnerID != nil {
+		predicates = append(predicates, controlobjectivehistory.OwnerIDEQ(*i.OwnerID))
+	}
+	if i.OwnerIDNEQ != nil {
+		predicates = append(predicates, controlobjectivehistory.OwnerIDNEQ(*i.OwnerIDNEQ))
+	}
+	if len(i.OwnerIDIn) > 0 {
+		predicates = append(predicates, controlobjectivehistory.OwnerIDIn(i.OwnerIDIn...))
+	}
+	if len(i.OwnerIDNotIn) > 0 {
+		predicates = append(predicates, controlobjectivehistory.OwnerIDNotIn(i.OwnerIDNotIn...))
+	}
+	if i.OwnerIDGT != nil {
+		predicates = append(predicates, controlobjectivehistory.OwnerIDGT(*i.OwnerIDGT))
+	}
+	if i.OwnerIDGTE != nil {
+		predicates = append(predicates, controlobjectivehistory.OwnerIDGTE(*i.OwnerIDGTE))
+	}
+	if i.OwnerIDLT != nil {
+		predicates = append(predicates, controlobjectivehistory.OwnerIDLT(*i.OwnerIDLT))
+	}
+	if i.OwnerIDLTE != nil {
+		predicates = append(predicates, controlobjectivehistory.OwnerIDLTE(*i.OwnerIDLTE))
+	}
+	if i.OwnerIDContains != nil {
+		predicates = append(predicates, controlobjectivehistory.OwnerIDContains(*i.OwnerIDContains))
+	}
+	if i.OwnerIDHasPrefix != nil {
+		predicates = append(predicates, controlobjectivehistory.OwnerIDHasPrefix(*i.OwnerIDHasPrefix))
+	}
+	if i.OwnerIDHasSuffix != nil {
+		predicates = append(predicates, controlobjectivehistory.OwnerIDHasSuffix(*i.OwnerIDHasSuffix))
+	}
+	if i.OwnerIDEqualFold != nil {
+		predicates = append(predicates, controlobjectivehistory.OwnerIDEqualFold(*i.OwnerIDEqualFold))
+	}
+	if i.OwnerIDContainsFold != nil {
+		predicates = append(predicates, controlobjectivehistory.OwnerIDContainsFold(*i.OwnerIDContainsFold))
 	}
 	if i.Name != nil {
 		predicates = append(predicates, controlobjectivehistory.NameEQ(*i.Name))
@@ -25626,6 +25822,18 @@ type GroupWhereInput struct {
 	HasRiskBlockedGroups     *bool             `json:"hasRiskBlockedGroups,omitempty"`
 	HasRiskBlockedGroupsWith []*RiskWhereInput `json:"hasRiskBlockedGroupsWith,omitempty"`
 
+	// "controlobjective_viewers" edge predicates.
+	HasControlobjectiveViewers     *bool                         `json:"hasControlobjectiveViewers,omitempty"`
+	HasControlobjectiveViewersWith []*ControlObjectiveWhereInput `json:"hasControlobjectiveViewersWith,omitempty"`
+
+	// "controlobjective_editors" edge predicates.
+	HasControlobjectiveEditors     *bool                         `json:"hasControlobjectiveEditors,omitempty"`
+	HasControlobjectiveEditorsWith []*ControlObjectiveWhereInput `json:"hasControlobjectiveEditorsWith,omitempty"`
+
+	// "controlobjective_blocked_groups" edge predicates.
+	HasControlobjectiveBlockedGroups     *bool                         `json:"hasControlobjectiveBlockedGroups,omitempty"`
+	HasControlobjectiveBlockedGroupsWith []*ControlObjectiveWhereInput `json:"hasControlobjectiveBlockedGroupsWith,omitempty"`
+
 	// "members" edge predicates.
 	HasMembers     *bool                        `json:"hasMembers,omitempty"`
 	HasMembersWith []*GroupMembershipWhereInput `json:"hasMembersWith,omitempty"`
@@ -26386,6 +26594,60 @@ func (i *GroupWhereInput) P() (predicate.Group, error) {
 			with = append(with, p)
 		}
 		predicates = append(predicates, group.HasRiskBlockedGroupsWith(with...))
+	}
+	if i.HasControlobjectiveViewers != nil {
+		p := group.HasControlobjectiveViewers()
+		if !*i.HasControlobjectiveViewers {
+			p = group.Not(p)
+		}
+		predicates = append(predicates, p)
+	}
+	if len(i.HasControlobjectiveViewersWith) > 0 {
+		with := make([]predicate.ControlObjective, 0, len(i.HasControlobjectiveViewersWith))
+		for _, w := range i.HasControlobjectiveViewersWith {
+			p, err := w.P()
+			if err != nil {
+				return nil, fmt.Errorf("%w: field 'HasControlobjectiveViewersWith'", err)
+			}
+			with = append(with, p)
+		}
+		predicates = append(predicates, group.HasControlobjectiveViewersWith(with...))
+	}
+	if i.HasControlobjectiveEditors != nil {
+		p := group.HasControlobjectiveEditors()
+		if !*i.HasControlobjectiveEditors {
+			p = group.Not(p)
+		}
+		predicates = append(predicates, p)
+	}
+	if len(i.HasControlobjectiveEditorsWith) > 0 {
+		with := make([]predicate.ControlObjective, 0, len(i.HasControlobjectiveEditorsWith))
+		for _, w := range i.HasControlobjectiveEditorsWith {
+			p, err := w.P()
+			if err != nil {
+				return nil, fmt.Errorf("%w: field 'HasControlobjectiveEditorsWith'", err)
+			}
+			with = append(with, p)
+		}
+		predicates = append(predicates, group.HasControlobjectiveEditorsWith(with...))
+	}
+	if i.HasControlobjectiveBlockedGroups != nil {
+		p := group.HasControlobjectiveBlockedGroups()
+		if !*i.HasControlobjectiveBlockedGroups {
+			p = group.Not(p)
+		}
+		predicates = append(predicates, p)
+	}
+	if len(i.HasControlobjectiveBlockedGroupsWith) > 0 {
+		with := make([]predicate.ControlObjective, 0, len(i.HasControlobjectiveBlockedGroupsWith))
+		for _, w := range i.HasControlobjectiveBlockedGroupsWith {
+			p, err := w.P()
+			if err != nil {
+				return nil, fmt.Errorf("%w: field 'HasControlobjectiveBlockedGroupsWith'", err)
+			}
+			with = append(with, p)
+		}
+		predicates = append(predicates, group.HasControlobjectiveBlockedGroupsWith(with...))
 	}
 	if i.HasMembers != nil {
 		p := group.HasMembers()
@@ -32891,6 +33153,14 @@ type InternalPolicyWhereInput struct {
 	HasOwner     *bool                     `json:"hasOwner,omitempty"`
 	HasOwnerWith []*OrganizationWhereInput `json:"hasOwnerWith,omitempty"`
 
+	// "blocked_groups" edge predicates.
+	HasBlockedGroups     *bool              `json:"hasBlockedGroups,omitempty"`
+	HasBlockedGroupsWith []*GroupWhereInput `json:"hasBlockedGroupsWith,omitempty"`
+
+	// "editors" edge predicates.
+	HasEditors     *bool              `json:"hasEditors,omitempty"`
+	HasEditorsWith []*GroupWhereInput `json:"hasEditorsWith,omitempty"`
+
 	// "controlobjectives" edge predicates.
 	HasControlobjectives     *bool                         `json:"hasControlobjectives,omitempty"`
 	HasControlobjectivesWith []*ControlObjectiveWhereInput `json:"hasControlobjectivesWith,omitempty"`
@@ -32914,14 +33184,6 @@ type InternalPolicyWhereInput struct {
 	// "programs" edge predicates.
 	HasPrograms     *bool                `json:"hasPrograms,omitempty"`
 	HasProgramsWith []*ProgramWhereInput `json:"hasProgramsWith,omitempty"`
-
-	// "editors" edge predicates.
-	HasEditors     *bool              `json:"hasEditors,omitempty"`
-	HasEditorsWith []*GroupWhereInput `json:"hasEditorsWith,omitempty"`
-
-	// "blocked_groups" edge predicates.
-	HasBlockedGroups     *bool              `json:"hasBlockedGroups,omitempty"`
-	HasBlockedGroupsWith []*GroupWhereInput `json:"hasBlockedGroupsWith,omitempty"`
 }
 
 // AddPredicates adds custom predicates to the where input to be used during the filtering phase.
@@ -33623,6 +33885,42 @@ func (i *InternalPolicyWhereInput) P() (predicate.InternalPolicy, error) {
 		}
 		predicates = append(predicates, internalpolicy.HasOwnerWith(with...))
 	}
+	if i.HasBlockedGroups != nil {
+		p := internalpolicy.HasBlockedGroups()
+		if !*i.HasBlockedGroups {
+			p = internalpolicy.Not(p)
+		}
+		predicates = append(predicates, p)
+	}
+	if len(i.HasBlockedGroupsWith) > 0 {
+		with := make([]predicate.Group, 0, len(i.HasBlockedGroupsWith))
+		for _, w := range i.HasBlockedGroupsWith {
+			p, err := w.P()
+			if err != nil {
+				return nil, fmt.Errorf("%w: field 'HasBlockedGroupsWith'", err)
+			}
+			with = append(with, p)
+		}
+		predicates = append(predicates, internalpolicy.HasBlockedGroupsWith(with...))
+	}
+	if i.HasEditors != nil {
+		p := internalpolicy.HasEditors()
+		if !*i.HasEditors {
+			p = internalpolicy.Not(p)
+		}
+		predicates = append(predicates, p)
+	}
+	if len(i.HasEditorsWith) > 0 {
+		with := make([]predicate.Group, 0, len(i.HasEditorsWith))
+		for _, w := range i.HasEditorsWith {
+			p, err := w.P()
+			if err != nil {
+				return nil, fmt.Errorf("%w: field 'HasEditorsWith'", err)
+			}
+			with = append(with, p)
+		}
+		predicates = append(predicates, internalpolicy.HasEditorsWith(with...))
+	}
 	if i.HasControlobjectives != nil {
 		p := internalpolicy.HasControlobjectives()
 		if !*i.HasControlobjectives {
@@ -33730,42 +34028,6 @@ func (i *InternalPolicyWhereInput) P() (predicate.InternalPolicy, error) {
 			with = append(with, p)
 		}
 		predicates = append(predicates, internalpolicy.HasProgramsWith(with...))
-	}
-	if i.HasEditors != nil {
-		p := internalpolicy.HasEditors()
-		if !*i.HasEditors {
-			p = internalpolicy.Not(p)
-		}
-		predicates = append(predicates, p)
-	}
-	if len(i.HasEditorsWith) > 0 {
-		with := make([]predicate.Group, 0, len(i.HasEditorsWith))
-		for _, w := range i.HasEditorsWith {
-			p, err := w.P()
-			if err != nil {
-				return nil, fmt.Errorf("%w: field 'HasEditorsWith'", err)
-			}
-			with = append(with, p)
-		}
-		predicates = append(predicates, internalpolicy.HasEditorsWith(with...))
-	}
-	if i.HasBlockedGroups != nil {
-		p := internalpolicy.HasBlockedGroups()
-		if !*i.HasBlockedGroups {
-			p = internalpolicy.Not(p)
-		}
-		predicates = append(predicates, p)
-	}
-	if len(i.HasBlockedGroupsWith) > 0 {
-		with := make([]predicate.Group, 0, len(i.HasBlockedGroupsWith))
-		for _, w := range i.HasBlockedGroupsWith {
-			p, err := w.P()
-			if err != nil {
-				return nil, fmt.Errorf("%w: field 'HasBlockedGroupsWith'", err)
-			}
-			with = append(with, p)
-		}
-		predicates = append(predicates, internalpolicy.HasBlockedGroupsWith(with...))
 	}
 	switch len(predicates) {
 	case 0:
@@ -42674,6 +42936,10 @@ type OrganizationWhereInput struct {
 	HasRisks     *bool             `json:"hasRisks,omitempty"`
 	HasRisksWith []*RiskWhereInput `json:"hasRisksWith,omitempty"`
 
+	// "controlobjectives" edge predicates.
+	HasControlobjectives     *bool                         `json:"hasControlobjectives,omitempty"`
+	HasControlobjectivesWith []*ControlObjectiveWhereInput `json:"hasControlobjectivesWith,omitempty"`
+
 	// "members" edge predicates.
 	HasMembers     *bool                      `json:"hasMembers,omitempty"`
 	HasMembersWith []*OrgMembershipWhereInput `json:"hasMembersWith,omitempty"`
@@ -43704,6 +43970,24 @@ func (i *OrganizationWhereInput) P() (predicate.Organization, error) {
 			with = append(with, p)
 		}
 		predicates = append(predicates, organization.HasRisksWith(with...))
+	}
+	if i.HasControlobjectives != nil {
+		p := organization.HasControlobjectives()
+		if !*i.HasControlobjectives {
+			p = organization.Not(p)
+		}
+		predicates = append(predicates, p)
+	}
+	if len(i.HasControlobjectivesWith) > 0 {
+		with := make([]predicate.ControlObjective, 0, len(i.HasControlobjectivesWith))
+		for _, w := range i.HasControlobjectivesWith {
+			p, err := w.P()
+			if err != nil {
+				return nil, fmt.Errorf("%w: field 'HasControlobjectivesWith'", err)
+			}
+			with = append(with, p)
+		}
+		predicates = append(predicates, organization.HasControlobjectivesWith(with...))
 	}
 	if i.HasMembers != nil {
 		p := organization.HasMembers()
@@ -47362,6 +47646,14 @@ type ProcedureWhereInput struct {
 	HasOwner     *bool                     `json:"hasOwner,omitempty"`
 	HasOwnerWith []*OrganizationWhereInput `json:"hasOwnerWith,omitempty"`
 
+	// "blocked_groups" edge predicates.
+	HasBlockedGroups     *bool              `json:"hasBlockedGroups,omitempty"`
+	HasBlockedGroupsWith []*GroupWhereInput `json:"hasBlockedGroupsWith,omitempty"`
+
+	// "editors" edge predicates.
+	HasEditors     *bool              `json:"hasEditors,omitempty"`
+	HasEditorsWith []*GroupWhereInput `json:"hasEditorsWith,omitempty"`
+
 	// "control" edge predicates.
 	HasControl     *bool                `json:"hasControl,omitempty"`
 	HasControlWith []*ControlWhereInput `json:"hasControlWith,omitempty"`
@@ -47385,14 +47677,6 @@ type ProcedureWhereInput struct {
 	// "programs" edge predicates.
 	HasPrograms     *bool                `json:"hasPrograms,omitempty"`
 	HasProgramsWith []*ProgramWhereInput `json:"hasProgramsWith,omitempty"`
-
-	// "editors" edge predicates.
-	HasEditors     *bool              `json:"hasEditors,omitempty"`
-	HasEditorsWith []*GroupWhereInput `json:"hasEditorsWith,omitempty"`
-
-	// "blocked_groups" edge predicates.
-	HasBlockedGroups     *bool              `json:"hasBlockedGroups,omitempty"`
-	HasBlockedGroupsWith []*GroupWhereInput `json:"hasBlockedGroupsWith,omitempty"`
 }
 
 // AddPredicates adds custom predicates to the where input to be used during the filtering phase.
@@ -48139,6 +48423,42 @@ func (i *ProcedureWhereInput) P() (predicate.Procedure, error) {
 		}
 		predicates = append(predicates, procedure.HasOwnerWith(with...))
 	}
+	if i.HasBlockedGroups != nil {
+		p := procedure.HasBlockedGroups()
+		if !*i.HasBlockedGroups {
+			p = procedure.Not(p)
+		}
+		predicates = append(predicates, p)
+	}
+	if len(i.HasBlockedGroupsWith) > 0 {
+		with := make([]predicate.Group, 0, len(i.HasBlockedGroupsWith))
+		for _, w := range i.HasBlockedGroupsWith {
+			p, err := w.P()
+			if err != nil {
+				return nil, fmt.Errorf("%w: field 'HasBlockedGroupsWith'", err)
+			}
+			with = append(with, p)
+		}
+		predicates = append(predicates, procedure.HasBlockedGroupsWith(with...))
+	}
+	if i.HasEditors != nil {
+		p := procedure.HasEditors()
+		if !*i.HasEditors {
+			p = procedure.Not(p)
+		}
+		predicates = append(predicates, p)
+	}
+	if len(i.HasEditorsWith) > 0 {
+		with := make([]predicate.Group, 0, len(i.HasEditorsWith))
+		for _, w := range i.HasEditorsWith {
+			p, err := w.P()
+			if err != nil {
+				return nil, fmt.Errorf("%w: field 'HasEditorsWith'", err)
+			}
+			with = append(with, p)
+		}
+		predicates = append(predicates, procedure.HasEditorsWith(with...))
+	}
 	if i.HasControl != nil {
 		p := procedure.HasControl()
 		if !*i.HasControl {
@@ -48246,42 +48566,6 @@ func (i *ProcedureWhereInput) P() (predicate.Procedure, error) {
 			with = append(with, p)
 		}
 		predicates = append(predicates, procedure.HasProgramsWith(with...))
-	}
-	if i.HasEditors != nil {
-		p := procedure.HasEditors()
-		if !*i.HasEditors {
-			p = procedure.Not(p)
-		}
-		predicates = append(predicates, p)
-	}
-	if len(i.HasEditorsWith) > 0 {
-		with := make([]predicate.Group, 0, len(i.HasEditorsWith))
-		for _, w := range i.HasEditorsWith {
-			p, err := w.P()
-			if err != nil {
-				return nil, fmt.Errorf("%w: field 'HasEditorsWith'", err)
-			}
-			with = append(with, p)
-		}
-		predicates = append(predicates, procedure.HasEditorsWith(with...))
-	}
-	if i.HasBlockedGroups != nil {
-		p := procedure.HasBlockedGroups()
-		if !*i.HasBlockedGroups {
-			p = procedure.Not(p)
-		}
-		predicates = append(predicates, p)
-	}
-	if len(i.HasBlockedGroupsWith) > 0 {
-		with := make([]predicate.Group, 0, len(i.HasBlockedGroupsWith))
-		for _, w := range i.HasBlockedGroupsWith {
-			p, err := w.P()
-			if err != nil {
-				return nil, fmt.Errorf("%w: field 'HasBlockedGroupsWith'", err)
-			}
-			with = append(with, p)
-		}
-		predicates = append(predicates, procedure.HasBlockedGroupsWith(with...))
 	}
 	switch len(predicates) {
 	case 0:
@@ -49602,6 +49886,18 @@ type ProgramWhereInput struct {
 	HasOwner     *bool                     `json:"hasOwner,omitempty"`
 	HasOwnerWith []*OrganizationWhereInput `json:"hasOwnerWith,omitempty"`
 
+	// "blocked_groups" edge predicates.
+	HasBlockedGroups     *bool              `json:"hasBlockedGroups,omitempty"`
+	HasBlockedGroupsWith []*GroupWhereInput `json:"hasBlockedGroupsWith,omitempty"`
+
+	// "editors" edge predicates.
+	HasEditors     *bool              `json:"hasEditors,omitempty"`
+	HasEditorsWith []*GroupWhereInput `json:"hasEditorsWith,omitempty"`
+
+	// "viewers" edge predicates.
+	HasViewers     *bool              `json:"hasViewers,omitempty"`
+	HasViewersWith []*GroupWhereInput `json:"hasViewersWith,omitempty"`
+
 	// "controls" edge predicates.
 	HasControls     *bool                `json:"hasControls,omitempty"`
 	HasControlsWith []*ControlWhereInput `json:"hasControlsWith,omitempty"`
@@ -49653,18 +49949,6 @@ type ProgramWhereInput struct {
 	// "users" edge predicates.
 	HasUsers     *bool             `json:"hasUsers,omitempty"`
 	HasUsersWith []*UserWhereInput `json:"hasUsersWith,omitempty"`
-
-	// "viewers" edge predicates.
-	HasViewers     *bool              `json:"hasViewers,omitempty"`
-	HasViewersWith []*GroupWhereInput `json:"hasViewersWith,omitempty"`
-
-	// "editors" edge predicates.
-	HasEditors     *bool              `json:"hasEditors,omitempty"`
-	HasEditorsWith []*GroupWhereInput `json:"hasEditorsWith,omitempty"`
-
-	// "blocked_groups" edge predicates.
-	HasBlockedGroups     *bool              `json:"hasBlockedGroups,omitempty"`
-	HasBlockedGroupsWith []*GroupWhereInput `json:"hasBlockedGroupsWith,omitempty"`
 
 	// "members" edge predicates.
 	HasMembers     *bool                          `json:"hasMembers,omitempty"`
@@ -50235,6 +50519,60 @@ func (i *ProgramWhereInput) P() (predicate.Program, error) {
 		}
 		predicates = append(predicates, program.HasOwnerWith(with...))
 	}
+	if i.HasBlockedGroups != nil {
+		p := program.HasBlockedGroups()
+		if !*i.HasBlockedGroups {
+			p = program.Not(p)
+		}
+		predicates = append(predicates, p)
+	}
+	if len(i.HasBlockedGroupsWith) > 0 {
+		with := make([]predicate.Group, 0, len(i.HasBlockedGroupsWith))
+		for _, w := range i.HasBlockedGroupsWith {
+			p, err := w.P()
+			if err != nil {
+				return nil, fmt.Errorf("%w: field 'HasBlockedGroupsWith'", err)
+			}
+			with = append(with, p)
+		}
+		predicates = append(predicates, program.HasBlockedGroupsWith(with...))
+	}
+	if i.HasEditors != nil {
+		p := program.HasEditors()
+		if !*i.HasEditors {
+			p = program.Not(p)
+		}
+		predicates = append(predicates, p)
+	}
+	if len(i.HasEditorsWith) > 0 {
+		with := make([]predicate.Group, 0, len(i.HasEditorsWith))
+		for _, w := range i.HasEditorsWith {
+			p, err := w.P()
+			if err != nil {
+				return nil, fmt.Errorf("%w: field 'HasEditorsWith'", err)
+			}
+			with = append(with, p)
+		}
+		predicates = append(predicates, program.HasEditorsWith(with...))
+	}
+	if i.HasViewers != nil {
+		p := program.HasViewers()
+		if !*i.HasViewers {
+			p = program.Not(p)
+		}
+		predicates = append(predicates, p)
+	}
+	if len(i.HasViewersWith) > 0 {
+		with := make([]predicate.Group, 0, len(i.HasViewersWith))
+		for _, w := range i.HasViewersWith {
+			p, err := w.P()
+			if err != nil {
+				return nil, fmt.Errorf("%w: field 'HasViewersWith'", err)
+			}
+			with = append(with, p)
+		}
+		predicates = append(predicates, program.HasViewersWith(with...))
+	}
 	if i.HasControls != nil {
 		p := program.HasControls()
 		if !*i.HasControls {
@@ -50468,60 +50806,6 @@ func (i *ProgramWhereInput) P() (predicate.Program, error) {
 			with = append(with, p)
 		}
 		predicates = append(predicates, program.HasUsersWith(with...))
-	}
-	if i.HasViewers != nil {
-		p := program.HasViewers()
-		if !*i.HasViewers {
-			p = program.Not(p)
-		}
-		predicates = append(predicates, p)
-	}
-	if len(i.HasViewersWith) > 0 {
-		with := make([]predicate.Group, 0, len(i.HasViewersWith))
-		for _, w := range i.HasViewersWith {
-			p, err := w.P()
-			if err != nil {
-				return nil, fmt.Errorf("%w: field 'HasViewersWith'", err)
-			}
-			with = append(with, p)
-		}
-		predicates = append(predicates, program.HasViewersWith(with...))
-	}
-	if i.HasEditors != nil {
-		p := program.HasEditors()
-		if !*i.HasEditors {
-			p = program.Not(p)
-		}
-		predicates = append(predicates, p)
-	}
-	if len(i.HasEditorsWith) > 0 {
-		with := make([]predicate.Group, 0, len(i.HasEditorsWith))
-		for _, w := range i.HasEditorsWith {
-			p, err := w.P()
-			if err != nil {
-				return nil, fmt.Errorf("%w: field 'HasEditorsWith'", err)
-			}
-			with = append(with, p)
-		}
-		predicates = append(predicates, program.HasEditorsWith(with...))
-	}
-	if i.HasBlockedGroups != nil {
-		p := program.HasBlockedGroups()
-		if !*i.HasBlockedGroups {
-			p = program.Not(p)
-		}
-		predicates = append(predicates, p)
-	}
-	if len(i.HasBlockedGroupsWith) > 0 {
-		with := make([]predicate.Group, 0, len(i.HasBlockedGroupsWith))
-		for _, w := range i.HasBlockedGroupsWith {
-			p, err := w.P()
-			if err != nil {
-				return nil, fmt.Errorf("%w: field 'HasBlockedGroupsWith'", err)
-			}
-			with = append(with, p)
-		}
-		predicates = append(predicates, program.HasBlockedGroupsWith(with...))
 	}
 	if i.HasMembers != nil {
 		p := program.HasMembers()
@@ -52823,6 +53107,21 @@ type RiskWhereInput struct {
 	DeletedByEqualFold    *string  `json:"deletedByEqualFold,omitempty"`
 	DeletedByContainsFold *string  `json:"deletedByContainsFold,omitempty"`
 
+	// "owner_id" field predicates.
+	OwnerID             *string  `json:"ownerID,omitempty"`
+	OwnerIDNEQ          *string  `json:"ownerIDNEQ,omitempty"`
+	OwnerIDIn           []string `json:"ownerIDIn,omitempty"`
+	OwnerIDNotIn        []string `json:"ownerIDNotIn,omitempty"`
+	OwnerIDGT           *string  `json:"ownerIDGT,omitempty"`
+	OwnerIDGTE          *string  `json:"ownerIDGTE,omitempty"`
+	OwnerIDLT           *string  `json:"ownerIDLT,omitempty"`
+	OwnerIDLTE          *string  `json:"ownerIDLTE,omitempty"`
+	OwnerIDContains     *string  `json:"ownerIDContains,omitempty"`
+	OwnerIDHasPrefix    *string  `json:"ownerIDHasPrefix,omitempty"`
+	OwnerIDHasSuffix    *string  `json:"ownerIDHasSuffix,omitempty"`
+	OwnerIDEqualFold    *string  `json:"ownerIDEqualFold,omitempty"`
+	OwnerIDContainsFold *string  `json:"ownerIDContainsFold,omitempty"`
+
 	// "name" field predicates.
 	Name             *string  `json:"name,omitempty"`
 	NameNEQ          *string  `json:"nameNEQ,omitempty"`
@@ -52956,20 +53255,21 @@ type RiskWhereInput struct {
 	SatisfiesEqualFold    *string  `json:"satisfiesEqualFold,omitempty"`
 	SatisfiesContainsFold *string  `json:"satisfiesContainsFold,omitempty"`
 
-	// "owner_id" field predicates.
-	OwnerID             *string  `json:"ownerID,omitempty"`
-	OwnerIDNEQ          *string  `json:"ownerIDNEQ,omitempty"`
-	OwnerIDIn           []string `json:"ownerIDIn,omitempty"`
-	OwnerIDNotIn        []string `json:"ownerIDNotIn,omitempty"`
-	OwnerIDGT           *string  `json:"ownerIDGT,omitempty"`
-	OwnerIDGTE          *string  `json:"ownerIDGTE,omitempty"`
-	OwnerIDLT           *string  `json:"ownerIDLT,omitempty"`
-	OwnerIDLTE          *string  `json:"ownerIDLTE,omitempty"`
-	OwnerIDContains     *string  `json:"ownerIDContains,omitempty"`
-	OwnerIDHasPrefix    *string  `json:"ownerIDHasPrefix,omitempty"`
-	OwnerIDHasSuffix    *string  `json:"ownerIDHasSuffix,omitempty"`
-	OwnerIDEqualFold    *string  `json:"ownerIDEqualFold,omitempty"`
-	OwnerIDContainsFold *string  `json:"ownerIDContainsFold,omitempty"`
+	// "owner" edge predicates.
+	HasOwner     *bool                     `json:"hasOwner,omitempty"`
+	HasOwnerWith []*OrganizationWhereInput `json:"hasOwnerWith,omitempty"`
+
+	// "blocked_groups" edge predicates.
+	HasBlockedGroups     *bool              `json:"hasBlockedGroups,omitempty"`
+	HasBlockedGroupsWith []*GroupWhereInput `json:"hasBlockedGroupsWith,omitempty"`
+
+	// "editors" edge predicates.
+	HasEditors     *bool              `json:"hasEditors,omitempty"`
+	HasEditorsWith []*GroupWhereInput `json:"hasEditorsWith,omitempty"`
+
+	// "viewers" edge predicates.
+	HasViewers     *bool              `json:"hasViewers,omitempty"`
+	HasViewersWith []*GroupWhereInput `json:"hasViewersWith,omitempty"`
 
 	// "control" edge predicates.
 	HasControl     *bool                `json:"hasControl,omitempty"`
@@ -52983,25 +53283,9 @@ type RiskWhereInput struct {
 	HasActionplans     *bool                   `json:"hasActionplans,omitempty"`
 	HasActionplansWith []*ActionPlanWhereInput `json:"hasActionplansWith,omitempty"`
 
-	// "owner" edge predicates.
-	HasOwner     *bool                     `json:"hasOwner,omitempty"`
-	HasOwnerWith []*OrganizationWhereInput `json:"hasOwnerWith,omitempty"`
-
-	// "program" edge predicates.
-	HasProgram     *bool                `json:"hasProgram,omitempty"`
-	HasProgramWith []*ProgramWhereInput `json:"hasProgramWith,omitempty"`
-
-	// "viewers" edge predicates.
-	HasViewers     *bool              `json:"hasViewers,omitempty"`
-	HasViewersWith []*GroupWhereInput `json:"hasViewersWith,omitempty"`
-
-	// "editors" edge predicates.
-	HasEditors     *bool              `json:"hasEditors,omitempty"`
-	HasEditorsWith []*GroupWhereInput `json:"hasEditorsWith,omitempty"`
-
-	// "blocked_groups" edge predicates.
-	HasBlockedGroups     *bool              `json:"hasBlockedGroups,omitempty"`
-	HasBlockedGroupsWith []*GroupWhereInput `json:"hasBlockedGroupsWith,omitempty"`
+	// "programs" edge predicates.
+	HasPrograms     *bool                `json:"hasPrograms,omitempty"`
+	HasProgramsWith []*ProgramWhereInput `json:"hasProgramsWith,omitempty"`
 }
 
 // AddPredicates adds custom predicates to the where input to be used during the filtering phase.
@@ -53329,6 +53613,45 @@ func (i *RiskWhereInput) P() (predicate.Risk, error) {
 	}
 	if i.DeletedByContainsFold != nil {
 		predicates = append(predicates, risk.DeletedByContainsFold(*i.DeletedByContainsFold))
+	}
+	if i.OwnerID != nil {
+		predicates = append(predicates, risk.OwnerIDEQ(*i.OwnerID))
+	}
+	if i.OwnerIDNEQ != nil {
+		predicates = append(predicates, risk.OwnerIDNEQ(*i.OwnerIDNEQ))
+	}
+	if len(i.OwnerIDIn) > 0 {
+		predicates = append(predicates, risk.OwnerIDIn(i.OwnerIDIn...))
+	}
+	if len(i.OwnerIDNotIn) > 0 {
+		predicates = append(predicates, risk.OwnerIDNotIn(i.OwnerIDNotIn...))
+	}
+	if i.OwnerIDGT != nil {
+		predicates = append(predicates, risk.OwnerIDGT(*i.OwnerIDGT))
+	}
+	if i.OwnerIDGTE != nil {
+		predicates = append(predicates, risk.OwnerIDGTE(*i.OwnerIDGTE))
+	}
+	if i.OwnerIDLT != nil {
+		predicates = append(predicates, risk.OwnerIDLT(*i.OwnerIDLT))
+	}
+	if i.OwnerIDLTE != nil {
+		predicates = append(predicates, risk.OwnerIDLTE(*i.OwnerIDLTE))
+	}
+	if i.OwnerIDContains != nil {
+		predicates = append(predicates, risk.OwnerIDContains(*i.OwnerIDContains))
+	}
+	if i.OwnerIDHasPrefix != nil {
+		predicates = append(predicates, risk.OwnerIDHasPrefix(*i.OwnerIDHasPrefix))
+	}
+	if i.OwnerIDHasSuffix != nil {
+		predicates = append(predicates, risk.OwnerIDHasSuffix(*i.OwnerIDHasSuffix))
+	}
+	if i.OwnerIDEqualFold != nil {
+		predicates = append(predicates, risk.OwnerIDEqualFold(*i.OwnerIDEqualFold))
+	}
+	if i.OwnerIDContainsFold != nil {
+		predicates = append(predicates, risk.OwnerIDContainsFold(*i.OwnerIDContainsFold))
 	}
 	if i.Name != nil {
 		predicates = append(predicates, risk.NameEQ(*i.Name))
@@ -53675,46 +53998,79 @@ func (i *RiskWhereInput) P() (predicate.Risk, error) {
 	if i.SatisfiesContainsFold != nil {
 		predicates = append(predicates, risk.SatisfiesContainsFold(*i.SatisfiesContainsFold))
 	}
-	if i.OwnerID != nil {
-		predicates = append(predicates, risk.OwnerIDEQ(*i.OwnerID))
-	}
-	if i.OwnerIDNEQ != nil {
-		predicates = append(predicates, risk.OwnerIDNEQ(*i.OwnerIDNEQ))
-	}
-	if len(i.OwnerIDIn) > 0 {
-		predicates = append(predicates, risk.OwnerIDIn(i.OwnerIDIn...))
-	}
-	if len(i.OwnerIDNotIn) > 0 {
-		predicates = append(predicates, risk.OwnerIDNotIn(i.OwnerIDNotIn...))
-	}
-	if i.OwnerIDGT != nil {
-		predicates = append(predicates, risk.OwnerIDGT(*i.OwnerIDGT))
-	}
-	if i.OwnerIDGTE != nil {
-		predicates = append(predicates, risk.OwnerIDGTE(*i.OwnerIDGTE))
-	}
-	if i.OwnerIDLT != nil {
-		predicates = append(predicates, risk.OwnerIDLT(*i.OwnerIDLT))
-	}
-	if i.OwnerIDLTE != nil {
-		predicates = append(predicates, risk.OwnerIDLTE(*i.OwnerIDLTE))
-	}
-	if i.OwnerIDContains != nil {
-		predicates = append(predicates, risk.OwnerIDContains(*i.OwnerIDContains))
-	}
-	if i.OwnerIDHasPrefix != nil {
-		predicates = append(predicates, risk.OwnerIDHasPrefix(*i.OwnerIDHasPrefix))
-	}
-	if i.OwnerIDHasSuffix != nil {
-		predicates = append(predicates, risk.OwnerIDHasSuffix(*i.OwnerIDHasSuffix))
-	}
-	if i.OwnerIDEqualFold != nil {
-		predicates = append(predicates, risk.OwnerIDEqualFold(*i.OwnerIDEqualFold))
-	}
-	if i.OwnerIDContainsFold != nil {
-		predicates = append(predicates, risk.OwnerIDContainsFold(*i.OwnerIDContainsFold))
-	}
 
+	if i.HasOwner != nil {
+		p := risk.HasOwner()
+		if !*i.HasOwner {
+			p = risk.Not(p)
+		}
+		predicates = append(predicates, p)
+	}
+	if len(i.HasOwnerWith) > 0 {
+		with := make([]predicate.Organization, 0, len(i.HasOwnerWith))
+		for _, w := range i.HasOwnerWith {
+			p, err := w.P()
+			if err != nil {
+				return nil, fmt.Errorf("%w: field 'HasOwnerWith'", err)
+			}
+			with = append(with, p)
+		}
+		predicates = append(predicates, risk.HasOwnerWith(with...))
+	}
+	if i.HasBlockedGroups != nil {
+		p := risk.HasBlockedGroups()
+		if !*i.HasBlockedGroups {
+			p = risk.Not(p)
+		}
+		predicates = append(predicates, p)
+	}
+	if len(i.HasBlockedGroupsWith) > 0 {
+		with := make([]predicate.Group, 0, len(i.HasBlockedGroupsWith))
+		for _, w := range i.HasBlockedGroupsWith {
+			p, err := w.P()
+			if err != nil {
+				return nil, fmt.Errorf("%w: field 'HasBlockedGroupsWith'", err)
+			}
+			with = append(with, p)
+		}
+		predicates = append(predicates, risk.HasBlockedGroupsWith(with...))
+	}
+	if i.HasEditors != nil {
+		p := risk.HasEditors()
+		if !*i.HasEditors {
+			p = risk.Not(p)
+		}
+		predicates = append(predicates, p)
+	}
+	if len(i.HasEditorsWith) > 0 {
+		with := make([]predicate.Group, 0, len(i.HasEditorsWith))
+		for _, w := range i.HasEditorsWith {
+			p, err := w.P()
+			if err != nil {
+				return nil, fmt.Errorf("%w: field 'HasEditorsWith'", err)
+			}
+			with = append(with, p)
+		}
+		predicates = append(predicates, risk.HasEditorsWith(with...))
+	}
+	if i.HasViewers != nil {
+		p := risk.HasViewers()
+		if !*i.HasViewers {
+			p = risk.Not(p)
+		}
+		predicates = append(predicates, p)
+	}
+	if len(i.HasViewersWith) > 0 {
+		with := make([]predicate.Group, 0, len(i.HasViewersWith))
+		for _, w := range i.HasViewersWith {
+			p, err := w.P()
+			if err != nil {
+				return nil, fmt.Errorf("%w: field 'HasViewersWith'", err)
+			}
+			with = append(with, p)
+		}
+		predicates = append(predicates, risk.HasViewersWith(with...))
+	}
 	if i.HasControl != nil {
 		p := risk.HasControl()
 		if !*i.HasControl {
@@ -53769,95 +54125,23 @@ func (i *RiskWhereInput) P() (predicate.Risk, error) {
 		}
 		predicates = append(predicates, risk.HasActionplansWith(with...))
 	}
-	if i.HasOwner != nil {
-		p := risk.HasOwner()
-		if !*i.HasOwner {
+	if i.HasPrograms != nil {
+		p := risk.HasPrograms()
+		if !*i.HasPrograms {
 			p = risk.Not(p)
 		}
 		predicates = append(predicates, p)
 	}
-	if len(i.HasOwnerWith) > 0 {
-		with := make([]predicate.Organization, 0, len(i.HasOwnerWith))
-		for _, w := range i.HasOwnerWith {
+	if len(i.HasProgramsWith) > 0 {
+		with := make([]predicate.Program, 0, len(i.HasProgramsWith))
+		for _, w := range i.HasProgramsWith {
 			p, err := w.P()
 			if err != nil {
-				return nil, fmt.Errorf("%w: field 'HasOwnerWith'", err)
+				return nil, fmt.Errorf("%w: field 'HasProgramsWith'", err)
 			}
 			with = append(with, p)
 		}
-		predicates = append(predicates, risk.HasOwnerWith(with...))
-	}
-	if i.HasProgram != nil {
-		p := risk.HasProgram()
-		if !*i.HasProgram {
-			p = risk.Not(p)
-		}
-		predicates = append(predicates, p)
-	}
-	if len(i.HasProgramWith) > 0 {
-		with := make([]predicate.Program, 0, len(i.HasProgramWith))
-		for _, w := range i.HasProgramWith {
-			p, err := w.P()
-			if err != nil {
-				return nil, fmt.Errorf("%w: field 'HasProgramWith'", err)
-			}
-			with = append(with, p)
-		}
-		predicates = append(predicates, risk.HasProgramWith(with...))
-	}
-	if i.HasViewers != nil {
-		p := risk.HasViewers()
-		if !*i.HasViewers {
-			p = risk.Not(p)
-		}
-		predicates = append(predicates, p)
-	}
-	if len(i.HasViewersWith) > 0 {
-		with := make([]predicate.Group, 0, len(i.HasViewersWith))
-		for _, w := range i.HasViewersWith {
-			p, err := w.P()
-			if err != nil {
-				return nil, fmt.Errorf("%w: field 'HasViewersWith'", err)
-			}
-			with = append(with, p)
-		}
-		predicates = append(predicates, risk.HasViewersWith(with...))
-	}
-	if i.HasEditors != nil {
-		p := risk.HasEditors()
-		if !*i.HasEditors {
-			p = risk.Not(p)
-		}
-		predicates = append(predicates, p)
-	}
-	if len(i.HasEditorsWith) > 0 {
-		with := make([]predicate.Group, 0, len(i.HasEditorsWith))
-		for _, w := range i.HasEditorsWith {
-			p, err := w.P()
-			if err != nil {
-				return nil, fmt.Errorf("%w: field 'HasEditorsWith'", err)
-			}
-			with = append(with, p)
-		}
-		predicates = append(predicates, risk.HasEditorsWith(with...))
-	}
-	if i.HasBlockedGroups != nil {
-		p := risk.HasBlockedGroups()
-		if !*i.HasBlockedGroups {
-			p = risk.Not(p)
-		}
-		predicates = append(predicates, p)
-	}
-	if len(i.HasBlockedGroupsWith) > 0 {
-		with := make([]predicate.Group, 0, len(i.HasBlockedGroupsWith))
-		for _, w := range i.HasBlockedGroupsWith {
-			p, err := w.P()
-			if err != nil {
-				return nil, fmt.Errorf("%w: field 'HasBlockedGroupsWith'", err)
-			}
-			with = append(with, p)
-		}
-		predicates = append(predicates, risk.HasBlockedGroupsWith(with...))
+		predicates = append(predicates, risk.HasProgramsWith(with...))
 	}
 	switch len(predicates) {
 	case 0:
@@ -54008,6 +54292,21 @@ type RiskHistoryWhereInput struct {
 	DeletedByEqualFold    *string  `json:"deletedByEqualFold,omitempty"`
 	DeletedByContainsFold *string  `json:"deletedByContainsFold,omitempty"`
 
+	// "owner_id" field predicates.
+	OwnerID             *string  `json:"ownerID,omitempty"`
+	OwnerIDNEQ          *string  `json:"ownerIDNEQ,omitempty"`
+	OwnerIDIn           []string `json:"ownerIDIn,omitempty"`
+	OwnerIDNotIn        []string `json:"ownerIDNotIn,omitempty"`
+	OwnerIDGT           *string  `json:"ownerIDGT,omitempty"`
+	OwnerIDGTE          *string  `json:"ownerIDGTE,omitempty"`
+	OwnerIDLT           *string  `json:"ownerIDLT,omitempty"`
+	OwnerIDLTE          *string  `json:"ownerIDLTE,omitempty"`
+	OwnerIDContains     *string  `json:"ownerIDContains,omitempty"`
+	OwnerIDHasPrefix    *string  `json:"ownerIDHasPrefix,omitempty"`
+	OwnerIDHasSuffix    *string  `json:"ownerIDHasSuffix,omitempty"`
+	OwnerIDEqualFold    *string  `json:"ownerIDEqualFold,omitempty"`
+	OwnerIDContainsFold *string  `json:"ownerIDContainsFold,omitempty"`
+
 	// "name" field predicates.
 	Name             *string  `json:"name,omitempty"`
 	NameNEQ          *string  `json:"nameNEQ,omitempty"`
@@ -54140,21 +54439,6 @@ type RiskHistoryWhereInput struct {
 	SatisfiesNotNil       bool     `json:"satisfiesNotNil,omitempty"`
 	SatisfiesEqualFold    *string  `json:"satisfiesEqualFold,omitempty"`
 	SatisfiesContainsFold *string  `json:"satisfiesContainsFold,omitempty"`
-
-	// "owner_id" field predicates.
-	OwnerID             *string  `json:"ownerID,omitempty"`
-	OwnerIDNEQ          *string  `json:"ownerIDNEQ,omitempty"`
-	OwnerIDIn           []string `json:"ownerIDIn,omitempty"`
-	OwnerIDNotIn        []string `json:"ownerIDNotIn,omitempty"`
-	OwnerIDGT           *string  `json:"ownerIDGT,omitempty"`
-	OwnerIDGTE          *string  `json:"ownerIDGTE,omitempty"`
-	OwnerIDLT           *string  `json:"ownerIDLT,omitempty"`
-	OwnerIDLTE          *string  `json:"ownerIDLTE,omitempty"`
-	OwnerIDContains     *string  `json:"ownerIDContains,omitempty"`
-	OwnerIDHasPrefix    *string  `json:"ownerIDHasPrefix,omitempty"`
-	OwnerIDHasSuffix    *string  `json:"ownerIDHasSuffix,omitempty"`
-	OwnerIDEqualFold    *string  `json:"ownerIDEqualFold,omitempty"`
-	OwnerIDContainsFold *string  `json:"ownerIDContainsFold,omitempty"`
 }
 
 // AddPredicates adds custom predicates to the where input to be used during the filtering phase.
@@ -54564,6 +54848,45 @@ func (i *RiskHistoryWhereInput) P() (predicate.RiskHistory, error) {
 	if i.DeletedByContainsFold != nil {
 		predicates = append(predicates, riskhistory.DeletedByContainsFold(*i.DeletedByContainsFold))
 	}
+	if i.OwnerID != nil {
+		predicates = append(predicates, riskhistory.OwnerIDEQ(*i.OwnerID))
+	}
+	if i.OwnerIDNEQ != nil {
+		predicates = append(predicates, riskhistory.OwnerIDNEQ(*i.OwnerIDNEQ))
+	}
+	if len(i.OwnerIDIn) > 0 {
+		predicates = append(predicates, riskhistory.OwnerIDIn(i.OwnerIDIn...))
+	}
+	if len(i.OwnerIDNotIn) > 0 {
+		predicates = append(predicates, riskhistory.OwnerIDNotIn(i.OwnerIDNotIn...))
+	}
+	if i.OwnerIDGT != nil {
+		predicates = append(predicates, riskhistory.OwnerIDGT(*i.OwnerIDGT))
+	}
+	if i.OwnerIDGTE != nil {
+		predicates = append(predicates, riskhistory.OwnerIDGTE(*i.OwnerIDGTE))
+	}
+	if i.OwnerIDLT != nil {
+		predicates = append(predicates, riskhistory.OwnerIDLT(*i.OwnerIDLT))
+	}
+	if i.OwnerIDLTE != nil {
+		predicates = append(predicates, riskhistory.OwnerIDLTE(*i.OwnerIDLTE))
+	}
+	if i.OwnerIDContains != nil {
+		predicates = append(predicates, riskhistory.OwnerIDContains(*i.OwnerIDContains))
+	}
+	if i.OwnerIDHasPrefix != nil {
+		predicates = append(predicates, riskhistory.OwnerIDHasPrefix(*i.OwnerIDHasPrefix))
+	}
+	if i.OwnerIDHasSuffix != nil {
+		predicates = append(predicates, riskhistory.OwnerIDHasSuffix(*i.OwnerIDHasSuffix))
+	}
+	if i.OwnerIDEqualFold != nil {
+		predicates = append(predicates, riskhistory.OwnerIDEqualFold(*i.OwnerIDEqualFold))
+	}
+	if i.OwnerIDContainsFold != nil {
+		predicates = append(predicates, riskhistory.OwnerIDContainsFold(*i.OwnerIDContainsFold))
+	}
 	if i.Name != nil {
 		predicates = append(predicates, riskhistory.NameEQ(*i.Name))
 	}
@@ -54908,45 +55231,6 @@ func (i *RiskHistoryWhereInput) P() (predicate.RiskHistory, error) {
 	}
 	if i.SatisfiesContainsFold != nil {
 		predicates = append(predicates, riskhistory.SatisfiesContainsFold(*i.SatisfiesContainsFold))
-	}
-	if i.OwnerID != nil {
-		predicates = append(predicates, riskhistory.OwnerIDEQ(*i.OwnerID))
-	}
-	if i.OwnerIDNEQ != nil {
-		predicates = append(predicates, riskhistory.OwnerIDNEQ(*i.OwnerIDNEQ))
-	}
-	if len(i.OwnerIDIn) > 0 {
-		predicates = append(predicates, riskhistory.OwnerIDIn(i.OwnerIDIn...))
-	}
-	if len(i.OwnerIDNotIn) > 0 {
-		predicates = append(predicates, riskhistory.OwnerIDNotIn(i.OwnerIDNotIn...))
-	}
-	if i.OwnerIDGT != nil {
-		predicates = append(predicates, riskhistory.OwnerIDGT(*i.OwnerIDGT))
-	}
-	if i.OwnerIDGTE != nil {
-		predicates = append(predicates, riskhistory.OwnerIDGTE(*i.OwnerIDGTE))
-	}
-	if i.OwnerIDLT != nil {
-		predicates = append(predicates, riskhistory.OwnerIDLT(*i.OwnerIDLT))
-	}
-	if i.OwnerIDLTE != nil {
-		predicates = append(predicates, riskhistory.OwnerIDLTE(*i.OwnerIDLTE))
-	}
-	if i.OwnerIDContains != nil {
-		predicates = append(predicates, riskhistory.OwnerIDContains(*i.OwnerIDContains))
-	}
-	if i.OwnerIDHasPrefix != nil {
-		predicates = append(predicates, riskhistory.OwnerIDHasPrefix(*i.OwnerIDHasPrefix))
-	}
-	if i.OwnerIDHasSuffix != nil {
-		predicates = append(predicates, riskhistory.OwnerIDHasSuffix(*i.OwnerIDHasSuffix))
-	}
-	if i.OwnerIDEqualFold != nil {
-		predicates = append(predicates, riskhistory.OwnerIDEqualFold(*i.OwnerIDEqualFold))
-	}
-	if i.OwnerIDContainsFold != nil {
-		predicates = append(predicates, riskhistory.OwnerIDContainsFold(*i.OwnerIDContainsFold))
 	}
 
 	switch len(predicates) {

--- a/internal/ent/generated/group.go
+++ b/internal/ent/generated/group.go
@@ -90,30 +90,39 @@ type GroupEdges struct {
 	RiskEditors []*Risk `json:"risk_editors,omitempty"`
 	// RiskBlockedGroups holds the value of the risk_blocked_groups edge.
 	RiskBlockedGroups []*Risk `json:"risk_blocked_groups,omitempty"`
+	// ControlobjectiveViewers holds the value of the controlobjective_viewers edge.
+	ControlobjectiveViewers []*ControlObjective `json:"controlobjective_viewers,omitempty"`
+	// ControlobjectiveEditors holds the value of the controlobjective_editors edge.
+	ControlobjectiveEditors []*ControlObjective `json:"controlobjective_editors,omitempty"`
+	// ControlobjectiveBlockedGroups holds the value of the controlobjective_blocked_groups edge.
+	ControlobjectiveBlockedGroups []*ControlObjective `json:"controlobjective_blocked_groups,omitempty"`
 	// Members holds the value of the members edge.
 	Members []*GroupMembership `json:"members,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [18]bool
+	loadedTypes [21]bool
 	// totalCount holds the count of the edges above.
-	totalCount [18]map[string]int
+	totalCount [21]map[string]int
 
-	namedUsers                       map[string][]*User
-	namedEvents                      map[string][]*Event
-	namedIntegrations                map[string][]*Integration
-	namedFiles                       map[string][]*File
-	namedTasks                       map[string][]*Task
-	namedProcedureEditors            map[string][]*Procedure
-	namedProcedureBlockedGroups      map[string][]*Procedure
-	namedInternalpolicyEditors       map[string][]*InternalPolicy
-	namedInternalpolicyBlockedGroups map[string][]*InternalPolicy
-	namedProgramViewers              map[string][]*Program
-	namedProgramEditors              map[string][]*Program
-	namedProgramBlockedGroups        map[string][]*Program
-	namedRiskViewers                 map[string][]*Risk
-	namedRiskEditors                 map[string][]*Risk
-	namedRiskBlockedGroups           map[string][]*Risk
-	namedMembers                     map[string][]*GroupMembership
+	namedUsers                         map[string][]*User
+	namedEvents                        map[string][]*Event
+	namedIntegrations                  map[string][]*Integration
+	namedFiles                         map[string][]*File
+	namedTasks                         map[string][]*Task
+	namedProcedureEditors              map[string][]*Procedure
+	namedProcedureBlockedGroups        map[string][]*Procedure
+	namedInternalpolicyEditors         map[string][]*InternalPolicy
+	namedInternalpolicyBlockedGroups   map[string][]*InternalPolicy
+	namedProgramViewers                map[string][]*Program
+	namedProgramEditors                map[string][]*Program
+	namedProgramBlockedGroups          map[string][]*Program
+	namedRiskViewers                   map[string][]*Risk
+	namedRiskEditors                   map[string][]*Risk
+	namedRiskBlockedGroups             map[string][]*Risk
+	namedControlobjectiveViewers       map[string][]*ControlObjective
+	namedControlobjectiveEditors       map[string][]*ControlObjective
+	namedControlobjectiveBlockedGroups map[string][]*ControlObjective
+	namedMembers                       map[string][]*GroupMembership
 }
 
 // OwnerOrErr returns the Owner value or an error if the edge
@@ -273,10 +282,37 @@ func (e GroupEdges) RiskBlockedGroupsOrErr() ([]*Risk, error) {
 	return nil, &NotLoadedError{edge: "risk_blocked_groups"}
 }
 
+// ControlobjectiveViewersOrErr returns the ControlobjectiveViewers value or an error if the edge
+// was not loaded in eager-loading.
+func (e GroupEdges) ControlobjectiveViewersOrErr() ([]*ControlObjective, error) {
+	if e.loadedTypes[17] {
+		return e.ControlobjectiveViewers, nil
+	}
+	return nil, &NotLoadedError{edge: "controlobjective_viewers"}
+}
+
+// ControlobjectiveEditorsOrErr returns the ControlobjectiveEditors value or an error if the edge
+// was not loaded in eager-loading.
+func (e GroupEdges) ControlobjectiveEditorsOrErr() ([]*ControlObjective, error) {
+	if e.loadedTypes[18] {
+		return e.ControlobjectiveEditors, nil
+	}
+	return nil, &NotLoadedError{edge: "controlobjective_editors"}
+}
+
+// ControlobjectiveBlockedGroupsOrErr returns the ControlobjectiveBlockedGroups value or an error if the edge
+// was not loaded in eager-loading.
+func (e GroupEdges) ControlobjectiveBlockedGroupsOrErr() ([]*ControlObjective, error) {
+	if e.loadedTypes[19] {
+		return e.ControlobjectiveBlockedGroups, nil
+	}
+	return nil, &NotLoadedError{edge: "controlobjective_blocked_groups"}
+}
+
 // MembersOrErr returns the Members value or an error if the edge
 // was not loaded in eager-loading.
 func (e GroupEdges) MembersOrErr() ([]*GroupMembership, error) {
-	if e.loadedTypes[17] {
+	if e.loadedTypes[20] {
 		return e.Members, nil
 	}
 	return nil, &NotLoadedError{edge: "members"}
@@ -496,6 +532,21 @@ func (gr *Group) QueryRiskEditors() *RiskQuery {
 // QueryRiskBlockedGroups queries the "risk_blocked_groups" edge of the Group entity.
 func (gr *Group) QueryRiskBlockedGroups() *RiskQuery {
 	return NewGroupClient(gr.config).QueryRiskBlockedGroups(gr)
+}
+
+// QueryControlobjectiveViewers queries the "controlobjective_viewers" edge of the Group entity.
+func (gr *Group) QueryControlobjectiveViewers() *ControlObjectiveQuery {
+	return NewGroupClient(gr.config).QueryControlobjectiveViewers(gr)
+}
+
+// QueryControlobjectiveEditors queries the "controlobjective_editors" edge of the Group entity.
+func (gr *Group) QueryControlobjectiveEditors() *ControlObjectiveQuery {
+	return NewGroupClient(gr.config).QueryControlobjectiveEditors(gr)
+}
+
+// QueryControlobjectiveBlockedGroups queries the "controlobjective_blocked_groups" edge of the Group entity.
+func (gr *Group) QueryControlobjectiveBlockedGroups() *ControlObjectiveQuery {
+	return NewGroupClient(gr.config).QueryControlobjectiveBlockedGroups(gr)
 }
 
 // QueryMembers queries the "members" edge of the Group entity.
@@ -928,6 +979,78 @@ func (gr *Group) appendNamedRiskBlockedGroups(name string, edges ...*Risk) {
 		gr.Edges.namedRiskBlockedGroups[name] = []*Risk{}
 	} else {
 		gr.Edges.namedRiskBlockedGroups[name] = append(gr.Edges.namedRiskBlockedGroups[name], edges...)
+	}
+}
+
+// NamedControlobjectiveViewers returns the ControlobjectiveViewers named value or an error if the edge was not
+// loaded in eager-loading with this name.
+func (gr *Group) NamedControlobjectiveViewers(name string) ([]*ControlObjective, error) {
+	if gr.Edges.namedControlobjectiveViewers == nil {
+		return nil, &NotLoadedError{edge: name}
+	}
+	nodes, ok := gr.Edges.namedControlobjectiveViewers[name]
+	if !ok {
+		return nil, &NotLoadedError{edge: name}
+	}
+	return nodes, nil
+}
+
+func (gr *Group) appendNamedControlobjectiveViewers(name string, edges ...*ControlObjective) {
+	if gr.Edges.namedControlobjectiveViewers == nil {
+		gr.Edges.namedControlobjectiveViewers = make(map[string][]*ControlObjective)
+	}
+	if len(edges) == 0 {
+		gr.Edges.namedControlobjectiveViewers[name] = []*ControlObjective{}
+	} else {
+		gr.Edges.namedControlobjectiveViewers[name] = append(gr.Edges.namedControlobjectiveViewers[name], edges...)
+	}
+}
+
+// NamedControlobjectiveEditors returns the ControlobjectiveEditors named value or an error if the edge was not
+// loaded in eager-loading with this name.
+func (gr *Group) NamedControlobjectiveEditors(name string) ([]*ControlObjective, error) {
+	if gr.Edges.namedControlobjectiveEditors == nil {
+		return nil, &NotLoadedError{edge: name}
+	}
+	nodes, ok := gr.Edges.namedControlobjectiveEditors[name]
+	if !ok {
+		return nil, &NotLoadedError{edge: name}
+	}
+	return nodes, nil
+}
+
+func (gr *Group) appendNamedControlobjectiveEditors(name string, edges ...*ControlObjective) {
+	if gr.Edges.namedControlobjectiveEditors == nil {
+		gr.Edges.namedControlobjectiveEditors = make(map[string][]*ControlObjective)
+	}
+	if len(edges) == 0 {
+		gr.Edges.namedControlobjectiveEditors[name] = []*ControlObjective{}
+	} else {
+		gr.Edges.namedControlobjectiveEditors[name] = append(gr.Edges.namedControlobjectiveEditors[name], edges...)
+	}
+}
+
+// NamedControlobjectiveBlockedGroups returns the ControlobjectiveBlockedGroups named value or an error if the edge was not
+// loaded in eager-loading with this name.
+func (gr *Group) NamedControlobjectiveBlockedGroups(name string) ([]*ControlObjective, error) {
+	if gr.Edges.namedControlobjectiveBlockedGroups == nil {
+		return nil, &NotLoadedError{edge: name}
+	}
+	nodes, ok := gr.Edges.namedControlobjectiveBlockedGroups[name]
+	if !ok {
+		return nil, &NotLoadedError{edge: name}
+	}
+	return nodes, nil
+}
+
+func (gr *Group) appendNamedControlobjectiveBlockedGroups(name string, edges ...*ControlObjective) {
+	if gr.Edges.namedControlobjectiveBlockedGroups == nil {
+		gr.Edges.namedControlobjectiveBlockedGroups = make(map[string][]*ControlObjective)
+	}
+	if len(edges) == 0 {
+		gr.Edges.namedControlobjectiveBlockedGroups[name] = []*ControlObjective{}
+	} else {
+		gr.Edges.namedControlobjectiveBlockedGroups[name] = append(gr.Edges.namedControlobjectiveBlockedGroups[name], edges...)
 	}
 }
 

--- a/internal/ent/generated/group/group.go
+++ b/internal/ent/generated/group/group.go
@@ -77,6 +77,12 @@ const (
 	EdgeRiskEditors = "risk_editors"
 	// EdgeRiskBlockedGroups holds the string denoting the risk_blocked_groups edge name in mutations.
 	EdgeRiskBlockedGroups = "risk_blocked_groups"
+	// EdgeControlobjectiveViewers holds the string denoting the controlobjective_viewers edge name in mutations.
+	EdgeControlobjectiveViewers = "controlobjective_viewers"
+	// EdgeControlobjectiveEditors holds the string denoting the controlobjective_editors edge name in mutations.
+	EdgeControlobjectiveEditors = "controlobjective_editors"
+	// EdgeControlobjectiveBlockedGroups holds the string denoting the controlobjective_blocked_groups edge name in mutations.
+	EdgeControlobjectiveBlockedGroups = "controlobjective_blocked_groups"
 	// EdgeMembers holds the string denoting the members edge name in mutations.
 	EdgeMembers = "members"
 	// Table holds the table name of the group in the database.
@@ -172,6 +178,21 @@ const (
 	// RiskBlockedGroupsInverseTable is the table name for the Risk entity.
 	// It exists in this package in order to avoid circular dependency with the "risk" package.
 	RiskBlockedGroupsInverseTable = "risks"
+	// ControlobjectiveViewersTable is the table that holds the controlobjective_viewers relation/edge. The primary key declared below.
+	ControlobjectiveViewersTable = "control_objective_viewers"
+	// ControlobjectiveViewersInverseTable is the table name for the ControlObjective entity.
+	// It exists in this package in order to avoid circular dependency with the "controlobjective" package.
+	ControlobjectiveViewersInverseTable = "control_objectives"
+	// ControlobjectiveEditorsTable is the table that holds the controlobjective_editors relation/edge. The primary key declared below.
+	ControlobjectiveEditorsTable = "control_objective_editors"
+	// ControlobjectiveEditorsInverseTable is the table name for the ControlObjective entity.
+	// It exists in this package in order to avoid circular dependency with the "controlobjective" package.
+	ControlobjectiveEditorsInverseTable = "control_objectives"
+	// ControlobjectiveBlockedGroupsTable is the table that holds the controlobjective_blocked_groups relation/edge. The primary key declared below.
+	ControlobjectiveBlockedGroupsTable = "control_objective_blocked_groups"
+	// ControlobjectiveBlockedGroupsInverseTable is the table name for the ControlObjective entity.
+	// It exists in this package in order to avoid circular dependency with the "controlobjective" package.
+	ControlobjectiveBlockedGroupsInverseTable = "control_objectives"
 	// MembersTable is the table that holds the members relation/edge.
 	MembersTable = "group_memberships"
 	// MembersInverseTable is the table name for the GroupMembership entity.
@@ -243,6 +264,15 @@ var (
 	// RiskBlockedGroupsPrimaryKey and RiskBlockedGroupsColumn2 are the table columns denoting the
 	// primary key for the risk_blocked_groups relation (M2M).
 	RiskBlockedGroupsPrimaryKey = []string{"risk_id", "group_id"}
+	// ControlobjectiveViewersPrimaryKey and ControlobjectiveViewersColumn2 are the table columns denoting the
+	// primary key for the controlobjective_viewers relation (M2M).
+	ControlobjectiveViewersPrimaryKey = []string{"control_objective_id", "group_id"}
+	// ControlobjectiveEditorsPrimaryKey and ControlobjectiveEditorsColumn2 are the table columns denoting the
+	// primary key for the controlobjective_editors relation (M2M).
+	ControlobjectiveEditorsPrimaryKey = []string{"control_objective_id", "group_id"}
+	// ControlobjectiveBlockedGroupsPrimaryKey and ControlobjectiveBlockedGroupsColumn2 are the table columns denoting the
+	// primary key for the controlobjective_blocked_groups relation (M2M).
+	ControlobjectiveBlockedGroupsPrimaryKey = []string{"control_objective_id", "group_id"}
 )
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -583,6 +613,48 @@ func ByRiskBlockedGroups(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption
 	}
 }
 
+// ByControlobjectiveViewersCount orders the results by controlobjective_viewers count.
+func ByControlobjectiveViewersCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newControlobjectiveViewersStep(), opts...)
+	}
+}
+
+// ByControlobjectiveViewers orders the results by controlobjective_viewers terms.
+func ByControlobjectiveViewers(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newControlobjectiveViewersStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByControlobjectiveEditorsCount orders the results by controlobjective_editors count.
+func ByControlobjectiveEditorsCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newControlobjectiveEditorsStep(), opts...)
+	}
+}
+
+// ByControlobjectiveEditors orders the results by controlobjective_editors terms.
+func ByControlobjectiveEditors(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newControlobjectiveEditorsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByControlobjectiveBlockedGroupsCount orders the results by controlobjective_blocked_groups count.
+func ByControlobjectiveBlockedGroupsCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newControlobjectiveBlockedGroupsStep(), opts...)
+	}
+}
+
+// ByControlobjectiveBlockedGroups orders the results by controlobjective_blocked_groups terms.
+func ByControlobjectiveBlockedGroups(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newControlobjectiveBlockedGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
 // ByMembersCount orders the results by members count.
 func ByMembersCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
@@ -713,6 +785,27 @@ func newRiskBlockedGroupsStep() *sqlgraph.Step {
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(RiskBlockedGroupsInverseTable, FieldID),
 		sqlgraph.Edge(sqlgraph.M2M, true, RiskBlockedGroupsTable, RiskBlockedGroupsPrimaryKey...),
+	)
+}
+func newControlobjectiveViewersStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(ControlobjectiveViewersInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, ControlobjectiveViewersTable, ControlobjectiveViewersPrimaryKey...),
+	)
+}
+func newControlobjectiveEditorsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(ControlobjectiveEditorsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, ControlobjectiveEditorsTable, ControlobjectiveEditorsPrimaryKey...),
+	)
+}
+func newControlobjectiveBlockedGroupsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(ControlobjectiveBlockedGroupsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, ControlobjectiveBlockedGroupsTable, ControlobjectiveBlockedGroupsPrimaryKey...),
 	)
 }
 func newMembersStep() *sqlgraph.Step {

--- a/internal/ent/generated/group/where.go
+++ b/internal/ent/generated/group/where.go
@@ -1505,6 +1505,93 @@ func HasRiskBlockedGroupsWith(preds ...predicate.Risk) predicate.Group {
 	})
 }
 
+// HasControlobjectiveViewers applies the HasEdge predicate on the "controlobjective_viewers" edge.
+func HasControlobjectiveViewers() predicate.Group {
+	return predicate.Group(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, ControlobjectiveViewersTable, ControlobjectiveViewersPrimaryKey...),
+		)
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.ControlObjective
+		step.Edge.Schema = schemaConfig.ControlObjectiveViewers
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasControlobjectiveViewersWith applies the HasEdge predicate on the "controlobjective_viewers" edge with a given conditions (other predicates).
+func HasControlobjectiveViewersWith(preds ...predicate.ControlObjective) predicate.Group {
+	return predicate.Group(func(s *sql.Selector) {
+		step := newControlobjectiveViewersStep()
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.ControlObjective
+		step.Edge.Schema = schemaConfig.ControlObjectiveViewers
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasControlobjectiveEditors applies the HasEdge predicate on the "controlobjective_editors" edge.
+func HasControlobjectiveEditors() predicate.Group {
+	return predicate.Group(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, ControlobjectiveEditorsTable, ControlobjectiveEditorsPrimaryKey...),
+		)
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.ControlObjective
+		step.Edge.Schema = schemaConfig.ControlObjectiveEditors
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasControlobjectiveEditorsWith applies the HasEdge predicate on the "controlobjective_editors" edge with a given conditions (other predicates).
+func HasControlobjectiveEditorsWith(preds ...predicate.ControlObjective) predicate.Group {
+	return predicate.Group(func(s *sql.Selector) {
+		step := newControlobjectiveEditorsStep()
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.ControlObjective
+		step.Edge.Schema = schemaConfig.ControlObjectiveEditors
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasControlobjectiveBlockedGroups applies the HasEdge predicate on the "controlobjective_blocked_groups" edge.
+func HasControlobjectiveBlockedGroups() predicate.Group {
+	return predicate.Group(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, ControlobjectiveBlockedGroupsTable, ControlobjectiveBlockedGroupsPrimaryKey...),
+		)
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.ControlObjective
+		step.Edge.Schema = schemaConfig.ControlObjectiveBlockedGroups
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasControlobjectiveBlockedGroupsWith applies the HasEdge predicate on the "controlobjective_blocked_groups" edge with a given conditions (other predicates).
+func HasControlobjectiveBlockedGroupsWith(preds ...predicate.ControlObjective) predicate.Group {
+	return predicate.Group(func(s *sql.Selector) {
+		step := newControlobjectiveBlockedGroupsStep()
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.ControlObjective
+		step.Edge.Schema = schemaConfig.ControlObjectiveBlockedGroups
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
 // HasMembers applies the HasEdge predicate on the "members" edge.
 func HasMembers() predicate.Group {
 	return predicate.Group(func(s *sql.Selector) {

--- a/internal/ent/generated/group_create.go
+++ b/internal/ent/generated/group_create.go
@@ -10,6 +10,7 @@ import (
 
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/theopenlane/core/internal/ent/generated/controlobjective"
 	"github.com/theopenlane/core/internal/ent/generated/event"
 	"github.com/theopenlane/core/internal/ent/generated/file"
 	"github.com/theopenlane/core/internal/ent/generated/group"
@@ -465,6 +466,51 @@ func (gc *GroupCreate) AddRiskBlockedGroups(r ...*Risk) *GroupCreate {
 		ids[i] = r[i].ID
 	}
 	return gc.AddRiskBlockedGroupIDs(ids...)
+}
+
+// AddControlobjectiveViewerIDs adds the "controlobjective_viewers" edge to the ControlObjective entity by IDs.
+func (gc *GroupCreate) AddControlobjectiveViewerIDs(ids ...string) *GroupCreate {
+	gc.mutation.AddControlobjectiveViewerIDs(ids...)
+	return gc
+}
+
+// AddControlobjectiveViewers adds the "controlobjective_viewers" edges to the ControlObjective entity.
+func (gc *GroupCreate) AddControlobjectiveViewers(c ...*ControlObjective) *GroupCreate {
+	ids := make([]string, len(c))
+	for i := range c {
+		ids[i] = c[i].ID
+	}
+	return gc.AddControlobjectiveViewerIDs(ids...)
+}
+
+// AddControlobjectiveEditorIDs adds the "controlobjective_editors" edge to the ControlObjective entity by IDs.
+func (gc *GroupCreate) AddControlobjectiveEditorIDs(ids ...string) *GroupCreate {
+	gc.mutation.AddControlobjectiveEditorIDs(ids...)
+	return gc
+}
+
+// AddControlobjectiveEditors adds the "controlobjective_editors" edges to the ControlObjective entity.
+func (gc *GroupCreate) AddControlobjectiveEditors(c ...*ControlObjective) *GroupCreate {
+	ids := make([]string, len(c))
+	for i := range c {
+		ids[i] = c[i].ID
+	}
+	return gc.AddControlobjectiveEditorIDs(ids...)
+}
+
+// AddControlobjectiveBlockedGroupIDs adds the "controlobjective_blocked_groups" edge to the ControlObjective entity by IDs.
+func (gc *GroupCreate) AddControlobjectiveBlockedGroupIDs(ids ...string) *GroupCreate {
+	gc.mutation.AddControlobjectiveBlockedGroupIDs(ids...)
+	return gc
+}
+
+// AddControlobjectiveBlockedGroups adds the "controlobjective_blocked_groups" edges to the ControlObjective entity.
+func (gc *GroupCreate) AddControlobjectiveBlockedGroups(c ...*ControlObjective) *GroupCreate {
+	ids := make([]string, len(c))
+	for i := range c {
+		ids[i] = c[i].ID
+	}
+	return gc.AddControlobjectiveBlockedGroupIDs(ids...)
 }
 
 // AddMemberIDs adds the "members" edge to the GroupMembership entity by IDs.
@@ -967,6 +1013,57 @@ func (gc *GroupCreate) createSpec() (*Group, *sqlgraph.CreateSpec) {
 			},
 		}
 		edge.Schema = gc.schemaConfig.RiskBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := gc.mutation.ControlobjectiveViewersIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   group.ControlobjectiveViewersTable,
+			Columns: group.ControlobjectiveViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = gc.schemaConfig.ControlObjectiveViewers
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := gc.mutation.ControlobjectiveEditorsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   group.ControlobjectiveEditorsTable,
+			Columns: group.ControlobjectiveEditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = gc.schemaConfig.ControlObjectiveEditors
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := gc.mutation.ControlobjectiveBlockedGroupsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   group.ControlobjectiveBlockedGroupsTable,
+			Columns: group.ControlobjectiveBlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = gc.schemaConfig.ControlObjectiveBlockedGroups
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}

--- a/internal/ent/generated/group_query.go
+++ b/internal/ent/generated/group_query.go
@@ -13,6 +13,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/theopenlane/core/internal/ent/generated/controlobjective"
 	"github.com/theopenlane/core/internal/ent/generated/event"
 	"github.com/theopenlane/core/internal/ent/generated/file"
 	"github.com/theopenlane/core/internal/ent/generated/group"
@@ -34,46 +35,52 @@ import (
 // GroupQuery is the builder for querying Group entities.
 type GroupQuery struct {
 	config
-	ctx                                  *QueryContext
-	order                                []group.OrderOption
-	inters                               []Interceptor
-	predicates                           []predicate.Group
-	withOwner                            *OrganizationQuery
-	withSetting                          *GroupSettingQuery
-	withUsers                            *UserQuery
-	withEvents                           *EventQuery
-	withIntegrations                     *IntegrationQuery
-	withFiles                            *FileQuery
-	withTasks                            *TaskQuery
-	withProcedureEditors                 *ProcedureQuery
-	withProcedureBlockedGroups           *ProcedureQuery
-	withInternalpolicyEditors            *InternalPolicyQuery
-	withInternalpolicyBlockedGroups      *InternalPolicyQuery
-	withProgramViewers                   *ProgramQuery
-	withProgramEditors                   *ProgramQuery
-	withProgramBlockedGroups             *ProgramQuery
-	withRiskViewers                      *RiskQuery
-	withRiskEditors                      *RiskQuery
-	withRiskBlockedGroups                *RiskQuery
-	withMembers                          *GroupMembershipQuery
-	loadTotal                            []func(context.Context, []*Group) error
-	modifiers                            []func(*sql.Selector)
-	withNamedUsers                       map[string]*UserQuery
-	withNamedEvents                      map[string]*EventQuery
-	withNamedIntegrations                map[string]*IntegrationQuery
-	withNamedFiles                       map[string]*FileQuery
-	withNamedTasks                       map[string]*TaskQuery
-	withNamedProcedureEditors            map[string]*ProcedureQuery
-	withNamedProcedureBlockedGroups      map[string]*ProcedureQuery
-	withNamedInternalpolicyEditors       map[string]*InternalPolicyQuery
-	withNamedInternalpolicyBlockedGroups map[string]*InternalPolicyQuery
-	withNamedProgramViewers              map[string]*ProgramQuery
-	withNamedProgramEditors              map[string]*ProgramQuery
-	withNamedProgramBlockedGroups        map[string]*ProgramQuery
-	withNamedRiskViewers                 map[string]*RiskQuery
-	withNamedRiskEditors                 map[string]*RiskQuery
-	withNamedRiskBlockedGroups           map[string]*RiskQuery
-	withNamedMembers                     map[string]*GroupMembershipQuery
+	ctx                                    *QueryContext
+	order                                  []group.OrderOption
+	inters                                 []Interceptor
+	predicates                             []predicate.Group
+	withOwner                              *OrganizationQuery
+	withSetting                            *GroupSettingQuery
+	withUsers                              *UserQuery
+	withEvents                             *EventQuery
+	withIntegrations                       *IntegrationQuery
+	withFiles                              *FileQuery
+	withTasks                              *TaskQuery
+	withProcedureEditors                   *ProcedureQuery
+	withProcedureBlockedGroups             *ProcedureQuery
+	withInternalpolicyEditors              *InternalPolicyQuery
+	withInternalpolicyBlockedGroups        *InternalPolicyQuery
+	withProgramViewers                     *ProgramQuery
+	withProgramEditors                     *ProgramQuery
+	withProgramBlockedGroups               *ProgramQuery
+	withRiskViewers                        *RiskQuery
+	withRiskEditors                        *RiskQuery
+	withRiskBlockedGroups                  *RiskQuery
+	withControlobjectiveViewers            *ControlObjectiveQuery
+	withControlobjectiveEditors            *ControlObjectiveQuery
+	withControlobjectiveBlockedGroups      *ControlObjectiveQuery
+	withMembers                            *GroupMembershipQuery
+	loadTotal                              []func(context.Context, []*Group) error
+	modifiers                              []func(*sql.Selector)
+	withNamedUsers                         map[string]*UserQuery
+	withNamedEvents                        map[string]*EventQuery
+	withNamedIntegrations                  map[string]*IntegrationQuery
+	withNamedFiles                         map[string]*FileQuery
+	withNamedTasks                         map[string]*TaskQuery
+	withNamedProcedureEditors              map[string]*ProcedureQuery
+	withNamedProcedureBlockedGroups        map[string]*ProcedureQuery
+	withNamedInternalpolicyEditors         map[string]*InternalPolicyQuery
+	withNamedInternalpolicyBlockedGroups   map[string]*InternalPolicyQuery
+	withNamedProgramViewers                map[string]*ProgramQuery
+	withNamedProgramEditors                map[string]*ProgramQuery
+	withNamedProgramBlockedGroups          map[string]*ProgramQuery
+	withNamedRiskViewers                   map[string]*RiskQuery
+	withNamedRiskEditors                   map[string]*RiskQuery
+	withNamedRiskBlockedGroups             map[string]*RiskQuery
+	withNamedControlobjectiveViewers       map[string]*ControlObjectiveQuery
+	withNamedControlobjectiveEditors       map[string]*ControlObjectiveQuery
+	withNamedControlobjectiveBlockedGroups map[string]*ControlObjectiveQuery
+	withNamedMembers                       map[string]*GroupMembershipQuery
 	// intermediate query (i.e. traversal path).
 	sql  *sql.Selector
 	path func(context.Context) (*sql.Selector, error)
@@ -535,6 +542,81 @@ func (gq *GroupQuery) QueryRiskBlockedGroups() *RiskQuery {
 	return query
 }
 
+// QueryControlobjectiveViewers chains the current query on the "controlobjective_viewers" edge.
+func (gq *GroupQuery) QueryControlobjectiveViewers() *ControlObjectiveQuery {
+	query := (&ControlObjectiveClient{config: gq.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := gq.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := gq.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(group.Table, group.FieldID, selector),
+			sqlgraph.To(controlobjective.Table, controlobjective.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, group.ControlobjectiveViewersTable, group.ControlobjectiveViewersPrimaryKey...),
+		)
+		schemaConfig := gq.schemaConfig
+		step.To.Schema = schemaConfig.ControlObjective
+		step.Edge.Schema = schemaConfig.ControlObjectiveViewers
+		fromU = sqlgraph.SetNeighbors(gq.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryControlobjectiveEditors chains the current query on the "controlobjective_editors" edge.
+func (gq *GroupQuery) QueryControlobjectiveEditors() *ControlObjectiveQuery {
+	query := (&ControlObjectiveClient{config: gq.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := gq.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := gq.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(group.Table, group.FieldID, selector),
+			sqlgraph.To(controlobjective.Table, controlobjective.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, group.ControlobjectiveEditorsTable, group.ControlobjectiveEditorsPrimaryKey...),
+		)
+		schemaConfig := gq.schemaConfig
+		step.To.Schema = schemaConfig.ControlObjective
+		step.Edge.Schema = schemaConfig.ControlObjectiveEditors
+		fromU = sqlgraph.SetNeighbors(gq.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryControlobjectiveBlockedGroups chains the current query on the "controlobjective_blocked_groups" edge.
+func (gq *GroupQuery) QueryControlobjectiveBlockedGroups() *ControlObjectiveQuery {
+	query := (&ControlObjectiveClient{config: gq.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := gq.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := gq.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(group.Table, group.FieldID, selector),
+			sqlgraph.To(controlobjective.Table, controlobjective.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, true, group.ControlobjectiveBlockedGroupsTable, group.ControlobjectiveBlockedGroupsPrimaryKey...),
+		)
+		schemaConfig := gq.schemaConfig
+		step.To.Schema = schemaConfig.ControlObjective
+		step.Edge.Schema = schemaConfig.ControlObjectiveBlockedGroups
+		fromU = sqlgraph.SetNeighbors(gq.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
 // QueryMembers chains the current query on the "members" edge.
 func (gq *GroupQuery) QueryMembers() *GroupMembershipQuery {
 	query := (&GroupMembershipClient{config: gq.config}).Query()
@@ -747,29 +829,32 @@ func (gq *GroupQuery) Clone() *GroupQuery {
 		return nil
 	}
 	return &GroupQuery{
-		config:                          gq.config,
-		ctx:                             gq.ctx.Clone(),
-		order:                           append([]group.OrderOption{}, gq.order...),
-		inters:                          append([]Interceptor{}, gq.inters...),
-		predicates:                      append([]predicate.Group{}, gq.predicates...),
-		withOwner:                       gq.withOwner.Clone(),
-		withSetting:                     gq.withSetting.Clone(),
-		withUsers:                       gq.withUsers.Clone(),
-		withEvents:                      gq.withEvents.Clone(),
-		withIntegrations:                gq.withIntegrations.Clone(),
-		withFiles:                       gq.withFiles.Clone(),
-		withTasks:                       gq.withTasks.Clone(),
-		withProcedureEditors:            gq.withProcedureEditors.Clone(),
-		withProcedureBlockedGroups:      gq.withProcedureBlockedGroups.Clone(),
-		withInternalpolicyEditors:       gq.withInternalpolicyEditors.Clone(),
-		withInternalpolicyBlockedGroups: gq.withInternalpolicyBlockedGroups.Clone(),
-		withProgramViewers:              gq.withProgramViewers.Clone(),
-		withProgramEditors:              gq.withProgramEditors.Clone(),
-		withProgramBlockedGroups:        gq.withProgramBlockedGroups.Clone(),
-		withRiskViewers:                 gq.withRiskViewers.Clone(),
-		withRiskEditors:                 gq.withRiskEditors.Clone(),
-		withRiskBlockedGroups:           gq.withRiskBlockedGroups.Clone(),
-		withMembers:                     gq.withMembers.Clone(),
+		config:                            gq.config,
+		ctx:                               gq.ctx.Clone(),
+		order:                             append([]group.OrderOption{}, gq.order...),
+		inters:                            append([]Interceptor{}, gq.inters...),
+		predicates:                        append([]predicate.Group{}, gq.predicates...),
+		withOwner:                         gq.withOwner.Clone(),
+		withSetting:                       gq.withSetting.Clone(),
+		withUsers:                         gq.withUsers.Clone(),
+		withEvents:                        gq.withEvents.Clone(),
+		withIntegrations:                  gq.withIntegrations.Clone(),
+		withFiles:                         gq.withFiles.Clone(),
+		withTasks:                         gq.withTasks.Clone(),
+		withProcedureEditors:              gq.withProcedureEditors.Clone(),
+		withProcedureBlockedGroups:        gq.withProcedureBlockedGroups.Clone(),
+		withInternalpolicyEditors:         gq.withInternalpolicyEditors.Clone(),
+		withInternalpolicyBlockedGroups:   gq.withInternalpolicyBlockedGroups.Clone(),
+		withProgramViewers:                gq.withProgramViewers.Clone(),
+		withProgramEditors:                gq.withProgramEditors.Clone(),
+		withProgramBlockedGroups:          gq.withProgramBlockedGroups.Clone(),
+		withRiskViewers:                   gq.withRiskViewers.Clone(),
+		withRiskEditors:                   gq.withRiskEditors.Clone(),
+		withRiskBlockedGroups:             gq.withRiskBlockedGroups.Clone(),
+		withControlobjectiveViewers:       gq.withControlobjectiveViewers.Clone(),
+		withControlobjectiveEditors:       gq.withControlobjectiveEditors.Clone(),
+		withControlobjectiveBlockedGroups: gq.withControlobjectiveBlockedGroups.Clone(),
+		withMembers:                       gq.withMembers.Clone(),
 		// clone intermediate query.
 		sql:       gq.sql.Clone(),
 		path:      gq.path,
@@ -964,6 +1049,39 @@ func (gq *GroupQuery) WithRiskBlockedGroups(opts ...func(*RiskQuery)) *GroupQuer
 	return gq
 }
 
+// WithControlobjectiveViewers tells the query-builder to eager-load the nodes that are connected to
+// the "controlobjective_viewers" edge. The optional arguments are used to configure the query builder of the edge.
+func (gq *GroupQuery) WithControlobjectiveViewers(opts ...func(*ControlObjectiveQuery)) *GroupQuery {
+	query := (&ControlObjectiveClient{config: gq.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	gq.withControlobjectiveViewers = query
+	return gq
+}
+
+// WithControlobjectiveEditors tells the query-builder to eager-load the nodes that are connected to
+// the "controlobjective_editors" edge. The optional arguments are used to configure the query builder of the edge.
+func (gq *GroupQuery) WithControlobjectiveEditors(opts ...func(*ControlObjectiveQuery)) *GroupQuery {
+	query := (&ControlObjectiveClient{config: gq.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	gq.withControlobjectiveEditors = query
+	return gq
+}
+
+// WithControlobjectiveBlockedGroups tells the query-builder to eager-load the nodes that are connected to
+// the "controlobjective_blocked_groups" edge. The optional arguments are used to configure the query builder of the edge.
+func (gq *GroupQuery) WithControlobjectiveBlockedGroups(opts ...func(*ControlObjectiveQuery)) *GroupQuery {
+	query := (&ControlObjectiveClient{config: gq.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	gq.withControlobjectiveBlockedGroups = query
+	return gq
+}
+
 // WithMembers tells the query-builder to eager-load the nodes that are connected to
 // the "members" edge. The optional arguments are used to configure the query builder of the edge.
 func (gq *GroupQuery) WithMembers(opts ...func(*GroupMembershipQuery)) *GroupQuery {
@@ -1059,7 +1177,7 @@ func (gq *GroupQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Group,
 	var (
 		nodes       = []*Group{}
 		_spec       = gq.querySpec()
-		loadedTypes = [18]bool{
+		loadedTypes = [21]bool{
 			gq.withOwner != nil,
 			gq.withSetting != nil,
 			gq.withUsers != nil,
@@ -1077,6 +1195,9 @@ func (gq *GroupQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Group,
 			gq.withRiskViewers != nil,
 			gq.withRiskEditors != nil,
 			gq.withRiskBlockedGroups != nil,
+			gq.withControlobjectiveViewers != nil,
+			gq.withControlobjectiveEditors != nil,
+			gq.withControlobjectiveBlockedGroups != nil,
 			gq.withMembers != nil,
 		}
 	)
@@ -1226,6 +1347,33 @@ func (gq *GroupQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Group,
 			return nil, err
 		}
 	}
+	if query := gq.withControlobjectiveViewers; query != nil {
+		if err := gq.loadControlobjectiveViewers(ctx, query, nodes,
+			func(n *Group) { n.Edges.ControlobjectiveViewers = []*ControlObjective{} },
+			func(n *Group, e *ControlObjective) {
+				n.Edges.ControlobjectiveViewers = append(n.Edges.ControlobjectiveViewers, e)
+			}); err != nil {
+			return nil, err
+		}
+	}
+	if query := gq.withControlobjectiveEditors; query != nil {
+		if err := gq.loadControlobjectiveEditors(ctx, query, nodes,
+			func(n *Group) { n.Edges.ControlobjectiveEditors = []*ControlObjective{} },
+			func(n *Group, e *ControlObjective) {
+				n.Edges.ControlobjectiveEditors = append(n.Edges.ControlobjectiveEditors, e)
+			}); err != nil {
+			return nil, err
+		}
+	}
+	if query := gq.withControlobjectiveBlockedGroups; query != nil {
+		if err := gq.loadControlobjectiveBlockedGroups(ctx, query, nodes,
+			func(n *Group) { n.Edges.ControlobjectiveBlockedGroups = []*ControlObjective{} },
+			func(n *Group, e *ControlObjective) {
+				n.Edges.ControlobjectiveBlockedGroups = append(n.Edges.ControlobjectiveBlockedGroups, e)
+			}); err != nil {
+			return nil, err
+		}
+	}
 	if query := gq.withMembers; query != nil {
 		if err := gq.loadMembers(ctx, query, nodes,
 			func(n *Group) { n.Edges.Members = []*GroupMembership{} },
@@ -1335,6 +1483,27 @@ func (gq *GroupQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Group,
 		if err := gq.loadRiskBlockedGroups(ctx, query, nodes,
 			func(n *Group) { n.appendNamedRiskBlockedGroups(name) },
 			func(n *Group, e *Risk) { n.appendNamedRiskBlockedGroups(name, e) }); err != nil {
+			return nil, err
+		}
+	}
+	for name, query := range gq.withNamedControlobjectiveViewers {
+		if err := gq.loadControlobjectiveViewers(ctx, query, nodes,
+			func(n *Group) { n.appendNamedControlobjectiveViewers(name) },
+			func(n *Group, e *ControlObjective) { n.appendNamedControlobjectiveViewers(name, e) }); err != nil {
+			return nil, err
+		}
+	}
+	for name, query := range gq.withNamedControlobjectiveEditors {
+		if err := gq.loadControlobjectiveEditors(ctx, query, nodes,
+			func(n *Group) { n.appendNamedControlobjectiveEditors(name) },
+			func(n *Group, e *ControlObjective) { n.appendNamedControlobjectiveEditors(name, e) }); err != nil {
+			return nil, err
+		}
+	}
+	for name, query := range gq.withNamedControlobjectiveBlockedGroups {
+		if err := gq.loadControlobjectiveBlockedGroups(ctx, query, nodes,
+			func(n *Group) { n.appendNamedControlobjectiveBlockedGroups(name) },
+			func(n *Group, e *ControlObjective) { n.appendNamedControlobjectiveBlockedGroups(name, e) }); err != nil {
 			return nil, err
 		}
 	}
@@ -2308,6 +2477,192 @@ func (gq *GroupQuery) loadRiskBlockedGroups(ctx context.Context, query *RiskQuer
 	}
 	return nil
 }
+func (gq *GroupQuery) loadControlobjectiveViewers(ctx context.Context, query *ControlObjectiveQuery, nodes []*Group, init func(*Group), assign func(*Group, *ControlObjective)) error {
+	edgeIDs := make([]driver.Value, len(nodes))
+	byID := make(map[string]*Group)
+	nids := make(map[string]map[*Group]struct{})
+	for i, node := range nodes {
+		edgeIDs[i] = node.ID
+		byID[node.ID] = node
+		if init != nil {
+			init(node)
+		}
+	}
+	query.Where(func(s *sql.Selector) {
+		joinT := sql.Table(group.ControlobjectiveViewersTable)
+		joinT.Schema(gq.schemaConfig.ControlObjectiveViewers)
+		s.Join(joinT).On(s.C(controlobjective.FieldID), joinT.C(group.ControlobjectiveViewersPrimaryKey[0]))
+		s.Where(sql.InValues(joinT.C(group.ControlobjectiveViewersPrimaryKey[1]), edgeIDs...))
+		columns := s.SelectedColumns()
+		s.Select(joinT.C(group.ControlobjectiveViewersPrimaryKey[1]))
+		s.AppendSelect(columns...)
+		s.SetDistinct(false)
+	})
+	if err := query.prepareQuery(ctx); err != nil {
+		return err
+	}
+	qr := QuerierFunc(func(ctx context.Context, q Query) (Value, error) {
+		return query.sqlAll(ctx, func(_ context.Context, spec *sqlgraph.QuerySpec) {
+			assign := spec.Assign
+			values := spec.ScanValues
+			spec.ScanValues = func(columns []string) ([]any, error) {
+				values, err := values(columns[1:])
+				if err != nil {
+					return nil, err
+				}
+				return append([]any{new(sql.NullString)}, values...), nil
+			}
+			spec.Assign = func(columns []string, values []any) error {
+				outValue := values[0].(*sql.NullString).String
+				inValue := values[1].(*sql.NullString).String
+				if nids[inValue] == nil {
+					nids[inValue] = map[*Group]struct{}{byID[outValue]: {}}
+					return assign(columns[1:], values[1:])
+				}
+				nids[inValue][byID[outValue]] = struct{}{}
+				return nil
+			}
+		})
+	})
+	neighbors, err := withInterceptors[[]*ControlObjective](ctx, query, qr, query.inters)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		nodes, ok := nids[n.ID]
+		if !ok {
+			return fmt.Errorf(`unexpected "controlobjective_viewers" node returned %v`, n.ID)
+		}
+		for kn := range nodes {
+			assign(kn, n)
+		}
+	}
+	return nil
+}
+func (gq *GroupQuery) loadControlobjectiveEditors(ctx context.Context, query *ControlObjectiveQuery, nodes []*Group, init func(*Group), assign func(*Group, *ControlObjective)) error {
+	edgeIDs := make([]driver.Value, len(nodes))
+	byID := make(map[string]*Group)
+	nids := make(map[string]map[*Group]struct{})
+	for i, node := range nodes {
+		edgeIDs[i] = node.ID
+		byID[node.ID] = node
+		if init != nil {
+			init(node)
+		}
+	}
+	query.Where(func(s *sql.Selector) {
+		joinT := sql.Table(group.ControlobjectiveEditorsTable)
+		joinT.Schema(gq.schemaConfig.ControlObjectiveEditors)
+		s.Join(joinT).On(s.C(controlobjective.FieldID), joinT.C(group.ControlobjectiveEditorsPrimaryKey[0]))
+		s.Where(sql.InValues(joinT.C(group.ControlobjectiveEditorsPrimaryKey[1]), edgeIDs...))
+		columns := s.SelectedColumns()
+		s.Select(joinT.C(group.ControlobjectiveEditorsPrimaryKey[1]))
+		s.AppendSelect(columns...)
+		s.SetDistinct(false)
+	})
+	if err := query.prepareQuery(ctx); err != nil {
+		return err
+	}
+	qr := QuerierFunc(func(ctx context.Context, q Query) (Value, error) {
+		return query.sqlAll(ctx, func(_ context.Context, spec *sqlgraph.QuerySpec) {
+			assign := spec.Assign
+			values := spec.ScanValues
+			spec.ScanValues = func(columns []string) ([]any, error) {
+				values, err := values(columns[1:])
+				if err != nil {
+					return nil, err
+				}
+				return append([]any{new(sql.NullString)}, values...), nil
+			}
+			spec.Assign = func(columns []string, values []any) error {
+				outValue := values[0].(*sql.NullString).String
+				inValue := values[1].(*sql.NullString).String
+				if nids[inValue] == nil {
+					nids[inValue] = map[*Group]struct{}{byID[outValue]: {}}
+					return assign(columns[1:], values[1:])
+				}
+				nids[inValue][byID[outValue]] = struct{}{}
+				return nil
+			}
+		})
+	})
+	neighbors, err := withInterceptors[[]*ControlObjective](ctx, query, qr, query.inters)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		nodes, ok := nids[n.ID]
+		if !ok {
+			return fmt.Errorf(`unexpected "controlobjective_editors" node returned %v`, n.ID)
+		}
+		for kn := range nodes {
+			assign(kn, n)
+		}
+	}
+	return nil
+}
+func (gq *GroupQuery) loadControlobjectiveBlockedGroups(ctx context.Context, query *ControlObjectiveQuery, nodes []*Group, init func(*Group), assign func(*Group, *ControlObjective)) error {
+	edgeIDs := make([]driver.Value, len(nodes))
+	byID := make(map[string]*Group)
+	nids := make(map[string]map[*Group]struct{})
+	for i, node := range nodes {
+		edgeIDs[i] = node.ID
+		byID[node.ID] = node
+		if init != nil {
+			init(node)
+		}
+	}
+	query.Where(func(s *sql.Selector) {
+		joinT := sql.Table(group.ControlobjectiveBlockedGroupsTable)
+		joinT.Schema(gq.schemaConfig.ControlObjectiveBlockedGroups)
+		s.Join(joinT).On(s.C(controlobjective.FieldID), joinT.C(group.ControlobjectiveBlockedGroupsPrimaryKey[0]))
+		s.Where(sql.InValues(joinT.C(group.ControlobjectiveBlockedGroupsPrimaryKey[1]), edgeIDs...))
+		columns := s.SelectedColumns()
+		s.Select(joinT.C(group.ControlobjectiveBlockedGroupsPrimaryKey[1]))
+		s.AppendSelect(columns...)
+		s.SetDistinct(false)
+	})
+	if err := query.prepareQuery(ctx); err != nil {
+		return err
+	}
+	qr := QuerierFunc(func(ctx context.Context, q Query) (Value, error) {
+		return query.sqlAll(ctx, func(_ context.Context, spec *sqlgraph.QuerySpec) {
+			assign := spec.Assign
+			values := spec.ScanValues
+			spec.ScanValues = func(columns []string) ([]any, error) {
+				values, err := values(columns[1:])
+				if err != nil {
+					return nil, err
+				}
+				return append([]any{new(sql.NullString)}, values...), nil
+			}
+			spec.Assign = func(columns []string, values []any) error {
+				outValue := values[0].(*sql.NullString).String
+				inValue := values[1].(*sql.NullString).String
+				if nids[inValue] == nil {
+					nids[inValue] = map[*Group]struct{}{byID[outValue]: {}}
+					return assign(columns[1:], values[1:])
+				}
+				nids[inValue][byID[outValue]] = struct{}{}
+				return nil
+			}
+		})
+	})
+	neighbors, err := withInterceptors[[]*ControlObjective](ctx, query, qr, query.inters)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		nodes, ok := nids[n.ID]
+		if !ok {
+			return fmt.Errorf(`unexpected "controlobjective_blocked_groups" node returned %v`, n.ID)
+		}
+		for kn := range nodes {
+			assign(kn, n)
+		}
+	}
+	return nil
+}
 func (gq *GroupQuery) loadMembers(ctx context.Context, query *GroupMembershipQuery, nodes []*Group, init func(*Group), assign func(*Group, *GroupMembership)) error {
 	fks := make([]driver.Value, 0, len(nodes))
 	nodeids := make(map[string]*Group)
@@ -2647,6 +3002,48 @@ func (gq *GroupQuery) WithNamedRiskBlockedGroups(name string, opts ...func(*Risk
 		gq.withNamedRiskBlockedGroups = make(map[string]*RiskQuery)
 	}
 	gq.withNamedRiskBlockedGroups[name] = query
+	return gq
+}
+
+// WithNamedControlobjectiveViewers tells the query-builder to eager-load the nodes that are connected to the "controlobjective_viewers"
+// edge with the given name. The optional arguments are used to configure the query builder of the edge.
+func (gq *GroupQuery) WithNamedControlobjectiveViewers(name string, opts ...func(*ControlObjectiveQuery)) *GroupQuery {
+	query := (&ControlObjectiveClient{config: gq.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	if gq.withNamedControlobjectiveViewers == nil {
+		gq.withNamedControlobjectiveViewers = make(map[string]*ControlObjectiveQuery)
+	}
+	gq.withNamedControlobjectiveViewers[name] = query
+	return gq
+}
+
+// WithNamedControlobjectiveEditors tells the query-builder to eager-load the nodes that are connected to the "controlobjective_editors"
+// edge with the given name. The optional arguments are used to configure the query builder of the edge.
+func (gq *GroupQuery) WithNamedControlobjectiveEditors(name string, opts ...func(*ControlObjectiveQuery)) *GroupQuery {
+	query := (&ControlObjectiveClient{config: gq.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	if gq.withNamedControlobjectiveEditors == nil {
+		gq.withNamedControlobjectiveEditors = make(map[string]*ControlObjectiveQuery)
+	}
+	gq.withNamedControlobjectiveEditors[name] = query
+	return gq
+}
+
+// WithNamedControlobjectiveBlockedGroups tells the query-builder to eager-load the nodes that are connected to the "controlobjective_blocked_groups"
+// edge with the given name. The optional arguments are used to configure the query builder of the edge.
+func (gq *GroupQuery) WithNamedControlobjectiveBlockedGroups(name string, opts ...func(*ControlObjectiveQuery)) *GroupQuery {
+	query := (&ControlObjectiveClient{config: gq.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	if gq.withNamedControlobjectiveBlockedGroups == nil {
+		gq.withNamedControlobjectiveBlockedGroups = make(map[string]*ControlObjectiveQuery)
+	}
+	gq.withNamedControlobjectiveBlockedGroups[name] = query
 	return gq
 }
 

--- a/internal/ent/generated/group_update.go
+++ b/internal/ent/generated/group_update.go
@@ -12,6 +12,7 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/dialect/sql/sqljson"
 	"entgo.io/ent/schema/field"
+	"github.com/theopenlane/core/internal/ent/generated/controlobjective"
 	"github.com/theopenlane/core/internal/ent/generated/event"
 	"github.com/theopenlane/core/internal/ent/generated/file"
 	"github.com/theopenlane/core/internal/ent/generated/group"
@@ -483,6 +484,51 @@ func (gu *GroupUpdate) AddRiskBlockedGroups(r ...*Risk) *GroupUpdate {
 	return gu.AddRiskBlockedGroupIDs(ids...)
 }
 
+// AddControlobjectiveViewerIDs adds the "controlobjective_viewers" edge to the ControlObjective entity by IDs.
+func (gu *GroupUpdate) AddControlobjectiveViewerIDs(ids ...string) *GroupUpdate {
+	gu.mutation.AddControlobjectiveViewerIDs(ids...)
+	return gu
+}
+
+// AddControlobjectiveViewers adds the "controlobjective_viewers" edges to the ControlObjective entity.
+func (gu *GroupUpdate) AddControlobjectiveViewers(c ...*ControlObjective) *GroupUpdate {
+	ids := make([]string, len(c))
+	for i := range c {
+		ids[i] = c[i].ID
+	}
+	return gu.AddControlobjectiveViewerIDs(ids...)
+}
+
+// AddControlobjectiveEditorIDs adds the "controlobjective_editors" edge to the ControlObjective entity by IDs.
+func (gu *GroupUpdate) AddControlobjectiveEditorIDs(ids ...string) *GroupUpdate {
+	gu.mutation.AddControlobjectiveEditorIDs(ids...)
+	return gu
+}
+
+// AddControlobjectiveEditors adds the "controlobjective_editors" edges to the ControlObjective entity.
+func (gu *GroupUpdate) AddControlobjectiveEditors(c ...*ControlObjective) *GroupUpdate {
+	ids := make([]string, len(c))
+	for i := range c {
+		ids[i] = c[i].ID
+	}
+	return gu.AddControlobjectiveEditorIDs(ids...)
+}
+
+// AddControlobjectiveBlockedGroupIDs adds the "controlobjective_blocked_groups" edge to the ControlObjective entity by IDs.
+func (gu *GroupUpdate) AddControlobjectiveBlockedGroupIDs(ids ...string) *GroupUpdate {
+	gu.mutation.AddControlobjectiveBlockedGroupIDs(ids...)
+	return gu
+}
+
+// AddControlobjectiveBlockedGroups adds the "controlobjective_blocked_groups" edges to the ControlObjective entity.
+func (gu *GroupUpdate) AddControlobjectiveBlockedGroups(c ...*ControlObjective) *GroupUpdate {
+	ids := make([]string, len(c))
+	for i := range c {
+		ids[i] = c[i].ID
+	}
+	return gu.AddControlobjectiveBlockedGroupIDs(ids...)
+}
+
 // AddMemberIDs adds the "members" edge to the GroupMembership entity by IDs.
 func (gu *GroupUpdate) AddMemberIDs(ids ...string) *GroupUpdate {
 	gu.mutation.AddMemberIDs(ids...)
@@ -828,6 +874,69 @@ func (gu *GroupUpdate) RemoveRiskBlockedGroups(r ...*Risk) *GroupUpdate {
 		ids[i] = r[i].ID
 	}
 	return gu.RemoveRiskBlockedGroupIDs(ids...)
+}
+
+// ClearControlobjectiveViewers clears all "controlobjective_viewers" edges to the ControlObjective entity.
+func (gu *GroupUpdate) ClearControlobjectiveViewers() *GroupUpdate {
+	gu.mutation.ClearControlobjectiveViewers()
+	return gu
+}
+
+// RemoveControlobjectiveViewerIDs removes the "controlobjective_viewers" edge to ControlObjective entities by IDs.
+func (gu *GroupUpdate) RemoveControlobjectiveViewerIDs(ids ...string) *GroupUpdate {
+	gu.mutation.RemoveControlobjectiveViewerIDs(ids...)
+	return gu
+}
+
+// RemoveControlobjectiveViewers removes "controlobjective_viewers" edges to ControlObjective entities.
+func (gu *GroupUpdate) RemoveControlobjectiveViewers(c ...*ControlObjective) *GroupUpdate {
+	ids := make([]string, len(c))
+	for i := range c {
+		ids[i] = c[i].ID
+	}
+	return gu.RemoveControlobjectiveViewerIDs(ids...)
+}
+
+// ClearControlobjectiveEditors clears all "controlobjective_editors" edges to the ControlObjective entity.
+func (gu *GroupUpdate) ClearControlobjectiveEditors() *GroupUpdate {
+	gu.mutation.ClearControlobjectiveEditors()
+	return gu
+}
+
+// RemoveControlobjectiveEditorIDs removes the "controlobjective_editors" edge to ControlObjective entities by IDs.
+func (gu *GroupUpdate) RemoveControlobjectiveEditorIDs(ids ...string) *GroupUpdate {
+	gu.mutation.RemoveControlobjectiveEditorIDs(ids...)
+	return gu
+}
+
+// RemoveControlobjectiveEditors removes "controlobjective_editors" edges to ControlObjective entities.
+func (gu *GroupUpdate) RemoveControlobjectiveEditors(c ...*ControlObjective) *GroupUpdate {
+	ids := make([]string, len(c))
+	for i := range c {
+		ids[i] = c[i].ID
+	}
+	return gu.RemoveControlobjectiveEditorIDs(ids...)
+}
+
+// ClearControlobjectiveBlockedGroups clears all "controlobjective_blocked_groups" edges to the ControlObjective entity.
+func (gu *GroupUpdate) ClearControlobjectiveBlockedGroups() *GroupUpdate {
+	gu.mutation.ClearControlobjectiveBlockedGroups()
+	return gu
+}
+
+// RemoveControlobjectiveBlockedGroupIDs removes the "controlobjective_blocked_groups" edge to ControlObjective entities by IDs.
+func (gu *GroupUpdate) RemoveControlobjectiveBlockedGroupIDs(ids ...string) *GroupUpdate {
+	gu.mutation.RemoveControlobjectiveBlockedGroupIDs(ids...)
+	return gu
+}
+
+// RemoveControlobjectiveBlockedGroups removes "controlobjective_blocked_groups" edges to ControlObjective entities.
+func (gu *GroupUpdate) RemoveControlobjectiveBlockedGroups(c ...*ControlObjective) *GroupUpdate {
+	ids := make([]string, len(c))
+	for i := range c {
+		ids[i] = c[i].ID
+	}
+	return gu.RemoveControlobjectiveBlockedGroupIDs(ids...)
 }
 
 // ClearMembers clears all "members" edges to the GroupMembership entity.
@@ -1802,6 +1911,150 @@ func (gu *GroupUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
+	if gu.mutation.ControlobjectiveViewersCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   group.ControlobjectiveViewersTable,
+			Columns: group.ControlobjectiveViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = gu.schemaConfig.ControlObjectiveViewers
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := gu.mutation.RemovedControlobjectiveViewersIDs(); len(nodes) > 0 && !gu.mutation.ControlobjectiveViewersCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   group.ControlobjectiveViewersTable,
+			Columns: group.ControlobjectiveViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = gu.schemaConfig.ControlObjectiveViewers
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := gu.mutation.ControlobjectiveViewersIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   group.ControlobjectiveViewersTable,
+			Columns: group.ControlobjectiveViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = gu.schemaConfig.ControlObjectiveViewers
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if gu.mutation.ControlobjectiveEditorsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   group.ControlobjectiveEditorsTable,
+			Columns: group.ControlobjectiveEditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = gu.schemaConfig.ControlObjectiveEditors
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := gu.mutation.RemovedControlobjectiveEditorsIDs(); len(nodes) > 0 && !gu.mutation.ControlobjectiveEditorsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   group.ControlobjectiveEditorsTable,
+			Columns: group.ControlobjectiveEditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = gu.schemaConfig.ControlObjectiveEditors
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := gu.mutation.ControlobjectiveEditorsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   group.ControlobjectiveEditorsTable,
+			Columns: group.ControlobjectiveEditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = gu.schemaConfig.ControlObjectiveEditors
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if gu.mutation.ControlobjectiveBlockedGroupsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   group.ControlobjectiveBlockedGroupsTable,
+			Columns: group.ControlobjectiveBlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = gu.schemaConfig.ControlObjectiveBlockedGroups
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := gu.mutation.RemovedControlobjectiveBlockedGroupsIDs(); len(nodes) > 0 && !gu.mutation.ControlobjectiveBlockedGroupsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   group.ControlobjectiveBlockedGroupsTable,
+			Columns: group.ControlobjectiveBlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = gu.schemaConfig.ControlObjectiveBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := gu.mutation.ControlobjectiveBlockedGroupsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   group.ControlobjectiveBlockedGroupsTable,
+			Columns: group.ControlobjectiveBlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = gu.schemaConfig.ControlObjectiveBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
 	if gu.mutation.MembersCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.O2M,
@@ -2313,6 +2566,51 @@ func (guo *GroupUpdateOne) AddRiskBlockedGroups(r ...*Risk) *GroupUpdateOne {
 	return guo.AddRiskBlockedGroupIDs(ids...)
 }
 
+// AddControlobjectiveViewerIDs adds the "controlobjective_viewers" edge to the ControlObjective entity by IDs.
+func (guo *GroupUpdateOne) AddControlobjectiveViewerIDs(ids ...string) *GroupUpdateOne {
+	guo.mutation.AddControlobjectiveViewerIDs(ids...)
+	return guo
+}
+
+// AddControlobjectiveViewers adds the "controlobjective_viewers" edges to the ControlObjective entity.
+func (guo *GroupUpdateOne) AddControlobjectiveViewers(c ...*ControlObjective) *GroupUpdateOne {
+	ids := make([]string, len(c))
+	for i := range c {
+		ids[i] = c[i].ID
+	}
+	return guo.AddControlobjectiveViewerIDs(ids...)
+}
+
+// AddControlobjectiveEditorIDs adds the "controlobjective_editors" edge to the ControlObjective entity by IDs.
+func (guo *GroupUpdateOne) AddControlobjectiveEditorIDs(ids ...string) *GroupUpdateOne {
+	guo.mutation.AddControlobjectiveEditorIDs(ids...)
+	return guo
+}
+
+// AddControlobjectiveEditors adds the "controlobjective_editors" edges to the ControlObjective entity.
+func (guo *GroupUpdateOne) AddControlobjectiveEditors(c ...*ControlObjective) *GroupUpdateOne {
+	ids := make([]string, len(c))
+	for i := range c {
+		ids[i] = c[i].ID
+	}
+	return guo.AddControlobjectiveEditorIDs(ids...)
+}
+
+// AddControlobjectiveBlockedGroupIDs adds the "controlobjective_blocked_groups" edge to the ControlObjective entity by IDs.
+func (guo *GroupUpdateOne) AddControlobjectiveBlockedGroupIDs(ids ...string) *GroupUpdateOne {
+	guo.mutation.AddControlobjectiveBlockedGroupIDs(ids...)
+	return guo
+}
+
+// AddControlobjectiveBlockedGroups adds the "controlobjective_blocked_groups" edges to the ControlObjective entity.
+func (guo *GroupUpdateOne) AddControlobjectiveBlockedGroups(c ...*ControlObjective) *GroupUpdateOne {
+	ids := make([]string, len(c))
+	for i := range c {
+		ids[i] = c[i].ID
+	}
+	return guo.AddControlobjectiveBlockedGroupIDs(ids...)
+}
+
 // AddMemberIDs adds the "members" edge to the GroupMembership entity by IDs.
 func (guo *GroupUpdateOne) AddMemberIDs(ids ...string) *GroupUpdateOne {
 	guo.mutation.AddMemberIDs(ids...)
@@ -2658,6 +2956,69 @@ func (guo *GroupUpdateOne) RemoveRiskBlockedGroups(r ...*Risk) *GroupUpdateOne {
 		ids[i] = r[i].ID
 	}
 	return guo.RemoveRiskBlockedGroupIDs(ids...)
+}
+
+// ClearControlobjectiveViewers clears all "controlobjective_viewers" edges to the ControlObjective entity.
+func (guo *GroupUpdateOne) ClearControlobjectiveViewers() *GroupUpdateOne {
+	guo.mutation.ClearControlobjectiveViewers()
+	return guo
+}
+
+// RemoveControlobjectiveViewerIDs removes the "controlobjective_viewers" edge to ControlObjective entities by IDs.
+func (guo *GroupUpdateOne) RemoveControlobjectiveViewerIDs(ids ...string) *GroupUpdateOne {
+	guo.mutation.RemoveControlobjectiveViewerIDs(ids...)
+	return guo
+}
+
+// RemoveControlobjectiveViewers removes "controlobjective_viewers" edges to ControlObjective entities.
+func (guo *GroupUpdateOne) RemoveControlobjectiveViewers(c ...*ControlObjective) *GroupUpdateOne {
+	ids := make([]string, len(c))
+	for i := range c {
+		ids[i] = c[i].ID
+	}
+	return guo.RemoveControlobjectiveViewerIDs(ids...)
+}
+
+// ClearControlobjectiveEditors clears all "controlobjective_editors" edges to the ControlObjective entity.
+func (guo *GroupUpdateOne) ClearControlobjectiveEditors() *GroupUpdateOne {
+	guo.mutation.ClearControlobjectiveEditors()
+	return guo
+}
+
+// RemoveControlobjectiveEditorIDs removes the "controlobjective_editors" edge to ControlObjective entities by IDs.
+func (guo *GroupUpdateOne) RemoveControlobjectiveEditorIDs(ids ...string) *GroupUpdateOne {
+	guo.mutation.RemoveControlobjectiveEditorIDs(ids...)
+	return guo
+}
+
+// RemoveControlobjectiveEditors removes "controlobjective_editors" edges to ControlObjective entities.
+func (guo *GroupUpdateOne) RemoveControlobjectiveEditors(c ...*ControlObjective) *GroupUpdateOne {
+	ids := make([]string, len(c))
+	for i := range c {
+		ids[i] = c[i].ID
+	}
+	return guo.RemoveControlobjectiveEditorIDs(ids...)
+}
+
+// ClearControlobjectiveBlockedGroups clears all "controlobjective_blocked_groups" edges to the ControlObjective entity.
+func (guo *GroupUpdateOne) ClearControlobjectiveBlockedGroups() *GroupUpdateOne {
+	guo.mutation.ClearControlobjectiveBlockedGroups()
+	return guo
+}
+
+// RemoveControlobjectiveBlockedGroupIDs removes the "controlobjective_blocked_groups" edge to ControlObjective entities by IDs.
+func (guo *GroupUpdateOne) RemoveControlobjectiveBlockedGroupIDs(ids ...string) *GroupUpdateOne {
+	guo.mutation.RemoveControlobjectiveBlockedGroupIDs(ids...)
+	return guo
+}
+
+// RemoveControlobjectiveBlockedGroups removes "controlobjective_blocked_groups" edges to ControlObjective entities.
+func (guo *GroupUpdateOne) RemoveControlobjectiveBlockedGroups(c ...*ControlObjective) *GroupUpdateOne {
+	ids := make([]string, len(c))
+	for i := range c {
+		ids[i] = c[i].ID
+	}
+	return guo.RemoveControlobjectiveBlockedGroupIDs(ids...)
 }
 
 // ClearMembers clears all "members" edges to the GroupMembership entity.
@@ -3657,6 +4018,150 @@ func (guo *GroupUpdateOne) sqlSave(ctx context.Context) (_node *Group, err error
 			},
 		}
 		edge.Schema = guo.schemaConfig.RiskBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if guo.mutation.ControlobjectiveViewersCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   group.ControlobjectiveViewersTable,
+			Columns: group.ControlobjectiveViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = guo.schemaConfig.ControlObjectiveViewers
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := guo.mutation.RemovedControlobjectiveViewersIDs(); len(nodes) > 0 && !guo.mutation.ControlobjectiveViewersCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   group.ControlobjectiveViewersTable,
+			Columns: group.ControlobjectiveViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = guo.schemaConfig.ControlObjectiveViewers
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := guo.mutation.ControlobjectiveViewersIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   group.ControlobjectiveViewersTable,
+			Columns: group.ControlobjectiveViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = guo.schemaConfig.ControlObjectiveViewers
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if guo.mutation.ControlobjectiveEditorsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   group.ControlobjectiveEditorsTable,
+			Columns: group.ControlobjectiveEditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = guo.schemaConfig.ControlObjectiveEditors
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := guo.mutation.RemovedControlobjectiveEditorsIDs(); len(nodes) > 0 && !guo.mutation.ControlobjectiveEditorsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   group.ControlobjectiveEditorsTable,
+			Columns: group.ControlobjectiveEditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = guo.schemaConfig.ControlObjectiveEditors
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := guo.mutation.ControlobjectiveEditorsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   group.ControlobjectiveEditorsTable,
+			Columns: group.ControlobjectiveEditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = guo.schemaConfig.ControlObjectiveEditors
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if guo.mutation.ControlobjectiveBlockedGroupsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   group.ControlobjectiveBlockedGroupsTable,
+			Columns: group.ControlobjectiveBlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = guo.schemaConfig.ControlObjectiveBlockedGroups
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := guo.mutation.RemovedControlobjectiveBlockedGroupsIDs(); len(nodes) > 0 && !guo.mutation.ControlobjectiveBlockedGroupsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   group.ControlobjectiveBlockedGroupsTable,
+			Columns: group.ControlobjectiveBlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = guo.schemaConfig.ControlObjectiveBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := guo.mutation.ControlobjectiveBlockedGroupsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: true,
+			Table:   group.ControlobjectiveBlockedGroupsTable,
+			Columns: group.ControlobjectiveBlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = guo.schemaConfig.ControlObjectiveBlockedGroups
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}

--- a/internal/ent/generated/history_from_mutation.go
+++ b/internal/ent/generated/history_from_mutation.go
@@ -896,6 +896,10 @@ func (m *ControlObjectiveMutation) CreateHistoryFromCreate(ctx context.Context) 
 		create = create.SetTags(tags)
 	}
 
+	if ownerID, exists := m.OwnerID(); exists {
+		create = create.SetOwnerID(ownerID)
+	}
+
 	if name, exists := m.Name(); exists {
 		create = create.SetName(name)
 	}
@@ -1018,6 +1022,12 @@ func (m *ControlObjectiveMutation) CreateHistoryFromUpdate(ctx context.Context) 
 			create = create.SetTags(controlobjective.Tags)
 		}
 
+		if ownerID, exists := m.OwnerID(); exists {
+			create = create.SetOwnerID(ownerID)
+		} else {
+			create = create.SetOwnerID(controlobjective.OwnerID)
+		}
+
 		if name, exists := m.Name(); exists {
 			create = create.SetName(name)
 		} else {
@@ -1124,6 +1134,7 @@ func (m *ControlObjectiveMutation) CreateHistoryFromDelete(ctx context.Context) 
 			SetDeletedBy(controlobjective.DeletedBy).
 			SetMappingID(controlobjective.MappingID).
 			SetTags(controlobjective.Tags).
+			SetOwnerID(controlobjective.OwnerID).
 			SetName(controlobjective.Name).
 			SetDescription(controlobjective.Description).
 			SetStatus(controlobjective.Status).
@@ -6962,6 +6973,10 @@ func (m *RiskMutation) CreateHistoryFromCreate(ctx context.Context) error {
 		create = create.SetTags(tags)
 	}
 
+	if ownerID, exists := m.OwnerID(); exists {
+		create = create.SetOwnerID(ownerID)
+	}
+
 	if name, exists := m.Name(); exists {
 		create = create.SetName(name)
 	}
@@ -7000,10 +7015,6 @@ func (m *RiskMutation) CreateHistoryFromCreate(ctx context.Context) error {
 
 	if details, exists := m.Details(); exists {
 		create = create.SetDetails(details)
-	}
-
-	if ownerID, exists := m.OwnerID(); exists {
-		create = create.SetOwnerID(ownerID)
 	}
 
 	_, err := create.Save(ctx)
@@ -7084,6 +7095,12 @@ func (m *RiskMutation) CreateHistoryFromUpdate(ctx context.Context) error {
 			create = create.SetTags(risk.Tags)
 		}
 
+		if ownerID, exists := m.OwnerID(); exists {
+			create = create.SetOwnerID(ownerID)
+		} else {
+			create = create.SetOwnerID(risk.OwnerID)
+		}
+
 		if name, exists := m.Name(); exists {
 			create = create.SetName(name)
 		} else {
@@ -7144,12 +7161,6 @@ func (m *RiskMutation) CreateHistoryFromUpdate(ctx context.Context) error {
 			create = create.SetDetails(risk.Details)
 		}
 
-		if ownerID, exists := m.OwnerID(); exists {
-			create = create.SetOwnerID(ownerID)
-		} else {
-			create = create.SetOwnerID(risk.OwnerID)
-		}
-
 		if _, err := create.Save(ctx); err != nil {
 			return err
 		}
@@ -7190,6 +7201,7 @@ func (m *RiskMutation) CreateHistoryFromDelete(ctx context.Context) error {
 			SetDeletedBy(risk.DeletedBy).
 			SetMappingID(risk.MappingID).
 			SetTags(risk.Tags).
+			SetOwnerID(risk.OwnerID).
 			SetName(risk.Name).
 			SetDescription(risk.Description).
 			SetStatus(risk.Status).
@@ -7200,7 +7212,6 @@ func (m *RiskMutation) CreateHistoryFromDelete(ctx context.Context) error {
 			SetMitigation(risk.Mitigation).
 			SetSatisfies(risk.Satisfies).
 			SetDetails(risk.Details).
-			SetOwnerID(risk.OwnerID).
 			Save(ctx)
 		if err != nil {
 			return err

--- a/internal/ent/generated/internal/schemaconfig.go
+++ b/internal/ent/generated/internal/schemaconfig.go
@@ -22,6 +22,9 @@ type SchemaConfig struct {
 	ControlTasks                     string // Control-tasks->Task table.
 	ControlHistory                   string // ControlHistory table.
 	ControlObjective                 string // ControlObjective table.
+	ControlObjectiveBlockedGroups    string // ControlObjective-blocked_groups->Group table.
+	ControlObjectiveEditors          string // ControlObjective-editors->Group table.
+	ControlObjectiveViewers          string // ControlObjective-viewers->Group table.
 	ControlObjectiveNarratives       string // ControlObjective-narratives->Narrative table.
 	ControlObjectiveTasks            string // ControlObjective-tasks->Task table.
 	ControlObjectiveHistory          string // ControlObjectiveHistory table.
@@ -73,12 +76,12 @@ type SchemaConfig struct {
 	IntegrationWebhooks              string // Integration-webhooks->Webhook table.
 	IntegrationHistory               string // IntegrationHistory table.
 	InternalPolicy                   string // InternalPolicy table.
+	InternalPolicyBlockedGroups      string // InternalPolicy-blocked_groups->Group table.
+	InternalPolicyEditors            string // InternalPolicy-editors->Group table.
 	InternalPolicyControlobjectives  string // InternalPolicy-controlobjectives->ControlObjective table.
 	InternalPolicyProcedures         string // InternalPolicy-procedures->Procedure table.
 	InternalPolicyNarratives         string // InternalPolicy-narratives->Narrative table.
 	InternalPolicyTasks              string // InternalPolicy-tasks->Task table.
-	InternalPolicyEditors            string // InternalPolicy-editors->Group table.
-	InternalPolicyBlockedGroups      string // InternalPolicy-blocked_groups->Group table.
 	InternalPolicyHistory            string // InternalPolicyHistory table.
 	Invite                           string // Invite table.
 	InviteEvents                     string // Invite-events->Event table.
@@ -107,13 +110,16 @@ type SchemaConfig struct {
 	PersonalAccessToken              string // PersonalAccessToken table.
 	PersonalAccessTokenEvents        string // PersonalAccessToken-events->Event table.
 	Procedure                        string // Procedure table.
+	ProcedureBlockedGroups           string // Procedure-blocked_groups->Group table.
+	ProcedureEditors                 string // Procedure-editors->Group table.
 	ProcedureNarratives              string // Procedure-narratives->Narrative table.
 	ProcedureRisks                   string // Procedure-risks->Risk table.
 	ProcedureTasks                   string // Procedure-tasks->Task table.
-	ProcedureEditors                 string // Procedure-editors->Group table.
-	ProcedureBlockedGroups           string // Procedure-blocked_groups->Group table.
 	ProcedureHistory                 string // ProcedureHistory table.
 	Program                          string // Program table.
+	ProgramBlockedGroups             string // Program-blocked_groups->Group table.
+	ProgramEditors                   string // Program-editors->Group table.
+	ProgramViewers                   string // Program-viewers->Group table.
 	ProgramControls                  string // Program-controls->Control table.
 	ProgramSubcontrols               string // Program-subcontrols->Subcontrol table.
 	ProgramControlobjectives         string // Program-controlobjectives->ControlObjective table.
@@ -125,17 +131,14 @@ type SchemaConfig struct {
 	ProgramFiles                     string // Program-files->File table.
 	ProgramNarratives                string // Program-narratives->Narrative table.
 	ProgramActionplans               string // Program-actionplans->ActionPlan table.
-	ProgramViewers                   string // Program-viewers->Group table.
-	ProgramEditors                   string // Program-editors->Group table.
-	ProgramBlockedGroups             string // Program-blocked_groups->Group table.
 	ProgramHistory                   string // ProgramHistory table.
 	ProgramMembership                string // ProgramMembership table.
 	ProgramMembershipHistory         string // ProgramMembershipHistory table.
 	Risk                             string // Risk table.
-	RiskActionplans                  string // Risk-actionplans->ActionPlan table.
-	RiskViewers                      string // Risk-viewers->Group table.
-	RiskEditors                      string // Risk-editors->Group table.
 	RiskBlockedGroups                string // Risk-blocked_groups->Group table.
+	RiskEditors                      string // Risk-editors->Group table.
+	RiskViewers                      string // Risk-viewers->Group table.
+	RiskActionplans                  string // Risk-actionplans->ActionPlan table.
 	RiskHistory                      string // RiskHistory table.
 	Standard                         string // Standard table.
 	StandardControlobjectives        string // Standard-controlobjectives->ControlObjective table.

--- a/internal/ent/generated/internalpolicy/internalpolicy.go
+++ b/internal/ent/generated/internalpolicy/internalpolicy.go
@@ -51,6 +51,10 @@ const (
 	FieldDetails = "details"
 	// EdgeOwner holds the string denoting the owner edge name in mutations.
 	EdgeOwner = "owner"
+	// EdgeBlockedGroups holds the string denoting the blocked_groups edge name in mutations.
+	EdgeBlockedGroups = "blocked_groups"
+	// EdgeEditors holds the string denoting the editors edge name in mutations.
+	EdgeEditors = "editors"
 	// EdgeControlobjectives holds the string denoting the controlobjectives edge name in mutations.
 	EdgeControlobjectives = "controlobjectives"
 	// EdgeControls holds the string denoting the controls edge name in mutations.
@@ -63,10 +67,6 @@ const (
 	EdgeTasks = "tasks"
 	// EdgePrograms holds the string denoting the programs edge name in mutations.
 	EdgePrograms = "programs"
-	// EdgeEditors holds the string denoting the editors edge name in mutations.
-	EdgeEditors = "editors"
-	// EdgeBlockedGroups holds the string denoting the blocked_groups edge name in mutations.
-	EdgeBlockedGroups = "blocked_groups"
 	// Table holds the table name of the internalpolicy in the database.
 	Table = "internal_policies"
 	// OwnerTable is the table that holds the owner relation/edge.
@@ -76,6 +76,16 @@ const (
 	OwnerInverseTable = "organizations"
 	// OwnerColumn is the table column denoting the owner relation/edge.
 	OwnerColumn = "owner_id"
+	// BlockedGroupsTable is the table that holds the blocked_groups relation/edge. The primary key declared below.
+	BlockedGroupsTable = "internal_policy_blocked_groups"
+	// BlockedGroupsInverseTable is the table name for the Group entity.
+	// It exists in this package in order to avoid circular dependency with the "group" package.
+	BlockedGroupsInverseTable = "groups"
+	// EditorsTable is the table that holds the editors relation/edge. The primary key declared below.
+	EditorsTable = "internal_policy_editors"
+	// EditorsInverseTable is the table name for the Group entity.
+	// It exists in this package in order to avoid circular dependency with the "group" package.
+	EditorsInverseTable = "groups"
 	// ControlobjectivesTable is the table that holds the controlobjectives relation/edge. The primary key declared below.
 	ControlobjectivesTable = "internal_policy_controlobjectives"
 	// ControlobjectivesInverseTable is the table name for the ControlObjective entity.
@@ -108,16 +118,6 @@ const (
 	// ProgramsInverseTable is the table name for the Program entity.
 	// It exists in this package in order to avoid circular dependency with the "program" package.
 	ProgramsInverseTable = "programs"
-	// EditorsTable is the table that holds the editors relation/edge. The primary key declared below.
-	EditorsTable = "internal_policy_editors"
-	// EditorsInverseTable is the table name for the Group entity.
-	// It exists in this package in order to avoid circular dependency with the "group" package.
-	EditorsInverseTable = "groups"
-	// BlockedGroupsTable is the table that holds the blocked_groups relation/edge. The primary key declared below.
-	BlockedGroupsTable = "internal_policy_blocked_groups"
-	// BlockedGroupsInverseTable is the table name for the Group entity.
-	// It exists in this package in order to avoid circular dependency with the "group" package.
-	BlockedGroupsInverseTable = "groups"
 )
 
 // Columns holds all SQL columns for internalpolicy fields.
@@ -143,6 +143,12 @@ var Columns = []string{
 }
 
 var (
+	// BlockedGroupsPrimaryKey and BlockedGroupsColumn2 are the table columns denoting the
+	// primary key for the blocked_groups relation (M2M).
+	BlockedGroupsPrimaryKey = []string{"internal_policy_id", "group_id"}
+	// EditorsPrimaryKey and EditorsColumn2 are the table columns denoting the
+	// primary key for the editors relation (M2M).
+	EditorsPrimaryKey = []string{"internal_policy_id", "group_id"}
 	// ControlobjectivesPrimaryKey and ControlobjectivesColumn2 are the table columns denoting the
 	// primary key for the controlobjectives relation (M2M).
 	ControlobjectivesPrimaryKey = []string{"internal_policy_id", "control_objective_id"}
@@ -158,12 +164,6 @@ var (
 	// ProgramsPrimaryKey and ProgramsColumn2 are the table columns denoting the
 	// primary key for the programs relation (M2M).
 	ProgramsPrimaryKey = []string{"program_id", "internal_policy_id"}
-	// EditorsPrimaryKey and EditorsColumn2 are the table columns denoting the
-	// primary key for the editors relation (M2M).
-	EditorsPrimaryKey = []string{"internal_policy_id", "group_id"}
-	// BlockedGroupsPrimaryKey and BlockedGroupsColumn2 are the table columns denoting the
-	// primary key for the blocked_groups relation (M2M).
-	BlockedGroupsPrimaryKey = []string{"internal_policy_id", "group_id"}
 )
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -183,7 +183,7 @@ func ValidColumn(column string) bool {
 //	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
 	Hooks        [7]ent.Hook
-	Interceptors [3]ent.Interceptor
+	Interceptors [2]ent.Interceptor
 	Policy       ent.Policy
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
@@ -293,6 +293,34 @@ func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
 	}
 }
 
+// ByBlockedGroupsCount orders the results by blocked_groups count.
+func ByBlockedGroupsCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newBlockedGroupsStep(), opts...)
+	}
+}
+
+// ByBlockedGroups orders the results by blocked_groups terms.
+func ByBlockedGroups(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newBlockedGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByEditorsCount orders the results by editors count.
+func ByEditorsCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newEditorsStep(), opts...)
+	}
+}
+
+// ByEditors orders the results by editors terms.
+func ByEditors(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newEditorsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
 // ByControlobjectivesCount orders the results by controlobjectives count.
 func ByControlobjectivesCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
@@ -376,39 +404,25 @@ func ByPrograms(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 		sqlgraph.OrderByNeighborTerms(s, newProgramsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
-
-// ByEditorsCount orders the results by editors count.
-func ByEditorsCount(opts ...sql.OrderTermOption) OrderOption {
-	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborsCount(s, newEditorsStep(), opts...)
-	}
-}
-
-// ByEditors orders the results by editors terms.
-func ByEditors(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
-	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborTerms(s, newEditorsStep(), append([]sql.OrderTerm{term}, terms...)...)
-	}
-}
-
-// ByBlockedGroupsCount orders the results by blocked_groups count.
-func ByBlockedGroupsCount(opts ...sql.OrderTermOption) OrderOption {
-	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborsCount(s, newBlockedGroupsStep(), opts...)
-	}
-}
-
-// ByBlockedGroups orders the results by blocked_groups terms.
-func ByBlockedGroups(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
-	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborTerms(s, newBlockedGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
-	}
-}
 func newOwnerStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(OwnerInverseTable, FieldID),
 		sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
+	)
+}
+func newBlockedGroupsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(BlockedGroupsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, BlockedGroupsTable, BlockedGroupsPrimaryKey...),
+	)
+}
+func newEditorsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(EditorsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, EditorsTable, EditorsPrimaryKey...),
 	)
 }
 func newControlobjectivesStep() *sqlgraph.Step {
@@ -451,19 +465,5 @@ func newProgramsStep() *sqlgraph.Step {
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(ProgramsInverseTable, FieldID),
 		sqlgraph.Edge(sqlgraph.M2M, true, ProgramsTable, ProgramsPrimaryKey...),
-	)
-}
-func newEditorsStep() *sqlgraph.Step {
-	return sqlgraph.NewStep(
-		sqlgraph.From(Table, FieldID),
-		sqlgraph.To(EditorsInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.M2M, false, EditorsTable, EditorsPrimaryKey...),
-	)
-}
-func newBlockedGroupsStep() *sqlgraph.Step {
-	return sqlgraph.NewStep(
-		sqlgraph.From(Table, FieldID),
-		sqlgraph.To(BlockedGroupsInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.M2M, false, BlockedGroupsTable, BlockedGroupsPrimaryKey...),
 	)
 }

--- a/internal/ent/generated/internalpolicy/where.go
+++ b/internal/ent/generated/internalpolicy/where.go
@@ -1221,6 +1221,64 @@ func HasOwnerWith(preds ...predicate.Organization) predicate.InternalPolicy {
 	})
 }
 
+// HasBlockedGroups applies the HasEdge predicate on the "blocked_groups" edge.
+func HasBlockedGroups() predicate.InternalPolicy {
+	return predicate.InternalPolicy(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, BlockedGroupsTable, BlockedGroupsPrimaryKey...),
+		)
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.InternalPolicyBlockedGroups
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasBlockedGroupsWith applies the HasEdge predicate on the "blocked_groups" edge with a given conditions (other predicates).
+func HasBlockedGroupsWith(preds ...predicate.Group) predicate.InternalPolicy {
+	return predicate.InternalPolicy(func(s *sql.Selector) {
+		step := newBlockedGroupsStep()
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.InternalPolicyBlockedGroups
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasEditors applies the HasEdge predicate on the "editors" edge.
+func HasEditors() predicate.InternalPolicy {
+	return predicate.InternalPolicy(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, EditorsTable, EditorsPrimaryKey...),
+		)
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.InternalPolicyEditors
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasEditorsWith applies the HasEdge predicate on the "editors" edge with a given conditions (other predicates).
+func HasEditorsWith(preds ...predicate.Group) predicate.InternalPolicy {
+	return predicate.InternalPolicy(func(s *sql.Selector) {
+		step := newEditorsStep()
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.InternalPolicyEditors
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
 // HasControlobjectives applies the HasEdge predicate on the "controlobjectives" edge.
 func HasControlobjectives() predicate.InternalPolicy {
 	return predicate.InternalPolicy(func(s *sql.Selector) {
@@ -1387,64 +1445,6 @@ func HasProgramsWith(preds ...predicate.Program) predicate.InternalPolicy {
 		schemaConfig := internal.SchemaConfigFromContext(s.Context())
 		step.To.Schema = schemaConfig.Program
 		step.Edge.Schema = schemaConfig.ProgramPolicies
-		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
-			for _, p := range preds {
-				p(s)
-			}
-		})
-	})
-}
-
-// HasEditors applies the HasEdge predicate on the "editors" edge.
-func HasEditors() predicate.InternalPolicy {
-	return predicate.InternalPolicy(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, EditorsTable, EditorsPrimaryKey...),
-		)
-		schemaConfig := internal.SchemaConfigFromContext(s.Context())
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.InternalPolicyEditors
-		sqlgraph.HasNeighbors(s, step)
-	})
-}
-
-// HasEditorsWith applies the HasEdge predicate on the "editors" edge with a given conditions (other predicates).
-func HasEditorsWith(preds ...predicate.Group) predicate.InternalPolicy {
-	return predicate.InternalPolicy(func(s *sql.Selector) {
-		step := newEditorsStep()
-		schemaConfig := internal.SchemaConfigFromContext(s.Context())
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.InternalPolicyEditors
-		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
-			for _, p := range preds {
-				p(s)
-			}
-		})
-	})
-}
-
-// HasBlockedGroups applies the HasEdge predicate on the "blocked_groups" edge.
-func HasBlockedGroups() predicate.InternalPolicy {
-	return predicate.InternalPolicy(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, BlockedGroupsTable, BlockedGroupsPrimaryKey...),
-		)
-		schemaConfig := internal.SchemaConfigFromContext(s.Context())
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.InternalPolicyBlockedGroups
-		sqlgraph.HasNeighbors(s, step)
-	})
-}
-
-// HasBlockedGroupsWith applies the HasEdge predicate on the "blocked_groups" edge with a given conditions (other predicates).
-func HasBlockedGroupsWith(preds ...predicate.Group) predicate.InternalPolicy {
-	return predicate.InternalPolicy(func(s *sql.Selector) {
-		step := newBlockedGroupsStep()
-		schemaConfig := internal.SchemaConfigFromContext(s.Context())
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.InternalPolicyBlockedGroups
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/internal/ent/generated/internalpolicy_create.go
+++ b/internal/ent/generated/internalpolicy_create.go
@@ -261,6 +261,36 @@ func (ipc *InternalPolicyCreate) SetOwner(o *Organization) *InternalPolicyCreate
 	return ipc.SetOwnerID(o.ID)
 }
 
+// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
+func (ipc *InternalPolicyCreate) AddBlockedGroupIDs(ids ...string) *InternalPolicyCreate {
+	ipc.mutation.AddBlockedGroupIDs(ids...)
+	return ipc
+}
+
+// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
+func (ipc *InternalPolicyCreate) AddBlockedGroups(g ...*Group) *InternalPolicyCreate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return ipc.AddBlockedGroupIDs(ids...)
+}
+
+// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
+func (ipc *InternalPolicyCreate) AddEditorIDs(ids ...string) *InternalPolicyCreate {
+	ipc.mutation.AddEditorIDs(ids...)
+	return ipc
+}
+
+// AddEditors adds the "editors" edges to the Group entity.
+func (ipc *InternalPolicyCreate) AddEditors(g ...*Group) *InternalPolicyCreate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return ipc.AddEditorIDs(ids...)
+}
+
 // AddControlobjectiveIDs adds the "controlobjectives" edge to the ControlObjective entity by IDs.
 func (ipc *InternalPolicyCreate) AddControlobjectiveIDs(ids ...string) *InternalPolicyCreate {
 	ipc.mutation.AddControlobjectiveIDs(ids...)
@@ -349,36 +379,6 @@ func (ipc *InternalPolicyCreate) AddPrograms(p ...*Program) *InternalPolicyCreat
 		ids[i] = p[i].ID
 	}
 	return ipc.AddProgramIDs(ids...)
-}
-
-// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
-func (ipc *InternalPolicyCreate) AddEditorIDs(ids ...string) *InternalPolicyCreate {
-	ipc.mutation.AddEditorIDs(ids...)
-	return ipc
-}
-
-// AddEditors adds the "editors" edges to the Group entity.
-func (ipc *InternalPolicyCreate) AddEditors(g ...*Group) *InternalPolicyCreate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return ipc.AddEditorIDs(ids...)
-}
-
-// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
-func (ipc *InternalPolicyCreate) AddBlockedGroupIDs(ids ...string) *InternalPolicyCreate {
-	ipc.mutation.AddBlockedGroupIDs(ids...)
-	return ipc
-}
-
-// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
-func (ipc *InternalPolicyCreate) AddBlockedGroups(g ...*Group) *InternalPolicyCreate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return ipc.AddBlockedGroupIDs(ids...)
 }
 
 // Mutation returns the InternalPolicyMutation object of the builder.
@@ -589,6 +589,40 @@ func (ipc *InternalPolicyCreate) createSpec() (*InternalPolicy, *sqlgraph.Create
 		_node.OwnerID = nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
+	if nodes := ipc.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   internalpolicy.BlockedGroupsTable,
+			Columns: internalpolicy.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ipc.schemaConfig.InternalPolicyBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := ipc.mutation.EditorsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   internalpolicy.EditorsTable,
+			Columns: internalpolicy.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ipc.schemaConfig.InternalPolicyEditors
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
 	if nodes := ipc.mutation.ControlobjectivesIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2M,
@@ -686,40 +720,6 @@ func (ipc *InternalPolicyCreate) createSpec() (*InternalPolicy, *sqlgraph.Create
 			},
 		}
 		edge.Schema = ipc.schemaConfig.ProgramPolicies
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges = append(_spec.Edges, edge)
-	}
-	if nodes := ipc.mutation.EditorsIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   internalpolicy.EditorsTable,
-			Columns: internalpolicy.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ipc.schemaConfig.InternalPolicyEditors
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges = append(_spec.Edges, edge)
-	}
-	if nodes := ipc.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   internalpolicy.BlockedGroupsTable,
-			Columns: internalpolicy.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ipc.schemaConfig.InternalPolicyBlockedGroups
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}

--- a/internal/ent/generated/internalpolicy_update.go
+++ b/internal/ent/generated/internalpolicy_update.go
@@ -301,6 +301,36 @@ func (ipu *InternalPolicyUpdate) SetOwner(o *Organization) *InternalPolicyUpdate
 	return ipu.SetOwnerID(o.ID)
 }
 
+// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
+func (ipu *InternalPolicyUpdate) AddBlockedGroupIDs(ids ...string) *InternalPolicyUpdate {
+	ipu.mutation.AddBlockedGroupIDs(ids...)
+	return ipu
+}
+
+// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
+func (ipu *InternalPolicyUpdate) AddBlockedGroups(g ...*Group) *InternalPolicyUpdate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return ipu.AddBlockedGroupIDs(ids...)
+}
+
+// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
+func (ipu *InternalPolicyUpdate) AddEditorIDs(ids ...string) *InternalPolicyUpdate {
+	ipu.mutation.AddEditorIDs(ids...)
+	return ipu
+}
+
+// AddEditors adds the "editors" edges to the Group entity.
+func (ipu *InternalPolicyUpdate) AddEditors(g ...*Group) *InternalPolicyUpdate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return ipu.AddEditorIDs(ids...)
+}
+
 // AddControlobjectiveIDs adds the "controlobjectives" edge to the ControlObjective entity by IDs.
 func (ipu *InternalPolicyUpdate) AddControlobjectiveIDs(ids ...string) *InternalPolicyUpdate {
 	ipu.mutation.AddControlobjectiveIDs(ids...)
@@ -391,36 +421,6 @@ func (ipu *InternalPolicyUpdate) AddPrograms(p ...*Program) *InternalPolicyUpdat
 	return ipu.AddProgramIDs(ids...)
 }
 
-// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
-func (ipu *InternalPolicyUpdate) AddEditorIDs(ids ...string) *InternalPolicyUpdate {
-	ipu.mutation.AddEditorIDs(ids...)
-	return ipu
-}
-
-// AddEditors adds the "editors" edges to the Group entity.
-func (ipu *InternalPolicyUpdate) AddEditors(g ...*Group) *InternalPolicyUpdate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return ipu.AddEditorIDs(ids...)
-}
-
-// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
-func (ipu *InternalPolicyUpdate) AddBlockedGroupIDs(ids ...string) *InternalPolicyUpdate {
-	ipu.mutation.AddBlockedGroupIDs(ids...)
-	return ipu
-}
-
-// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
-func (ipu *InternalPolicyUpdate) AddBlockedGroups(g ...*Group) *InternalPolicyUpdate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return ipu.AddBlockedGroupIDs(ids...)
-}
-
 // Mutation returns the InternalPolicyMutation object of the builder.
 func (ipu *InternalPolicyUpdate) Mutation() *InternalPolicyMutation {
 	return ipu.mutation
@@ -430,6 +430,48 @@ func (ipu *InternalPolicyUpdate) Mutation() *InternalPolicyMutation {
 func (ipu *InternalPolicyUpdate) ClearOwner() *InternalPolicyUpdate {
 	ipu.mutation.ClearOwner()
 	return ipu
+}
+
+// ClearBlockedGroups clears all "blocked_groups" edges to the Group entity.
+func (ipu *InternalPolicyUpdate) ClearBlockedGroups() *InternalPolicyUpdate {
+	ipu.mutation.ClearBlockedGroups()
+	return ipu
+}
+
+// RemoveBlockedGroupIDs removes the "blocked_groups" edge to Group entities by IDs.
+func (ipu *InternalPolicyUpdate) RemoveBlockedGroupIDs(ids ...string) *InternalPolicyUpdate {
+	ipu.mutation.RemoveBlockedGroupIDs(ids...)
+	return ipu
+}
+
+// RemoveBlockedGroups removes "blocked_groups" edges to Group entities.
+func (ipu *InternalPolicyUpdate) RemoveBlockedGroups(g ...*Group) *InternalPolicyUpdate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return ipu.RemoveBlockedGroupIDs(ids...)
+}
+
+// ClearEditors clears all "editors" edges to the Group entity.
+func (ipu *InternalPolicyUpdate) ClearEditors() *InternalPolicyUpdate {
+	ipu.mutation.ClearEditors()
+	return ipu
+}
+
+// RemoveEditorIDs removes the "editors" edge to Group entities by IDs.
+func (ipu *InternalPolicyUpdate) RemoveEditorIDs(ids ...string) *InternalPolicyUpdate {
+	ipu.mutation.RemoveEditorIDs(ids...)
+	return ipu
+}
+
+// RemoveEditors removes "editors" edges to Group entities.
+func (ipu *InternalPolicyUpdate) RemoveEditors(g ...*Group) *InternalPolicyUpdate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return ipu.RemoveEditorIDs(ids...)
 }
 
 // ClearControlobjectives clears all "controlobjectives" edges to the ControlObjective entity.
@@ -556,48 +598,6 @@ func (ipu *InternalPolicyUpdate) RemovePrograms(p ...*Program) *InternalPolicyUp
 		ids[i] = p[i].ID
 	}
 	return ipu.RemoveProgramIDs(ids...)
-}
-
-// ClearEditors clears all "editors" edges to the Group entity.
-func (ipu *InternalPolicyUpdate) ClearEditors() *InternalPolicyUpdate {
-	ipu.mutation.ClearEditors()
-	return ipu
-}
-
-// RemoveEditorIDs removes the "editors" edge to Group entities by IDs.
-func (ipu *InternalPolicyUpdate) RemoveEditorIDs(ids ...string) *InternalPolicyUpdate {
-	ipu.mutation.RemoveEditorIDs(ids...)
-	return ipu
-}
-
-// RemoveEditors removes "editors" edges to Group entities.
-func (ipu *InternalPolicyUpdate) RemoveEditors(g ...*Group) *InternalPolicyUpdate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return ipu.RemoveEditorIDs(ids...)
-}
-
-// ClearBlockedGroups clears all "blocked_groups" edges to the Group entity.
-func (ipu *InternalPolicyUpdate) ClearBlockedGroups() *InternalPolicyUpdate {
-	ipu.mutation.ClearBlockedGroups()
-	return ipu
-}
-
-// RemoveBlockedGroupIDs removes the "blocked_groups" edge to Group entities by IDs.
-func (ipu *InternalPolicyUpdate) RemoveBlockedGroupIDs(ids ...string) *InternalPolicyUpdate {
-	ipu.mutation.RemoveBlockedGroupIDs(ids...)
-	return ipu
-}
-
-// RemoveBlockedGroups removes "blocked_groups" edges to Group entities.
-func (ipu *InternalPolicyUpdate) RemoveBlockedGroups(g ...*Group) *InternalPolicyUpdate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return ipu.RemoveBlockedGroupIDs(ids...)
 }
 
 // Save executes the query and returns the number of nodes affected by the update operation.
@@ -787,6 +787,102 @@ func (ipu *InternalPolicyUpdate) sqlSave(ctx context.Context) (n int, err error)
 			},
 		}
 		edge.Schema = ipu.schemaConfig.InternalPolicy
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if ipu.mutation.BlockedGroupsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   internalpolicy.BlockedGroupsTable,
+			Columns: internalpolicy.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ipu.schemaConfig.InternalPolicyBlockedGroups
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ipu.mutation.RemovedBlockedGroupsIDs(); len(nodes) > 0 && !ipu.mutation.BlockedGroupsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   internalpolicy.BlockedGroupsTable,
+			Columns: internalpolicy.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ipu.schemaConfig.InternalPolicyBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ipu.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   internalpolicy.BlockedGroupsTable,
+			Columns: internalpolicy.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ipu.schemaConfig.InternalPolicyBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if ipu.mutation.EditorsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   internalpolicy.EditorsTable,
+			Columns: internalpolicy.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ipu.schemaConfig.InternalPolicyEditors
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ipu.mutation.RemovedEditorsIDs(); len(nodes) > 0 && !ipu.mutation.EditorsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   internalpolicy.EditorsTable,
+			Columns: internalpolicy.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ipu.schemaConfig.InternalPolicyEditors
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ipu.mutation.EditorsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   internalpolicy.EditorsTable,
+			Columns: internalpolicy.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ipu.schemaConfig.InternalPolicyEditors
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
@@ -1080,102 +1176,6 @@ func (ipu *InternalPolicyUpdate) sqlSave(ctx context.Context) (n int, err error)
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
-	if ipu.mutation.EditorsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   internalpolicy.EditorsTable,
-			Columns: internalpolicy.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ipu.schemaConfig.InternalPolicyEditors
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := ipu.mutation.RemovedEditorsIDs(); len(nodes) > 0 && !ipu.mutation.EditorsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   internalpolicy.EditorsTable,
-			Columns: internalpolicy.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ipu.schemaConfig.InternalPolicyEditors
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := ipu.mutation.EditorsIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   internalpolicy.EditorsTable,
-			Columns: internalpolicy.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ipu.schemaConfig.InternalPolicyEditors
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
-	if ipu.mutation.BlockedGroupsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   internalpolicy.BlockedGroupsTable,
-			Columns: internalpolicy.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ipu.schemaConfig.InternalPolicyBlockedGroups
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := ipu.mutation.RemovedBlockedGroupsIDs(); len(nodes) > 0 && !ipu.mutation.BlockedGroupsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   internalpolicy.BlockedGroupsTable,
-			Columns: internalpolicy.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ipu.schemaConfig.InternalPolicyBlockedGroups
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := ipu.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   internalpolicy.BlockedGroupsTable,
-			Columns: internalpolicy.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ipu.schemaConfig.InternalPolicyBlockedGroups
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
 	_spec.Node.Schema = ipu.schemaConfig.InternalPolicy
 	ctx = internal.NewSchemaConfigContext(ctx, ipu.schemaConfig)
 	_spec.AddModifiers(ipu.modifiers...)
@@ -1461,6 +1461,36 @@ func (ipuo *InternalPolicyUpdateOne) SetOwner(o *Organization) *InternalPolicyUp
 	return ipuo.SetOwnerID(o.ID)
 }
 
+// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
+func (ipuo *InternalPolicyUpdateOne) AddBlockedGroupIDs(ids ...string) *InternalPolicyUpdateOne {
+	ipuo.mutation.AddBlockedGroupIDs(ids...)
+	return ipuo
+}
+
+// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
+func (ipuo *InternalPolicyUpdateOne) AddBlockedGroups(g ...*Group) *InternalPolicyUpdateOne {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return ipuo.AddBlockedGroupIDs(ids...)
+}
+
+// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
+func (ipuo *InternalPolicyUpdateOne) AddEditorIDs(ids ...string) *InternalPolicyUpdateOne {
+	ipuo.mutation.AddEditorIDs(ids...)
+	return ipuo
+}
+
+// AddEditors adds the "editors" edges to the Group entity.
+func (ipuo *InternalPolicyUpdateOne) AddEditors(g ...*Group) *InternalPolicyUpdateOne {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return ipuo.AddEditorIDs(ids...)
+}
+
 // AddControlobjectiveIDs adds the "controlobjectives" edge to the ControlObjective entity by IDs.
 func (ipuo *InternalPolicyUpdateOne) AddControlobjectiveIDs(ids ...string) *InternalPolicyUpdateOne {
 	ipuo.mutation.AddControlobjectiveIDs(ids...)
@@ -1551,36 +1581,6 @@ func (ipuo *InternalPolicyUpdateOne) AddPrograms(p ...*Program) *InternalPolicyU
 	return ipuo.AddProgramIDs(ids...)
 }
 
-// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
-func (ipuo *InternalPolicyUpdateOne) AddEditorIDs(ids ...string) *InternalPolicyUpdateOne {
-	ipuo.mutation.AddEditorIDs(ids...)
-	return ipuo
-}
-
-// AddEditors adds the "editors" edges to the Group entity.
-func (ipuo *InternalPolicyUpdateOne) AddEditors(g ...*Group) *InternalPolicyUpdateOne {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return ipuo.AddEditorIDs(ids...)
-}
-
-// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
-func (ipuo *InternalPolicyUpdateOne) AddBlockedGroupIDs(ids ...string) *InternalPolicyUpdateOne {
-	ipuo.mutation.AddBlockedGroupIDs(ids...)
-	return ipuo
-}
-
-// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
-func (ipuo *InternalPolicyUpdateOne) AddBlockedGroups(g ...*Group) *InternalPolicyUpdateOne {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return ipuo.AddBlockedGroupIDs(ids...)
-}
-
 // Mutation returns the InternalPolicyMutation object of the builder.
 func (ipuo *InternalPolicyUpdateOne) Mutation() *InternalPolicyMutation {
 	return ipuo.mutation
@@ -1590,6 +1590,48 @@ func (ipuo *InternalPolicyUpdateOne) Mutation() *InternalPolicyMutation {
 func (ipuo *InternalPolicyUpdateOne) ClearOwner() *InternalPolicyUpdateOne {
 	ipuo.mutation.ClearOwner()
 	return ipuo
+}
+
+// ClearBlockedGroups clears all "blocked_groups" edges to the Group entity.
+func (ipuo *InternalPolicyUpdateOne) ClearBlockedGroups() *InternalPolicyUpdateOne {
+	ipuo.mutation.ClearBlockedGroups()
+	return ipuo
+}
+
+// RemoveBlockedGroupIDs removes the "blocked_groups" edge to Group entities by IDs.
+func (ipuo *InternalPolicyUpdateOne) RemoveBlockedGroupIDs(ids ...string) *InternalPolicyUpdateOne {
+	ipuo.mutation.RemoveBlockedGroupIDs(ids...)
+	return ipuo
+}
+
+// RemoveBlockedGroups removes "blocked_groups" edges to Group entities.
+func (ipuo *InternalPolicyUpdateOne) RemoveBlockedGroups(g ...*Group) *InternalPolicyUpdateOne {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return ipuo.RemoveBlockedGroupIDs(ids...)
+}
+
+// ClearEditors clears all "editors" edges to the Group entity.
+func (ipuo *InternalPolicyUpdateOne) ClearEditors() *InternalPolicyUpdateOne {
+	ipuo.mutation.ClearEditors()
+	return ipuo
+}
+
+// RemoveEditorIDs removes the "editors" edge to Group entities by IDs.
+func (ipuo *InternalPolicyUpdateOne) RemoveEditorIDs(ids ...string) *InternalPolicyUpdateOne {
+	ipuo.mutation.RemoveEditorIDs(ids...)
+	return ipuo
+}
+
+// RemoveEditors removes "editors" edges to Group entities.
+func (ipuo *InternalPolicyUpdateOne) RemoveEditors(g ...*Group) *InternalPolicyUpdateOne {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return ipuo.RemoveEditorIDs(ids...)
 }
 
 // ClearControlobjectives clears all "controlobjectives" edges to the ControlObjective entity.
@@ -1716,48 +1758,6 @@ func (ipuo *InternalPolicyUpdateOne) RemovePrograms(p ...*Program) *InternalPoli
 		ids[i] = p[i].ID
 	}
 	return ipuo.RemoveProgramIDs(ids...)
-}
-
-// ClearEditors clears all "editors" edges to the Group entity.
-func (ipuo *InternalPolicyUpdateOne) ClearEditors() *InternalPolicyUpdateOne {
-	ipuo.mutation.ClearEditors()
-	return ipuo
-}
-
-// RemoveEditorIDs removes the "editors" edge to Group entities by IDs.
-func (ipuo *InternalPolicyUpdateOne) RemoveEditorIDs(ids ...string) *InternalPolicyUpdateOne {
-	ipuo.mutation.RemoveEditorIDs(ids...)
-	return ipuo
-}
-
-// RemoveEditors removes "editors" edges to Group entities.
-func (ipuo *InternalPolicyUpdateOne) RemoveEditors(g ...*Group) *InternalPolicyUpdateOne {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return ipuo.RemoveEditorIDs(ids...)
-}
-
-// ClearBlockedGroups clears all "blocked_groups" edges to the Group entity.
-func (ipuo *InternalPolicyUpdateOne) ClearBlockedGroups() *InternalPolicyUpdateOne {
-	ipuo.mutation.ClearBlockedGroups()
-	return ipuo
-}
-
-// RemoveBlockedGroupIDs removes the "blocked_groups" edge to Group entities by IDs.
-func (ipuo *InternalPolicyUpdateOne) RemoveBlockedGroupIDs(ids ...string) *InternalPolicyUpdateOne {
-	ipuo.mutation.RemoveBlockedGroupIDs(ids...)
-	return ipuo
-}
-
-// RemoveBlockedGroups removes "blocked_groups" edges to Group entities.
-func (ipuo *InternalPolicyUpdateOne) RemoveBlockedGroups(g ...*Group) *InternalPolicyUpdateOne {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return ipuo.RemoveBlockedGroupIDs(ids...)
 }
 
 // Where appends a list predicates to the InternalPolicyUpdate builder.
@@ -1977,6 +1977,102 @@ func (ipuo *InternalPolicyUpdateOne) sqlSave(ctx context.Context) (_node *Intern
 			},
 		}
 		edge.Schema = ipuo.schemaConfig.InternalPolicy
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if ipuo.mutation.BlockedGroupsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   internalpolicy.BlockedGroupsTable,
+			Columns: internalpolicy.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ipuo.schemaConfig.InternalPolicyBlockedGroups
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ipuo.mutation.RemovedBlockedGroupsIDs(); len(nodes) > 0 && !ipuo.mutation.BlockedGroupsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   internalpolicy.BlockedGroupsTable,
+			Columns: internalpolicy.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ipuo.schemaConfig.InternalPolicyBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ipuo.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   internalpolicy.BlockedGroupsTable,
+			Columns: internalpolicy.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ipuo.schemaConfig.InternalPolicyBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if ipuo.mutation.EditorsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   internalpolicy.EditorsTable,
+			Columns: internalpolicy.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ipuo.schemaConfig.InternalPolicyEditors
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ipuo.mutation.RemovedEditorsIDs(); len(nodes) > 0 && !ipuo.mutation.EditorsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   internalpolicy.EditorsTable,
+			Columns: internalpolicy.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ipuo.schemaConfig.InternalPolicyEditors
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ipuo.mutation.EditorsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   internalpolicy.EditorsTable,
+			Columns: internalpolicy.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ipuo.schemaConfig.InternalPolicyEditors
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
@@ -2265,102 +2361,6 @@ func (ipuo *InternalPolicyUpdateOne) sqlSave(ctx context.Context) (_node *Intern
 			},
 		}
 		edge.Schema = ipuo.schemaConfig.ProgramPolicies
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
-	if ipuo.mutation.EditorsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   internalpolicy.EditorsTable,
-			Columns: internalpolicy.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ipuo.schemaConfig.InternalPolicyEditors
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := ipuo.mutation.RemovedEditorsIDs(); len(nodes) > 0 && !ipuo.mutation.EditorsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   internalpolicy.EditorsTable,
-			Columns: internalpolicy.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ipuo.schemaConfig.InternalPolicyEditors
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := ipuo.mutation.EditorsIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   internalpolicy.EditorsTable,
-			Columns: internalpolicy.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ipuo.schemaConfig.InternalPolicyEditors
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
-	if ipuo.mutation.BlockedGroupsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   internalpolicy.BlockedGroupsTable,
-			Columns: internalpolicy.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ipuo.schemaConfig.InternalPolicyBlockedGroups
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := ipuo.mutation.RemovedBlockedGroupsIDs(); len(nodes) > 0 && !ipuo.mutation.BlockedGroupsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   internalpolicy.BlockedGroupsTable,
-			Columns: internalpolicy.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ipuo.schemaConfig.InternalPolicyBlockedGroups
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := ipuo.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   internalpolicy.BlockedGroupsTable,
-			Columns: internalpolicy.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ipuo.schemaConfig.InternalPolicyBlockedGroups
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}

--- a/internal/ent/generated/migrate/schema.go
+++ b/internal/ent/generated/migrate/schema.go
@@ -288,6 +288,7 @@ var (
 		{Name: "mapped_frameworks", Type: field.TypeString, Nullable: true, Size: 2147483647},
 		{Name: "details", Type: field.TypeJSON, Nullable: true},
 		{Name: "control_controlobjectives", Type: field.TypeString, Nullable: true},
+		{Name: "owner_id", Type: field.TypeString},
 	}
 	// ControlObjectivesTable holds the schema information for the "control_objectives" table.
 	ControlObjectivesTable = &schema.Table{
@@ -300,6 +301,12 @@ var (
 				Columns:    []*schema.Column{ControlObjectivesColumns[20]},
 				RefColumns: []*schema.Column{ControlsColumns[0]},
 				OnDelete:   schema.SetNull,
+			},
+			{
+				Symbol:     "control_objectives_organizations_controlobjectives",
+				Columns:    []*schema.Column{ControlObjectivesColumns[21]},
+				RefColumns: []*schema.Column{OrganizationsColumns[0]},
+				OnDelete:   schema.NoAction,
 			},
 		},
 	}
@@ -317,6 +324,7 @@ var (
 		{Name: "deleted_by", Type: field.TypeString, Nullable: true},
 		{Name: "mapping_id", Type: field.TypeString},
 		{Name: "tags", Type: field.TypeJSON, Nullable: true},
+		{Name: "owner_id", Type: field.TypeString},
 		{Name: "name", Type: field.TypeString},
 		{Name: "description", Type: field.TypeString, Nullable: true, Size: 2147483647},
 		{Name: "status", Type: field.TypeString, Nullable: true},
@@ -2341,6 +2349,7 @@ var (
 		{Name: "deleted_by", Type: field.TypeString, Nullable: true},
 		{Name: "mapping_id", Type: field.TypeString},
 		{Name: "tags", Type: field.TypeJSON, Nullable: true},
+		{Name: "owner_id", Type: field.TypeString},
 		{Name: "name", Type: field.TypeString},
 		{Name: "description", Type: field.TypeString, Nullable: true, Size: 2147483647},
 		{Name: "status", Type: field.TypeString, Nullable: true},
@@ -2351,7 +2360,6 @@ var (
 		{Name: "mitigation", Type: field.TypeString, Nullable: true, Size: 2147483647},
 		{Name: "satisfies", Type: field.TypeString, Nullable: true, Size: 2147483647},
 		{Name: "details", Type: field.TypeJSON, Nullable: true},
-		{Name: "owner_id", Type: field.TypeString},
 	}
 	// RiskHistoryTable holds the schema information for the "risk_history" table.
 	RiskHistoryTable = &schema.Table{
@@ -3234,6 +3242,81 @@ var (
 			},
 		},
 	}
+	// ControlObjectiveBlockedGroupsColumns holds the columns for the "control_objective_blocked_groups" table.
+	ControlObjectiveBlockedGroupsColumns = []*schema.Column{
+		{Name: "control_objective_id", Type: field.TypeString},
+		{Name: "group_id", Type: field.TypeString},
+	}
+	// ControlObjectiveBlockedGroupsTable holds the schema information for the "control_objective_blocked_groups" table.
+	ControlObjectiveBlockedGroupsTable = &schema.Table{
+		Name:       "control_objective_blocked_groups",
+		Columns:    ControlObjectiveBlockedGroupsColumns,
+		PrimaryKey: []*schema.Column{ControlObjectiveBlockedGroupsColumns[0], ControlObjectiveBlockedGroupsColumns[1]},
+		ForeignKeys: []*schema.ForeignKey{
+			{
+				Symbol:     "control_objective_blocked_groups_control_objective_id",
+				Columns:    []*schema.Column{ControlObjectiveBlockedGroupsColumns[0]},
+				RefColumns: []*schema.Column{ControlObjectivesColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+			{
+				Symbol:     "control_objective_blocked_groups_group_id",
+				Columns:    []*schema.Column{ControlObjectiveBlockedGroupsColumns[1]},
+				RefColumns: []*schema.Column{GroupsColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+		},
+	}
+	// ControlObjectiveEditorsColumns holds the columns for the "control_objective_editors" table.
+	ControlObjectiveEditorsColumns = []*schema.Column{
+		{Name: "control_objective_id", Type: field.TypeString},
+		{Name: "group_id", Type: field.TypeString},
+	}
+	// ControlObjectiveEditorsTable holds the schema information for the "control_objective_editors" table.
+	ControlObjectiveEditorsTable = &schema.Table{
+		Name:       "control_objective_editors",
+		Columns:    ControlObjectiveEditorsColumns,
+		PrimaryKey: []*schema.Column{ControlObjectiveEditorsColumns[0], ControlObjectiveEditorsColumns[1]},
+		ForeignKeys: []*schema.ForeignKey{
+			{
+				Symbol:     "control_objective_editors_control_objective_id",
+				Columns:    []*schema.Column{ControlObjectiveEditorsColumns[0]},
+				RefColumns: []*schema.Column{ControlObjectivesColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+			{
+				Symbol:     "control_objective_editors_group_id",
+				Columns:    []*schema.Column{ControlObjectiveEditorsColumns[1]},
+				RefColumns: []*schema.Column{GroupsColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+		},
+	}
+	// ControlObjectiveViewersColumns holds the columns for the "control_objective_viewers" table.
+	ControlObjectiveViewersColumns = []*schema.Column{
+		{Name: "control_objective_id", Type: field.TypeString},
+		{Name: "group_id", Type: field.TypeString},
+	}
+	// ControlObjectiveViewersTable holds the schema information for the "control_objective_viewers" table.
+	ControlObjectiveViewersTable = &schema.Table{
+		Name:       "control_objective_viewers",
+		Columns:    ControlObjectiveViewersColumns,
+		PrimaryKey: []*schema.Column{ControlObjectiveViewersColumns[0], ControlObjectiveViewersColumns[1]},
+		ForeignKeys: []*schema.ForeignKey{
+			{
+				Symbol:     "control_objective_viewers_control_objective_id",
+				Columns:    []*schema.Column{ControlObjectiveViewersColumns[0]},
+				RefColumns: []*schema.Column{ControlObjectivesColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+			{
+				Symbol:     "control_objective_viewers_group_id",
+				Columns:    []*schema.Column{ControlObjectiveViewersColumns[1]},
+				RefColumns: []*schema.Column{GroupsColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+		},
+	}
 	// ControlObjectiveNarrativesColumns holds the columns for the "control_objective_narratives" table.
 	ControlObjectiveNarrativesColumns = []*schema.Column{
 		{Name: "control_objective_id", Type: field.TypeString},
@@ -3734,6 +3817,56 @@ var (
 			},
 		},
 	}
+	// InternalPolicyBlockedGroupsColumns holds the columns for the "internal_policy_blocked_groups" table.
+	InternalPolicyBlockedGroupsColumns = []*schema.Column{
+		{Name: "internal_policy_id", Type: field.TypeString},
+		{Name: "group_id", Type: field.TypeString},
+	}
+	// InternalPolicyBlockedGroupsTable holds the schema information for the "internal_policy_blocked_groups" table.
+	InternalPolicyBlockedGroupsTable = &schema.Table{
+		Name:       "internal_policy_blocked_groups",
+		Columns:    InternalPolicyBlockedGroupsColumns,
+		PrimaryKey: []*schema.Column{InternalPolicyBlockedGroupsColumns[0], InternalPolicyBlockedGroupsColumns[1]},
+		ForeignKeys: []*schema.ForeignKey{
+			{
+				Symbol:     "internal_policy_blocked_groups_internal_policy_id",
+				Columns:    []*schema.Column{InternalPolicyBlockedGroupsColumns[0]},
+				RefColumns: []*schema.Column{InternalPoliciesColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+			{
+				Symbol:     "internal_policy_blocked_groups_group_id",
+				Columns:    []*schema.Column{InternalPolicyBlockedGroupsColumns[1]},
+				RefColumns: []*schema.Column{GroupsColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+		},
+	}
+	// InternalPolicyEditorsColumns holds the columns for the "internal_policy_editors" table.
+	InternalPolicyEditorsColumns = []*schema.Column{
+		{Name: "internal_policy_id", Type: field.TypeString},
+		{Name: "group_id", Type: field.TypeString},
+	}
+	// InternalPolicyEditorsTable holds the schema information for the "internal_policy_editors" table.
+	InternalPolicyEditorsTable = &schema.Table{
+		Name:       "internal_policy_editors",
+		Columns:    InternalPolicyEditorsColumns,
+		PrimaryKey: []*schema.Column{InternalPolicyEditorsColumns[0], InternalPolicyEditorsColumns[1]},
+		ForeignKeys: []*schema.ForeignKey{
+			{
+				Symbol:     "internal_policy_editors_internal_policy_id",
+				Columns:    []*schema.Column{InternalPolicyEditorsColumns[0]},
+				RefColumns: []*schema.Column{InternalPoliciesColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+			{
+				Symbol:     "internal_policy_editors_group_id",
+				Columns:    []*schema.Column{InternalPolicyEditorsColumns[1]},
+				RefColumns: []*schema.Column{GroupsColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+		},
+	}
 	// InternalPolicyControlobjectivesColumns holds the columns for the "internal_policy_controlobjectives" table.
 	InternalPolicyControlobjectivesColumns = []*schema.Column{
 		{Name: "internal_policy_id", Type: field.TypeString},
@@ -3830,56 +3963,6 @@ var (
 				Symbol:     "internal_policy_tasks_task_id",
 				Columns:    []*schema.Column{InternalPolicyTasksColumns[1]},
 				RefColumns: []*schema.Column{TasksColumns[0]},
-				OnDelete:   schema.Cascade,
-			},
-		},
-	}
-	// InternalPolicyEditorsColumns holds the columns for the "internal_policy_editors" table.
-	InternalPolicyEditorsColumns = []*schema.Column{
-		{Name: "internal_policy_id", Type: field.TypeString},
-		{Name: "group_id", Type: field.TypeString},
-	}
-	// InternalPolicyEditorsTable holds the schema information for the "internal_policy_editors" table.
-	InternalPolicyEditorsTable = &schema.Table{
-		Name:       "internal_policy_editors",
-		Columns:    InternalPolicyEditorsColumns,
-		PrimaryKey: []*schema.Column{InternalPolicyEditorsColumns[0], InternalPolicyEditorsColumns[1]},
-		ForeignKeys: []*schema.ForeignKey{
-			{
-				Symbol:     "internal_policy_editors_internal_policy_id",
-				Columns:    []*schema.Column{InternalPolicyEditorsColumns[0]},
-				RefColumns: []*schema.Column{InternalPoliciesColumns[0]},
-				OnDelete:   schema.Cascade,
-			},
-			{
-				Symbol:     "internal_policy_editors_group_id",
-				Columns:    []*schema.Column{InternalPolicyEditorsColumns[1]},
-				RefColumns: []*schema.Column{GroupsColumns[0]},
-				OnDelete:   schema.Cascade,
-			},
-		},
-	}
-	// InternalPolicyBlockedGroupsColumns holds the columns for the "internal_policy_blocked_groups" table.
-	InternalPolicyBlockedGroupsColumns = []*schema.Column{
-		{Name: "internal_policy_id", Type: field.TypeString},
-		{Name: "group_id", Type: field.TypeString},
-	}
-	// InternalPolicyBlockedGroupsTable holds the schema information for the "internal_policy_blocked_groups" table.
-	InternalPolicyBlockedGroupsTable = &schema.Table{
-		Name:       "internal_policy_blocked_groups",
-		Columns:    InternalPolicyBlockedGroupsColumns,
-		PrimaryKey: []*schema.Column{InternalPolicyBlockedGroupsColumns[0], InternalPolicyBlockedGroupsColumns[1]},
-		ForeignKeys: []*schema.ForeignKey{
-			{
-				Symbol:     "internal_policy_blocked_groups_internal_policy_id",
-				Columns:    []*schema.Column{InternalPolicyBlockedGroupsColumns[0]},
-				RefColumns: []*schema.Column{InternalPoliciesColumns[0]},
-				OnDelete:   schema.Cascade,
-			},
-			{
-				Symbol:     "internal_policy_blocked_groups_group_id",
-				Columns:    []*schema.Column{InternalPolicyBlockedGroupsColumns[1]},
-				RefColumns: []*schema.Column{GroupsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 		},
@@ -4134,6 +4217,56 @@ var (
 			},
 		},
 	}
+	// ProcedureBlockedGroupsColumns holds the columns for the "procedure_blocked_groups" table.
+	ProcedureBlockedGroupsColumns = []*schema.Column{
+		{Name: "procedure_id", Type: field.TypeString},
+		{Name: "group_id", Type: field.TypeString},
+	}
+	// ProcedureBlockedGroupsTable holds the schema information for the "procedure_blocked_groups" table.
+	ProcedureBlockedGroupsTable = &schema.Table{
+		Name:       "procedure_blocked_groups",
+		Columns:    ProcedureBlockedGroupsColumns,
+		PrimaryKey: []*schema.Column{ProcedureBlockedGroupsColumns[0], ProcedureBlockedGroupsColumns[1]},
+		ForeignKeys: []*schema.ForeignKey{
+			{
+				Symbol:     "procedure_blocked_groups_procedure_id",
+				Columns:    []*schema.Column{ProcedureBlockedGroupsColumns[0]},
+				RefColumns: []*schema.Column{ProceduresColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+			{
+				Symbol:     "procedure_blocked_groups_group_id",
+				Columns:    []*schema.Column{ProcedureBlockedGroupsColumns[1]},
+				RefColumns: []*schema.Column{GroupsColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+		},
+	}
+	// ProcedureEditorsColumns holds the columns for the "procedure_editors" table.
+	ProcedureEditorsColumns = []*schema.Column{
+		{Name: "procedure_id", Type: field.TypeString},
+		{Name: "group_id", Type: field.TypeString},
+	}
+	// ProcedureEditorsTable holds the schema information for the "procedure_editors" table.
+	ProcedureEditorsTable = &schema.Table{
+		Name:       "procedure_editors",
+		Columns:    ProcedureEditorsColumns,
+		PrimaryKey: []*schema.Column{ProcedureEditorsColumns[0], ProcedureEditorsColumns[1]},
+		ForeignKeys: []*schema.ForeignKey{
+			{
+				Symbol:     "procedure_editors_procedure_id",
+				Columns:    []*schema.Column{ProcedureEditorsColumns[0]},
+				RefColumns: []*schema.Column{ProceduresColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+			{
+				Symbol:     "procedure_editors_group_id",
+				Columns:    []*schema.Column{ProcedureEditorsColumns[1]},
+				RefColumns: []*schema.Column{GroupsColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+		},
+	}
 	// ProcedureNarrativesColumns holds the columns for the "procedure_narratives" table.
 	ProcedureNarrativesColumns = []*schema.Column{
 		{Name: "procedure_id", Type: field.TypeString},
@@ -4209,51 +4342,76 @@ var (
 			},
 		},
 	}
-	// ProcedureEditorsColumns holds the columns for the "procedure_editors" table.
-	ProcedureEditorsColumns = []*schema.Column{
-		{Name: "procedure_id", Type: field.TypeString},
+	// ProgramBlockedGroupsColumns holds the columns for the "program_blocked_groups" table.
+	ProgramBlockedGroupsColumns = []*schema.Column{
+		{Name: "program_id", Type: field.TypeString},
 		{Name: "group_id", Type: field.TypeString},
 	}
-	// ProcedureEditorsTable holds the schema information for the "procedure_editors" table.
-	ProcedureEditorsTable = &schema.Table{
-		Name:       "procedure_editors",
-		Columns:    ProcedureEditorsColumns,
-		PrimaryKey: []*schema.Column{ProcedureEditorsColumns[0], ProcedureEditorsColumns[1]},
+	// ProgramBlockedGroupsTable holds the schema information for the "program_blocked_groups" table.
+	ProgramBlockedGroupsTable = &schema.Table{
+		Name:       "program_blocked_groups",
+		Columns:    ProgramBlockedGroupsColumns,
+		PrimaryKey: []*schema.Column{ProgramBlockedGroupsColumns[0], ProgramBlockedGroupsColumns[1]},
 		ForeignKeys: []*schema.ForeignKey{
 			{
-				Symbol:     "procedure_editors_procedure_id",
-				Columns:    []*schema.Column{ProcedureEditorsColumns[0]},
-				RefColumns: []*schema.Column{ProceduresColumns[0]},
+				Symbol:     "program_blocked_groups_program_id",
+				Columns:    []*schema.Column{ProgramBlockedGroupsColumns[0]},
+				RefColumns: []*schema.Column{ProgramsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
-				Symbol:     "procedure_editors_group_id",
-				Columns:    []*schema.Column{ProcedureEditorsColumns[1]},
+				Symbol:     "program_blocked_groups_group_id",
+				Columns:    []*schema.Column{ProgramBlockedGroupsColumns[1]},
 				RefColumns: []*schema.Column{GroupsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 		},
 	}
-	// ProcedureBlockedGroupsColumns holds the columns for the "procedure_blocked_groups" table.
-	ProcedureBlockedGroupsColumns = []*schema.Column{
-		{Name: "procedure_id", Type: field.TypeString},
+	// ProgramEditorsColumns holds the columns for the "program_editors" table.
+	ProgramEditorsColumns = []*schema.Column{
+		{Name: "program_id", Type: field.TypeString},
 		{Name: "group_id", Type: field.TypeString},
 	}
-	// ProcedureBlockedGroupsTable holds the schema information for the "procedure_blocked_groups" table.
-	ProcedureBlockedGroupsTable = &schema.Table{
-		Name:       "procedure_blocked_groups",
-		Columns:    ProcedureBlockedGroupsColumns,
-		PrimaryKey: []*schema.Column{ProcedureBlockedGroupsColumns[0], ProcedureBlockedGroupsColumns[1]},
+	// ProgramEditorsTable holds the schema information for the "program_editors" table.
+	ProgramEditorsTable = &schema.Table{
+		Name:       "program_editors",
+		Columns:    ProgramEditorsColumns,
+		PrimaryKey: []*schema.Column{ProgramEditorsColumns[0], ProgramEditorsColumns[1]},
 		ForeignKeys: []*schema.ForeignKey{
 			{
-				Symbol:     "procedure_blocked_groups_procedure_id",
-				Columns:    []*schema.Column{ProcedureBlockedGroupsColumns[0]},
-				RefColumns: []*schema.Column{ProceduresColumns[0]},
+				Symbol:     "program_editors_program_id",
+				Columns:    []*schema.Column{ProgramEditorsColumns[0]},
+				RefColumns: []*schema.Column{ProgramsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
-				Symbol:     "procedure_blocked_groups_group_id",
-				Columns:    []*schema.Column{ProcedureBlockedGroupsColumns[1]},
+				Symbol:     "program_editors_group_id",
+				Columns:    []*schema.Column{ProgramEditorsColumns[1]},
+				RefColumns: []*schema.Column{GroupsColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+		},
+	}
+	// ProgramViewersColumns holds the columns for the "program_viewers" table.
+	ProgramViewersColumns = []*schema.Column{
+		{Name: "program_id", Type: field.TypeString},
+		{Name: "group_id", Type: field.TypeString},
+	}
+	// ProgramViewersTable holds the schema information for the "program_viewers" table.
+	ProgramViewersTable = &schema.Table{
+		Name:       "program_viewers",
+		Columns:    ProgramViewersColumns,
+		PrimaryKey: []*schema.Column{ProgramViewersColumns[0], ProgramViewersColumns[1]},
+		ForeignKeys: []*schema.ForeignKey{
+			{
+				Symbol:     "program_viewers_program_id",
+				Columns:    []*schema.Column{ProgramViewersColumns[0]},
+				RefColumns: []*schema.Column{ProgramsColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+			{
+				Symbol:     "program_viewers_group_id",
+				Columns:    []*schema.Column{ProgramViewersColumns[1]},
 				RefColumns: []*schema.Column{GroupsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
@@ -4534,126 +4692,26 @@ var (
 			},
 		},
 	}
-	// ProgramViewersColumns holds the columns for the "program_viewers" table.
-	ProgramViewersColumns = []*schema.Column{
-		{Name: "program_id", Type: field.TypeString},
-		{Name: "group_id", Type: field.TypeString},
-	}
-	// ProgramViewersTable holds the schema information for the "program_viewers" table.
-	ProgramViewersTable = &schema.Table{
-		Name:       "program_viewers",
-		Columns:    ProgramViewersColumns,
-		PrimaryKey: []*schema.Column{ProgramViewersColumns[0], ProgramViewersColumns[1]},
-		ForeignKeys: []*schema.ForeignKey{
-			{
-				Symbol:     "program_viewers_program_id",
-				Columns:    []*schema.Column{ProgramViewersColumns[0]},
-				RefColumns: []*schema.Column{ProgramsColumns[0]},
-				OnDelete:   schema.Cascade,
-			},
-			{
-				Symbol:     "program_viewers_group_id",
-				Columns:    []*schema.Column{ProgramViewersColumns[1]},
-				RefColumns: []*schema.Column{GroupsColumns[0]},
-				OnDelete:   schema.Cascade,
-			},
-		},
-	}
-	// ProgramEditorsColumns holds the columns for the "program_editors" table.
-	ProgramEditorsColumns = []*schema.Column{
-		{Name: "program_id", Type: field.TypeString},
-		{Name: "group_id", Type: field.TypeString},
-	}
-	// ProgramEditorsTable holds the schema information for the "program_editors" table.
-	ProgramEditorsTable = &schema.Table{
-		Name:       "program_editors",
-		Columns:    ProgramEditorsColumns,
-		PrimaryKey: []*schema.Column{ProgramEditorsColumns[0], ProgramEditorsColumns[1]},
-		ForeignKeys: []*schema.ForeignKey{
-			{
-				Symbol:     "program_editors_program_id",
-				Columns:    []*schema.Column{ProgramEditorsColumns[0]},
-				RefColumns: []*schema.Column{ProgramsColumns[0]},
-				OnDelete:   schema.Cascade,
-			},
-			{
-				Symbol:     "program_editors_group_id",
-				Columns:    []*schema.Column{ProgramEditorsColumns[1]},
-				RefColumns: []*schema.Column{GroupsColumns[0]},
-				OnDelete:   schema.Cascade,
-			},
-		},
-	}
-	// ProgramBlockedGroupsColumns holds the columns for the "program_blocked_groups" table.
-	ProgramBlockedGroupsColumns = []*schema.Column{
-		{Name: "program_id", Type: field.TypeString},
-		{Name: "group_id", Type: field.TypeString},
-	}
-	// ProgramBlockedGroupsTable holds the schema information for the "program_blocked_groups" table.
-	ProgramBlockedGroupsTable = &schema.Table{
-		Name:       "program_blocked_groups",
-		Columns:    ProgramBlockedGroupsColumns,
-		PrimaryKey: []*schema.Column{ProgramBlockedGroupsColumns[0], ProgramBlockedGroupsColumns[1]},
-		ForeignKeys: []*schema.ForeignKey{
-			{
-				Symbol:     "program_blocked_groups_program_id",
-				Columns:    []*schema.Column{ProgramBlockedGroupsColumns[0]},
-				RefColumns: []*schema.Column{ProgramsColumns[0]},
-				OnDelete:   schema.Cascade,
-			},
-			{
-				Symbol:     "program_blocked_groups_group_id",
-				Columns:    []*schema.Column{ProgramBlockedGroupsColumns[1]},
-				RefColumns: []*schema.Column{GroupsColumns[0]},
-				OnDelete:   schema.Cascade,
-			},
-		},
-	}
-	// RiskActionplansColumns holds the columns for the "risk_actionplans" table.
-	RiskActionplansColumns = []*schema.Column{
+	// RiskBlockedGroupsColumns holds the columns for the "risk_blocked_groups" table.
+	RiskBlockedGroupsColumns = []*schema.Column{
 		{Name: "risk_id", Type: field.TypeString},
-		{Name: "action_plan_id", Type: field.TypeString},
+		{Name: "group_id", Type: field.TypeString},
 	}
-	// RiskActionplansTable holds the schema information for the "risk_actionplans" table.
-	RiskActionplansTable = &schema.Table{
-		Name:       "risk_actionplans",
-		Columns:    RiskActionplansColumns,
-		PrimaryKey: []*schema.Column{RiskActionplansColumns[0], RiskActionplansColumns[1]},
+	// RiskBlockedGroupsTable holds the schema information for the "risk_blocked_groups" table.
+	RiskBlockedGroupsTable = &schema.Table{
+		Name:       "risk_blocked_groups",
+		Columns:    RiskBlockedGroupsColumns,
+		PrimaryKey: []*schema.Column{RiskBlockedGroupsColumns[0], RiskBlockedGroupsColumns[1]},
 		ForeignKeys: []*schema.ForeignKey{
 			{
-				Symbol:     "risk_actionplans_risk_id",
-				Columns:    []*schema.Column{RiskActionplansColumns[0]},
+				Symbol:     "risk_blocked_groups_risk_id",
+				Columns:    []*schema.Column{RiskBlockedGroupsColumns[0]},
 				RefColumns: []*schema.Column{RisksColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
-				Symbol:     "risk_actionplans_action_plan_id",
-				Columns:    []*schema.Column{RiskActionplansColumns[1]},
-				RefColumns: []*schema.Column{ActionPlansColumns[0]},
-				OnDelete:   schema.Cascade,
-			},
-		},
-	}
-	// RiskViewersColumns holds the columns for the "risk_viewers" table.
-	RiskViewersColumns = []*schema.Column{
-		{Name: "risk_id", Type: field.TypeString},
-		{Name: "group_id", Type: field.TypeString},
-	}
-	// RiskViewersTable holds the schema information for the "risk_viewers" table.
-	RiskViewersTable = &schema.Table{
-		Name:       "risk_viewers",
-		Columns:    RiskViewersColumns,
-		PrimaryKey: []*schema.Column{RiskViewersColumns[0], RiskViewersColumns[1]},
-		ForeignKeys: []*schema.ForeignKey{
-			{
-				Symbol:     "risk_viewers_risk_id",
-				Columns:    []*schema.Column{RiskViewersColumns[0]},
-				RefColumns: []*schema.Column{RisksColumns[0]},
-				OnDelete:   schema.Cascade,
-			},
-			{
-				Symbol:     "risk_viewers_group_id",
-				Columns:    []*schema.Column{RiskViewersColumns[1]},
+				Symbol:     "risk_blocked_groups_group_id",
+				Columns:    []*schema.Column{RiskBlockedGroupsColumns[1]},
 				RefColumns: []*schema.Column{GroupsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
@@ -4684,27 +4742,52 @@ var (
 			},
 		},
 	}
-	// RiskBlockedGroupsColumns holds the columns for the "risk_blocked_groups" table.
-	RiskBlockedGroupsColumns = []*schema.Column{
+	// RiskViewersColumns holds the columns for the "risk_viewers" table.
+	RiskViewersColumns = []*schema.Column{
 		{Name: "risk_id", Type: field.TypeString},
 		{Name: "group_id", Type: field.TypeString},
 	}
-	// RiskBlockedGroupsTable holds the schema information for the "risk_blocked_groups" table.
-	RiskBlockedGroupsTable = &schema.Table{
-		Name:       "risk_blocked_groups",
-		Columns:    RiskBlockedGroupsColumns,
-		PrimaryKey: []*schema.Column{RiskBlockedGroupsColumns[0], RiskBlockedGroupsColumns[1]},
+	// RiskViewersTable holds the schema information for the "risk_viewers" table.
+	RiskViewersTable = &schema.Table{
+		Name:       "risk_viewers",
+		Columns:    RiskViewersColumns,
+		PrimaryKey: []*schema.Column{RiskViewersColumns[0], RiskViewersColumns[1]},
 		ForeignKeys: []*schema.ForeignKey{
 			{
-				Symbol:     "risk_blocked_groups_risk_id",
-				Columns:    []*schema.Column{RiskBlockedGroupsColumns[0]},
+				Symbol:     "risk_viewers_risk_id",
+				Columns:    []*schema.Column{RiskViewersColumns[0]},
 				RefColumns: []*schema.Column{RisksColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
-				Symbol:     "risk_blocked_groups_group_id",
-				Columns:    []*schema.Column{RiskBlockedGroupsColumns[1]},
+				Symbol:     "risk_viewers_group_id",
+				Columns:    []*schema.Column{RiskViewersColumns[1]},
 				RefColumns: []*schema.Column{GroupsColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+		},
+	}
+	// RiskActionplansColumns holds the columns for the "risk_actionplans" table.
+	RiskActionplansColumns = []*schema.Column{
+		{Name: "risk_id", Type: field.TypeString},
+		{Name: "action_plan_id", Type: field.TypeString},
+	}
+	// RiskActionplansTable holds the schema information for the "risk_actionplans" table.
+	RiskActionplansTable = &schema.Table{
+		Name:       "risk_actionplans",
+		Columns:    RiskActionplansColumns,
+		PrimaryKey: []*schema.Column{RiskActionplansColumns[0], RiskActionplansColumns[1]},
+		ForeignKeys: []*schema.ForeignKey{
+			{
+				Symbol:     "risk_actionplans_risk_id",
+				Columns:    []*schema.Column{RiskActionplansColumns[0]},
+				RefColumns: []*schema.Column{RisksColumns[0]},
+				OnDelete:   schema.Cascade,
+			},
+			{
+				Symbol:     "risk_actionplans_action_plan_id",
+				Columns:    []*schema.Column{RiskActionplansColumns[1]},
+				RefColumns: []*schema.Column{ActionPlansColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 		},
@@ -5124,6 +5207,9 @@ var (
 		ControlRisksTable,
 		ControlActionplansTable,
 		ControlTasksTable,
+		ControlObjectiveBlockedGroupsTable,
+		ControlObjectiveEditorsTable,
+		ControlObjectiveViewersTable,
 		ControlObjectiveNarrativesTable,
 		ControlObjectiveTasksTable,
 		DocumentDataFilesTable,
@@ -5144,12 +5230,12 @@ var (
 		IntegrationOauth2tokensTable,
 		IntegrationEventsTable,
 		IntegrationWebhooksTable,
+		InternalPolicyBlockedGroupsTable,
+		InternalPolicyEditorsTable,
 		InternalPolicyControlobjectivesTable,
 		InternalPolicyProceduresTable,
 		InternalPolicyNarrativesTable,
 		InternalPolicyTasksTable,
-		InternalPolicyEditorsTable,
-		InternalPolicyBlockedGroupsTable,
 		InviteEventsTable,
 		OhAuthTooTokenEventsTable,
 		OrgMembershipEventsTable,
@@ -5160,11 +5246,14 @@ var (
 		OrganizationTasksTable,
 		OrganizationSettingFilesTable,
 		PersonalAccessTokenEventsTable,
+		ProcedureBlockedGroupsTable,
+		ProcedureEditorsTable,
 		ProcedureNarrativesTable,
 		ProcedureRisksTable,
 		ProcedureTasksTable,
-		ProcedureEditorsTable,
-		ProcedureBlockedGroupsTable,
+		ProgramBlockedGroupsTable,
+		ProgramEditorsTable,
+		ProgramViewersTable,
 		ProgramControlsTable,
 		ProgramSubcontrolsTable,
 		ProgramControlobjectivesTable,
@@ -5176,13 +5265,10 @@ var (
 		ProgramFilesTable,
 		ProgramNarrativesTable,
 		ProgramActionplansTable,
-		ProgramViewersTable,
-		ProgramEditorsTable,
-		ProgramBlockedGroupsTable,
-		RiskActionplansTable,
-		RiskViewersTable,
-		RiskEditorsTable,
 		RiskBlockedGroupsTable,
+		RiskEditorsTable,
+		RiskViewersTable,
+		RiskActionplansTable,
 		StandardControlobjectivesTable,
 		StandardControlsTable,
 		StandardActionplansTable,
@@ -5214,6 +5300,7 @@ func init() {
 		Table: "control_history",
 	}
 	ControlObjectivesTable.ForeignKeys[0].RefTable = ControlsTable
+	ControlObjectivesTable.ForeignKeys[1].RefTable = OrganizationsTable
 	ControlObjectiveHistoryTable.Annotation = &entsql.Annotation{
 		Table: "control_objective_history",
 	}
@@ -5379,6 +5466,12 @@ func init() {
 	ControlActionplansTable.ForeignKeys[1].RefTable = ActionPlansTable
 	ControlTasksTable.ForeignKeys[0].RefTable = ControlsTable
 	ControlTasksTable.ForeignKeys[1].RefTable = TasksTable
+	ControlObjectiveBlockedGroupsTable.ForeignKeys[0].RefTable = ControlObjectivesTable
+	ControlObjectiveBlockedGroupsTable.ForeignKeys[1].RefTable = GroupsTable
+	ControlObjectiveEditorsTable.ForeignKeys[0].RefTable = ControlObjectivesTable
+	ControlObjectiveEditorsTable.ForeignKeys[1].RefTable = GroupsTable
+	ControlObjectiveViewersTable.ForeignKeys[0].RefTable = ControlObjectivesTable
+	ControlObjectiveViewersTable.ForeignKeys[1].RefTable = GroupsTable
 	ControlObjectiveNarrativesTable.ForeignKeys[0].RefTable = ControlObjectivesTable
 	ControlObjectiveNarrativesTable.ForeignKeys[1].RefTable = NarrativesTable
 	ControlObjectiveTasksTable.ForeignKeys[0].RefTable = ControlObjectivesTable
@@ -5419,6 +5512,10 @@ func init() {
 	IntegrationEventsTable.ForeignKeys[1].RefTable = EventsTable
 	IntegrationWebhooksTable.ForeignKeys[0].RefTable = IntegrationsTable
 	IntegrationWebhooksTable.ForeignKeys[1].RefTable = WebhooksTable
+	InternalPolicyBlockedGroupsTable.ForeignKeys[0].RefTable = InternalPoliciesTable
+	InternalPolicyBlockedGroupsTable.ForeignKeys[1].RefTable = GroupsTable
+	InternalPolicyEditorsTable.ForeignKeys[0].RefTable = InternalPoliciesTable
+	InternalPolicyEditorsTable.ForeignKeys[1].RefTable = GroupsTable
 	InternalPolicyControlobjectivesTable.ForeignKeys[0].RefTable = InternalPoliciesTable
 	InternalPolicyControlobjectivesTable.ForeignKeys[1].RefTable = ControlObjectivesTable
 	InternalPolicyProceduresTable.ForeignKeys[0].RefTable = InternalPoliciesTable
@@ -5427,10 +5524,6 @@ func init() {
 	InternalPolicyNarrativesTable.ForeignKeys[1].RefTable = NarrativesTable
 	InternalPolicyTasksTable.ForeignKeys[0].RefTable = InternalPoliciesTable
 	InternalPolicyTasksTable.ForeignKeys[1].RefTable = TasksTable
-	InternalPolicyEditorsTable.ForeignKeys[0].RefTable = InternalPoliciesTable
-	InternalPolicyEditorsTable.ForeignKeys[1].RefTable = GroupsTable
-	InternalPolicyBlockedGroupsTable.ForeignKeys[0].RefTable = InternalPoliciesTable
-	InternalPolicyBlockedGroupsTable.ForeignKeys[1].RefTable = GroupsTable
 	InviteEventsTable.ForeignKeys[0].RefTable = InvitesTable
 	InviteEventsTable.ForeignKeys[1].RefTable = EventsTable
 	OhAuthTooTokenEventsTable.ForeignKeys[0].RefTable = OhAuthTooTokensTable
@@ -5451,16 +5544,22 @@ func init() {
 	OrganizationSettingFilesTable.ForeignKeys[1].RefTable = FilesTable
 	PersonalAccessTokenEventsTable.ForeignKeys[0].RefTable = PersonalAccessTokensTable
 	PersonalAccessTokenEventsTable.ForeignKeys[1].RefTable = EventsTable
+	ProcedureBlockedGroupsTable.ForeignKeys[0].RefTable = ProceduresTable
+	ProcedureBlockedGroupsTable.ForeignKeys[1].RefTable = GroupsTable
+	ProcedureEditorsTable.ForeignKeys[0].RefTable = ProceduresTable
+	ProcedureEditorsTable.ForeignKeys[1].RefTable = GroupsTable
 	ProcedureNarrativesTable.ForeignKeys[0].RefTable = ProceduresTable
 	ProcedureNarrativesTable.ForeignKeys[1].RefTable = NarrativesTable
 	ProcedureRisksTable.ForeignKeys[0].RefTable = ProceduresTable
 	ProcedureRisksTable.ForeignKeys[1].RefTable = RisksTable
 	ProcedureTasksTable.ForeignKeys[0].RefTable = ProceduresTable
 	ProcedureTasksTable.ForeignKeys[1].RefTable = TasksTable
-	ProcedureEditorsTable.ForeignKeys[0].RefTable = ProceduresTable
-	ProcedureEditorsTable.ForeignKeys[1].RefTable = GroupsTable
-	ProcedureBlockedGroupsTable.ForeignKeys[0].RefTable = ProceduresTable
-	ProcedureBlockedGroupsTable.ForeignKeys[1].RefTable = GroupsTable
+	ProgramBlockedGroupsTable.ForeignKeys[0].RefTable = ProgramsTable
+	ProgramBlockedGroupsTable.ForeignKeys[1].RefTable = GroupsTable
+	ProgramEditorsTable.ForeignKeys[0].RefTable = ProgramsTable
+	ProgramEditorsTable.ForeignKeys[1].RefTable = GroupsTable
+	ProgramViewersTable.ForeignKeys[0].RefTable = ProgramsTable
+	ProgramViewersTable.ForeignKeys[1].RefTable = GroupsTable
 	ProgramControlsTable.ForeignKeys[0].RefTable = ProgramsTable
 	ProgramControlsTable.ForeignKeys[1].RefTable = ControlsTable
 	ProgramSubcontrolsTable.ForeignKeys[0].RefTable = ProgramsTable
@@ -5483,20 +5582,14 @@ func init() {
 	ProgramNarrativesTable.ForeignKeys[1].RefTable = NarrativesTable
 	ProgramActionplansTable.ForeignKeys[0].RefTable = ProgramsTable
 	ProgramActionplansTable.ForeignKeys[1].RefTable = ActionPlansTable
-	ProgramViewersTable.ForeignKeys[0].RefTable = ProgramsTable
-	ProgramViewersTable.ForeignKeys[1].RefTable = GroupsTable
-	ProgramEditorsTable.ForeignKeys[0].RefTable = ProgramsTable
-	ProgramEditorsTable.ForeignKeys[1].RefTable = GroupsTable
-	ProgramBlockedGroupsTable.ForeignKeys[0].RefTable = ProgramsTable
-	ProgramBlockedGroupsTable.ForeignKeys[1].RefTable = GroupsTable
-	RiskActionplansTable.ForeignKeys[0].RefTable = RisksTable
-	RiskActionplansTable.ForeignKeys[1].RefTable = ActionPlansTable
-	RiskViewersTable.ForeignKeys[0].RefTable = RisksTable
-	RiskViewersTable.ForeignKeys[1].RefTable = GroupsTable
-	RiskEditorsTable.ForeignKeys[0].RefTable = RisksTable
-	RiskEditorsTable.ForeignKeys[1].RefTable = GroupsTable
 	RiskBlockedGroupsTable.ForeignKeys[0].RefTable = RisksTable
 	RiskBlockedGroupsTable.ForeignKeys[1].RefTable = GroupsTable
+	RiskEditorsTable.ForeignKeys[0].RefTable = RisksTable
+	RiskEditorsTable.ForeignKeys[1].RefTable = GroupsTable
+	RiskViewersTable.ForeignKeys[0].RefTable = RisksTable
+	RiskViewersTable.ForeignKeys[1].RefTable = GroupsTable
+	RiskActionplansTable.ForeignKeys[0].RefTable = RisksTable
+	RiskActionplansTable.ForeignKeys[1].RefTable = ActionPlansTable
 	StandardControlobjectivesTable.ForeignKeys[0].RefTable = StandardsTable
 	StandardControlobjectivesTable.ForeignKeys[1].RefTable = ControlObjectivesTable
 	StandardControlsTable.ForeignKeys[0].RefTable = StandardsTable

--- a/internal/ent/generated/organization.go
+++ b/internal/ent/generated/organization.go
@@ -119,13 +119,15 @@ type OrganizationEdges struct {
 	Internalpolicies []*InternalPolicy `json:"internalpolicies,omitempty"`
 	// Risks holds the value of the risks edge.
 	Risks []*Risk `json:"risks,omitempty"`
+	// Controlobjectives holds the value of the controlobjectives edge.
+	Controlobjectives []*ControlObjective `json:"controlobjectives,omitempty"`
 	// Members holds the value of the members edge.
 	Members []*OrgMembership `json:"members,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [32]bool
+	loadedTypes [33]bool
 	// totalCount holds the count of the edges above.
-	totalCount [32]map[string]int
+	totalCount [33]map[string]int
 
 	namedChildren                map[string][]*Organization
 	namedGroups                  map[string][]*Group
@@ -156,6 +158,7 @@ type OrganizationEdges struct {
 	namedProcedures              map[string][]*Procedure
 	namedInternalpolicies        map[string][]*InternalPolicy
 	namedRisks                   map[string][]*Risk
+	namedControlobjectives       map[string][]*ControlObjective
 	namedMembers                 map[string][]*OrgMembership
 }
 
@@ -442,10 +445,19 @@ func (e OrganizationEdges) RisksOrErr() ([]*Risk, error) {
 	return nil, &NotLoadedError{edge: "risks"}
 }
 
+// ControlobjectivesOrErr returns the Controlobjectives value or an error if the edge
+// was not loaded in eager-loading.
+func (e OrganizationEdges) ControlobjectivesOrErr() ([]*ControlObjective, error) {
+	if e.loadedTypes[31] {
+		return e.Controlobjectives, nil
+	}
+	return nil, &NotLoadedError{edge: "controlobjectives"}
+}
+
 // MembersOrErr returns the Members value or an error if the edge
 // was not loaded in eager-loading.
 func (e OrganizationEdges) MembersOrErr() ([]*OrgMembership, error) {
-	if e.loadedTypes[31] {
+	if e.loadedTypes[32] {
 		return e.Members, nil
 	}
 	return nil, &NotLoadedError{edge: "members"}
@@ -744,6 +756,11 @@ func (o *Organization) QueryInternalpolicies() *InternalPolicyQuery {
 // QueryRisks queries the "risks" edge of the Organization entity.
 func (o *Organization) QueryRisks() *RiskQuery {
 	return NewOrganizationClient(o.config).QueryRisks(o)
+}
+
+// QueryControlobjectives queries the "controlobjectives" edge of the Organization entity.
+func (o *Organization) QueryControlobjectives() *ControlObjectiveQuery {
+	return NewOrganizationClient(o.config).QueryControlobjectives(o)
 }
 
 // QueryMembers queries the "members" edge of the Organization entity.
@@ -1517,6 +1534,30 @@ func (o *Organization) appendNamedRisks(name string, edges ...*Risk) {
 		o.Edges.namedRisks[name] = []*Risk{}
 	} else {
 		o.Edges.namedRisks[name] = append(o.Edges.namedRisks[name], edges...)
+	}
+}
+
+// NamedControlobjectives returns the Controlobjectives named value or an error if the edge was not
+// loaded in eager-loading with this name.
+func (o *Organization) NamedControlobjectives(name string) ([]*ControlObjective, error) {
+	if o.Edges.namedControlobjectives == nil {
+		return nil, &NotLoadedError{edge: name}
+	}
+	nodes, ok := o.Edges.namedControlobjectives[name]
+	if !ok {
+		return nil, &NotLoadedError{edge: name}
+	}
+	return nodes, nil
+}
+
+func (o *Organization) appendNamedControlobjectives(name string, edges ...*ControlObjective) {
+	if o.Edges.namedControlobjectives == nil {
+		o.Edges.namedControlobjectives = make(map[string][]*ControlObjective)
+	}
+	if len(edges) == 0 {
+		o.Edges.namedControlobjectives[name] = []*ControlObjective{}
+	} else {
+		o.Edges.namedControlobjectives[name] = append(o.Edges.namedControlobjectives[name], edges...)
 	}
 }
 

--- a/internal/ent/generated/organization/organization.go
+++ b/internal/ent/generated/organization/organization.go
@@ -107,6 +107,8 @@ const (
 	EdgeInternalpolicies = "internalpolicies"
 	// EdgeRisks holds the string denoting the risks edge name in mutations.
 	EdgeRisks = "risks"
+	// EdgeControlobjectives holds the string denoting the controlobjectives edge name in mutations.
+	EdgeControlobjectives = "controlobjectives"
 	// EdgeMembers holds the string denoting the members edge name in mutations.
 	EdgeMembers = "members"
 	// Table holds the table name of the organization in the database.
@@ -310,6 +312,13 @@ const (
 	RisksInverseTable = "risks"
 	// RisksColumn is the table column denoting the risks relation/edge.
 	RisksColumn = "owner_id"
+	// ControlobjectivesTable is the table that holds the controlobjectives relation/edge.
+	ControlobjectivesTable = "control_objectives"
+	// ControlobjectivesInverseTable is the table name for the ControlObjective entity.
+	// It exists in this package in order to avoid circular dependency with the "controlobjective" package.
+	ControlobjectivesInverseTable = "control_objectives"
+	// ControlobjectivesColumn is the table column denoting the controlobjectives relation/edge.
+	ControlobjectivesColumn = "owner_id"
 	// MembersTable is the table that holds the members relation/edge.
 	MembersTable = "org_memberships"
 	// MembersInverseTable is the table name for the OrgMembership entity.
@@ -903,6 +912,20 @@ func ByRisks(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	}
 }
 
+// ByControlobjectivesCount orders the results by controlobjectives count.
+func ByControlobjectivesCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newControlobjectivesStep(), opts...)
+	}
+}
+
+// ByControlobjectives orders the results by controlobjectives terms.
+func ByControlobjectives(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newControlobjectivesStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
 // ByMembersCount orders the results by members count.
 func ByMembersCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
@@ -1131,6 +1154,13 @@ func newRisksStep() *sqlgraph.Step {
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(RisksInverseTable, FieldID),
 		sqlgraph.Edge(sqlgraph.O2M, false, RisksTable, RisksColumn),
+	)
+}
+func newControlobjectivesStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(ControlobjectivesInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, ControlobjectivesTable, ControlobjectivesColumn),
 	)
 }
 func newMembersStep() *sqlgraph.Step {

--- a/internal/ent/generated/organization/where.go
+++ b/internal/ent/generated/organization/where.go
@@ -1871,6 +1871,35 @@ func HasRisksWith(preds ...predicate.Risk) predicate.Organization {
 	})
 }
 
+// HasControlobjectives applies the HasEdge predicate on the "controlobjectives" edge.
+func HasControlobjectives() predicate.Organization {
+	return predicate.Organization(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, ControlobjectivesTable, ControlobjectivesColumn),
+		)
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.ControlObjective
+		step.Edge.Schema = schemaConfig.ControlObjective
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasControlobjectivesWith applies the HasEdge predicate on the "controlobjectives" edge with a given conditions (other predicates).
+func HasControlobjectivesWith(preds ...predicate.ControlObjective) predicate.Organization {
+	return predicate.Organization(func(s *sql.Selector) {
+		step := newControlobjectivesStep()
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.ControlObjective
+		step.Edge.Schema = schemaConfig.ControlObjective
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
 // HasMembers applies the HasEdge predicate on the "members" edge.
 func HasMembers() predicate.Organization {
 	return predicate.Organization(func(s *sql.Selector) {

--- a/internal/ent/generated/organization_create.go
+++ b/internal/ent/generated/organization_create.go
@@ -12,6 +12,7 @@ import (
 	"entgo.io/ent/schema/field"
 	"github.com/theopenlane/core/internal/ent/generated/apitoken"
 	"github.com/theopenlane/core/internal/ent/generated/contact"
+	"github.com/theopenlane/core/internal/ent/generated/controlobjective"
 	"github.com/theopenlane/core/internal/ent/generated/documentdata"
 	"github.com/theopenlane/core/internal/ent/generated/entitlement"
 	"github.com/theopenlane/core/internal/ent/generated/entitlementplan"
@@ -728,6 +729,21 @@ func (oc *OrganizationCreate) AddRisks(r ...*Risk) *OrganizationCreate {
 		ids[i] = r[i].ID
 	}
 	return oc.AddRiskIDs(ids...)
+}
+
+// AddControlobjectiveIDs adds the "controlobjectives" edge to the ControlObjective entity by IDs.
+func (oc *OrganizationCreate) AddControlobjectiveIDs(ids ...string) *OrganizationCreate {
+	oc.mutation.AddControlobjectiveIDs(ids...)
+	return oc
+}
+
+// AddControlobjectives adds the "controlobjectives" edges to the ControlObjective entity.
+func (oc *OrganizationCreate) AddControlobjectives(c ...*ControlObjective) *OrganizationCreate {
+	ids := make([]string, len(c))
+	for i := range c {
+		ids[i] = c[i].ID
+	}
+	return oc.AddControlobjectiveIDs(ids...)
 }
 
 // AddMemberIDs adds the "members" edge to the OrgMembership entity by IDs.
@@ -1480,6 +1496,23 @@ func (oc *OrganizationCreate) createSpec() (*Organization, *sqlgraph.CreateSpec)
 			},
 		}
 		edge.Schema = oc.schemaConfig.Risk
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := oc.mutation.ControlobjectivesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   organization.ControlobjectivesTable,
+			Columns: []string{organization.ControlobjectivesColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = oc.schemaConfig.ControlObjective
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}

--- a/internal/ent/generated/organization_update.go
+++ b/internal/ent/generated/organization_update.go
@@ -14,6 +14,7 @@ import (
 	"entgo.io/ent/schema/field"
 	"github.com/theopenlane/core/internal/ent/generated/apitoken"
 	"github.com/theopenlane/core/internal/ent/generated/contact"
+	"github.com/theopenlane/core/internal/ent/generated/controlobjective"
 	"github.com/theopenlane/core/internal/ent/generated/documentdata"
 	"github.com/theopenlane/core/internal/ent/generated/entitlement"
 	"github.com/theopenlane/core/internal/ent/generated/entitlementplan"
@@ -687,6 +688,21 @@ func (ou *OrganizationUpdate) AddRisks(r ...*Risk) *OrganizationUpdate {
 	return ou.AddRiskIDs(ids...)
 }
 
+// AddControlobjectiveIDs adds the "controlobjectives" edge to the ControlObjective entity by IDs.
+func (ou *OrganizationUpdate) AddControlobjectiveIDs(ids ...string) *OrganizationUpdate {
+	ou.mutation.AddControlobjectiveIDs(ids...)
+	return ou
+}
+
+// AddControlobjectives adds the "controlobjectives" edges to the ControlObjective entity.
+func (ou *OrganizationUpdate) AddControlobjectives(c ...*ControlObjective) *OrganizationUpdate {
+	ids := make([]string, len(c))
+	for i := range c {
+		ids[i] = c[i].ID
+	}
+	return ou.AddControlobjectiveIDs(ids...)
+}
+
 // AddMemberIDs adds the "members" edge to the OrgMembership entity by IDs.
 func (ou *OrganizationUpdate) AddMemberIDs(ids ...string) *OrganizationUpdate {
 	ou.mutation.AddMemberIDs(ids...)
@@ -1320,6 +1336,27 @@ func (ou *OrganizationUpdate) RemoveRisks(r ...*Risk) *OrganizationUpdate {
 		ids[i] = r[i].ID
 	}
 	return ou.RemoveRiskIDs(ids...)
+}
+
+// ClearControlobjectives clears all "controlobjectives" edges to the ControlObjective entity.
+func (ou *OrganizationUpdate) ClearControlobjectives() *OrganizationUpdate {
+	ou.mutation.ClearControlobjectives()
+	return ou
+}
+
+// RemoveControlobjectiveIDs removes the "controlobjectives" edge to ControlObjective entities by IDs.
+func (ou *OrganizationUpdate) RemoveControlobjectiveIDs(ids ...string) *OrganizationUpdate {
+	ou.mutation.RemoveControlobjectiveIDs(ids...)
+	return ou
+}
+
+// RemoveControlobjectives removes "controlobjectives" edges to ControlObjective entities.
+func (ou *OrganizationUpdate) RemoveControlobjectives(c ...*ControlObjective) *OrganizationUpdate {
+	ids := make([]string, len(c))
+	for i := range c {
+		ids[i] = c[i].ID
+	}
+	return ou.RemoveControlobjectiveIDs(ids...)
 }
 
 // ClearMembers clears all "members" edges to the OrgMembership entity.
@@ -2932,6 +2969,54 @@ func (ou *OrganizationUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
+	if ou.mutation.ControlobjectivesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   organization.ControlobjectivesTable,
+			Columns: []string{organization.ControlobjectivesColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ou.schemaConfig.ControlObjective
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ou.mutation.RemovedControlobjectivesIDs(); len(nodes) > 0 && !ou.mutation.ControlobjectivesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   organization.ControlobjectivesTable,
+			Columns: []string{organization.ControlobjectivesColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ou.schemaConfig.ControlObjective
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ou.mutation.ControlobjectivesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   organization.ControlobjectivesTable,
+			Columns: []string{organization.ControlobjectivesColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ou.schemaConfig.ControlObjective
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
 	if ou.mutation.MembersCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.O2M,
@@ -3630,6 +3715,21 @@ func (ouo *OrganizationUpdateOne) AddRisks(r ...*Risk) *OrganizationUpdateOne {
 	return ouo.AddRiskIDs(ids...)
 }
 
+// AddControlobjectiveIDs adds the "controlobjectives" edge to the ControlObjective entity by IDs.
+func (ouo *OrganizationUpdateOne) AddControlobjectiveIDs(ids ...string) *OrganizationUpdateOne {
+	ouo.mutation.AddControlobjectiveIDs(ids...)
+	return ouo
+}
+
+// AddControlobjectives adds the "controlobjectives" edges to the ControlObjective entity.
+func (ouo *OrganizationUpdateOne) AddControlobjectives(c ...*ControlObjective) *OrganizationUpdateOne {
+	ids := make([]string, len(c))
+	for i := range c {
+		ids[i] = c[i].ID
+	}
+	return ouo.AddControlobjectiveIDs(ids...)
+}
+
 // AddMemberIDs adds the "members" edge to the OrgMembership entity by IDs.
 func (ouo *OrganizationUpdateOne) AddMemberIDs(ids ...string) *OrganizationUpdateOne {
 	ouo.mutation.AddMemberIDs(ids...)
@@ -4263,6 +4363,27 @@ func (ouo *OrganizationUpdateOne) RemoveRisks(r ...*Risk) *OrganizationUpdateOne
 		ids[i] = r[i].ID
 	}
 	return ouo.RemoveRiskIDs(ids...)
+}
+
+// ClearControlobjectives clears all "controlobjectives" edges to the ControlObjective entity.
+func (ouo *OrganizationUpdateOne) ClearControlobjectives() *OrganizationUpdateOne {
+	ouo.mutation.ClearControlobjectives()
+	return ouo
+}
+
+// RemoveControlobjectiveIDs removes the "controlobjectives" edge to ControlObjective entities by IDs.
+func (ouo *OrganizationUpdateOne) RemoveControlobjectiveIDs(ids ...string) *OrganizationUpdateOne {
+	ouo.mutation.RemoveControlobjectiveIDs(ids...)
+	return ouo
+}
+
+// RemoveControlobjectives removes "controlobjectives" edges to ControlObjective entities.
+func (ouo *OrganizationUpdateOne) RemoveControlobjectives(c ...*ControlObjective) *OrganizationUpdateOne {
+	ids := make([]string, len(c))
+	for i := range c {
+		ids[i] = c[i].ID
+	}
+	return ouo.RemoveControlobjectiveIDs(ids...)
 }
 
 // ClearMembers clears all "members" edges to the OrgMembership entity.
@@ -5900,6 +6021,54 @@ func (ouo *OrganizationUpdateOne) sqlSave(ctx context.Context) (_node *Organizat
 			},
 		}
 		edge.Schema = ouo.schemaConfig.Risk
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if ouo.mutation.ControlobjectivesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   organization.ControlobjectivesTable,
+			Columns: []string{organization.ControlobjectivesColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ouo.schemaConfig.ControlObjective
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ouo.mutation.RemovedControlobjectivesIDs(); len(nodes) > 0 && !ouo.mutation.ControlobjectivesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   organization.ControlobjectivesTable,
+			Columns: []string{organization.ControlobjectivesColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ouo.schemaConfig.ControlObjective
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ouo.mutation.ControlobjectivesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   organization.ControlobjectivesTable,
+			Columns: []string{organization.ControlobjectivesColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(controlobjective.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ouo.schemaConfig.ControlObjective
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}

--- a/internal/ent/generated/procedure/where.go
+++ b/internal/ent/generated/procedure/where.go
@@ -1301,6 +1301,64 @@ func HasOwnerWith(preds ...predicate.Organization) predicate.Procedure {
 	})
 }
 
+// HasBlockedGroups applies the HasEdge predicate on the "blocked_groups" edge.
+func HasBlockedGroups() predicate.Procedure {
+	return predicate.Procedure(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, BlockedGroupsTable, BlockedGroupsPrimaryKey...),
+		)
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.ProcedureBlockedGroups
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasBlockedGroupsWith applies the HasEdge predicate on the "blocked_groups" edge with a given conditions (other predicates).
+func HasBlockedGroupsWith(preds ...predicate.Group) predicate.Procedure {
+	return predicate.Procedure(func(s *sql.Selector) {
+		step := newBlockedGroupsStep()
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.ProcedureBlockedGroups
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasEditors applies the HasEdge predicate on the "editors" edge.
+func HasEditors() predicate.Procedure {
+	return predicate.Procedure(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, EditorsTable, EditorsPrimaryKey...),
+		)
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.ProcedureEditors
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasEditorsWith applies the HasEdge predicate on the "editors" edge with a given conditions (other predicates).
+func HasEditorsWith(preds ...predicate.Group) predicate.Procedure {
+	return predicate.Procedure(func(s *sql.Selector) {
+		step := newEditorsStep()
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.ProcedureEditors
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
 // HasControl applies the HasEdge predicate on the "control" edge.
 func HasControl() predicate.Procedure {
 	return predicate.Procedure(func(s *sql.Selector) {
@@ -1467,64 +1525,6 @@ func HasProgramsWith(preds ...predicate.Program) predicate.Procedure {
 		schemaConfig := internal.SchemaConfigFromContext(s.Context())
 		step.To.Schema = schemaConfig.Program
 		step.Edge.Schema = schemaConfig.ProgramProcedures
-		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
-			for _, p := range preds {
-				p(s)
-			}
-		})
-	})
-}
-
-// HasEditors applies the HasEdge predicate on the "editors" edge.
-func HasEditors() predicate.Procedure {
-	return predicate.Procedure(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, EditorsTable, EditorsPrimaryKey...),
-		)
-		schemaConfig := internal.SchemaConfigFromContext(s.Context())
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.ProcedureEditors
-		sqlgraph.HasNeighbors(s, step)
-	})
-}
-
-// HasEditorsWith applies the HasEdge predicate on the "editors" edge with a given conditions (other predicates).
-func HasEditorsWith(preds ...predicate.Group) predicate.Procedure {
-	return predicate.Procedure(func(s *sql.Selector) {
-		step := newEditorsStep()
-		schemaConfig := internal.SchemaConfigFromContext(s.Context())
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.ProcedureEditors
-		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
-			for _, p := range preds {
-				p(s)
-			}
-		})
-	})
-}
-
-// HasBlockedGroups applies the HasEdge predicate on the "blocked_groups" edge.
-func HasBlockedGroups() predicate.Procedure {
-	return predicate.Procedure(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, BlockedGroupsTable, BlockedGroupsPrimaryKey...),
-		)
-		schemaConfig := internal.SchemaConfigFromContext(s.Context())
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.ProcedureBlockedGroups
-		sqlgraph.HasNeighbors(s, step)
-	})
-}
-
-// HasBlockedGroupsWith applies the HasEdge predicate on the "blocked_groups" edge with a given conditions (other predicates).
-func HasBlockedGroupsWith(preds ...predicate.Group) predicate.Procedure {
-	return predicate.Procedure(func(s *sql.Selector) {
-		step := newBlockedGroupsStep()
-		schemaConfig := internal.SchemaConfigFromContext(s.Context())
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.ProcedureBlockedGroups
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/internal/ent/generated/procedure_create.go
+++ b/internal/ent/generated/procedure_create.go
@@ -275,6 +275,36 @@ func (pc *ProcedureCreate) SetOwner(o *Organization) *ProcedureCreate {
 	return pc.SetOwnerID(o.ID)
 }
 
+// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
+func (pc *ProcedureCreate) AddBlockedGroupIDs(ids ...string) *ProcedureCreate {
+	pc.mutation.AddBlockedGroupIDs(ids...)
+	return pc
+}
+
+// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
+func (pc *ProcedureCreate) AddBlockedGroups(g ...*Group) *ProcedureCreate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return pc.AddBlockedGroupIDs(ids...)
+}
+
+// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
+func (pc *ProcedureCreate) AddEditorIDs(ids ...string) *ProcedureCreate {
+	pc.mutation.AddEditorIDs(ids...)
+	return pc
+}
+
+// AddEditors adds the "editors" edges to the Group entity.
+func (pc *ProcedureCreate) AddEditors(g ...*Group) *ProcedureCreate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return pc.AddEditorIDs(ids...)
+}
+
 // AddControlIDs adds the "control" edge to the Control entity by IDs.
 func (pc *ProcedureCreate) AddControlIDs(ids ...string) *ProcedureCreate {
 	pc.mutation.AddControlIDs(ids...)
@@ -363,36 +393,6 @@ func (pc *ProcedureCreate) AddPrograms(p ...*Program) *ProcedureCreate {
 		ids[i] = p[i].ID
 	}
 	return pc.AddProgramIDs(ids...)
-}
-
-// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
-func (pc *ProcedureCreate) AddEditorIDs(ids ...string) *ProcedureCreate {
-	pc.mutation.AddEditorIDs(ids...)
-	return pc
-}
-
-// AddEditors adds the "editors" edges to the Group entity.
-func (pc *ProcedureCreate) AddEditors(g ...*Group) *ProcedureCreate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return pc.AddEditorIDs(ids...)
-}
-
-// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
-func (pc *ProcedureCreate) AddBlockedGroupIDs(ids ...string) *ProcedureCreate {
-	pc.mutation.AddBlockedGroupIDs(ids...)
-	return pc
-}
-
-// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
-func (pc *ProcedureCreate) AddBlockedGroups(g ...*Group) *ProcedureCreate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return pc.AddBlockedGroupIDs(ids...)
 }
 
 // Mutation returns the ProcedureMutation object of the builder.
@@ -607,6 +607,40 @@ func (pc *ProcedureCreate) createSpec() (*Procedure, *sqlgraph.CreateSpec) {
 		_node.OwnerID = nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
+	if nodes := pc.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   procedure.BlockedGroupsTable,
+			Columns: procedure.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = pc.schemaConfig.ProcedureBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := pc.mutation.EditorsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   procedure.EditorsTable,
+			Columns: procedure.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = pc.schemaConfig.ProcedureEditors
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
 	if nodes := pc.mutation.ControlIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2M,
@@ -704,40 +738,6 @@ func (pc *ProcedureCreate) createSpec() (*Procedure, *sqlgraph.CreateSpec) {
 			},
 		}
 		edge.Schema = pc.schemaConfig.ProgramProcedures
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges = append(_spec.Edges, edge)
-	}
-	if nodes := pc.mutation.EditorsIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   procedure.EditorsTable,
-			Columns: procedure.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = pc.schemaConfig.ProcedureEditors
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges = append(_spec.Edges, edge)
-	}
-	if nodes := pc.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   procedure.BlockedGroupsTable,
-			Columns: procedure.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = pc.schemaConfig.ProcedureBlockedGroups
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}

--- a/internal/ent/generated/procedure_query.go
+++ b/internal/ent/generated/procedure_query.go
@@ -35,25 +35,25 @@ type ProcedureQuery struct {
 	inters                  []Interceptor
 	predicates              []predicate.Procedure
 	withOwner               *OrganizationQuery
+	withBlockedGroups       *GroupQuery
+	withEditors             *GroupQuery
 	withControl             *ControlQuery
 	withInternalpolicy      *InternalPolicyQuery
 	withNarratives          *NarrativeQuery
 	withRisks               *RiskQuery
 	withTasks               *TaskQuery
 	withPrograms            *ProgramQuery
-	withEditors             *GroupQuery
-	withBlockedGroups       *GroupQuery
 	withFKs                 bool
 	loadTotal               []func(context.Context, []*Procedure) error
 	modifiers               []func(*sql.Selector)
+	withNamedBlockedGroups  map[string]*GroupQuery
+	withNamedEditors        map[string]*GroupQuery
 	withNamedControl        map[string]*ControlQuery
 	withNamedInternalpolicy map[string]*InternalPolicyQuery
 	withNamedNarratives     map[string]*NarrativeQuery
 	withNamedRisks          map[string]*RiskQuery
 	withNamedTasks          map[string]*TaskQuery
 	withNamedPrograms       map[string]*ProgramQuery
-	withNamedEditors        map[string]*GroupQuery
-	withNamedBlockedGroups  map[string]*GroupQuery
 	// intermediate query (i.e. traversal path).
 	sql  *sql.Selector
 	path func(context.Context) (*sql.Selector, error)
@@ -109,6 +109,56 @@ func (pq *ProcedureQuery) QueryOwner() *OrganizationQuery {
 		schemaConfig := pq.schemaConfig
 		step.To.Schema = schemaConfig.Organization
 		step.Edge.Schema = schemaConfig.Procedure
+		fromU = sqlgraph.SetNeighbors(pq.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryBlockedGroups chains the current query on the "blocked_groups" edge.
+func (pq *ProcedureQuery) QueryBlockedGroups() *GroupQuery {
+	query := (&GroupClient{config: pq.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := pq.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := pq.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(procedure.Table, procedure.FieldID, selector),
+			sqlgraph.To(group.Table, group.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, procedure.BlockedGroupsTable, procedure.BlockedGroupsPrimaryKey...),
+		)
+		schemaConfig := pq.schemaConfig
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.ProcedureBlockedGroups
+		fromU = sqlgraph.SetNeighbors(pq.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryEditors chains the current query on the "editors" edge.
+func (pq *ProcedureQuery) QueryEditors() *GroupQuery {
+	query := (&GroupClient{config: pq.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := pq.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := pq.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(procedure.Table, procedure.FieldID, selector),
+			sqlgraph.To(group.Table, group.FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, procedure.EditorsTable, procedure.EditorsPrimaryKey...),
+		)
+		schemaConfig := pq.schemaConfig
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.ProcedureEditors
 		fromU = sqlgraph.SetNeighbors(pq.driver.Dialect(), step)
 		return fromU, nil
 	}
@@ -259,56 +309,6 @@ func (pq *ProcedureQuery) QueryPrograms() *ProgramQuery {
 		schemaConfig := pq.schemaConfig
 		step.To.Schema = schemaConfig.Program
 		step.Edge.Schema = schemaConfig.ProgramProcedures
-		fromU = sqlgraph.SetNeighbors(pq.driver.Dialect(), step)
-		return fromU, nil
-	}
-	return query
-}
-
-// QueryEditors chains the current query on the "editors" edge.
-func (pq *ProcedureQuery) QueryEditors() *GroupQuery {
-	query := (&GroupClient{config: pq.config}).Query()
-	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
-		if err := pq.prepareQuery(ctx); err != nil {
-			return nil, err
-		}
-		selector := pq.sqlQuery(ctx)
-		if err := selector.Err(); err != nil {
-			return nil, err
-		}
-		step := sqlgraph.NewStep(
-			sqlgraph.From(procedure.Table, procedure.FieldID, selector),
-			sqlgraph.To(group.Table, group.FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, procedure.EditorsTable, procedure.EditorsPrimaryKey...),
-		)
-		schemaConfig := pq.schemaConfig
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.ProcedureEditors
-		fromU = sqlgraph.SetNeighbors(pq.driver.Dialect(), step)
-		return fromU, nil
-	}
-	return query
-}
-
-// QueryBlockedGroups chains the current query on the "blocked_groups" edge.
-func (pq *ProcedureQuery) QueryBlockedGroups() *GroupQuery {
-	query := (&GroupClient{config: pq.config}).Query()
-	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
-		if err := pq.prepareQuery(ctx); err != nil {
-			return nil, err
-		}
-		selector := pq.sqlQuery(ctx)
-		if err := selector.Err(); err != nil {
-			return nil, err
-		}
-		step := sqlgraph.NewStep(
-			sqlgraph.From(procedure.Table, procedure.FieldID, selector),
-			sqlgraph.To(group.Table, group.FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, procedure.BlockedGroupsTable, procedure.BlockedGroupsPrimaryKey...),
-		)
-		schemaConfig := pq.schemaConfig
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.ProcedureBlockedGroups
 		fromU = sqlgraph.SetNeighbors(pq.driver.Dialect(), step)
 		return fromU, nil
 	}
@@ -508,14 +508,14 @@ func (pq *ProcedureQuery) Clone() *ProcedureQuery {
 		inters:             append([]Interceptor{}, pq.inters...),
 		predicates:         append([]predicate.Procedure{}, pq.predicates...),
 		withOwner:          pq.withOwner.Clone(),
+		withBlockedGroups:  pq.withBlockedGroups.Clone(),
+		withEditors:        pq.withEditors.Clone(),
 		withControl:        pq.withControl.Clone(),
 		withInternalpolicy: pq.withInternalpolicy.Clone(),
 		withNarratives:     pq.withNarratives.Clone(),
 		withRisks:          pq.withRisks.Clone(),
 		withTasks:          pq.withTasks.Clone(),
 		withPrograms:       pq.withPrograms.Clone(),
-		withEditors:        pq.withEditors.Clone(),
-		withBlockedGroups:  pq.withBlockedGroups.Clone(),
 		// clone intermediate query.
 		sql:       pq.sql.Clone(),
 		path:      pq.path,
@@ -531,6 +531,28 @@ func (pq *ProcedureQuery) WithOwner(opts ...func(*OrganizationQuery)) *Procedure
 		opt(query)
 	}
 	pq.withOwner = query
+	return pq
+}
+
+// WithBlockedGroups tells the query-builder to eager-load the nodes that are connected to
+// the "blocked_groups" edge. The optional arguments are used to configure the query builder of the edge.
+func (pq *ProcedureQuery) WithBlockedGroups(opts ...func(*GroupQuery)) *ProcedureQuery {
+	query := (&GroupClient{config: pq.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	pq.withBlockedGroups = query
+	return pq
+}
+
+// WithEditors tells the query-builder to eager-load the nodes that are connected to
+// the "editors" edge. The optional arguments are used to configure the query builder of the edge.
+func (pq *ProcedureQuery) WithEditors(opts ...func(*GroupQuery)) *ProcedureQuery {
+	query := (&GroupClient{config: pq.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	pq.withEditors = query
 	return pq
 }
 
@@ -597,28 +619,6 @@ func (pq *ProcedureQuery) WithPrograms(opts ...func(*ProgramQuery)) *ProcedureQu
 		opt(query)
 	}
 	pq.withPrograms = query
-	return pq
-}
-
-// WithEditors tells the query-builder to eager-load the nodes that are connected to
-// the "editors" edge. The optional arguments are used to configure the query builder of the edge.
-func (pq *ProcedureQuery) WithEditors(opts ...func(*GroupQuery)) *ProcedureQuery {
-	query := (&GroupClient{config: pq.config}).Query()
-	for _, opt := range opts {
-		opt(query)
-	}
-	pq.withEditors = query
-	return pq
-}
-
-// WithBlockedGroups tells the query-builder to eager-load the nodes that are connected to
-// the "blocked_groups" edge. The optional arguments are used to configure the query builder of the edge.
-func (pq *ProcedureQuery) WithBlockedGroups(opts ...func(*GroupQuery)) *ProcedureQuery {
-	query := (&GroupClient{config: pq.config}).Query()
-	for _, opt := range opts {
-		opt(query)
-	}
-	pq.withBlockedGroups = query
 	return pq
 }
 
@@ -709,14 +709,14 @@ func (pq *ProcedureQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Pr
 		_spec       = pq.querySpec()
 		loadedTypes = [9]bool{
 			pq.withOwner != nil,
+			pq.withBlockedGroups != nil,
+			pq.withEditors != nil,
 			pq.withControl != nil,
 			pq.withInternalpolicy != nil,
 			pq.withNarratives != nil,
 			pq.withRisks != nil,
 			pq.withTasks != nil,
 			pq.withPrograms != nil,
-			pq.withEditors != nil,
-			pq.withBlockedGroups != nil,
 		}
 	)
 	if withFKs {
@@ -748,6 +748,20 @@ func (pq *ProcedureQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Pr
 	if query := pq.withOwner; query != nil {
 		if err := pq.loadOwner(ctx, query, nodes, nil,
 			func(n *Procedure, e *Organization) { n.Edges.Owner = e }); err != nil {
+			return nil, err
+		}
+	}
+	if query := pq.withBlockedGroups; query != nil {
+		if err := pq.loadBlockedGroups(ctx, query, nodes,
+			func(n *Procedure) { n.Edges.BlockedGroups = []*Group{} },
+			func(n *Procedure, e *Group) { n.Edges.BlockedGroups = append(n.Edges.BlockedGroups, e) }); err != nil {
+			return nil, err
+		}
+	}
+	if query := pq.withEditors; query != nil {
+		if err := pq.loadEditors(ctx, query, nodes,
+			func(n *Procedure) { n.Edges.Editors = []*Group{} },
+			func(n *Procedure, e *Group) { n.Edges.Editors = append(n.Edges.Editors, e) }); err != nil {
 			return nil, err
 		}
 	}
@@ -793,17 +807,17 @@ func (pq *ProcedureQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Pr
 			return nil, err
 		}
 	}
-	if query := pq.withEditors; query != nil {
-		if err := pq.loadEditors(ctx, query, nodes,
-			func(n *Procedure) { n.Edges.Editors = []*Group{} },
-			func(n *Procedure, e *Group) { n.Edges.Editors = append(n.Edges.Editors, e) }); err != nil {
+	for name, query := range pq.withNamedBlockedGroups {
+		if err := pq.loadBlockedGroups(ctx, query, nodes,
+			func(n *Procedure) { n.appendNamedBlockedGroups(name) },
+			func(n *Procedure, e *Group) { n.appendNamedBlockedGroups(name, e) }); err != nil {
 			return nil, err
 		}
 	}
-	if query := pq.withBlockedGroups; query != nil {
-		if err := pq.loadBlockedGroups(ctx, query, nodes,
-			func(n *Procedure) { n.Edges.BlockedGroups = []*Group{} },
-			func(n *Procedure, e *Group) { n.Edges.BlockedGroups = append(n.Edges.BlockedGroups, e) }); err != nil {
+	for name, query := range pq.withNamedEditors {
+		if err := pq.loadEditors(ctx, query, nodes,
+			func(n *Procedure) { n.appendNamedEditors(name) },
+			func(n *Procedure, e *Group) { n.appendNamedEditors(name, e) }); err != nil {
 			return nil, err
 		}
 	}
@@ -849,20 +863,6 @@ func (pq *ProcedureQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Pr
 			return nil, err
 		}
 	}
-	for name, query := range pq.withNamedEditors {
-		if err := pq.loadEditors(ctx, query, nodes,
-			func(n *Procedure) { n.appendNamedEditors(name) },
-			func(n *Procedure, e *Group) { n.appendNamedEditors(name, e) }); err != nil {
-			return nil, err
-		}
-	}
-	for name, query := range pq.withNamedBlockedGroups {
-		if err := pq.loadBlockedGroups(ctx, query, nodes,
-			func(n *Procedure) { n.appendNamedBlockedGroups(name) },
-			func(n *Procedure, e *Group) { n.appendNamedBlockedGroups(name, e) }); err != nil {
-			return nil, err
-		}
-	}
 	for i := range pq.loadTotal {
 		if err := pq.loadTotal[i](ctx, nodes); err != nil {
 			return nil, err
@@ -896,6 +896,130 @@ func (pq *ProcedureQuery) loadOwner(ctx context.Context, query *OrganizationQuer
 		}
 		for i := range nodes {
 			assign(nodes[i], n)
+		}
+	}
+	return nil
+}
+func (pq *ProcedureQuery) loadBlockedGroups(ctx context.Context, query *GroupQuery, nodes []*Procedure, init func(*Procedure), assign func(*Procedure, *Group)) error {
+	edgeIDs := make([]driver.Value, len(nodes))
+	byID := make(map[string]*Procedure)
+	nids := make(map[string]map[*Procedure]struct{})
+	for i, node := range nodes {
+		edgeIDs[i] = node.ID
+		byID[node.ID] = node
+		if init != nil {
+			init(node)
+		}
+	}
+	query.Where(func(s *sql.Selector) {
+		joinT := sql.Table(procedure.BlockedGroupsTable)
+		joinT.Schema(pq.schemaConfig.ProcedureBlockedGroups)
+		s.Join(joinT).On(s.C(group.FieldID), joinT.C(procedure.BlockedGroupsPrimaryKey[1]))
+		s.Where(sql.InValues(joinT.C(procedure.BlockedGroupsPrimaryKey[0]), edgeIDs...))
+		columns := s.SelectedColumns()
+		s.Select(joinT.C(procedure.BlockedGroupsPrimaryKey[0]))
+		s.AppendSelect(columns...)
+		s.SetDistinct(false)
+	})
+	if err := query.prepareQuery(ctx); err != nil {
+		return err
+	}
+	qr := QuerierFunc(func(ctx context.Context, q Query) (Value, error) {
+		return query.sqlAll(ctx, func(_ context.Context, spec *sqlgraph.QuerySpec) {
+			assign := spec.Assign
+			values := spec.ScanValues
+			spec.ScanValues = func(columns []string) ([]any, error) {
+				values, err := values(columns[1:])
+				if err != nil {
+					return nil, err
+				}
+				return append([]any{new(sql.NullString)}, values...), nil
+			}
+			spec.Assign = func(columns []string, values []any) error {
+				outValue := values[0].(*sql.NullString).String
+				inValue := values[1].(*sql.NullString).String
+				if nids[inValue] == nil {
+					nids[inValue] = map[*Procedure]struct{}{byID[outValue]: {}}
+					return assign(columns[1:], values[1:])
+				}
+				nids[inValue][byID[outValue]] = struct{}{}
+				return nil
+			}
+		})
+	})
+	neighbors, err := withInterceptors[[]*Group](ctx, query, qr, query.inters)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		nodes, ok := nids[n.ID]
+		if !ok {
+			return fmt.Errorf(`unexpected "blocked_groups" node returned %v`, n.ID)
+		}
+		for kn := range nodes {
+			assign(kn, n)
+		}
+	}
+	return nil
+}
+func (pq *ProcedureQuery) loadEditors(ctx context.Context, query *GroupQuery, nodes []*Procedure, init func(*Procedure), assign func(*Procedure, *Group)) error {
+	edgeIDs := make([]driver.Value, len(nodes))
+	byID := make(map[string]*Procedure)
+	nids := make(map[string]map[*Procedure]struct{})
+	for i, node := range nodes {
+		edgeIDs[i] = node.ID
+		byID[node.ID] = node
+		if init != nil {
+			init(node)
+		}
+	}
+	query.Where(func(s *sql.Selector) {
+		joinT := sql.Table(procedure.EditorsTable)
+		joinT.Schema(pq.schemaConfig.ProcedureEditors)
+		s.Join(joinT).On(s.C(group.FieldID), joinT.C(procedure.EditorsPrimaryKey[1]))
+		s.Where(sql.InValues(joinT.C(procedure.EditorsPrimaryKey[0]), edgeIDs...))
+		columns := s.SelectedColumns()
+		s.Select(joinT.C(procedure.EditorsPrimaryKey[0]))
+		s.AppendSelect(columns...)
+		s.SetDistinct(false)
+	})
+	if err := query.prepareQuery(ctx); err != nil {
+		return err
+	}
+	qr := QuerierFunc(func(ctx context.Context, q Query) (Value, error) {
+		return query.sqlAll(ctx, func(_ context.Context, spec *sqlgraph.QuerySpec) {
+			assign := spec.Assign
+			values := spec.ScanValues
+			spec.ScanValues = func(columns []string) ([]any, error) {
+				values, err := values(columns[1:])
+				if err != nil {
+					return nil, err
+				}
+				return append([]any{new(sql.NullString)}, values...), nil
+			}
+			spec.Assign = func(columns []string, values []any) error {
+				outValue := values[0].(*sql.NullString).String
+				inValue := values[1].(*sql.NullString).String
+				if nids[inValue] == nil {
+					nids[inValue] = map[*Procedure]struct{}{byID[outValue]: {}}
+					return assign(columns[1:], values[1:])
+				}
+				nids[inValue][byID[outValue]] = struct{}{}
+				return nil
+			}
+		})
+	})
+	neighbors, err := withInterceptors[[]*Group](ctx, query, qr, query.inters)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		nodes, ok := nids[n.ID]
+		if !ok {
+			return fmt.Errorf(`unexpected "editors" node returned %v`, n.ID)
+		}
+		for kn := range nodes {
+			assign(kn, n)
 		}
 	}
 	return nil
@@ -1272,130 +1396,6 @@ func (pq *ProcedureQuery) loadPrograms(ctx context.Context, query *ProgramQuery,
 	}
 	return nil
 }
-func (pq *ProcedureQuery) loadEditors(ctx context.Context, query *GroupQuery, nodes []*Procedure, init func(*Procedure), assign func(*Procedure, *Group)) error {
-	edgeIDs := make([]driver.Value, len(nodes))
-	byID := make(map[string]*Procedure)
-	nids := make(map[string]map[*Procedure]struct{})
-	for i, node := range nodes {
-		edgeIDs[i] = node.ID
-		byID[node.ID] = node
-		if init != nil {
-			init(node)
-		}
-	}
-	query.Where(func(s *sql.Selector) {
-		joinT := sql.Table(procedure.EditorsTable)
-		joinT.Schema(pq.schemaConfig.ProcedureEditors)
-		s.Join(joinT).On(s.C(group.FieldID), joinT.C(procedure.EditorsPrimaryKey[1]))
-		s.Where(sql.InValues(joinT.C(procedure.EditorsPrimaryKey[0]), edgeIDs...))
-		columns := s.SelectedColumns()
-		s.Select(joinT.C(procedure.EditorsPrimaryKey[0]))
-		s.AppendSelect(columns...)
-		s.SetDistinct(false)
-	})
-	if err := query.prepareQuery(ctx); err != nil {
-		return err
-	}
-	qr := QuerierFunc(func(ctx context.Context, q Query) (Value, error) {
-		return query.sqlAll(ctx, func(_ context.Context, spec *sqlgraph.QuerySpec) {
-			assign := spec.Assign
-			values := spec.ScanValues
-			spec.ScanValues = func(columns []string) ([]any, error) {
-				values, err := values(columns[1:])
-				if err != nil {
-					return nil, err
-				}
-				return append([]any{new(sql.NullString)}, values...), nil
-			}
-			spec.Assign = func(columns []string, values []any) error {
-				outValue := values[0].(*sql.NullString).String
-				inValue := values[1].(*sql.NullString).String
-				if nids[inValue] == nil {
-					nids[inValue] = map[*Procedure]struct{}{byID[outValue]: {}}
-					return assign(columns[1:], values[1:])
-				}
-				nids[inValue][byID[outValue]] = struct{}{}
-				return nil
-			}
-		})
-	})
-	neighbors, err := withInterceptors[[]*Group](ctx, query, qr, query.inters)
-	if err != nil {
-		return err
-	}
-	for _, n := range neighbors {
-		nodes, ok := nids[n.ID]
-		if !ok {
-			return fmt.Errorf(`unexpected "editors" node returned %v`, n.ID)
-		}
-		for kn := range nodes {
-			assign(kn, n)
-		}
-	}
-	return nil
-}
-func (pq *ProcedureQuery) loadBlockedGroups(ctx context.Context, query *GroupQuery, nodes []*Procedure, init func(*Procedure), assign func(*Procedure, *Group)) error {
-	edgeIDs := make([]driver.Value, len(nodes))
-	byID := make(map[string]*Procedure)
-	nids := make(map[string]map[*Procedure]struct{})
-	for i, node := range nodes {
-		edgeIDs[i] = node.ID
-		byID[node.ID] = node
-		if init != nil {
-			init(node)
-		}
-	}
-	query.Where(func(s *sql.Selector) {
-		joinT := sql.Table(procedure.BlockedGroupsTable)
-		joinT.Schema(pq.schemaConfig.ProcedureBlockedGroups)
-		s.Join(joinT).On(s.C(group.FieldID), joinT.C(procedure.BlockedGroupsPrimaryKey[1]))
-		s.Where(sql.InValues(joinT.C(procedure.BlockedGroupsPrimaryKey[0]), edgeIDs...))
-		columns := s.SelectedColumns()
-		s.Select(joinT.C(procedure.BlockedGroupsPrimaryKey[0]))
-		s.AppendSelect(columns...)
-		s.SetDistinct(false)
-	})
-	if err := query.prepareQuery(ctx); err != nil {
-		return err
-	}
-	qr := QuerierFunc(func(ctx context.Context, q Query) (Value, error) {
-		return query.sqlAll(ctx, func(_ context.Context, spec *sqlgraph.QuerySpec) {
-			assign := spec.Assign
-			values := spec.ScanValues
-			spec.ScanValues = func(columns []string) ([]any, error) {
-				values, err := values(columns[1:])
-				if err != nil {
-					return nil, err
-				}
-				return append([]any{new(sql.NullString)}, values...), nil
-			}
-			spec.Assign = func(columns []string, values []any) error {
-				outValue := values[0].(*sql.NullString).String
-				inValue := values[1].(*sql.NullString).String
-				if nids[inValue] == nil {
-					nids[inValue] = map[*Procedure]struct{}{byID[outValue]: {}}
-					return assign(columns[1:], values[1:])
-				}
-				nids[inValue][byID[outValue]] = struct{}{}
-				return nil
-			}
-		})
-	})
-	neighbors, err := withInterceptors[[]*Group](ctx, query, qr, query.inters)
-	if err != nil {
-		return err
-	}
-	for _, n := range neighbors {
-		nodes, ok := nids[n.ID]
-		if !ok {
-			return fmt.Errorf(`unexpected "blocked_groups" node returned %v`, n.ID)
-		}
-		for kn := range nodes {
-			assign(kn, n)
-		}
-	}
-	return nil
-}
 
 func (pq *ProcedureQuery) sqlCount(ctx context.Context) (int, error) {
 	_spec := pq.querySpec()
@@ -1498,6 +1498,34 @@ func (pq *ProcedureQuery) Modify(modifiers ...func(s *sql.Selector)) *ProcedureS
 	return pq.Select()
 }
 
+// WithNamedBlockedGroups tells the query-builder to eager-load the nodes that are connected to the "blocked_groups"
+// edge with the given name. The optional arguments are used to configure the query builder of the edge.
+func (pq *ProcedureQuery) WithNamedBlockedGroups(name string, opts ...func(*GroupQuery)) *ProcedureQuery {
+	query := (&GroupClient{config: pq.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	if pq.withNamedBlockedGroups == nil {
+		pq.withNamedBlockedGroups = make(map[string]*GroupQuery)
+	}
+	pq.withNamedBlockedGroups[name] = query
+	return pq
+}
+
+// WithNamedEditors tells the query-builder to eager-load the nodes that are connected to the "editors"
+// edge with the given name. The optional arguments are used to configure the query builder of the edge.
+func (pq *ProcedureQuery) WithNamedEditors(name string, opts ...func(*GroupQuery)) *ProcedureQuery {
+	query := (&GroupClient{config: pq.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	if pq.withNamedEditors == nil {
+		pq.withNamedEditors = make(map[string]*GroupQuery)
+	}
+	pq.withNamedEditors[name] = query
+	return pq
+}
+
 // WithNamedControl tells the query-builder to eager-load the nodes that are connected to the "control"
 // edge with the given name. The optional arguments are used to configure the query builder of the edge.
 func (pq *ProcedureQuery) WithNamedControl(name string, opts ...func(*ControlQuery)) *ProcedureQuery {
@@ -1579,34 +1607,6 @@ func (pq *ProcedureQuery) WithNamedPrograms(name string, opts ...func(*ProgramQu
 		pq.withNamedPrograms = make(map[string]*ProgramQuery)
 	}
 	pq.withNamedPrograms[name] = query
-	return pq
-}
-
-// WithNamedEditors tells the query-builder to eager-load the nodes that are connected to the "editors"
-// edge with the given name. The optional arguments are used to configure the query builder of the edge.
-func (pq *ProcedureQuery) WithNamedEditors(name string, opts ...func(*GroupQuery)) *ProcedureQuery {
-	query := (&GroupClient{config: pq.config}).Query()
-	for _, opt := range opts {
-		opt(query)
-	}
-	if pq.withNamedEditors == nil {
-		pq.withNamedEditors = make(map[string]*GroupQuery)
-	}
-	pq.withNamedEditors[name] = query
-	return pq
-}
-
-// WithNamedBlockedGroups tells the query-builder to eager-load the nodes that are connected to the "blocked_groups"
-// edge with the given name. The optional arguments are used to configure the query builder of the edge.
-func (pq *ProcedureQuery) WithNamedBlockedGroups(name string, opts ...func(*GroupQuery)) *ProcedureQuery {
-	query := (&GroupClient{config: pq.config}).Query()
-	for _, opt := range opts {
-		opt(query)
-	}
-	if pq.withNamedBlockedGroups == nil {
-		pq.withNamedBlockedGroups = make(map[string]*GroupQuery)
-	}
-	pq.withNamedBlockedGroups[name] = query
 	return pq
 }
 

--- a/internal/ent/generated/procedure_update.go
+++ b/internal/ent/generated/procedure_update.go
@@ -321,6 +321,36 @@ func (pu *ProcedureUpdate) SetOwner(o *Organization) *ProcedureUpdate {
 	return pu.SetOwnerID(o.ID)
 }
 
+// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
+func (pu *ProcedureUpdate) AddBlockedGroupIDs(ids ...string) *ProcedureUpdate {
+	pu.mutation.AddBlockedGroupIDs(ids...)
+	return pu
+}
+
+// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
+func (pu *ProcedureUpdate) AddBlockedGroups(g ...*Group) *ProcedureUpdate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return pu.AddBlockedGroupIDs(ids...)
+}
+
+// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
+func (pu *ProcedureUpdate) AddEditorIDs(ids ...string) *ProcedureUpdate {
+	pu.mutation.AddEditorIDs(ids...)
+	return pu
+}
+
+// AddEditors adds the "editors" edges to the Group entity.
+func (pu *ProcedureUpdate) AddEditors(g ...*Group) *ProcedureUpdate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return pu.AddEditorIDs(ids...)
+}
+
 // AddControlIDs adds the "control" edge to the Control entity by IDs.
 func (pu *ProcedureUpdate) AddControlIDs(ids ...string) *ProcedureUpdate {
 	pu.mutation.AddControlIDs(ids...)
@@ -411,36 +441,6 @@ func (pu *ProcedureUpdate) AddPrograms(p ...*Program) *ProcedureUpdate {
 	return pu.AddProgramIDs(ids...)
 }
 
-// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
-func (pu *ProcedureUpdate) AddEditorIDs(ids ...string) *ProcedureUpdate {
-	pu.mutation.AddEditorIDs(ids...)
-	return pu
-}
-
-// AddEditors adds the "editors" edges to the Group entity.
-func (pu *ProcedureUpdate) AddEditors(g ...*Group) *ProcedureUpdate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return pu.AddEditorIDs(ids...)
-}
-
-// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
-func (pu *ProcedureUpdate) AddBlockedGroupIDs(ids ...string) *ProcedureUpdate {
-	pu.mutation.AddBlockedGroupIDs(ids...)
-	return pu
-}
-
-// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
-func (pu *ProcedureUpdate) AddBlockedGroups(g ...*Group) *ProcedureUpdate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return pu.AddBlockedGroupIDs(ids...)
-}
-
 // Mutation returns the ProcedureMutation object of the builder.
 func (pu *ProcedureUpdate) Mutation() *ProcedureMutation {
 	return pu.mutation
@@ -450,6 +450,48 @@ func (pu *ProcedureUpdate) Mutation() *ProcedureMutation {
 func (pu *ProcedureUpdate) ClearOwner() *ProcedureUpdate {
 	pu.mutation.ClearOwner()
 	return pu
+}
+
+// ClearBlockedGroups clears all "blocked_groups" edges to the Group entity.
+func (pu *ProcedureUpdate) ClearBlockedGroups() *ProcedureUpdate {
+	pu.mutation.ClearBlockedGroups()
+	return pu
+}
+
+// RemoveBlockedGroupIDs removes the "blocked_groups" edge to Group entities by IDs.
+func (pu *ProcedureUpdate) RemoveBlockedGroupIDs(ids ...string) *ProcedureUpdate {
+	pu.mutation.RemoveBlockedGroupIDs(ids...)
+	return pu
+}
+
+// RemoveBlockedGroups removes "blocked_groups" edges to Group entities.
+func (pu *ProcedureUpdate) RemoveBlockedGroups(g ...*Group) *ProcedureUpdate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return pu.RemoveBlockedGroupIDs(ids...)
+}
+
+// ClearEditors clears all "editors" edges to the Group entity.
+func (pu *ProcedureUpdate) ClearEditors() *ProcedureUpdate {
+	pu.mutation.ClearEditors()
+	return pu
+}
+
+// RemoveEditorIDs removes the "editors" edge to Group entities by IDs.
+func (pu *ProcedureUpdate) RemoveEditorIDs(ids ...string) *ProcedureUpdate {
+	pu.mutation.RemoveEditorIDs(ids...)
+	return pu
+}
+
+// RemoveEditors removes "editors" edges to Group entities.
+func (pu *ProcedureUpdate) RemoveEditors(g ...*Group) *ProcedureUpdate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return pu.RemoveEditorIDs(ids...)
 }
 
 // ClearControl clears all "control" edges to the Control entity.
@@ -576,48 +618,6 @@ func (pu *ProcedureUpdate) RemovePrograms(p ...*Program) *ProcedureUpdate {
 		ids[i] = p[i].ID
 	}
 	return pu.RemoveProgramIDs(ids...)
-}
-
-// ClearEditors clears all "editors" edges to the Group entity.
-func (pu *ProcedureUpdate) ClearEditors() *ProcedureUpdate {
-	pu.mutation.ClearEditors()
-	return pu
-}
-
-// RemoveEditorIDs removes the "editors" edge to Group entities by IDs.
-func (pu *ProcedureUpdate) RemoveEditorIDs(ids ...string) *ProcedureUpdate {
-	pu.mutation.RemoveEditorIDs(ids...)
-	return pu
-}
-
-// RemoveEditors removes "editors" edges to Group entities.
-func (pu *ProcedureUpdate) RemoveEditors(g ...*Group) *ProcedureUpdate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return pu.RemoveEditorIDs(ids...)
-}
-
-// ClearBlockedGroups clears all "blocked_groups" edges to the Group entity.
-func (pu *ProcedureUpdate) ClearBlockedGroups() *ProcedureUpdate {
-	pu.mutation.ClearBlockedGroups()
-	return pu
-}
-
-// RemoveBlockedGroupIDs removes the "blocked_groups" edge to Group entities by IDs.
-func (pu *ProcedureUpdate) RemoveBlockedGroupIDs(ids ...string) *ProcedureUpdate {
-	pu.mutation.RemoveBlockedGroupIDs(ids...)
-	return pu
-}
-
-// RemoveBlockedGroups removes "blocked_groups" edges to Group entities.
-func (pu *ProcedureUpdate) RemoveBlockedGroups(g ...*Group) *ProcedureUpdate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return pu.RemoveBlockedGroupIDs(ids...)
 }
 
 // Save executes the query and returns the number of nodes affected by the update operation.
@@ -813,6 +813,102 @@ func (pu *ProcedureUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			},
 		}
 		edge.Schema = pu.schemaConfig.Procedure
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if pu.mutation.BlockedGroupsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   procedure.BlockedGroupsTable,
+			Columns: procedure.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = pu.schemaConfig.ProcedureBlockedGroups
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := pu.mutation.RemovedBlockedGroupsIDs(); len(nodes) > 0 && !pu.mutation.BlockedGroupsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   procedure.BlockedGroupsTable,
+			Columns: procedure.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = pu.schemaConfig.ProcedureBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := pu.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   procedure.BlockedGroupsTable,
+			Columns: procedure.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = pu.schemaConfig.ProcedureBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if pu.mutation.EditorsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   procedure.EditorsTable,
+			Columns: procedure.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = pu.schemaConfig.ProcedureEditors
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := pu.mutation.RemovedEditorsIDs(); len(nodes) > 0 && !pu.mutation.EditorsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   procedure.EditorsTable,
+			Columns: procedure.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = pu.schemaConfig.ProcedureEditors
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := pu.mutation.EditorsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   procedure.EditorsTable,
+			Columns: procedure.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = pu.schemaConfig.ProcedureEditors
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
@@ -1101,102 +1197,6 @@ func (pu *ProcedureUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			},
 		}
 		edge.Schema = pu.schemaConfig.ProgramProcedures
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
-	if pu.mutation.EditorsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   procedure.EditorsTable,
-			Columns: procedure.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = pu.schemaConfig.ProcedureEditors
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := pu.mutation.RemovedEditorsIDs(); len(nodes) > 0 && !pu.mutation.EditorsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   procedure.EditorsTable,
-			Columns: procedure.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = pu.schemaConfig.ProcedureEditors
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := pu.mutation.EditorsIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   procedure.EditorsTable,
-			Columns: procedure.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = pu.schemaConfig.ProcedureEditors
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
-	if pu.mutation.BlockedGroupsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   procedure.BlockedGroupsTable,
-			Columns: procedure.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = pu.schemaConfig.ProcedureBlockedGroups
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := pu.mutation.RemovedBlockedGroupsIDs(); len(nodes) > 0 && !pu.mutation.BlockedGroupsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   procedure.BlockedGroupsTable,
-			Columns: procedure.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = pu.schemaConfig.ProcedureBlockedGroups
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := pu.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   procedure.BlockedGroupsTable,
-			Columns: procedure.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = pu.schemaConfig.ProcedureBlockedGroups
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
@@ -1507,6 +1507,36 @@ func (puo *ProcedureUpdateOne) SetOwner(o *Organization) *ProcedureUpdateOne {
 	return puo.SetOwnerID(o.ID)
 }
 
+// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
+func (puo *ProcedureUpdateOne) AddBlockedGroupIDs(ids ...string) *ProcedureUpdateOne {
+	puo.mutation.AddBlockedGroupIDs(ids...)
+	return puo
+}
+
+// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
+func (puo *ProcedureUpdateOne) AddBlockedGroups(g ...*Group) *ProcedureUpdateOne {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return puo.AddBlockedGroupIDs(ids...)
+}
+
+// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
+func (puo *ProcedureUpdateOne) AddEditorIDs(ids ...string) *ProcedureUpdateOne {
+	puo.mutation.AddEditorIDs(ids...)
+	return puo
+}
+
+// AddEditors adds the "editors" edges to the Group entity.
+func (puo *ProcedureUpdateOne) AddEditors(g ...*Group) *ProcedureUpdateOne {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return puo.AddEditorIDs(ids...)
+}
+
 // AddControlIDs adds the "control" edge to the Control entity by IDs.
 func (puo *ProcedureUpdateOne) AddControlIDs(ids ...string) *ProcedureUpdateOne {
 	puo.mutation.AddControlIDs(ids...)
@@ -1597,36 +1627,6 @@ func (puo *ProcedureUpdateOne) AddPrograms(p ...*Program) *ProcedureUpdateOne {
 	return puo.AddProgramIDs(ids...)
 }
 
-// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
-func (puo *ProcedureUpdateOne) AddEditorIDs(ids ...string) *ProcedureUpdateOne {
-	puo.mutation.AddEditorIDs(ids...)
-	return puo
-}
-
-// AddEditors adds the "editors" edges to the Group entity.
-func (puo *ProcedureUpdateOne) AddEditors(g ...*Group) *ProcedureUpdateOne {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return puo.AddEditorIDs(ids...)
-}
-
-// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
-func (puo *ProcedureUpdateOne) AddBlockedGroupIDs(ids ...string) *ProcedureUpdateOne {
-	puo.mutation.AddBlockedGroupIDs(ids...)
-	return puo
-}
-
-// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
-func (puo *ProcedureUpdateOne) AddBlockedGroups(g ...*Group) *ProcedureUpdateOne {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return puo.AddBlockedGroupIDs(ids...)
-}
-
 // Mutation returns the ProcedureMutation object of the builder.
 func (puo *ProcedureUpdateOne) Mutation() *ProcedureMutation {
 	return puo.mutation
@@ -1636,6 +1636,48 @@ func (puo *ProcedureUpdateOne) Mutation() *ProcedureMutation {
 func (puo *ProcedureUpdateOne) ClearOwner() *ProcedureUpdateOne {
 	puo.mutation.ClearOwner()
 	return puo
+}
+
+// ClearBlockedGroups clears all "blocked_groups" edges to the Group entity.
+func (puo *ProcedureUpdateOne) ClearBlockedGroups() *ProcedureUpdateOne {
+	puo.mutation.ClearBlockedGroups()
+	return puo
+}
+
+// RemoveBlockedGroupIDs removes the "blocked_groups" edge to Group entities by IDs.
+func (puo *ProcedureUpdateOne) RemoveBlockedGroupIDs(ids ...string) *ProcedureUpdateOne {
+	puo.mutation.RemoveBlockedGroupIDs(ids...)
+	return puo
+}
+
+// RemoveBlockedGroups removes "blocked_groups" edges to Group entities.
+func (puo *ProcedureUpdateOne) RemoveBlockedGroups(g ...*Group) *ProcedureUpdateOne {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return puo.RemoveBlockedGroupIDs(ids...)
+}
+
+// ClearEditors clears all "editors" edges to the Group entity.
+func (puo *ProcedureUpdateOne) ClearEditors() *ProcedureUpdateOne {
+	puo.mutation.ClearEditors()
+	return puo
+}
+
+// RemoveEditorIDs removes the "editors" edge to Group entities by IDs.
+func (puo *ProcedureUpdateOne) RemoveEditorIDs(ids ...string) *ProcedureUpdateOne {
+	puo.mutation.RemoveEditorIDs(ids...)
+	return puo
+}
+
+// RemoveEditors removes "editors" edges to Group entities.
+func (puo *ProcedureUpdateOne) RemoveEditors(g ...*Group) *ProcedureUpdateOne {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return puo.RemoveEditorIDs(ids...)
 }
 
 // ClearControl clears all "control" edges to the Control entity.
@@ -1762,48 +1804,6 @@ func (puo *ProcedureUpdateOne) RemovePrograms(p ...*Program) *ProcedureUpdateOne
 		ids[i] = p[i].ID
 	}
 	return puo.RemoveProgramIDs(ids...)
-}
-
-// ClearEditors clears all "editors" edges to the Group entity.
-func (puo *ProcedureUpdateOne) ClearEditors() *ProcedureUpdateOne {
-	puo.mutation.ClearEditors()
-	return puo
-}
-
-// RemoveEditorIDs removes the "editors" edge to Group entities by IDs.
-func (puo *ProcedureUpdateOne) RemoveEditorIDs(ids ...string) *ProcedureUpdateOne {
-	puo.mutation.RemoveEditorIDs(ids...)
-	return puo
-}
-
-// RemoveEditors removes "editors" edges to Group entities.
-func (puo *ProcedureUpdateOne) RemoveEditors(g ...*Group) *ProcedureUpdateOne {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return puo.RemoveEditorIDs(ids...)
-}
-
-// ClearBlockedGroups clears all "blocked_groups" edges to the Group entity.
-func (puo *ProcedureUpdateOne) ClearBlockedGroups() *ProcedureUpdateOne {
-	puo.mutation.ClearBlockedGroups()
-	return puo
-}
-
-// RemoveBlockedGroupIDs removes the "blocked_groups" edge to Group entities by IDs.
-func (puo *ProcedureUpdateOne) RemoveBlockedGroupIDs(ids ...string) *ProcedureUpdateOne {
-	puo.mutation.RemoveBlockedGroupIDs(ids...)
-	return puo
-}
-
-// RemoveBlockedGroups removes "blocked_groups" edges to Group entities.
-func (puo *ProcedureUpdateOne) RemoveBlockedGroups(g ...*Group) *ProcedureUpdateOne {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return puo.RemoveBlockedGroupIDs(ids...)
 }
 
 // Where appends a list predicates to the ProcedureUpdate builder.
@@ -2029,6 +2029,102 @@ func (puo *ProcedureUpdateOne) sqlSave(ctx context.Context) (_node *Procedure, e
 			},
 		}
 		edge.Schema = puo.schemaConfig.Procedure
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if puo.mutation.BlockedGroupsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   procedure.BlockedGroupsTable,
+			Columns: procedure.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = puo.schemaConfig.ProcedureBlockedGroups
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := puo.mutation.RemovedBlockedGroupsIDs(); len(nodes) > 0 && !puo.mutation.BlockedGroupsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   procedure.BlockedGroupsTable,
+			Columns: procedure.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = puo.schemaConfig.ProcedureBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := puo.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   procedure.BlockedGroupsTable,
+			Columns: procedure.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = puo.schemaConfig.ProcedureBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if puo.mutation.EditorsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   procedure.EditorsTable,
+			Columns: procedure.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = puo.schemaConfig.ProcedureEditors
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := puo.mutation.RemovedEditorsIDs(); len(nodes) > 0 && !puo.mutation.EditorsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   procedure.EditorsTable,
+			Columns: procedure.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = puo.schemaConfig.ProcedureEditors
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := puo.mutation.EditorsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   procedure.EditorsTable,
+			Columns: procedure.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = puo.schemaConfig.ProcedureEditors
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
@@ -2317,102 +2413,6 @@ func (puo *ProcedureUpdateOne) sqlSave(ctx context.Context) (_node *Procedure, e
 			},
 		}
 		edge.Schema = puo.schemaConfig.ProgramProcedures
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
-	if puo.mutation.EditorsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   procedure.EditorsTable,
-			Columns: procedure.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = puo.schemaConfig.ProcedureEditors
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := puo.mutation.RemovedEditorsIDs(); len(nodes) > 0 && !puo.mutation.EditorsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   procedure.EditorsTable,
-			Columns: procedure.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = puo.schemaConfig.ProcedureEditors
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := puo.mutation.EditorsIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   procedure.EditorsTable,
-			Columns: procedure.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = puo.schemaConfig.ProcedureEditors
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
-	if puo.mutation.BlockedGroupsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   procedure.BlockedGroupsTable,
-			Columns: procedure.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = puo.schemaConfig.ProcedureBlockedGroups
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := puo.mutation.RemovedBlockedGroupsIDs(); len(nodes) > 0 && !puo.mutation.BlockedGroupsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   procedure.BlockedGroupsTable,
-			Columns: procedure.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = puo.schemaConfig.ProcedureBlockedGroups
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := puo.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   procedure.BlockedGroupsTable,
-			Columns: procedure.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = puo.schemaConfig.ProcedureBlockedGroups
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}

--- a/internal/ent/generated/program/program.go
+++ b/internal/ent/generated/program/program.go
@@ -54,6 +54,12 @@ const (
 	FieldAuditorReadComments = "auditor_read_comments"
 	// EdgeOwner holds the string denoting the owner edge name in mutations.
 	EdgeOwner = "owner"
+	// EdgeBlockedGroups holds the string denoting the blocked_groups edge name in mutations.
+	EdgeBlockedGroups = "blocked_groups"
+	// EdgeEditors holds the string denoting the editors edge name in mutations.
+	EdgeEditors = "editors"
+	// EdgeViewers holds the string denoting the viewers edge name in mutations.
+	EdgeViewers = "viewers"
 	// EdgeControls holds the string denoting the controls edge name in mutations.
 	EdgeControls = "controls"
 	// EdgeSubcontrols holds the string denoting the subcontrols edge name in mutations.
@@ -80,12 +86,6 @@ const (
 	EdgeStandards = "standards"
 	// EdgeUsers holds the string denoting the users edge name in mutations.
 	EdgeUsers = "users"
-	// EdgeViewers holds the string denoting the viewers edge name in mutations.
-	EdgeViewers = "viewers"
-	// EdgeEditors holds the string denoting the editors edge name in mutations.
-	EdgeEditors = "editors"
-	// EdgeBlockedGroups holds the string denoting the blocked_groups edge name in mutations.
-	EdgeBlockedGroups = "blocked_groups"
 	// EdgeMembers holds the string denoting the members edge name in mutations.
 	EdgeMembers = "members"
 	// Table holds the table name of the program in the database.
@@ -97,6 +97,21 @@ const (
 	OwnerInverseTable = "organizations"
 	// OwnerColumn is the table column denoting the owner relation/edge.
 	OwnerColumn = "owner_id"
+	// BlockedGroupsTable is the table that holds the blocked_groups relation/edge. The primary key declared below.
+	BlockedGroupsTable = "program_blocked_groups"
+	// BlockedGroupsInverseTable is the table name for the Group entity.
+	// It exists in this package in order to avoid circular dependency with the "group" package.
+	BlockedGroupsInverseTable = "groups"
+	// EditorsTable is the table that holds the editors relation/edge. The primary key declared below.
+	EditorsTable = "program_editors"
+	// EditorsInverseTable is the table name for the Group entity.
+	// It exists in this package in order to avoid circular dependency with the "group" package.
+	EditorsInverseTable = "groups"
+	// ViewersTable is the table that holds the viewers relation/edge. The primary key declared below.
+	ViewersTable = "program_viewers"
+	// ViewersInverseTable is the table name for the Group entity.
+	// It exists in this package in order to avoid circular dependency with the "group" package.
+	ViewersInverseTable = "groups"
 	// ControlsTable is the table that holds the controls relation/edge. The primary key declared below.
 	ControlsTable = "program_controls"
 	// ControlsInverseTable is the table name for the Control entity.
@@ -162,21 +177,6 @@ const (
 	// UsersInverseTable is the table name for the User entity.
 	// It exists in this package in order to avoid circular dependency with the "user" package.
 	UsersInverseTable = "users"
-	// ViewersTable is the table that holds the viewers relation/edge. The primary key declared below.
-	ViewersTable = "program_viewers"
-	// ViewersInverseTable is the table name for the Group entity.
-	// It exists in this package in order to avoid circular dependency with the "group" package.
-	ViewersInverseTable = "groups"
-	// EditorsTable is the table that holds the editors relation/edge. The primary key declared below.
-	EditorsTable = "program_editors"
-	// EditorsInverseTable is the table name for the Group entity.
-	// It exists in this package in order to avoid circular dependency with the "group" package.
-	EditorsInverseTable = "groups"
-	// BlockedGroupsTable is the table that holds the blocked_groups relation/edge. The primary key declared below.
-	BlockedGroupsTable = "program_blocked_groups"
-	// BlockedGroupsInverseTable is the table name for the Group entity.
-	// It exists in this package in order to avoid circular dependency with the "group" package.
-	BlockedGroupsInverseTable = "groups"
 	// MembersTable is the table that holds the members relation/edge.
 	MembersTable = "program_memberships"
 	// MembersInverseTable is the table name for the ProgramMembership entity.
@@ -209,6 +209,15 @@ var Columns = []string{
 }
 
 var (
+	// BlockedGroupsPrimaryKey and BlockedGroupsColumn2 are the table columns denoting the
+	// primary key for the blocked_groups relation (M2M).
+	BlockedGroupsPrimaryKey = []string{"program_id", "group_id"}
+	// EditorsPrimaryKey and EditorsColumn2 are the table columns denoting the
+	// primary key for the editors relation (M2M).
+	EditorsPrimaryKey = []string{"program_id", "group_id"}
+	// ViewersPrimaryKey and ViewersColumn2 are the table columns denoting the
+	// primary key for the viewers relation (M2M).
+	ViewersPrimaryKey = []string{"program_id", "group_id"}
 	// ControlsPrimaryKey and ControlsColumn2 are the table columns denoting the
 	// primary key for the controls relation (M2M).
 	ControlsPrimaryKey = []string{"program_id", "control_id"}
@@ -248,15 +257,6 @@ var (
 	// UsersPrimaryKey and UsersColumn2 are the table columns denoting the
 	// primary key for the users relation (M2M).
 	UsersPrimaryKey = []string{"user_id", "program_id"}
-	// ViewersPrimaryKey and ViewersColumn2 are the table columns denoting the
-	// primary key for the viewers relation (M2M).
-	ViewersPrimaryKey = []string{"program_id", "group_id"}
-	// EditorsPrimaryKey and EditorsColumn2 are the table columns denoting the
-	// primary key for the editors relation (M2M).
-	EditorsPrimaryKey = []string{"program_id", "group_id"}
-	// BlockedGroupsPrimaryKey and BlockedGroupsColumn2 are the table columns denoting the
-	// primary key for the blocked_groups relation (M2M).
-	BlockedGroupsPrimaryKey = []string{"program_id", "group_id"}
 )
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -406,6 +406,48 @@ func ByAuditorReadComments(opts ...sql.OrderTermOption) OrderOption {
 func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByBlockedGroupsCount orders the results by blocked_groups count.
+func ByBlockedGroupsCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newBlockedGroupsStep(), opts...)
+	}
+}
+
+// ByBlockedGroups orders the results by blocked_groups terms.
+func ByBlockedGroups(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newBlockedGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByEditorsCount orders the results by editors count.
+func ByEditorsCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newEditorsStep(), opts...)
+	}
+}
+
+// ByEditors orders the results by editors terms.
+func ByEditors(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newEditorsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByViewersCount orders the results by viewers count.
+func ByViewersCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newViewersStep(), opts...)
+	}
+}
+
+// ByViewers orders the results by viewers terms.
+func ByViewers(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newViewersStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
 
@@ -591,48 +633,6 @@ func ByUsers(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	}
 }
 
-// ByViewersCount orders the results by viewers count.
-func ByViewersCount(opts ...sql.OrderTermOption) OrderOption {
-	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborsCount(s, newViewersStep(), opts...)
-	}
-}
-
-// ByViewers orders the results by viewers terms.
-func ByViewers(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
-	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborTerms(s, newViewersStep(), append([]sql.OrderTerm{term}, terms...)...)
-	}
-}
-
-// ByEditorsCount orders the results by editors count.
-func ByEditorsCount(opts ...sql.OrderTermOption) OrderOption {
-	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborsCount(s, newEditorsStep(), opts...)
-	}
-}
-
-// ByEditors orders the results by editors terms.
-func ByEditors(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
-	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborTerms(s, newEditorsStep(), append([]sql.OrderTerm{term}, terms...)...)
-	}
-}
-
-// ByBlockedGroupsCount orders the results by blocked_groups count.
-func ByBlockedGroupsCount(opts ...sql.OrderTermOption) OrderOption {
-	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborsCount(s, newBlockedGroupsStep(), opts...)
-	}
-}
-
-// ByBlockedGroups orders the results by blocked_groups terms.
-func ByBlockedGroups(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
-	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborTerms(s, newBlockedGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
-	}
-}
-
 // ByMembersCount orders the results by members count.
 func ByMembersCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
@@ -651,6 +651,27 @@ func newOwnerStep() *sqlgraph.Step {
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(OwnerInverseTable, FieldID),
 		sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
+	)
+}
+func newBlockedGroupsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(BlockedGroupsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, BlockedGroupsTable, BlockedGroupsPrimaryKey...),
+	)
+}
+func newEditorsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(EditorsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, EditorsTable, EditorsPrimaryKey...),
+	)
+}
+func newViewersStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(ViewersInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, ViewersTable, ViewersPrimaryKey...),
 	)
 }
 func newControlsStep() *sqlgraph.Step {
@@ -742,27 +763,6 @@ func newUsersStep() *sqlgraph.Step {
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(UsersInverseTable, FieldID),
 		sqlgraph.Edge(sqlgraph.M2M, true, UsersTable, UsersPrimaryKey...),
-	)
-}
-func newViewersStep() *sqlgraph.Step {
-	return sqlgraph.NewStep(
-		sqlgraph.From(Table, FieldID),
-		sqlgraph.To(ViewersInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.M2M, false, ViewersTable, ViewersPrimaryKey...),
-	)
-}
-func newEditorsStep() *sqlgraph.Step {
-	return sqlgraph.NewStep(
-		sqlgraph.From(Table, FieldID),
-		sqlgraph.To(EditorsInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.M2M, false, EditorsTable, EditorsPrimaryKey...),
-	)
-}
-func newBlockedGroupsStep() *sqlgraph.Step {
-	return sqlgraph.NewStep(
-		sqlgraph.From(Table, FieldID),
-		sqlgraph.To(BlockedGroupsInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.M2M, false, BlockedGroupsTable, BlockedGroupsPrimaryKey...),
 	)
 }
 func newMembersStep() *sqlgraph.Step {

--- a/internal/ent/generated/program/where.go
+++ b/internal/ent/generated/program/where.go
@@ -997,6 +997,93 @@ func HasOwnerWith(preds ...predicate.Organization) predicate.Program {
 	})
 }
 
+// HasBlockedGroups applies the HasEdge predicate on the "blocked_groups" edge.
+func HasBlockedGroups() predicate.Program {
+	return predicate.Program(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, BlockedGroupsTable, BlockedGroupsPrimaryKey...),
+		)
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.ProgramBlockedGroups
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasBlockedGroupsWith applies the HasEdge predicate on the "blocked_groups" edge with a given conditions (other predicates).
+func HasBlockedGroupsWith(preds ...predicate.Group) predicate.Program {
+	return predicate.Program(func(s *sql.Selector) {
+		step := newBlockedGroupsStep()
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.ProgramBlockedGroups
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasEditors applies the HasEdge predicate on the "editors" edge.
+func HasEditors() predicate.Program {
+	return predicate.Program(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, EditorsTable, EditorsPrimaryKey...),
+		)
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.ProgramEditors
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasEditorsWith applies the HasEdge predicate on the "editors" edge with a given conditions (other predicates).
+func HasEditorsWith(preds ...predicate.Group) predicate.Program {
+	return predicate.Program(func(s *sql.Selector) {
+		step := newEditorsStep()
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.ProgramEditors
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasViewers applies the HasEdge predicate on the "viewers" edge.
+func HasViewers() predicate.Program {
+	return predicate.Program(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, ViewersTable, ViewersPrimaryKey...),
+		)
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.ProgramViewers
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasViewersWith applies the HasEdge predicate on the "viewers" edge with a given conditions (other predicates).
+func HasViewersWith(preds ...predicate.Group) predicate.Program {
+	return predicate.Program(func(s *sql.Selector) {
+		step := newViewersStep()
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.ProgramViewers
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
 // HasControls applies the HasEdge predicate on the "controls" edge.
 func HasControls() predicate.Program {
 	return predicate.Program(func(s *sql.Selector) {
@@ -1366,93 +1453,6 @@ func HasUsersWith(preds ...predicate.User) predicate.Program {
 		schemaConfig := internal.SchemaConfigFromContext(s.Context())
 		step.To.Schema = schemaConfig.User
 		step.Edge.Schema = schemaConfig.ProgramMembership
-		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
-			for _, p := range preds {
-				p(s)
-			}
-		})
-	})
-}
-
-// HasViewers applies the HasEdge predicate on the "viewers" edge.
-func HasViewers() predicate.Program {
-	return predicate.Program(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, ViewersTable, ViewersPrimaryKey...),
-		)
-		schemaConfig := internal.SchemaConfigFromContext(s.Context())
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.ProgramViewers
-		sqlgraph.HasNeighbors(s, step)
-	})
-}
-
-// HasViewersWith applies the HasEdge predicate on the "viewers" edge with a given conditions (other predicates).
-func HasViewersWith(preds ...predicate.Group) predicate.Program {
-	return predicate.Program(func(s *sql.Selector) {
-		step := newViewersStep()
-		schemaConfig := internal.SchemaConfigFromContext(s.Context())
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.ProgramViewers
-		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
-			for _, p := range preds {
-				p(s)
-			}
-		})
-	})
-}
-
-// HasEditors applies the HasEdge predicate on the "editors" edge.
-func HasEditors() predicate.Program {
-	return predicate.Program(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, EditorsTable, EditorsPrimaryKey...),
-		)
-		schemaConfig := internal.SchemaConfigFromContext(s.Context())
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.ProgramEditors
-		sqlgraph.HasNeighbors(s, step)
-	})
-}
-
-// HasEditorsWith applies the HasEdge predicate on the "editors" edge with a given conditions (other predicates).
-func HasEditorsWith(preds ...predicate.Group) predicate.Program {
-	return predicate.Program(func(s *sql.Selector) {
-		step := newEditorsStep()
-		schemaConfig := internal.SchemaConfigFromContext(s.Context())
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.ProgramEditors
-		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
-			for _, p := range preds {
-				p(s)
-			}
-		})
-	})
-}
-
-// HasBlockedGroups applies the HasEdge predicate on the "blocked_groups" edge.
-func HasBlockedGroups() predicate.Program {
-	return predicate.Program(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, BlockedGroupsTable, BlockedGroupsPrimaryKey...),
-		)
-		schemaConfig := internal.SchemaConfigFromContext(s.Context())
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.ProgramBlockedGroups
-		sqlgraph.HasNeighbors(s, step)
-	})
-}
-
-// HasBlockedGroupsWith applies the HasEdge predicate on the "blocked_groups" edge with a given conditions (other predicates).
-func HasBlockedGroupsWith(preds ...predicate.Group) predicate.Program {
-	return predicate.Program(func(s *sql.Selector) {
-		step := newBlockedGroupsStep()
-		schemaConfig := internal.SchemaConfigFromContext(s.Context())
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.ProgramBlockedGroups
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/internal/ent/generated/program_create.go
+++ b/internal/ent/generated/program_create.go
@@ -278,6 +278,51 @@ func (pc *ProgramCreate) SetOwner(o *Organization) *ProgramCreate {
 	return pc.SetOwnerID(o.ID)
 }
 
+// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
+func (pc *ProgramCreate) AddBlockedGroupIDs(ids ...string) *ProgramCreate {
+	pc.mutation.AddBlockedGroupIDs(ids...)
+	return pc
+}
+
+// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
+func (pc *ProgramCreate) AddBlockedGroups(g ...*Group) *ProgramCreate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return pc.AddBlockedGroupIDs(ids...)
+}
+
+// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
+func (pc *ProgramCreate) AddEditorIDs(ids ...string) *ProgramCreate {
+	pc.mutation.AddEditorIDs(ids...)
+	return pc
+}
+
+// AddEditors adds the "editors" edges to the Group entity.
+func (pc *ProgramCreate) AddEditors(g ...*Group) *ProgramCreate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return pc.AddEditorIDs(ids...)
+}
+
+// AddViewerIDs adds the "viewers" edge to the Group entity by IDs.
+func (pc *ProgramCreate) AddViewerIDs(ids ...string) *ProgramCreate {
+	pc.mutation.AddViewerIDs(ids...)
+	return pc
+}
+
+// AddViewers adds the "viewers" edges to the Group entity.
+func (pc *ProgramCreate) AddViewers(g ...*Group) *ProgramCreate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return pc.AddViewerIDs(ids...)
+}
+
 // AddControlIDs adds the "controls" edge to the Control entity by IDs.
 func (pc *ProgramCreate) AddControlIDs(ids ...string) *ProgramCreate {
 	pc.mutation.AddControlIDs(ids...)
@@ -471,51 +516,6 @@ func (pc *ProgramCreate) AddUsers(u ...*User) *ProgramCreate {
 		ids[i] = u[i].ID
 	}
 	return pc.AddUserIDs(ids...)
-}
-
-// AddViewerIDs adds the "viewers" edge to the Group entity by IDs.
-func (pc *ProgramCreate) AddViewerIDs(ids ...string) *ProgramCreate {
-	pc.mutation.AddViewerIDs(ids...)
-	return pc
-}
-
-// AddViewers adds the "viewers" edges to the Group entity.
-func (pc *ProgramCreate) AddViewers(g ...*Group) *ProgramCreate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return pc.AddViewerIDs(ids...)
-}
-
-// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
-func (pc *ProgramCreate) AddEditorIDs(ids ...string) *ProgramCreate {
-	pc.mutation.AddEditorIDs(ids...)
-	return pc
-}
-
-// AddEditors adds the "editors" edges to the Group entity.
-func (pc *ProgramCreate) AddEditors(g ...*Group) *ProgramCreate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return pc.AddEditorIDs(ids...)
-}
-
-// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
-func (pc *ProgramCreate) AddBlockedGroupIDs(ids ...string) *ProgramCreate {
-	pc.mutation.AddBlockedGroupIDs(ids...)
-	return pc
-}
-
-// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
-func (pc *ProgramCreate) AddBlockedGroups(g ...*Group) *ProgramCreate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return pc.AddBlockedGroupIDs(ids...)
 }
 
 // AddMemberIDs adds the "members" edge to the ProgramMembership entity by IDs.
@@ -774,6 +774,57 @@ func (pc *ProgramCreate) createSpec() (*Program, *sqlgraph.CreateSpec) {
 		_node.OwnerID = nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
+	if nodes := pc.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   program.BlockedGroupsTable,
+			Columns: program.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = pc.schemaConfig.ProgramBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := pc.mutation.EditorsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   program.EditorsTable,
+			Columns: program.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = pc.schemaConfig.ProgramEditors
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := pc.mutation.ViewersIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   program.ViewersTable,
+			Columns: program.ViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = pc.schemaConfig.ProgramViewers
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
 	if nodes := pc.mutation.ControlsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2M,
@@ -999,57 +1050,6 @@ func (pc *ProgramCreate) createSpec() (*Program, *sqlgraph.CreateSpec) {
 		edge.Target.Fields = specE.Fields
 		if specE.ID.Value != nil {
 			edge.Target.Fields = append(edge.Target.Fields, specE.ID)
-		}
-		_spec.Edges = append(_spec.Edges, edge)
-	}
-	if nodes := pc.mutation.ViewersIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   program.ViewersTable,
-			Columns: program.ViewersPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = pc.schemaConfig.ProgramViewers
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges = append(_spec.Edges, edge)
-	}
-	if nodes := pc.mutation.EditorsIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   program.EditorsTable,
-			Columns: program.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = pc.schemaConfig.ProgramEditors
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges = append(_spec.Edges, edge)
-	}
-	if nodes := pc.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   program.BlockedGroupsTable,
-			Columns: program.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = pc.schemaConfig.ProgramBlockedGroups
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
 		_spec.Edges = append(_spec.Edges, edge)
 	}

--- a/internal/ent/generated/program_update.go
+++ b/internal/ent/generated/program_update.go
@@ -294,6 +294,51 @@ func (pu *ProgramUpdate) SetOwner(o *Organization) *ProgramUpdate {
 	return pu.SetOwnerID(o.ID)
 }
 
+// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
+func (pu *ProgramUpdate) AddBlockedGroupIDs(ids ...string) *ProgramUpdate {
+	pu.mutation.AddBlockedGroupIDs(ids...)
+	return pu
+}
+
+// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
+func (pu *ProgramUpdate) AddBlockedGroups(g ...*Group) *ProgramUpdate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return pu.AddBlockedGroupIDs(ids...)
+}
+
+// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
+func (pu *ProgramUpdate) AddEditorIDs(ids ...string) *ProgramUpdate {
+	pu.mutation.AddEditorIDs(ids...)
+	return pu
+}
+
+// AddEditors adds the "editors" edges to the Group entity.
+func (pu *ProgramUpdate) AddEditors(g ...*Group) *ProgramUpdate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return pu.AddEditorIDs(ids...)
+}
+
+// AddViewerIDs adds the "viewers" edge to the Group entity by IDs.
+func (pu *ProgramUpdate) AddViewerIDs(ids ...string) *ProgramUpdate {
+	pu.mutation.AddViewerIDs(ids...)
+	return pu
+}
+
+// AddViewers adds the "viewers" edges to the Group entity.
+func (pu *ProgramUpdate) AddViewers(g ...*Group) *ProgramUpdate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return pu.AddViewerIDs(ids...)
+}
+
 // AddControlIDs adds the "controls" edge to the Control entity by IDs.
 func (pu *ProgramUpdate) AddControlIDs(ids ...string) *ProgramUpdate {
 	pu.mutation.AddControlIDs(ids...)
@@ -489,51 +534,6 @@ func (pu *ProgramUpdate) AddUsers(u ...*User) *ProgramUpdate {
 	return pu.AddUserIDs(ids...)
 }
 
-// AddViewerIDs adds the "viewers" edge to the Group entity by IDs.
-func (pu *ProgramUpdate) AddViewerIDs(ids ...string) *ProgramUpdate {
-	pu.mutation.AddViewerIDs(ids...)
-	return pu
-}
-
-// AddViewers adds the "viewers" edges to the Group entity.
-func (pu *ProgramUpdate) AddViewers(g ...*Group) *ProgramUpdate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return pu.AddViewerIDs(ids...)
-}
-
-// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
-func (pu *ProgramUpdate) AddEditorIDs(ids ...string) *ProgramUpdate {
-	pu.mutation.AddEditorIDs(ids...)
-	return pu
-}
-
-// AddEditors adds the "editors" edges to the Group entity.
-func (pu *ProgramUpdate) AddEditors(g ...*Group) *ProgramUpdate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return pu.AddEditorIDs(ids...)
-}
-
-// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
-func (pu *ProgramUpdate) AddBlockedGroupIDs(ids ...string) *ProgramUpdate {
-	pu.mutation.AddBlockedGroupIDs(ids...)
-	return pu
-}
-
-// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
-func (pu *ProgramUpdate) AddBlockedGroups(g ...*Group) *ProgramUpdate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return pu.AddBlockedGroupIDs(ids...)
-}
-
 // AddMemberIDs adds the "members" edge to the ProgramMembership entity by IDs.
 func (pu *ProgramUpdate) AddMemberIDs(ids ...string) *ProgramUpdate {
 	pu.mutation.AddMemberIDs(ids...)
@@ -558,6 +558,69 @@ func (pu *ProgramUpdate) Mutation() *ProgramMutation {
 func (pu *ProgramUpdate) ClearOwner() *ProgramUpdate {
 	pu.mutation.ClearOwner()
 	return pu
+}
+
+// ClearBlockedGroups clears all "blocked_groups" edges to the Group entity.
+func (pu *ProgramUpdate) ClearBlockedGroups() *ProgramUpdate {
+	pu.mutation.ClearBlockedGroups()
+	return pu
+}
+
+// RemoveBlockedGroupIDs removes the "blocked_groups" edge to Group entities by IDs.
+func (pu *ProgramUpdate) RemoveBlockedGroupIDs(ids ...string) *ProgramUpdate {
+	pu.mutation.RemoveBlockedGroupIDs(ids...)
+	return pu
+}
+
+// RemoveBlockedGroups removes "blocked_groups" edges to Group entities.
+func (pu *ProgramUpdate) RemoveBlockedGroups(g ...*Group) *ProgramUpdate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return pu.RemoveBlockedGroupIDs(ids...)
+}
+
+// ClearEditors clears all "editors" edges to the Group entity.
+func (pu *ProgramUpdate) ClearEditors() *ProgramUpdate {
+	pu.mutation.ClearEditors()
+	return pu
+}
+
+// RemoveEditorIDs removes the "editors" edge to Group entities by IDs.
+func (pu *ProgramUpdate) RemoveEditorIDs(ids ...string) *ProgramUpdate {
+	pu.mutation.RemoveEditorIDs(ids...)
+	return pu
+}
+
+// RemoveEditors removes "editors" edges to Group entities.
+func (pu *ProgramUpdate) RemoveEditors(g ...*Group) *ProgramUpdate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return pu.RemoveEditorIDs(ids...)
+}
+
+// ClearViewers clears all "viewers" edges to the Group entity.
+func (pu *ProgramUpdate) ClearViewers() *ProgramUpdate {
+	pu.mutation.ClearViewers()
+	return pu
+}
+
+// RemoveViewerIDs removes the "viewers" edge to Group entities by IDs.
+func (pu *ProgramUpdate) RemoveViewerIDs(ids ...string) *ProgramUpdate {
+	pu.mutation.RemoveViewerIDs(ids...)
+	return pu
+}
+
+// RemoveViewers removes "viewers" edges to Group entities.
+func (pu *ProgramUpdate) RemoveViewers(g ...*Group) *ProgramUpdate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return pu.RemoveViewerIDs(ids...)
 }
 
 // ClearControls clears all "controls" edges to the Control entity.
@@ -833,69 +896,6 @@ func (pu *ProgramUpdate) RemoveUsers(u ...*User) *ProgramUpdate {
 	return pu.RemoveUserIDs(ids...)
 }
 
-// ClearViewers clears all "viewers" edges to the Group entity.
-func (pu *ProgramUpdate) ClearViewers() *ProgramUpdate {
-	pu.mutation.ClearViewers()
-	return pu
-}
-
-// RemoveViewerIDs removes the "viewers" edge to Group entities by IDs.
-func (pu *ProgramUpdate) RemoveViewerIDs(ids ...string) *ProgramUpdate {
-	pu.mutation.RemoveViewerIDs(ids...)
-	return pu
-}
-
-// RemoveViewers removes "viewers" edges to Group entities.
-func (pu *ProgramUpdate) RemoveViewers(g ...*Group) *ProgramUpdate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return pu.RemoveViewerIDs(ids...)
-}
-
-// ClearEditors clears all "editors" edges to the Group entity.
-func (pu *ProgramUpdate) ClearEditors() *ProgramUpdate {
-	pu.mutation.ClearEditors()
-	return pu
-}
-
-// RemoveEditorIDs removes the "editors" edge to Group entities by IDs.
-func (pu *ProgramUpdate) RemoveEditorIDs(ids ...string) *ProgramUpdate {
-	pu.mutation.RemoveEditorIDs(ids...)
-	return pu
-}
-
-// RemoveEditors removes "editors" edges to Group entities.
-func (pu *ProgramUpdate) RemoveEditors(g ...*Group) *ProgramUpdate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return pu.RemoveEditorIDs(ids...)
-}
-
-// ClearBlockedGroups clears all "blocked_groups" edges to the Group entity.
-func (pu *ProgramUpdate) ClearBlockedGroups() *ProgramUpdate {
-	pu.mutation.ClearBlockedGroups()
-	return pu
-}
-
-// RemoveBlockedGroupIDs removes the "blocked_groups" edge to Group entities by IDs.
-func (pu *ProgramUpdate) RemoveBlockedGroupIDs(ids ...string) *ProgramUpdate {
-	pu.mutation.RemoveBlockedGroupIDs(ids...)
-	return pu
-}
-
-// RemoveBlockedGroups removes "blocked_groups" edges to Group entities.
-func (pu *ProgramUpdate) RemoveBlockedGroups(g ...*Group) *ProgramUpdate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return pu.RemoveBlockedGroupIDs(ids...)
-}
-
 // ClearMembers clears all "members" edges to the ProgramMembership entity.
 func (pu *ProgramUpdate) ClearMembers() *ProgramUpdate {
 	pu.mutation.ClearMembers()
@@ -1097,6 +1097,150 @@ func (pu *ProgramUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			},
 		}
 		edge.Schema = pu.schemaConfig.Program
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if pu.mutation.BlockedGroupsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   program.BlockedGroupsTable,
+			Columns: program.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = pu.schemaConfig.ProgramBlockedGroups
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := pu.mutation.RemovedBlockedGroupsIDs(); len(nodes) > 0 && !pu.mutation.BlockedGroupsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   program.BlockedGroupsTable,
+			Columns: program.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = pu.schemaConfig.ProgramBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := pu.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   program.BlockedGroupsTable,
+			Columns: program.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = pu.schemaConfig.ProgramBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if pu.mutation.EditorsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   program.EditorsTable,
+			Columns: program.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = pu.schemaConfig.ProgramEditors
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := pu.mutation.RemovedEditorsIDs(); len(nodes) > 0 && !pu.mutation.EditorsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   program.EditorsTable,
+			Columns: program.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = pu.schemaConfig.ProgramEditors
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := pu.mutation.EditorsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   program.EditorsTable,
+			Columns: program.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = pu.schemaConfig.ProgramEditors
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if pu.mutation.ViewersCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   program.ViewersTable,
+			Columns: program.ViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = pu.schemaConfig.ProgramViewers
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := pu.mutation.RemovedViewersIDs(); len(nodes) > 0 && !pu.mutation.ViewersCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   program.ViewersTable,
+			Columns: program.ViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = pu.schemaConfig.ProgramViewers
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := pu.mutation.ViewersIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   program.ViewersTable,
+			Columns: program.ViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = pu.schemaConfig.ProgramViewers
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
@@ -1747,150 +1891,6 @@ func (pu *ProgramUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
-	if pu.mutation.ViewersCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   program.ViewersTable,
-			Columns: program.ViewersPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = pu.schemaConfig.ProgramViewers
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := pu.mutation.RemovedViewersIDs(); len(nodes) > 0 && !pu.mutation.ViewersCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   program.ViewersTable,
-			Columns: program.ViewersPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = pu.schemaConfig.ProgramViewers
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := pu.mutation.ViewersIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   program.ViewersTable,
-			Columns: program.ViewersPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = pu.schemaConfig.ProgramViewers
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
-	if pu.mutation.EditorsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   program.EditorsTable,
-			Columns: program.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = pu.schemaConfig.ProgramEditors
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := pu.mutation.RemovedEditorsIDs(); len(nodes) > 0 && !pu.mutation.EditorsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   program.EditorsTable,
-			Columns: program.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = pu.schemaConfig.ProgramEditors
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := pu.mutation.EditorsIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   program.EditorsTable,
-			Columns: program.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = pu.schemaConfig.ProgramEditors
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
-	if pu.mutation.BlockedGroupsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   program.BlockedGroupsTable,
-			Columns: program.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = pu.schemaConfig.ProgramBlockedGroups
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := pu.mutation.RemovedBlockedGroupsIDs(); len(nodes) > 0 && !pu.mutation.BlockedGroupsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   program.BlockedGroupsTable,
-			Columns: program.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = pu.schemaConfig.ProgramBlockedGroups
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := pu.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   program.BlockedGroupsTable,
-			Columns: program.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = pu.schemaConfig.ProgramBlockedGroups
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
 	if pu.mutation.MembersCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.O2M,
@@ -2208,6 +2208,51 @@ func (puo *ProgramUpdateOne) SetOwner(o *Organization) *ProgramUpdateOne {
 	return puo.SetOwnerID(o.ID)
 }
 
+// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
+func (puo *ProgramUpdateOne) AddBlockedGroupIDs(ids ...string) *ProgramUpdateOne {
+	puo.mutation.AddBlockedGroupIDs(ids...)
+	return puo
+}
+
+// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
+func (puo *ProgramUpdateOne) AddBlockedGroups(g ...*Group) *ProgramUpdateOne {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return puo.AddBlockedGroupIDs(ids...)
+}
+
+// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
+func (puo *ProgramUpdateOne) AddEditorIDs(ids ...string) *ProgramUpdateOne {
+	puo.mutation.AddEditorIDs(ids...)
+	return puo
+}
+
+// AddEditors adds the "editors" edges to the Group entity.
+func (puo *ProgramUpdateOne) AddEditors(g ...*Group) *ProgramUpdateOne {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return puo.AddEditorIDs(ids...)
+}
+
+// AddViewerIDs adds the "viewers" edge to the Group entity by IDs.
+func (puo *ProgramUpdateOne) AddViewerIDs(ids ...string) *ProgramUpdateOne {
+	puo.mutation.AddViewerIDs(ids...)
+	return puo
+}
+
+// AddViewers adds the "viewers" edges to the Group entity.
+func (puo *ProgramUpdateOne) AddViewers(g ...*Group) *ProgramUpdateOne {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return puo.AddViewerIDs(ids...)
+}
+
 // AddControlIDs adds the "controls" edge to the Control entity by IDs.
 func (puo *ProgramUpdateOne) AddControlIDs(ids ...string) *ProgramUpdateOne {
 	puo.mutation.AddControlIDs(ids...)
@@ -2403,51 +2448,6 @@ func (puo *ProgramUpdateOne) AddUsers(u ...*User) *ProgramUpdateOne {
 	return puo.AddUserIDs(ids...)
 }
 
-// AddViewerIDs adds the "viewers" edge to the Group entity by IDs.
-func (puo *ProgramUpdateOne) AddViewerIDs(ids ...string) *ProgramUpdateOne {
-	puo.mutation.AddViewerIDs(ids...)
-	return puo
-}
-
-// AddViewers adds the "viewers" edges to the Group entity.
-func (puo *ProgramUpdateOne) AddViewers(g ...*Group) *ProgramUpdateOne {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return puo.AddViewerIDs(ids...)
-}
-
-// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
-func (puo *ProgramUpdateOne) AddEditorIDs(ids ...string) *ProgramUpdateOne {
-	puo.mutation.AddEditorIDs(ids...)
-	return puo
-}
-
-// AddEditors adds the "editors" edges to the Group entity.
-func (puo *ProgramUpdateOne) AddEditors(g ...*Group) *ProgramUpdateOne {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return puo.AddEditorIDs(ids...)
-}
-
-// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
-func (puo *ProgramUpdateOne) AddBlockedGroupIDs(ids ...string) *ProgramUpdateOne {
-	puo.mutation.AddBlockedGroupIDs(ids...)
-	return puo
-}
-
-// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
-func (puo *ProgramUpdateOne) AddBlockedGroups(g ...*Group) *ProgramUpdateOne {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return puo.AddBlockedGroupIDs(ids...)
-}
-
 // AddMemberIDs adds the "members" edge to the ProgramMembership entity by IDs.
 func (puo *ProgramUpdateOne) AddMemberIDs(ids ...string) *ProgramUpdateOne {
 	puo.mutation.AddMemberIDs(ids...)
@@ -2472,6 +2472,69 @@ func (puo *ProgramUpdateOne) Mutation() *ProgramMutation {
 func (puo *ProgramUpdateOne) ClearOwner() *ProgramUpdateOne {
 	puo.mutation.ClearOwner()
 	return puo
+}
+
+// ClearBlockedGroups clears all "blocked_groups" edges to the Group entity.
+func (puo *ProgramUpdateOne) ClearBlockedGroups() *ProgramUpdateOne {
+	puo.mutation.ClearBlockedGroups()
+	return puo
+}
+
+// RemoveBlockedGroupIDs removes the "blocked_groups" edge to Group entities by IDs.
+func (puo *ProgramUpdateOne) RemoveBlockedGroupIDs(ids ...string) *ProgramUpdateOne {
+	puo.mutation.RemoveBlockedGroupIDs(ids...)
+	return puo
+}
+
+// RemoveBlockedGroups removes "blocked_groups" edges to Group entities.
+func (puo *ProgramUpdateOne) RemoveBlockedGroups(g ...*Group) *ProgramUpdateOne {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return puo.RemoveBlockedGroupIDs(ids...)
+}
+
+// ClearEditors clears all "editors" edges to the Group entity.
+func (puo *ProgramUpdateOne) ClearEditors() *ProgramUpdateOne {
+	puo.mutation.ClearEditors()
+	return puo
+}
+
+// RemoveEditorIDs removes the "editors" edge to Group entities by IDs.
+func (puo *ProgramUpdateOne) RemoveEditorIDs(ids ...string) *ProgramUpdateOne {
+	puo.mutation.RemoveEditorIDs(ids...)
+	return puo
+}
+
+// RemoveEditors removes "editors" edges to Group entities.
+func (puo *ProgramUpdateOne) RemoveEditors(g ...*Group) *ProgramUpdateOne {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return puo.RemoveEditorIDs(ids...)
+}
+
+// ClearViewers clears all "viewers" edges to the Group entity.
+func (puo *ProgramUpdateOne) ClearViewers() *ProgramUpdateOne {
+	puo.mutation.ClearViewers()
+	return puo
+}
+
+// RemoveViewerIDs removes the "viewers" edge to Group entities by IDs.
+func (puo *ProgramUpdateOne) RemoveViewerIDs(ids ...string) *ProgramUpdateOne {
+	puo.mutation.RemoveViewerIDs(ids...)
+	return puo
+}
+
+// RemoveViewers removes "viewers" edges to Group entities.
+func (puo *ProgramUpdateOne) RemoveViewers(g ...*Group) *ProgramUpdateOne {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return puo.RemoveViewerIDs(ids...)
 }
 
 // ClearControls clears all "controls" edges to the Control entity.
@@ -2747,69 +2810,6 @@ func (puo *ProgramUpdateOne) RemoveUsers(u ...*User) *ProgramUpdateOne {
 	return puo.RemoveUserIDs(ids...)
 }
 
-// ClearViewers clears all "viewers" edges to the Group entity.
-func (puo *ProgramUpdateOne) ClearViewers() *ProgramUpdateOne {
-	puo.mutation.ClearViewers()
-	return puo
-}
-
-// RemoveViewerIDs removes the "viewers" edge to Group entities by IDs.
-func (puo *ProgramUpdateOne) RemoveViewerIDs(ids ...string) *ProgramUpdateOne {
-	puo.mutation.RemoveViewerIDs(ids...)
-	return puo
-}
-
-// RemoveViewers removes "viewers" edges to Group entities.
-func (puo *ProgramUpdateOne) RemoveViewers(g ...*Group) *ProgramUpdateOne {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return puo.RemoveViewerIDs(ids...)
-}
-
-// ClearEditors clears all "editors" edges to the Group entity.
-func (puo *ProgramUpdateOne) ClearEditors() *ProgramUpdateOne {
-	puo.mutation.ClearEditors()
-	return puo
-}
-
-// RemoveEditorIDs removes the "editors" edge to Group entities by IDs.
-func (puo *ProgramUpdateOne) RemoveEditorIDs(ids ...string) *ProgramUpdateOne {
-	puo.mutation.RemoveEditorIDs(ids...)
-	return puo
-}
-
-// RemoveEditors removes "editors" edges to Group entities.
-func (puo *ProgramUpdateOne) RemoveEditors(g ...*Group) *ProgramUpdateOne {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return puo.RemoveEditorIDs(ids...)
-}
-
-// ClearBlockedGroups clears all "blocked_groups" edges to the Group entity.
-func (puo *ProgramUpdateOne) ClearBlockedGroups() *ProgramUpdateOne {
-	puo.mutation.ClearBlockedGroups()
-	return puo
-}
-
-// RemoveBlockedGroupIDs removes the "blocked_groups" edge to Group entities by IDs.
-func (puo *ProgramUpdateOne) RemoveBlockedGroupIDs(ids ...string) *ProgramUpdateOne {
-	puo.mutation.RemoveBlockedGroupIDs(ids...)
-	return puo
-}
-
-// RemoveBlockedGroups removes "blocked_groups" edges to Group entities.
-func (puo *ProgramUpdateOne) RemoveBlockedGroups(g ...*Group) *ProgramUpdateOne {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return puo.RemoveBlockedGroupIDs(ids...)
-}
-
 // ClearMembers clears all "members" edges to the ProgramMembership entity.
 func (puo *ProgramUpdateOne) ClearMembers() *ProgramUpdateOne {
 	puo.mutation.ClearMembers()
@@ -3041,6 +3041,150 @@ func (puo *ProgramUpdateOne) sqlSave(ctx context.Context) (_node *Program, err e
 			},
 		}
 		edge.Schema = puo.schemaConfig.Program
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if puo.mutation.BlockedGroupsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   program.BlockedGroupsTable,
+			Columns: program.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = puo.schemaConfig.ProgramBlockedGroups
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := puo.mutation.RemovedBlockedGroupsIDs(); len(nodes) > 0 && !puo.mutation.BlockedGroupsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   program.BlockedGroupsTable,
+			Columns: program.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = puo.schemaConfig.ProgramBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := puo.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   program.BlockedGroupsTable,
+			Columns: program.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = puo.schemaConfig.ProgramBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if puo.mutation.EditorsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   program.EditorsTable,
+			Columns: program.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = puo.schemaConfig.ProgramEditors
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := puo.mutation.RemovedEditorsIDs(); len(nodes) > 0 && !puo.mutation.EditorsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   program.EditorsTable,
+			Columns: program.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = puo.schemaConfig.ProgramEditors
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := puo.mutation.EditorsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   program.EditorsTable,
+			Columns: program.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = puo.schemaConfig.ProgramEditors
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if puo.mutation.ViewersCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   program.ViewersTable,
+			Columns: program.ViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = puo.schemaConfig.ProgramViewers
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := puo.mutation.RemovedViewersIDs(); len(nodes) > 0 && !puo.mutation.ViewersCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   program.ViewersTable,
+			Columns: program.ViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = puo.schemaConfig.ProgramViewers
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := puo.mutation.ViewersIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   program.ViewersTable,
+			Columns: program.ViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = puo.schemaConfig.ProgramViewers
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
@@ -3688,150 +3832,6 @@ func (puo *ProgramUpdateOne) sqlSave(ctx context.Context) (_node *Program, err e
 		edge.Target.Fields = specE.Fields
 		if specE.ID.Value != nil {
 			edge.Target.Fields = append(edge.Target.Fields, specE.ID)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
-	if puo.mutation.ViewersCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   program.ViewersTable,
-			Columns: program.ViewersPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = puo.schemaConfig.ProgramViewers
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := puo.mutation.RemovedViewersIDs(); len(nodes) > 0 && !puo.mutation.ViewersCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   program.ViewersTable,
-			Columns: program.ViewersPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = puo.schemaConfig.ProgramViewers
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := puo.mutation.ViewersIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   program.ViewersTable,
-			Columns: program.ViewersPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = puo.schemaConfig.ProgramViewers
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
-	if puo.mutation.EditorsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   program.EditorsTable,
-			Columns: program.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = puo.schemaConfig.ProgramEditors
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := puo.mutation.RemovedEditorsIDs(); len(nodes) > 0 && !puo.mutation.EditorsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   program.EditorsTable,
-			Columns: program.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = puo.schemaConfig.ProgramEditors
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := puo.mutation.EditorsIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   program.EditorsTable,
-			Columns: program.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = puo.schemaConfig.ProgramEditors
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
-	if puo.mutation.BlockedGroupsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   program.BlockedGroupsTable,
-			Columns: program.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = puo.schemaConfig.ProgramBlockedGroups
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := puo.mutation.RemovedBlockedGroupsIDs(); len(nodes) > 0 && !puo.mutation.BlockedGroupsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   program.BlockedGroupsTable,
-			Columns: program.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = puo.schemaConfig.ProgramBlockedGroups
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := puo.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   program.BlockedGroupsTable,
-			Columns: program.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = puo.schemaConfig.ProgramBlockedGroups
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}

--- a/internal/ent/generated/risk/risk.go
+++ b/internal/ent/generated/risk/risk.go
@@ -34,6 +34,8 @@ const (
 	FieldMappingID = "mapping_id"
 	// FieldTags holds the string denoting the tags field in the database.
 	FieldTags = "tags"
+	// FieldOwnerID holds the string denoting the owner_id field in the database.
+	FieldOwnerID = "owner_id"
 	// FieldName holds the string denoting the name field in the database.
 	FieldName = "name"
 	// FieldDescription holds the string denoting the description field in the database.
@@ -54,26 +56,46 @@ const (
 	FieldSatisfies = "satisfies"
 	// FieldDetails holds the string denoting the details field in the database.
 	FieldDetails = "details"
-	// FieldOwnerID holds the string denoting the owner_id field in the database.
-	FieldOwnerID = "owner_id"
+	// EdgeOwner holds the string denoting the owner edge name in mutations.
+	EdgeOwner = "owner"
+	// EdgeBlockedGroups holds the string denoting the blocked_groups edge name in mutations.
+	EdgeBlockedGroups = "blocked_groups"
+	// EdgeEditors holds the string denoting the editors edge name in mutations.
+	EdgeEditors = "editors"
+	// EdgeViewers holds the string denoting the viewers edge name in mutations.
+	EdgeViewers = "viewers"
 	// EdgeControl holds the string denoting the control edge name in mutations.
 	EdgeControl = "control"
 	// EdgeProcedure holds the string denoting the procedure edge name in mutations.
 	EdgeProcedure = "procedure"
 	// EdgeActionplans holds the string denoting the actionplans edge name in mutations.
 	EdgeActionplans = "actionplans"
-	// EdgeOwner holds the string denoting the owner edge name in mutations.
-	EdgeOwner = "owner"
-	// EdgeProgram holds the string denoting the program edge name in mutations.
-	EdgeProgram = "program"
-	// EdgeViewers holds the string denoting the viewers edge name in mutations.
-	EdgeViewers = "viewers"
-	// EdgeEditors holds the string denoting the editors edge name in mutations.
-	EdgeEditors = "editors"
-	// EdgeBlockedGroups holds the string denoting the blocked_groups edge name in mutations.
-	EdgeBlockedGroups = "blocked_groups"
+	// EdgePrograms holds the string denoting the programs edge name in mutations.
+	EdgePrograms = "programs"
 	// Table holds the table name of the risk in the database.
 	Table = "risks"
+	// OwnerTable is the table that holds the owner relation/edge.
+	OwnerTable = "risks"
+	// OwnerInverseTable is the table name for the Organization entity.
+	// It exists in this package in order to avoid circular dependency with the "organization" package.
+	OwnerInverseTable = "organizations"
+	// OwnerColumn is the table column denoting the owner relation/edge.
+	OwnerColumn = "owner_id"
+	// BlockedGroupsTable is the table that holds the blocked_groups relation/edge. The primary key declared below.
+	BlockedGroupsTable = "risk_blocked_groups"
+	// BlockedGroupsInverseTable is the table name for the Group entity.
+	// It exists in this package in order to avoid circular dependency with the "group" package.
+	BlockedGroupsInverseTable = "groups"
+	// EditorsTable is the table that holds the editors relation/edge. The primary key declared below.
+	EditorsTable = "risk_editors"
+	// EditorsInverseTable is the table name for the Group entity.
+	// It exists in this package in order to avoid circular dependency with the "group" package.
+	EditorsInverseTable = "groups"
+	// ViewersTable is the table that holds the viewers relation/edge. The primary key declared below.
+	ViewersTable = "risk_viewers"
+	// ViewersInverseTable is the table name for the Group entity.
+	// It exists in this package in order to avoid circular dependency with the "group" package.
+	ViewersInverseTable = "groups"
 	// ControlTable is the table that holds the control relation/edge. The primary key declared below.
 	ControlTable = "control_risks"
 	// ControlInverseTable is the table name for the Control entity.
@@ -89,33 +111,11 @@ const (
 	// ActionplansInverseTable is the table name for the ActionPlan entity.
 	// It exists in this package in order to avoid circular dependency with the "actionplan" package.
 	ActionplansInverseTable = "action_plans"
-	// OwnerTable is the table that holds the owner relation/edge.
-	OwnerTable = "risks"
-	// OwnerInverseTable is the table name for the Organization entity.
-	// It exists in this package in order to avoid circular dependency with the "organization" package.
-	OwnerInverseTable = "organizations"
-	// OwnerColumn is the table column denoting the owner relation/edge.
-	OwnerColumn = "owner_id"
-	// ProgramTable is the table that holds the program relation/edge. The primary key declared below.
-	ProgramTable = "program_risks"
-	// ProgramInverseTable is the table name for the Program entity.
+	// ProgramsTable is the table that holds the programs relation/edge. The primary key declared below.
+	ProgramsTable = "program_risks"
+	// ProgramsInverseTable is the table name for the Program entity.
 	// It exists in this package in order to avoid circular dependency with the "program" package.
-	ProgramInverseTable = "programs"
-	// ViewersTable is the table that holds the viewers relation/edge. The primary key declared below.
-	ViewersTable = "risk_viewers"
-	// ViewersInverseTable is the table name for the Group entity.
-	// It exists in this package in order to avoid circular dependency with the "group" package.
-	ViewersInverseTable = "groups"
-	// EditorsTable is the table that holds the editors relation/edge. The primary key declared below.
-	EditorsTable = "risk_editors"
-	// EditorsInverseTable is the table name for the Group entity.
-	// It exists in this package in order to avoid circular dependency with the "group" package.
-	EditorsInverseTable = "groups"
-	// BlockedGroupsTable is the table that holds the blocked_groups relation/edge. The primary key declared below.
-	BlockedGroupsTable = "risk_blocked_groups"
-	// BlockedGroupsInverseTable is the table name for the Group entity.
-	// It exists in this package in order to avoid circular dependency with the "group" package.
-	BlockedGroupsInverseTable = "groups"
+	ProgramsInverseTable = "programs"
 )
 
 // Columns holds all SQL columns for risk fields.
@@ -129,6 +129,7 @@ var Columns = []string{
 	FieldDeletedBy,
 	FieldMappingID,
 	FieldTags,
+	FieldOwnerID,
 	FieldName,
 	FieldDescription,
 	FieldStatus,
@@ -139,7 +140,6 @@ var Columns = []string{
 	FieldMitigation,
 	FieldSatisfies,
 	FieldDetails,
-	FieldOwnerID,
 }
 
 // ForeignKeys holds the SQL foreign-keys that are owned by the "risks"
@@ -149,6 +149,15 @@ var ForeignKeys = []string{
 }
 
 var (
+	// BlockedGroupsPrimaryKey and BlockedGroupsColumn2 are the table columns denoting the
+	// primary key for the blocked_groups relation (M2M).
+	BlockedGroupsPrimaryKey = []string{"risk_id", "group_id"}
+	// EditorsPrimaryKey and EditorsColumn2 are the table columns denoting the
+	// primary key for the editors relation (M2M).
+	EditorsPrimaryKey = []string{"risk_id", "group_id"}
+	// ViewersPrimaryKey and ViewersColumn2 are the table columns denoting the
+	// primary key for the viewers relation (M2M).
+	ViewersPrimaryKey = []string{"risk_id", "group_id"}
 	// ControlPrimaryKey and ControlColumn2 are the table columns denoting the
 	// primary key for the control relation (M2M).
 	ControlPrimaryKey = []string{"control_id", "risk_id"}
@@ -158,18 +167,9 @@ var (
 	// ActionplansPrimaryKey and ActionplansColumn2 are the table columns denoting the
 	// primary key for the actionplans relation (M2M).
 	ActionplansPrimaryKey = []string{"risk_id", "action_plan_id"}
-	// ProgramPrimaryKey and ProgramColumn2 are the table columns denoting the
-	// primary key for the program relation (M2M).
-	ProgramPrimaryKey = []string{"program_id", "risk_id"}
-	// ViewersPrimaryKey and ViewersColumn2 are the table columns denoting the
-	// primary key for the viewers relation (M2M).
-	ViewersPrimaryKey = []string{"risk_id", "group_id"}
-	// EditorsPrimaryKey and EditorsColumn2 are the table columns denoting the
-	// primary key for the editors relation (M2M).
-	EditorsPrimaryKey = []string{"risk_id", "group_id"}
-	// BlockedGroupsPrimaryKey and BlockedGroupsColumn2 are the table columns denoting the
-	// primary key for the blocked_groups relation (M2M).
-	BlockedGroupsPrimaryKey = []string{"risk_id", "group_id"}
+	// ProgramsPrimaryKey and ProgramsColumn2 are the table columns denoting the
+	// primary key for the programs relation (M2M).
+	ProgramsPrimaryKey = []string{"program_id", "risk_id"}
 )
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -194,7 +194,7 @@ func ValidColumn(column string) bool {
 //	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
 	Hooks        [9]ent.Hook
-	Interceptors [3]ent.Interceptor
+	Interceptors [2]ent.Interceptor
 	Policy       ent.Policy
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
@@ -206,10 +206,10 @@ var (
 	DefaultMappingID func() string
 	// DefaultTags holds the default value on creation for the "tags" field.
 	DefaultTags []string
-	// NameValidator is a validator for the "name" field. It is called by the builders before save.
-	NameValidator func(string) error
 	// OwnerIDValidator is a validator for the "owner_id" field. It is called by the builders before save.
 	OwnerIDValidator func(string) error
+	// NameValidator is a validator for the "name" field. It is called by the builders before save.
+	NameValidator func(string) error
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() string
 )
@@ -281,6 +281,11 @@ func ByMappingID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldMappingID, opts...).ToFunc()
 }
 
+// ByOwnerID orders the results by the owner_id field.
+func ByOwnerID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldOwnerID, opts...).ToFunc()
+}
+
 // ByName orders the results by the name field.
 func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
@@ -326,9 +331,53 @@ func BySatisfies(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldSatisfies, opts...).ToFunc()
 }
 
-// ByOwnerID orders the results by the owner_id field.
-func ByOwnerID(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldOwnerID, opts...).ToFunc()
+// ByOwnerField orders the results by owner field.
+func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByBlockedGroupsCount orders the results by blocked_groups count.
+func ByBlockedGroupsCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newBlockedGroupsStep(), opts...)
+	}
+}
+
+// ByBlockedGroups orders the results by blocked_groups terms.
+func ByBlockedGroups(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newBlockedGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByEditorsCount orders the results by editors count.
+func ByEditorsCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newEditorsStep(), opts...)
+	}
+}
+
+// ByEditors orders the results by editors terms.
+func ByEditors(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newEditorsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
+// ByViewersCount orders the results by viewers count.
+func ByViewersCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newViewersStep(), opts...)
+	}
+}
+
+// ByViewers orders the results by viewers terms.
+func ByViewers(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newViewersStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
 }
 
 // ByControlCount orders the results by control count.
@@ -373,67 +422,46 @@ func ByActionplans(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	}
 }
 
-// ByOwnerField orders the results by owner field.
-func ByOwnerField(field string, opts ...sql.OrderTermOption) OrderOption {
+// ByProgramsCount orders the results by programs count.
+func ByProgramsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborTerms(s, newOwnerStep(), sql.OrderByField(field, opts...))
+		sqlgraph.OrderByNeighborsCount(s, newProgramsStep(), opts...)
 	}
 }
 
-// ByProgramCount orders the results by program count.
-func ByProgramCount(opts ...sql.OrderTermOption) OrderOption {
+// ByPrograms orders the results by programs terms.
+func ByPrograms(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborsCount(s, newProgramStep(), opts...)
+		sqlgraph.OrderByNeighborTerms(s, newProgramsStep(), append([]sql.OrderTerm{term}, terms...)...)
 	}
 }
-
-// ByProgram orders the results by program terms.
-func ByProgram(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
-	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborTerms(s, newProgramStep(), append([]sql.OrderTerm{term}, terms...)...)
-	}
+func newOwnerStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(OwnerInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
+	)
 }
-
-// ByViewersCount orders the results by viewers count.
-func ByViewersCount(opts ...sql.OrderTermOption) OrderOption {
-	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborsCount(s, newViewersStep(), opts...)
-	}
+func newBlockedGroupsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(BlockedGroupsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, BlockedGroupsTable, BlockedGroupsPrimaryKey...),
+	)
 }
-
-// ByViewers orders the results by viewers terms.
-func ByViewers(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
-	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborTerms(s, newViewersStep(), append([]sql.OrderTerm{term}, terms...)...)
-	}
+func newEditorsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(EditorsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, EditorsTable, EditorsPrimaryKey...),
+	)
 }
-
-// ByEditorsCount orders the results by editors count.
-func ByEditorsCount(opts ...sql.OrderTermOption) OrderOption {
-	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborsCount(s, newEditorsStep(), opts...)
-	}
-}
-
-// ByEditors orders the results by editors terms.
-func ByEditors(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
-	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborTerms(s, newEditorsStep(), append([]sql.OrderTerm{term}, terms...)...)
-	}
-}
-
-// ByBlockedGroupsCount orders the results by blocked_groups count.
-func ByBlockedGroupsCount(opts ...sql.OrderTermOption) OrderOption {
-	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborsCount(s, newBlockedGroupsStep(), opts...)
-	}
-}
-
-// ByBlockedGroups orders the results by blocked_groups terms.
-func ByBlockedGroups(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
-	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborTerms(s, newBlockedGroupsStep(), append([]sql.OrderTerm{term}, terms...)...)
-	}
+func newViewersStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(ViewersInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, false, ViewersTable, ViewersPrimaryKey...),
+	)
 }
 func newControlStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
@@ -456,39 +484,11 @@ func newActionplansStep() *sqlgraph.Step {
 		sqlgraph.Edge(sqlgraph.M2M, false, ActionplansTable, ActionplansPrimaryKey...),
 	)
 }
-func newOwnerStep() *sqlgraph.Step {
+func newProgramsStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
-		sqlgraph.To(OwnerInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
-	)
-}
-func newProgramStep() *sqlgraph.Step {
-	return sqlgraph.NewStep(
-		sqlgraph.From(Table, FieldID),
-		sqlgraph.To(ProgramInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.M2M, true, ProgramTable, ProgramPrimaryKey...),
-	)
-}
-func newViewersStep() *sqlgraph.Step {
-	return sqlgraph.NewStep(
-		sqlgraph.From(Table, FieldID),
-		sqlgraph.To(ViewersInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.M2M, false, ViewersTable, ViewersPrimaryKey...),
-	)
-}
-func newEditorsStep() *sqlgraph.Step {
-	return sqlgraph.NewStep(
-		sqlgraph.From(Table, FieldID),
-		sqlgraph.To(EditorsInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.M2M, false, EditorsTable, EditorsPrimaryKey...),
-	)
-}
-func newBlockedGroupsStep() *sqlgraph.Step {
-	return sqlgraph.NewStep(
-		sqlgraph.From(Table, FieldID),
-		sqlgraph.To(BlockedGroupsInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.M2M, false, BlockedGroupsTable, BlockedGroupsPrimaryKey...),
+		sqlgraph.To(ProgramsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2M, true, ProgramsTable, ProgramsPrimaryKey...),
 	)
 }
 

--- a/internal/ent/generated/risk/where.go
+++ b/internal/ent/generated/risk/where.go
@@ -103,6 +103,11 @@ func MappingID(v string) predicate.Risk {
 	return predicate.Risk(sql.FieldEQ(FieldMappingID, v))
 }
 
+// OwnerID applies equality check predicate on the "owner_id" field. It's identical to OwnerIDEQ.
+func OwnerID(v string) predicate.Risk {
+	return predicate.Risk(sql.FieldEQ(FieldOwnerID, v))
+}
+
 // Name applies equality check predicate on the "name" field. It's identical to NameEQ.
 func Name(v string) predicate.Risk {
 	return predicate.Risk(sql.FieldEQ(FieldName, v))
@@ -136,11 +141,6 @@ func Mitigation(v string) predicate.Risk {
 // Satisfies applies equality check predicate on the "satisfies" field. It's identical to SatisfiesEQ.
 func Satisfies(v string) predicate.Risk {
 	return predicate.Risk(sql.FieldEQ(FieldSatisfies, v))
-}
-
-// OwnerID applies equality check predicate on the "owner_id" field. It's identical to OwnerIDEQ.
-func OwnerID(v string) predicate.Risk {
-	return predicate.Risk(sql.FieldEQ(FieldOwnerID, v))
 }
 
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
@@ -591,6 +591,71 @@ func TagsIsNil() predicate.Risk {
 // TagsNotNil applies the NotNil predicate on the "tags" field.
 func TagsNotNil() predicate.Risk {
 	return predicate.Risk(sql.FieldNotNull(FieldTags))
+}
+
+// OwnerIDEQ applies the EQ predicate on the "owner_id" field.
+func OwnerIDEQ(v string) predicate.Risk {
+	return predicate.Risk(sql.FieldEQ(FieldOwnerID, v))
+}
+
+// OwnerIDNEQ applies the NEQ predicate on the "owner_id" field.
+func OwnerIDNEQ(v string) predicate.Risk {
+	return predicate.Risk(sql.FieldNEQ(FieldOwnerID, v))
+}
+
+// OwnerIDIn applies the In predicate on the "owner_id" field.
+func OwnerIDIn(vs ...string) predicate.Risk {
+	return predicate.Risk(sql.FieldIn(FieldOwnerID, vs...))
+}
+
+// OwnerIDNotIn applies the NotIn predicate on the "owner_id" field.
+func OwnerIDNotIn(vs ...string) predicate.Risk {
+	return predicate.Risk(sql.FieldNotIn(FieldOwnerID, vs...))
+}
+
+// OwnerIDGT applies the GT predicate on the "owner_id" field.
+func OwnerIDGT(v string) predicate.Risk {
+	return predicate.Risk(sql.FieldGT(FieldOwnerID, v))
+}
+
+// OwnerIDGTE applies the GTE predicate on the "owner_id" field.
+func OwnerIDGTE(v string) predicate.Risk {
+	return predicate.Risk(sql.FieldGTE(FieldOwnerID, v))
+}
+
+// OwnerIDLT applies the LT predicate on the "owner_id" field.
+func OwnerIDLT(v string) predicate.Risk {
+	return predicate.Risk(sql.FieldLT(FieldOwnerID, v))
+}
+
+// OwnerIDLTE applies the LTE predicate on the "owner_id" field.
+func OwnerIDLTE(v string) predicate.Risk {
+	return predicate.Risk(sql.FieldLTE(FieldOwnerID, v))
+}
+
+// OwnerIDContains applies the Contains predicate on the "owner_id" field.
+func OwnerIDContains(v string) predicate.Risk {
+	return predicate.Risk(sql.FieldContains(FieldOwnerID, v))
+}
+
+// OwnerIDHasPrefix applies the HasPrefix predicate on the "owner_id" field.
+func OwnerIDHasPrefix(v string) predicate.Risk {
+	return predicate.Risk(sql.FieldHasPrefix(FieldOwnerID, v))
+}
+
+// OwnerIDHasSuffix applies the HasSuffix predicate on the "owner_id" field.
+func OwnerIDHasSuffix(v string) predicate.Risk {
+	return predicate.Risk(sql.FieldHasSuffix(FieldOwnerID, v))
+}
+
+// OwnerIDEqualFold applies the EqualFold predicate on the "owner_id" field.
+func OwnerIDEqualFold(v string) predicate.Risk {
+	return predicate.Risk(sql.FieldEqualFold(FieldOwnerID, v))
+}
+
+// OwnerIDContainsFold applies the ContainsFold predicate on the "owner_id" field.
+func OwnerIDContainsFold(v string) predicate.Risk {
+	return predicate.Risk(sql.FieldContainsFold(FieldOwnerID, v))
 }
 
 // NameEQ applies the EQ predicate on the "name" field.
@@ -1198,69 +1263,120 @@ func DetailsNotNil() predicate.Risk {
 	return predicate.Risk(sql.FieldNotNull(FieldDetails))
 }
 
-// OwnerIDEQ applies the EQ predicate on the "owner_id" field.
-func OwnerIDEQ(v string) predicate.Risk {
-	return predicate.Risk(sql.FieldEQ(FieldOwnerID, v))
+// HasOwner applies the HasEdge predicate on the "owner" edge.
+func HasOwner() predicate.Risk {
+	return predicate.Risk(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
+		)
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Organization
+		step.Edge.Schema = schemaConfig.Risk
+		sqlgraph.HasNeighbors(s, step)
+	})
 }
 
-// OwnerIDNEQ applies the NEQ predicate on the "owner_id" field.
-func OwnerIDNEQ(v string) predicate.Risk {
-	return predicate.Risk(sql.FieldNEQ(FieldOwnerID, v))
+// HasOwnerWith applies the HasEdge predicate on the "owner" edge with a given conditions (other predicates).
+func HasOwnerWith(preds ...predicate.Organization) predicate.Risk {
+	return predicate.Risk(func(s *sql.Selector) {
+		step := newOwnerStep()
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Organization
+		step.Edge.Schema = schemaConfig.Risk
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
 }
 
-// OwnerIDIn applies the In predicate on the "owner_id" field.
-func OwnerIDIn(vs ...string) predicate.Risk {
-	return predicate.Risk(sql.FieldIn(FieldOwnerID, vs...))
+// HasBlockedGroups applies the HasEdge predicate on the "blocked_groups" edge.
+func HasBlockedGroups() predicate.Risk {
+	return predicate.Risk(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, BlockedGroupsTable, BlockedGroupsPrimaryKey...),
+		)
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.RiskBlockedGroups
+		sqlgraph.HasNeighbors(s, step)
+	})
 }
 
-// OwnerIDNotIn applies the NotIn predicate on the "owner_id" field.
-func OwnerIDNotIn(vs ...string) predicate.Risk {
-	return predicate.Risk(sql.FieldNotIn(FieldOwnerID, vs...))
+// HasBlockedGroupsWith applies the HasEdge predicate on the "blocked_groups" edge with a given conditions (other predicates).
+func HasBlockedGroupsWith(preds ...predicate.Group) predicate.Risk {
+	return predicate.Risk(func(s *sql.Selector) {
+		step := newBlockedGroupsStep()
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.RiskBlockedGroups
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
 }
 
-// OwnerIDGT applies the GT predicate on the "owner_id" field.
-func OwnerIDGT(v string) predicate.Risk {
-	return predicate.Risk(sql.FieldGT(FieldOwnerID, v))
+// HasEditors applies the HasEdge predicate on the "editors" edge.
+func HasEditors() predicate.Risk {
+	return predicate.Risk(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, EditorsTable, EditorsPrimaryKey...),
+		)
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.RiskEditors
+		sqlgraph.HasNeighbors(s, step)
+	})
 }
 
-// OwnerIDGTE applies the GTE predicate on the "owner_id" field.
-func OwnerIDGTE(v string) predicate.Risk {
-	return predicate.Risk(sql.FieldGTE(FieldOwnerID, v))
+// HasEditorsWith applies the HasEdge predicate on the "editors" edge with a given conditions (other predicates).
+func HasEditorsWith(preds ...predicate.Group) predicate.Risk {
+	return predicate.Risk(func(s *sql.Selector) {
+		step := newEditorsStep()
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.RiskEditors
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
 }
 
-// OwnerIDLT applies the LT predicate on the "owner_id" field.
-func OwnerIDLT(v string) predicate.Risk {
-	return predicate.Risk(sql.FieldLT(FieldOwnerID, v))
+// HasViewers applies the HasEdge predicate on the "viewers" edge.
+func HasViewers() predicate.Risk {
+	return predicate.Risk(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2M, false, ViewersTable, ViewersPrimaryKey...),
+		)
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.RiskViewers
+		sqlgraph.HasNeighbors(s, step)
+	})
 }
 
-// OwnerIDLTE applies the LTE predicate on the "owner_id" field.
-func OwnerIDLTE(v string) predicate.Risk {
-	return predicate.Risk(sql.FieldLTE(FieldOwnerID, v))
-}
-
-// OwnerIDContains applies the Contains predicate on the "owner_id" field.
-func OwnerIDContains(v string) predicate.Risk {
-	return predicate.Risk(sql.FieldContains(FieldOwnerID, v))
-}
-
-// OwnerIDHasPrefix applies the HasPrefix predicate on the "owner_id" field.
-func OwnerIDHasPrefix(v string) predicate.Risk {
-	return predicate.Risk(sql.FieldHasPrefix(FieldOwnerID, v))
-}
-
-// OwnerIDHasSuffix applies the HasSuffix predicate on the "owner_id" field.
-func OwnerIDHasSuffix(v string) predicate.Risk {
-	return predicate.Risk(sql.FieldHasSuffix(FieldOwnerID, v))
-}
-
-// OwnerIDEqualFold applies the EqualFold predicate on the "owner_id" field.
-func OwnerIDEqualFold(v string) predicate.Risk {
-	return predicate.Risk(sql.FieldEqualFold(FieldOwnerID, v))
-}
-
-// OwnerIDContainsFold applies the ContainsFold predicate on the "owner_id" field.
-func OwnerIDContainsFold(v string) predicate.Risk {
-	return predicate.Risk(sql.FieldContainsFold(FieldOwnerID, v))
+// HasViewersWith applies the HasEdge predicate on the "viewers" edge with a given conditions (other predicates).
+func HasViewersWith(preds ...predicate.Group) predicate.Risk {
+	return predicate.Risk(func(s *sql.Selector) {
+		step := newViewersStep()
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Group
+		step.Edge.Schema = schemaConfig.RiskViewers
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
 }
 
 // HasControl applies the HasEdge predicate on the "control" edge.
@@ -1350,41 +1466,12 @@ func HasActionplansWith(preds ...predicate.ActionPlan) predicate.Risk {
 	})
 }
 
-// HasOwner applies the HasEdge predicate on the "owner" edge.
-func HasOwner() predicate.Risk {
+// HasPrograms applies the HasEdge predicate on the "programs" edge.
+func HasPrograms() predicate.Risk {
 	return predicate.Risk(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
-		)
-		schemaConfig := internal.SchemaConfigFromContext(s.Context())
-		step.To.Schema = schemaConfig.Organization
-		step.Edge.Schema = schemaConfig.Risk
-		sqlgraph.HasNeighbors(s, step)
-	})
-}
-
-// HasOwnerWith applies the HasEdge predicate on the "owner" edge with a given conditions (other predicates).
-func HasOwnerWith(preds ...predicate.Organization) predicate.Risk {
-	return predicate.Risk(func(s *sql.Selector) {
-		step := newOwnerStep()
-		schemaConfig := internal.SchemaConfigFromContext(s.Context())
-		step.To.Schema = schemaConfig.Organization
-		step.Edge.Schema = schemaConfig.Risk
-		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
-			for _, p := range preds {
-				p(s)
-			}
-		})
-	})
-}
-
-// HasProgram applies the HasEdge predicate on the "program" edge.
-func HasProgram() predicate.Risk {
-	return predicate.Risk(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, true, ProgramTable, ProgramPrimaryKey...),
+			sqlgraph.Edge(sqlgraph.M2M, true, ProgramsTable, ProgramsPrimaryKey...),
 		)
 		schemaConfig := internal.SchemaConfigFromContext(s.Context())
 		step.To.Schema = schemaConfig.Program
@@ -1393,100 +1480,13 @@ func HasProgram() predicate.Risk {
 	})
 }
 
-// HasProgramWith applies the HasEdge predicate on the "program" edge with a given conditions (other predicates).
-func HasProgramWith(preds ...predicate.Program) predicate.Risk {
+// HasProgramsWith applies the HasEdge predicate on the "programs" edge with a given conditions (other predicates).
+func HasProgramsWith(preds ...predicate.Program) predicate.Risk {
 	return predicate.Risk(func(s *sql.Selector) {
-		step := newProgramStep()
+		step := newProgramsStep()
 		schemaConfig := internal.SchemaConfigFromContext(s.Context())
 		step.To.Schema = schemaConfig.Program
 		step.Edge.Schema = schemaConfig.ProgramRisks
-		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
-			for _, p := range preds {
-				p(s)
-			}
-		})
-	})
-}
-
-// HasViewers applies the HasEdge predicate on the "viewers" edge.
-func HasViewers() predicate.Risk {
-	return predicate.Risk(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, ViewersTable, ViewersPrimaryKey...),
-		)
-		schemaConfig := internal.SchemaConfigFromContext(s.Context())
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.RiskViewers
-		sqlgraph.HasNeighbors(s, step)
-	})
-}
-
-// HasViewersWith applies the HasEdge predicate on the "viewers" edge with a given conditions (other predicates).
-func HasViewersWith(preds ...predicate.Group) predicate.Risk {
-	return predicate.Risk(func(s *sql.Selector) {
-		step := newViewersStep()
-		schemaConfig := internal.SchemaConfigFromContext(s.Context())
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.RiskViewers
-		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
-			for _, p := range preds {
-				p(s)
-			}
-		})
-	})
-}
-
-// HasEditors applies the HasEdge predicate on the "editors" edge.
-func HasEditors() predicate.Risk {
-	return predicate.Risk(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, EditorsTable, EditorsPrimaryKey...),
-		)
-		schemaConfig := internal.SchemaConfigFromContext(s.Context())
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.RiskEditors
-		sqlgraph.HasNeighbors(s, step)
-	})
-}
-
-// HasEditorsWith applies the HasEdge predicate on the "editors" edge with a given conditions (other predicates).
-func HasEditorsWith(preds ...predicate.Group) predicate.Risk {
-	return predicate.Risk(func(s *sql.Selector) {
-		step := newEditorsStep()
-		schemaConfig := internal.SchemaConfigFromContext(s.Context())
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.RiskEditors
-		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
-			for _, p := range preds {
-				p(s)
-			}
-		})
-	})
-}
-
-// HasBlockedGroups applies the HasEdge predicate on the "blocked_groups" edge.
-func HasBlockedGroups() predicate.Risk {
-	return predicate.Risk(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, BlockedGroupsTable, BlockedGroupsPrimaryKey...),
-		)
-		schemaConfig := internal.SchemaConfigFromContext(s.Context())
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.RiskBlockedGroups
-		sqlgraph.HasNeighbors(s, step)
-	})
-}
-
-// HasBlockedGroupsWith applies the HasEdge predicate on the "blocked_groups" edge with a given conditions (other predicates).
-func HasBlockedGroupsWith(preds ...predicate.Group) predicate.Risk {
-	return predicate.Risk(func(s *sql.Selector) {
-		step := newBlockedGroupsStep()
-		schemaConfig := internal.SchemaConfigFromContext(s.Context())
-		step.To.Schema = schemaConfig.Group
-		step.Edge.Schema = schemaConfig.RiskBlockedGroups
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/internal/ent/generated/risk_create.go
+++ b/internal/ent/generated/risk_create.go
@@ -131,6 +131,12 @@ func (rc *RiskCreate) SetTags(s []string) *RiskCreate {
 	return rc
 }
 
+// SetOwnerID sets the "owner_id" field.
+func (rc *RiskCreate) SetOwnerID(s string) *RiskCreate {
+	rc.mutation.SetOwnerID(s)
+	return rc
+}
+
 // SetName sets the "name" field.
 func (rc *RiskCreate) SetName(s string) *RiskCreate {
 	rc.mutation.SetName(s)
@@ -255,12 +261,6 @@ func (rc *RiskCreate) SetDetails(m map[string]interface{}) *RiskCreate {
 	return rc
 }
 
-// SetOwnerID sets the "owner_id" field.
-func (rc *RiskCreate) SetOwnerID(s string) *RiskCreate {
-	rc.mutation.SetOwnerID(s)
-	return rc
-}
-
 // SetID sets the "id" field.
 func (rc *RiskCreate) SetID(s string) *RiskCreate {
 	rc.mutation.SetID(s)
@@ -273,6 +273,56 @@ func (rc *RiskCreate) SetNillableID(s *string) *RiskCreate {
 		rc.SetID(*s)
 	}
 	return rc
+}
+
+// SetOwner sets the "owner" edge to the Organization entity.
+func (rc *RiskCreate) SetOwner(o *Organization) *RiskCreate {
+	return rc.SetOwnerID(o.ID)
+}
+
+// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
+func (rc *RiskCreate) AddBlockedGroupIDs(ids ...string) *RiskCreate {
+	rc.mutation.AddBlockedGroupIDs(ids...)
+	return rc
+}
+
+// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
+func (rc *RiskCreate) AddBlockedGroups(g ...*Group) *RiskCreate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return rc.AddBlockedGroupIDs(ids...)
+}
+
+// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
+func (rc *RiskCreate) AddEditorIDs(ids ...string) *RiskCreate {
+	rc.mutation.AddEditorIDs(ids...)
+	return rc
+}
+
+// AddEditors adds the "editors" edges to the Group entity.
+func (rc *RiskCreate) AddEditors(g ...*Group) *RiskCreate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return rc.AddEditorIDs(ids...)
+}
+
+// AddViewerIDs adds the "viewers" edge to the Group entity by IDs.
+func (rc *RiskCreate) AddViewerIDs(ids ...string) *RiskCreate {
+	rc.mutation.AddViewerIDs(ids...)
+	return rc
+}
+
+// AddViewers adds the "viewers" edges to the Group entity.
+func (rc *RiskCreate) AddViewers(g ...*Group) *RiskCreate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return rc.AddViewerIDs(ids...)
 }
 
 // AddControlIDs adds the "control" edge to the Control entity by IDs.
@@ -320,69 +370,19 @@ func (rc *RiskCreate) AddActionplans(a ...*ActionPlan) *RiskCreate {
 	return rc.AddActionplanIDs(ids...)
 }
 
-// SetOwner sets the "owner" edge to the Organization entity.
-func (rc *RiskCreate) SetOwner(o *Organization) *RiskCreate {
-	return rc.SetOwnerID(o.ID)
-}
-
-// AddProgramIDs adds the "program" edge to the Program entity by IDs.
+// AddProgramIDs adds the "programs" edge to the Program entity by IDs.
 func (rc *RiskCreate) AddProgramIDs(ids ...string) *RiskCreate {
 	rc.mutation.AddProgramIDs(ids...)
 	return rc
 }
 
-// AddProgram adds the "program" edges to the Program entity.
-func (rc *RiskCreate) AddProgram(p ...*Program) *RiskCreate {
+// AddPrograms adds the "programs" edges to the Program entity.
+func (rc *RiskCreate) AddPrograms(p ...*Program) *RiskCreate {
 	ids := make([]string, len(p))
 	for i := range p {
 		ids[i] = p[i].ID
 	}
 	return rc.AddProgramIDs(ids...)
-}
-
-// AddViewerIDs adds the "viewers" edge to the Group entity by IDs.
-func (rc *RiskCreate) AddViewerIDs(ids ...string) *RiskCreate {
-	rc.mutation.AddViewerIDs(ids...)
-	return rc
-}
-
-// AddViewers adds the "viewers" edges to the Group entity.
-func (rc *RiskCreate) AddViewers(g ...*Group) *RiskCreate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return rc.AddViewerIDs(ids...)
-}
-
-// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
-func (rc *RiskCreate) AddEditorIDs(ids ...string) *RiskCreate {
-	rc.mutation.AddEditorIDs(ids...)
-	return rc
-}
-
-// AddEditors adds the "editors" edges to the Group entity.
-func (rc *RiskCreate) AddEditors(g ...*Group) *RiskCreate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return rc.AddEditorIDs(ids...)
-}
-
-// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
-func (rc *RiskCreate) AddBlockedGroupIDs(ids ...string) *RiskCreate {
-	rc.mutation.AddBlockedGroupIDs(ids...)
-	return rc
-}
-
-// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
-func (rc *RiskCreate) AddBlockedGroups(g ...*Group) *RiskCreate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return rc.AddBlockedGroupIDs(ids...)
 }
 
 // Mutation returns the RiskMutation object of the builder.
@@ -470,6 +470,14 @@ func (rc *RiskCreate) check() error {
 	if _, ok := rc.mutation.MappingID(); !ok {
 		return &ValidationError{Name: "mapping_id", err: errors.New(`generated: missing required field "Risk.mapping_id"`)}
 	}
+	if _, ok := rc.mutation.OwnerID(); !ok {
+		return &ValidationError{Name: "owner_id", err: errors.New(`generated: missing required field "Risk.owner_id"`)}
+	}
+	if v, ok := rc.mutation.OwnerID(); ok {
+		if err := risk.OwnerIDValidator(v); err != nil {
+			return &ValidationError{Name: "owner_id", err: fmt.Errorf(`generated: validator failed for field "Risk.owner_id": %w`, err)}
+		}
+	}
 	if _, ok := rc.mutation.Name(); !ok {
 		return &ValidationError{Name: "name", err: errors.New(`generated: missing required field "Risk.name"`)}
 	}
@@ -486,14 +494,6 @@ func (rc *RiskCreate) check() error {
 	if v, ok := rc.mutation.Likelihood(); ok {
 		if err := risk.LikelihoodValidator(v); err != nil {
 			return &ValidationError{Name: "likelihood", err: fmt.Errorf(`generated: validator failed for field "Risk.likelihood": %w`, err)}
-		}
-	}
-	if _, ok := rc.mutation.OwnerID(); !ok {
-		return &ValidationError{Name: "owner_id", err: errors.New(`generated: missing required field "Risk.owner_id"`)}
-	}
-	if v, ok := rc.mutation.OwnerID(); ok {
-		if err := risk.OwnerIDValidator(v); err != nil {
-			return &ValidationError{Name: "owner_id", err: fmt.Errorf(`generated: validator failed for field "Risk.owner_id": %w`, err)}
 		}
 	}
 	if len(rc.mutation.OwnerIDs()) == 0 {
@@ -607,6 +607,75 @@ func (rc *RiskCreate) createSpec() (*Risk, *sqlgraph.CreateSpec) {
 		_spec.SetField(risk.FieldDetails, field.TypeJSON, value)
 		_node.Details = value
 	}
+	if nodes := rc.mutation.OwnerIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   risk.OwnerTable,
+			Columns: []string{risk.OwnerColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(organization.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = rc.schemaConfig.Risk
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_node.OwnerID = nodes[0]
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := rc.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   risk.BlockedGroupsTable,
+			Columns: risk.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = rc.schemaConfig.RiskBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := rc.mutation.EditorsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   risk.EditorsTable,
+			Columns: risk.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = rc.schemaConfig.RiskEditors
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := rc.mutation.ViewersIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   risk.ViewersTable,
+			Columns: risk.ViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = rc.schemaConfig.RiskViewers
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
 	if nodes := rc.mutation.ControlIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2M,
@@ -658,87 +727,18 @@ func (rc *RiskCreate) createSpec() (*Risk, *sqlgraph.CreateSpec) {
 		}
 		_spec.Edges = append(_spec.Edges, edge)
 	}
-	if nodes := rc.mutation.OwnerIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: true,
-			Table:   risk.OwnerTable,
-			Columns: []string{risk.OwnerColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(organization.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = rc.schemaConfig.Risk
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_node.OwnerID = nodes[0]
-		_spec.Edges = append(_spec.Edges, edge)
-	}
-	if nodes := rc.mutation.ProgramIDs(); len(nodes) > 0 {
+	if nodes := rc.mutation.ProgramsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2M,
 			Inverse: true,
-			Table:   risk.ProgramTable,
-			Columns: risk.ProgramPrimaryKey,
+			Table:   risk.ProgramsTable,
+			Columns: risk.ProgramsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(program.FieldID, field.TypeString),
 			},
 		}
 		edge.Schema = rc.schemaConfig.ProgramRisks
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges = append(_spec.Edges, edge)
-	}
-	if nodes := rc.mutation.ViewersIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   risk.ViewersTable,
-			Columns: risk.ViewersPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = rc.schemaConfig.RiskViewers
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges = append(_spec.Edges, edge)
-	}
-	if nodes := rc.mutation.EditorsIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   risk.EditorsTable,
-			Columns: risk.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = rc.schemaConfig.RiskEditors
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges = append(_spec.Edges, edge)
-	}
-	if nodes := rc.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   risk.BlockedGroupsTable,
-			Columns: risk.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = rc.schemaConfig.RiskBlockedGroups
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}

--- a/internal/ent/generated/risk_update.go
+++ b/internal/ent/generated/risk_update.go
@@ -129,6 +129,20 @@ func (ru *RiskUpdate) ClearTags() *RiskUpdate {
 	return ru
 }
 
+// SetOwnerID sets the "owner_id" field.
+func (ru *RiskUpdate) SetOwnerID(s string) *RiskUpdate {
+	ru.mutation.SetOwnerID(s)
+	return ru
+}
+
+// SetNillableOwnerID sets the "owner_id" field if the given value is not nil.
+func (ru *RiskUpdate) SetNillableOwnerID(s *string) *RiskUpdate {
+	if s != nil {
+		ru.SetOwnerID(*s)
+	}
+	return ru
+}
+
 // SetName sets the "name" field.
 func (ru *RiskUpdate) SetName(s string) *RiskUpdate {
 	ru.mutation.SetName(s)
@@ -315,18 +329,54 @@ func (ru *RiskUpdate) ClearDetails() *RiskUpdate {
 	return ru
 }
 
-// SetOwnerID sets the "owner_id" field.
-func (ru *RiskUpdate) SetOwnerID(s string) *RiskUpdate {
-	ru.mutation.SetOwnerID(s)
+// SetOwner sets the "owner" edge to the Organization entity.
+func (ru *RiskUpdate) SetOwner(o *Organization) *RiskUpdate {
+	return ru.SetOwnerID(o.ID)
+}
+
+// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
+func (ru *RiskUpdate) AddBlockedGroupIDs(ids ...string) *RiskUpdate {
+	ru.mutation.AddBlockedGroupIDs(ids...)
 	return ru
 }
 
-// SetNillableOwnerID sets the "owner_id" field if the given value is not nil.
-func (ru *RiskUpdate) SetNillableOwnerID(s *string) *RiskUpdate {
-	if s != nil {
-		ru.SetOwnerID(*s)
+// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
+func (ru *RiskUpdate) AddBlockedGroups(g ...*Group) *RiskUpdate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
 	}
+	return ru.AddBlockedGroupIDs(ids...)
+}
+
+// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
+func (ru *RiskUpdate) AddEditorIDs(ids ...string) *RiskUpdate {
+	ru.mutation.AddEditorIDs(ids...)
 	return ru
+}
+
+// AddEditors adds the "editors" edges to the Group entity.
+func (ru *RiskUpdate) AddEditors(g ...*Group) *RiskUpdate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return ru.AddEditorIDs(ids...)
+}
+
+// AddViewerIDs adds the "viewers" edge to the Group entity by IDs.
+func (ru *RiskUpdate) AddViewerIDs(ids ...string) *RiskUpdate {
+	ru.mutation.AddViewerIDs(ids...)
+	return ru
+}
+
+// AddViewers adds the "viewers" edges to the Group entity.
+func (ru *RiskUpdate) AddViewers(g ...*Group) *RiskUpdate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return ru.AddViewerIDs(ids...)
 }
 
 // AddControlIDs adds the "control" edge to the Control entity by IDs.
@@ -374,19 +424,14 @@ func (ru *RiskUpdate) AddActionplans(a ...*ActionPlan) *RiskUpdate {
 	return ru.AddActionplanIDs(ids...)
 }
 
-// SetOwner sets the "owner" edge to the Organization entity.
-func (ru *RiskUpdate) SetOwner(o *Organization) *RiskUpdate {
-	return ru.SetOwnerID(o.ID)
-}
-
-// AddProgramIDs adds the "program" edge to the Program entity by IDs.
+// AddProgramIDs adds the "programs" edge to the Program entity by IDs.
 func (ru *RiskUpdate) AddProgramIDs(ids ...string) *RiskUpdate {
 	ru.mutation.AddProgramIDs(ids...)
 	return ru
 }
 
-// AddProgram adds the "program" edges to the Program entity.
-func (ru *RiskUpdate) AddProgram(p ...*Program) *RiskUpdate {
+// AddPrograms adds the "programs" edges to the Program entity.
+func (ru *RiskUpdate) AddPrograms(p ...*Program) *RiskUpdate {
 	ids := make([]string, len(p))
 	for i := range p {
 		ids[i] = p[i].ID
@@ -394,54 +439,78 @@ func (ru *RiskUpdate) AddProgram(p ...*Program) *RiskUpdate {
 	return ru.AddProgramIDs(ids...)
 }
 
-// AddViewerIDs adds the "viewers" edge to the Group entity by IDs.
-func (ru *RiskUpdate) AddViewerIDs(ids ...string) *RiskUpdate {
-	ru.mutation.AddViewerIDs(ids...)
-	return ru
-}
-
-// AddViewers adds the "viewers" edges to the Group entity.
-func (ru *RiskUpdate) AddViewers(g ...*Group) *RiskUpdate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return ru.AddViewerIDs(ids...)
-}
-
-// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
-func (ru *RiskUpdate) AddEditorIDs(ids ...string) *RiskUpdate {
-	ru.mutation.AddEditorIDs(ids...)
-	return ru
-}
-
-// AddEditors adds the "editors" edges to the Group entity.
-func (ru *RiskUpdate) AddEditors(g ...*Group) *RiskUpdate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return ru.AddEditorIDs(ids...)
-}
-
-// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
-func (ru *RiskUpdate) AddBlockedGroupIDs(ids ...string) *RiskUpdate {
-	ru.mutation.AddBlockedGroupIDs(ids...)
-	return ru
-}
-
-// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
-func (ru *RiskUpdate) AddBlockedGroups(g ...*Group) *RiskUpdate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return ru.AddBlockedGroupIDs(ids...)
-}
-
 // Mutation returns the RiskMutation object of the builder.
 func (ru *RiskUpdate) Mutation() *RiskMutation {
 	return ru.mutation
+}
+
+// ClearOwner clears the "owner" edge to the Organization entity.
+func (ru *RiskUpdate) ClearOwner() *RiskUpdate {
+	ru.mutation.ClearOwner()
+	return ru
+}
+
+// ClearBlockedGroups clears all "blocked_groups" edges to the Group entity.
+func (ru *RiskUpdate) ClearBlockedGroups() *RiskUpdate {
+	ru.mutation.ClearBlockedGroups()
+	return ru
+}
+
+// RemoveBlockedGroupIDs removes the "blocked_groups" edge to Group entities by IDs.
+func (ru *RiskUpdate) RemoveBlockedGroupIDs(ids ...string) *RiskUpdate {
+	ru.mutation.RemoveBlockedGroupIDs(ids...)
+	return ru
+}
+
+// RemoveBlockedGroups removes "blocked_groups" edges to Group entities.
+func (ru *RiskUpdate) RemoveBlockedGroups(g ...*Group) *RiskUpdate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return ru.RemoveBlockedGroupIDs(ids...)
+}
+
+// ClearEditors clears all "editors" edges to the Group entity.
+func (ru *RiskUpdate) ClearEditors() *RiskUpdate {
+	ru.mutation.ClearEditors()
+	return ru
+}
+
+// RemoveEditorIDs removes the "editors" edge to Group entities by IDs.
+func (ru *RiskUpdate) RemoveEditorIDs(ids ...string) *RiskUpdate {
+	ru.mutation.RemoveEditorIDs(ids...)
+	return ru
+}
+
+// RemoveEditors removes "editors" edges to Group entities.
+func (ru *RiskUpdate) RemoveEditors(g ...*Group) *RiskUpdate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return ru.RemoveEditorIDs(ids...)
+}
+
+// ClearViewers clears all "viewers" edges to the Group entity.
+func (ru *RiskUpdate) ClearViewers() *RiskUpdate {
+	ru.mutation.ClearViewers()
+	return ru
+}
+
+// RemoveViewerIDs removes the "viewers" edge to Group entities by IDs.
+func (ru *RiskUpdate) RemoveViewerIDs(ids ...string) *RiskUpdate {
+	ru.mutation.RemoveViewerIDs(ids...)
+	return ru
+}
+
+// RemoveViewers removes "viewers" edges to Group entities.
+func (ru *RiskUpdate) RemoveViewers(g ...*Group) *RiskUpdate {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return ru.RemoveViewerIDs(ids...)
 }
 
 // ClearControl clears all "control" edges to the Control entity.
@@ -507,94 +576,25 @@ func (ru *RiskUpdate) RemoveActionplans(a ...*ActionPlan) *RiskUpdate {
 	return ru.RemoveActionplanIDs(ids...)
 }
 
-// ClearOwner clears the "owner" edge to the Organization entity.
-func (ru *RiskUpdate) ClearOwner() *RiskUpdate {
-	ru.mutation.ClearOwner()
+// ClearPrograms clears all "programs" edges to the Program entity.
+func (ru *RiskUpdate) ClearPrograms() *RiskUpdate {
+	ru.mutation.ClearPrograms()
 	return ru
 }
 
-// ClearProgram clears all "program" edges to the Program entity.
-func (ru *RiskUpdate) ClearProgram() *RiskUpdate {
-	ru.mutation.ClearProgram()
-	return ru
-}
-
-// RemoveProgramIDs removes the "program" edge to Program entities by IDs.
+// RemoveProgramIDs removes the "programs" edge to Program entities by IDs.
 func (ru *RiskUpdate) RemoveProgramIDs(ids ...string) *RiskUpdate {
 	ru.mutation.RemoveProgramIDs(ids...)
 	return ru
 }
 
-// RemoveProgram removes "program" edges to Program entities.
-func (ru *RiskUpdate) RemoveProgram(p ...*Program) *RiskUpdate {
+// RemovePrograms removes "programs" edges to Program entities.
+func (ru *RiskUpdate) RemovePrograms(p ...*Program) *RiskUpdate {
 	ids := make([]string, len(p))
 	for i := range p {
 		ids[i] = p[i].ID
 	}
 	return ru.RemoveProgramIDs(ids...)
-}
-
-// ClearViewers clears all "viewers" edges to the Group entity.
-func (ru *RiskUpdate) ClearViewers() *RiskUpdate {
-	ru.mutation.ClearViewers()
-	return ru
-}
-
-// RemoveViewerIDs removes the "viewers" edge to Group entities by IDs.
-func (ru *RiskUpdate) RemoveViewerIDs(ids ...string) *RiskUpdate {
-	ru.mutation.RemoveViewerIDs(ids...)
-	return ru
-}
-
-// RemoveViewers removes "viewers" edges to Group entities.
-func (ru *RiskUpdate) RemoveViewers(g ...*Group) *RiskUpdate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return ru.RemoveViewerIDs(ids...)
-}
-
-// ClearEditors clears all "editors" edges to the Group entity.
-func (ru *RiskUpdate) ClearEditors() *RiskUpdate {
-	ru.mutation.ClearEditors()
-	return ru
-}
-
-// RemoveEditorIDs removes the "editors" edge to Group entities by IDs.
-func (ru *RiskUpdate) RemoveEditorIDs(ids ...string) *RiskUpdate {
-	ru.mutation.RemoveEditorIDs(ids...)
-	return ru
-}
-
-// RemoveEditors removes "editors" edges to Group entities.
-func (ru *RiskUpdate) RemoveEditors(g ...*Group) *RiskUpdate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return ru.RemoveEditorIDs(ids...)
-}
-
-// ClearBlockedGroups clears all "blocked_groups" edges to the Group entity.
-func (ru *RiskUpdate) ClearBlockedGroups() *RiskUpdate {
-	ru.mutation.ClearBlockedGroups()
-	return ru
-}
-
-// RemoveBlockedGroupIDs removes the "blocked_groups" edge to Group entities by IDs.
-func (ru *RiskUpdate) RemoveBlockedGroupIDs(ids ...string) *RiskUpdate {
-	ru.mutation.RemoveBlockedGroupIDs(ids...)
-	return ru
-}
-
-// RemoveBlockedGroups removes "blocked_groups" edges to Group entities.
-func (ru *RiskUpdate) RemoveBlockedGroups(g ...*Group) *RiskUpdate {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return ru.RemoveBlockedGroupIDs(ids...)
 }
 
 // Save executes the query and returns the number of nodes affected by the update operation.
@@ -641,6 +641,11 @@ func (ru *RiskUpdate) defaults() error {
 
 // check runs all checks and user-defined validators on the builder.
 func (ru *RiskUpdate) check() error {
+	if v, ok := ru.mutation.OwnerID(); ok {
+		if err := risk.OwnerIDValidator(v); err != nil {
+			return &ValidationError{Name: "owner_id", err: fmt.Errorf(`generated: validator failed for field "Risk.owner_id": %w`, err)}
+		}
+	}
 	if v, ok := ru.mutation.Name(); ok {
 		if err := risk.NameValidator(v); err != nil {
 			return &ValidationError{Name: "name", err: fmt.Errorf(`generated: validator failed for field "Risk.name": %w`, err)}
@@ -654,11 +659,6 @@ func (ru *RiskUpdate) check() error {
 	if v, ok := ru.mutation.Likelihood(); ok {
 		if err := risk.LikelihoodValidator(v); err != nil {
 			return &ValidationError{Name: "likelihood", err: fmt.Errorf(`generated: validator failed for field "Risk.likelihood": %w`, err)}
-		}
-	}
-	if v, ok := ru.mutation.OwnerID(); ok {
-		if err := risk.OwnerIDValidator(v); err != nil {
-			return &ValidationError{Name: "owner_id", err: fmt.Errorf(`generated: validator failed for field "Risk.owner_id": %w`, err)}
 		}
 	}
 	if ru.mutation.OwnerCleared() && len(ru.mutation.OwnerIDs()) > 0 {
@@ -782,6 +782,181 @@ func (ru *RiskUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if ru.mutation.DetailsCleared() {
 		_spec.ClearField(risk.FieldDetails, field.TypeJSON)
+	}
+	if ru.mutation.OwnerCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   risk.OwnerTable,
+			Columns: []string{risk.OwnerColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(organization.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ru.schemaConfig.Risk
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ru.mutation.OwnerIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   risk.OwnerTable,
+			Columns: []string{risk.OwnerColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(organization.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ru.schemaConfig.Risk
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if ru.mutation.BlockedGroupsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   risk.BlockedGroupsTable,
+			Columns: risk.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ru.schemaConfig.RiskBlockedGroups
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ru.mutation.RemovedBlockedGroupsIDs(); len(nodes) > 0 && !ru.mutation.BlockedGroupsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   risk.BlockedGroupsTable,
+			Columns: risk.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ru.schemaConfig.RiskBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ru.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   risk.BlockedGroupsTable,
+			Columns: risk.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ru.schemaConfig.RiskBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if ru.mutation.EditorsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   risk.EditorsTable,
+			Columns: risk.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ru.schemaConfig.RiskEditors
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ru.mutation.RemovedEditorsIDs(); len(nodes) > 0 && !ru.mutation.EditorsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   risk.EditorsTable,
+			Columns: risk.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ru.schemaConfig.RiskEditors
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ru.mutation.EditorsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   risk.EditorsTable,
+			Columns: risk.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ru.schemaConfig.RiskEditors
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if ru.mutation.ViewersCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   risk.ViewersTable,
+			Columns: risk.ViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ru.schemaConfig.RiskViewers
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ru.mutation.RemovedViewersIDs(); len(nodes) > 0 && !ru.mutation.ViewersCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   risk.ViewersTable,
+			Columns: risk.ViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ru.schemaConfig.RiskViewers
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ru.mutation.ViewersIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   risk.ViewersTable,
+			Columns: risk.ViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ru.schemaConfig.RiskViewers
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if ru.mutation.ControlCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -927,43 +1102,12 @@ func (ru *RiskUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
-	if ru.mutation.OwnerCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: true,
-			Table:   risk.OwnerTable,
-			Columns: []string{risk.OwnerColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(organization.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ru.schemaConfig.Risk
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := ru.mutation.OwnerIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: true,
-			Table:   risk.OwnerTable,
-			Columns: []string{risk.OwnerColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(organization.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ru.schemaConfig.Risk
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
-	if ru.mutation.ProgramCleared() {
+	if ru.mutation.ProgramsCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2M,
 			Inverse: true,
-			Table:   risk.ProgramTable,
-			Columns: risk.ProgramPrimaryKey,
+			Table:   risk.ProgramsTable,
+			Columns: risk.ProgramsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(program.FieldID, field.TypeString),
@@ -972,12 +1116,12 @@ func (ru *RiskUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		edge.Schema = ru.schemaConfig.ProgramRisks
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
-	if nodes := ru.mutation.RemovedProgramIDs(); len(nodes) > 0 && !ru.mutation.ProgramCleared() {
+	if nodes := ru.mutation.RemovedProgramsIDs(); len(nodes) > 0 && !ru.mutation.ProgramsCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2M,
 			Inverse: true,
-			Table:   risk.ProgramTable,
-			Columns: risk.ProgramPrimaryKey,
+			Table:   risk.ProgramsTable,
+			Columns: risk.ProgramsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(program.FieldID, field.TypeString),
@@ -989,162 +1133,18 @@ func (ru *RiskUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
-	if nodes := ru.mutation.ProgramIDs(); len(nodes) > 0 {
+	if nodes := ru.mutation.ProgramsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2M,
 			Inverse: true,
-			Table:   risk.ProgramTable,
-			Columns: risk.ProgramPrimaryKey,
+			Table:   risk.ProgramsTable,
+			Columns: risk.ProgramsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(program.FieldID, field.TypeString),
 			},
 		}
 		edge.Schema = ru.schemaConfig.ProgramRisks
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
-	if ru.mutation.ViewersCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   risk.ViewersTable,
-			Columns: risk.ViewersPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ru.schemaConfig.RiskViewers
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := ru.mutation.RemovedViewersIDs(); len(nodes) > 0 && !ru.mutation.ViewersCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   risk.ViewersTable,
-			Columns: risk.ViewersPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ru.schemaConfig.RiskViewers
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := ru.mutation.ViewersIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   risk.ViewersTable,
-			Columns: risk.ViewersPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ru.schemaConfig.RiskViewers
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
-	if ru.mutation.EditorsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   risk.EditorsTable,
-			Columns: risk.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ru.schemaConfig.RiskEditors
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := ru.mutation.RemovedEditorsIDs(); len(nodes) > 0 && !ru.mutation.EditorsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   risk.EditorsTable,
-			Columns: risk.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ru.schemaConfig.RiskEditors
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := ru.mutation.EditorsIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   risk.EditorsTable,
-			Columns: risk.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ru.schemaConfig.RiskEditors
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
-	if ru.mutation.BlockedGroupsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   risk.BlockedGroupsTable,
-			Columns: risk.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ru.schemaConfig.RiskBlockedGroups
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := ru.mutation.RemovedBlockedGroupsIDs(); len(nodes) > 0 && !ru.mutation.BlockedGroupsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   risk.BlockedGroupsTable,
-			Columns: risk.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ru.schemaConfig.RiskBlockedGroups
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := ru.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   risk.BlockedGroupsTable,
-			Columns: risk.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ru.schemaConfig.RiskBlockedGroups
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
@@ -1261,6 +1261,20 @@ func (ruo *RiskUpdateOne) AppendTags(s []string) *RiskUpdateOne {
 // ClearTags clears the value of the "tags" field.
 func (ruo *RiskUpdateOne) ClearTags() *RiskUpdateOne {
 	ruo.mutation.ClearTags()
+	return ruo
+}
+
+// SetOwnerID sets the "owner_id" field.
+func (ruo *RiskUpdateOne) SetOwnerID(s string) *RiskUpdateOne {
+	ruo.mutation.SetOwnerID(s)
+	return ruo
+}
+
+// SetNillableOwnerID sets the "owner_id" field if the given value is not nil.
+func (ruo *RiskUpdateOne) SetNillableOwnerID(s *string) *RiskUpdateOne {
+	if s != nil {
+		ruo.SetOwnerID(*s)
+	}
 	return ruo
 }
 
@@ -1450,18 +1464,54 @@ func (ruo *RiskUpdateOne) ClearDetails() *RiskUpdateOne {
 	return ruo
 }
 
-// SetOwnerID sets the "owner_id" field.
-func (ruo *RiskUpdateOne) SetOwnerID(s string) *RiskUpdateOne {
-	ruo.mutation.SetOwnerID(s)
+// SetOwner sets the "owner" edge to the Organization entity.
+func (ruo *RiskUpdateOne) SetOwner(o *Organization) *RiskUpdateOne {
+	return ruo.SetOwnerID(o.ID)
+}
+
+// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
+func (ruo *RiskUpdateOne) AddBlockedGroupIDs(ids ...string) *RiskUpdateOne {
+	ruo.mutation.AddBlockedGroupIDs(ids...)
 	return ruo
 }
 
-// SetNillableOwnerID sets the "owner_id" field if the given value is not nil.
-func (ruo *RiskUpdateOne) SetNillableOwnerID(s *string) *RiskUpdateOne {
-	if s != nil {
-		ruo.SetOwnerID(*s)
+// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
+func (ruo *RiskUpdateOne) AddBlockedGroups(g ...*Group) *RiskUpdateOne {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
 	}
+	return ruo.AddBlockedGroupIDs(ids...)
+}
+
+// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
+func (ruo *RiskUpdateOne) AddEditorIDs(ids ...string) *RiskUpdateOne {
+	ruo.mutation.AddEditorIDs(ids...)
 	return ruo
+}
+
+// AddEditors adds the "editors" edges to the Group entity.
+func (ruo *RiskUpdateOne) AddEditors(g ...*Group) *RiskUpdateOne {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return ruo.AddEditorIDs(ids...)
+}
+
+// AddViewerIDs adds the "viewers" edge to the Group entity by IDs.
+func (ruo *RiskUpdateOne) AddViewerIDs(ids ...string) *RiskUpdateOne {
+	ruo.mutation.AddViewerIDs(ids...)
+	return ruo
+}
+
+// AddViewers adds the "viewers" edges to the Group entity.
+func (ruo *RiskUpdateOne) AddViewers(g ...*Group) *RiskUpdateOne {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return ruo.AddViewerIDs(ids...)
 }
 
 // AddControlIDs adds the "control" edge to the Control entity by IDs.
@@ -1509,19 +1559,14 @@ func (ruo *RiskUpdateOne) AddActionplans(a ...*ActionPlan) *RiskUpdateOne {
 	return ruo.AddActionplanIDs(ids...)
 }
 
-// SetOwner sets the "owner" edge to the Organization entity.
-func (ruo *RiskUpdateOne) SetOwner(o *Organization) *RiskUpdateOne {
-	return ruo.SetOwnerID(o.ID)
-}
-
-// AddProgramIDs adds the "program" edge to the Program entity by IDs.
+// AddProgramIDs adds the "programs" edge to the Program entity by IDs.
 func (ruo *RiskUpdateOne) AddProgramIDs(ids ...string) *RiskUpdateOne {
 	ruo.mutation.AddProgramIDs(ids...)
 	return ruo
 }
 
-// AddProgram adds the "program" edges to the Program entity.
-func (ruo *RiskUpdateOne) AddProgram(p ...*Program) *RiskUpdateOne {
+// AddPrograms adds the "programs" edges to the Program entity.
+func (ruo *RiskUpdateOne) AddPrograms(p ...*Program) *RiskUpdateOne {
 	ids := make([]string, len(p))
 	for i := range p {
 		ids[i] = p[i].ID
@@ -1529,54 +1574,78 @@ func (ruo *RiskUpdateOne) AddProgram(p ...*Program) *RiskUpdateOne {
 	return ruo.AddProgramIDs(ids...)
 }
 
-// AddViewerIDs adds the "viewers" edge to the Group entity by IDs.
-func (ruo *RiskUpdateOne) AddViewerIDs(ids ...string) *RiskUpdateOne {
-	ruo.mutation.AddViewerIDs(ids...)
-	return ruo
-}
-
-// AddViewers adds the "viewers" edges to the Group entity.
-func (ruo *RiskUpdateOne) AddViewers(g ...*Group) *RiskUpdateOne {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return ruo.AddViewerIDs(ids...)
-}
-
-// AddEditorIDs adds the "editors" edge to the Group entity by IDs.
-func (ruo *RiskUpdateOne) AddEditorIDs(ids ...string) *RiskUpdateOne {
-	ruo.mutation.AddEditorIDs(ids...)
-	return ruo
-}
-
-// AddEditors adds the "editors" edges to the Group entity.
-func (ruo *RiskUpdateOne) AddEditors(g ...*Group) *RiskUpdateOne {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return ruo.AddEditorIDs(ids...)
-}
-
-// AddBlockedGroupIDs adds the "blocked_groups" edge to the Group entity by IDs.
-func (ruo *RiskUpdateOne) AddBlockedGroupIDs(ids ...string) *RiskUpdateOne {
-	ruo.mutation.AddBlockedGroupIDs(ids...)
-	return ruo
-}
-
-// AddBlockedGroups adds the "blocked_groups" edges to the Group entity.
-func (ruo *RiskUpdateOne) AddBlockedGroups(g ...*Group) *RiskUpdateOne {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return ruo.AddBlockedGroupIDs(ids...)
-}
-
 // Mutation returns the RiskMutation object of the builder.
 func (ruo *RiskUpdateOne) Mutation() *RiskMutation {
 	return ruo.mutation
+}
+
+// ClearOwner clears the "owner" edge to the Organization entity.
+func (ruo *RiskUpdateOne) ClearOwner() *RiskUpdateOne {
+	ruo.mutation.ClearOwner()
+	return ruo
+}
+
+// ClearBlockedGroups clears all "blocked_groups" edges to the Group entity.
+func (ruo *RiskUpdateOne) ClearBlockedGroups() *RiskUpdateOne {
+	ruo.mutation.ClearBlockedGroups()
+	return ruo
+}
+
+// RemoveBlockedGroupIDs removes the "blocked_groups" edge to Group entities by IDs.
+func (ruo *RiskUpdateOne) RemoveBlockedGroupIDs(ids ...string) *RiskUpdateOne {
+	ruo.mutation.RemoveBlockedGroupIDs(ids...)
+	return ruo
+}
+
+// RemoveBlockedGroups removes "blocked_groups" edges to Group entities.
+func (ruo *RiskUpdateOne) RemoveBlockedGroups(g ...*Group) *RiskUpdateOne {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return ruo.RemoveBlockedGroupIDs(ids...)
+}
+
+// ClearEditors clears all "editors" edges to the Group entity.
+func (ruo *RiskUpdateOne) ClearEditors() *RiskUpdateOne {
+	ruo.mutation.ClearEditors()
+	return ruo
+}
+
+// RemoveEditorIDs removes the "editors" edge to Group entities by IDs.
+func (ruo *RiskUpdateOne) RemoveEditorIDs(ids ...string) *RiskUpdateOne {
+	ruo.mutation.RemoveEditorIDs(ids...)
+	return ruo
+}
+
+// RemoveEditors removes "editors" edges to Group entities.
+func (ruo *RiskUpdateOne) RemoveEditors(g ...*Group) *RiskUpdateOne {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return ruo.RemoveEditorIDs(ids...)
+}
+
+// ClearViewers clears all "viewers" edges to the Group entity.
+func (ruo *RiskUpdateOne) ClearViewers() *RiskUpdateOne {
+	ruo.mutation.ClearViewers()
+	return ruo
+}
+
+// RemoveViewerIDs removes the "viewers" edge to Group entities by IDs.
+func (ruo *RiskUpdateOne) RemoveViewerIDs(ids ...string) *RiskUpdateOne {
+	ruo.mutation.RemoveViewerIDs(ids...)
+	return ruo
+}
+
+// RemoveViewers removes "viewers" edges to Group entities.
+func (ruo *RiskUpdateOne) RemoveViewers(g ...*Group) *RiskUpdateOne {
+	ids := make([]string, len(g))
+	for i := range g {
+		ids[i] = g[i].ID
+	}
+	return ruo.RemoveViewerIDs(ids...)
 }
 
 // ClearControl clears all "control" edges to the Control entity.
@@ -1642,94 +1711,25 @@ func (ruo *RiskUpdateOne) RemoveActionplans(a ...*ActionPlan) *RiskUpdateOne {
 	return ruo.RemoveActionplanIDs(ids...)
 }
 
-// ClearOwner clears the "owner" edge to the Organization entity.
-func (ruo *RiskUpdateOne) ClearOwner() *RiskUpdateOne {
-	ruo.mutation.ClearOwner()
+// ClearPrograms clears all "programs" edges to the Program entity.
+func (ruo *RiskUpdateOne) ClearPrograms() *RiskUpdateOne {
+	ruo.mutation.ClearPrograms()
 	return ruo
 }
 
-// ClearProgram clears all "program" edges to the Program entity.
-func (ruo *RiskUpdateOne) ClearProgram() *RiskUpdateOne {
-	ruo.mutation.ClearProgram()
-	return ruo
-}
-
-// RemoveProgramIDs removes the "program" edge to Program entities by IDs.
+// RemoveProgramIDs removes the "programs" edge to Program entities by IDs.
 func (ruo *RiskUpdateOne) RemoveProgramIDs(ids ...string) *RiskUpdateOne {
 	ruo.mutation.RemoveProgramIDs(ids...)
 	return ruo
 }
 
-// RemoveProgram removes "program" edges to Program entities.
-func (ruo *RiskUpdateOne) RemoveProgram(p ...*Program) *RiskUpdateOne {
+// RemovePrograms removes "programs" edges to Program entities.
+func (ruo *RiskUpdateOne) RemovePrograms(p ...*Program) *RiskUpdateOne {
 	ids := make([]string, len(p))
 	for i := range p {
 		ids[i] = p[i].ID
 	}
 	return ruo.RemoveProgramIDs(ids...)
-}
-
-// ClearViewers clears all "viewers" edges to the Group entity.
-func (ruo *RiskUpdateOne) ClearViewers() *RiskUpdateOne {
-	ruo.mutation.ClearViewers()
-	return ruo
-}
-
-// RemoveViewerIDs removes the "viewers" edge to Group entities by IDs.
-func (ruo *RiskUpdateOne) RemoveViewerIDs(ids ...string) *RiskUpdateOne {
-	ruo.mutation.RemoveViewerIDs(ids...)
-	return ruo
-}
-
-// RemoveViewers removes "viewers" edges to Group entities.
-func (ruo *RiskUpdateOne) RemoveViewers(g ...*Group) *RiskUpdateOne {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return ruo.RemoveViewerIDs(ids...)
-}
-
-// ClearEditors clears all "editors" edges to the Group entity.
-func (ruo *RiskUpdateOne) ClearEditors() *RiskUpdateOne {
-	ruo.mutation.ClearEditors()
-	return ruo
-}
-
-// RemoveEditorIDs removes the "editors" edge to Group entities by IDs.
-func (ruo *RiskUpdateOne) RemoveEditorIDs(ids ...string) *RiskUpdateOne {
-	ruo.mutation.RemoveEditorIDs(ids...)
-	return ruo
-}
-
-// RemoveEditors removes "editors" edges to Group entities.
-func (ruo *RiskUpdateOne) RemoveEditors(g ...*Group) *RiskUpdateOne {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return ruo.RemoveEditorIDs(ids...)
-}
-
-// ClearBlockedGroups clears all "blocked_groups" edges to the Group entity.
-func (ruo *RiskUpdateOne) ClearBlockedGroups() *RiskUpdateOne {
-	ruo.mutation.ClearBlockedGroups()
-	return ruo
-}
-
-// RemoveBlockedGroupIDs removes the "blocked_groups" edge to Group entities by IDs.
-func (ruo *RiskUpdateOne) RemoveBlockedGroupIDs(ids ...string) *RiskUpdateOne {
-	ruo.mutation.RemoveBlockedGroupIDs(ids...)
-	return ruo
-}
-
-// RemoveBlockedGroups removes "blocked_groups" edges to Group entities.
-func (ruo *RiskUpdateOne) RemoveBlockedGroups(g ...*Group) *RiskUpdateOne {
-	ids := make([]string, len(g))
-	for i := range g {
-		ids[i] = g[i].ID
-	}
-	return ruo.RemoveBlockedGroupIDs(ids...)
 }
 
 // Where appends a list predicates to the RiskUpdate builder.
@@ -1789,6 +1789,11 @@ func (ruo *RiskUpdateOne) defaults() error {
 
 // check runs all checks and user-defined validators on the builder.
 func (ruo *RiskUpdateOne) check() error {
+	if v, ok := ruo.mutation.OwnerID(); ok {
+		if err := risk.OwnerIDValidator(v); err != nil {
+			return &ValidationError{Name: "owner_id", err: fmt.Errorf(`generated: validator failed for field "Risk.owner_id": %w`, err)}
+		}
+	}
 	if v, ok := ruo.mutation.Name(); ok {
 		if err := risk.NameValidator(v); err != nil {
 			return &ValidationError{Name: "name", err: fmt.Errorf(`generated: validator failed for field "Risk.name": %w`, err)}
@@ -1802,11 +1807,6 @@ func (ruo *RiskUpdateOne) check() error {
 	if v, ok := ruo.mutation.Likelihood(); ok {
 		if err := risk.LikelihoodValidator(v); err != nil {
 			return &ValidationError{Name: "likelihood", err: fmt.Errorf(`generated: validator failed for field "Risk.likelihood": %w`, err)}
-		}
-	}
-	if v, ok := ruo.mutation.OwnerID(); ok {
-		if err := risk.OwnerIDValidator(v); err != nil {
-			return &ValidationError{Name: "owner_id", err: fmt.Errorf(`generated: validator failed for field "Risk.owner_id": %w`, err)}
 		}
 	}
 	if ruo.mutation.OwnerCleared() && len(ruo.mutation.OwnerIDs()) > 0 {
@@ -1947,6 +1947,181 @@ func (ruo *RiskUpdateOne) sqlSave(ctx context.Context) (_node *Risk, err error) 
 	}
 	if ruo.mutation.DetailsCleared() {
 		_spec.ClearField(risk.FieldDetails, field.TypeJSON)
+	}
+	if ruo.mutation.OwnerCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   risk.OwnerTable,
+			Columns: []string{risk.OwnerColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(organization.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ruo.schemaConfig.Risk
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ruo.mutation.OwnerIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   risk.OwnerTable,
+			Columns: []string{risk.OwnerColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(organization.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ruo.schemaConfig.Risk
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if ruo.mutation.BlockedGroupsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   risk.BlockedGroupsTable,
+			Columns: risk.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ruo.schemaConfig.RiskBlockedGroups
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ruo.mutation.RemovedBlockedGroupsIDs(); len(nodes) > 0 && !ruo.mutation.BlockedGroupsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   risk.BlockedGroupsTable,
+			Columns: risk.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ruo.schemaConfig.RiskBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ruo.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   risk.BlockedGroupsTable,
+			Columns: risk.BlockedGroupsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ruo.schemaConfig.RiskBlockedGroups
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if ruo.mutation.EditorsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   risk.EditorsTable,
+			Columns: risk.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ruo.schemaConfig.RiskEditors
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ruo.mutation.RemovedEditorsIDs(); len(nodes) > 0 && !ruo.mutation.EditorsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   risk.EditorsTable,
+			Columns: risk.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ruo.schemaConfig.RiskEditors
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ruo.mutation.EditorsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   risk.EditorsTable,
+			Columns: risk.EditorsPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ruo.schemaConfig.RiskEditors
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if ruo.mutation.ViewersCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   risk.ViewersTable,
+			Columns: risk.ViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ruo.schemaConfig.RiskViewers
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ruo.mutation.RemovedViewersIDs(); len(nodes) > 0 && !ruo.mutation.ViewersCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   risk.ViewersTable,
+			Columns: risk.ViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ruo.schemaConfig.RiskViewers
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := ruo.mutation.ViewersIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2M,
+			Inverse: false,
+			Table:   risk.ViewersTable,
+			Columns: risk.ViewersPrimaryKey,
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = ruo.schemaConfig.RiskViewers
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if ruo.mutation.ControlCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -2092,43 +2267,12 @@ func (ruo *RiskUpdateOne) sqlSave(ctx context.Context) (_node *Risk, err error) 
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
-	if ruo.mutation.OwnerCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: true,
-			Table:   risk.OwnerTable,
-			Columns: []string{risk.OwnerColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(organization.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ruo.schemaConfig.Risk
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := ruo.mutation.OwnerIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: true,
-			Table:   risk.OwnerTable,
-			Columns: []string{risk.OwnerColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(organization.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ruo.schemaConfig.Risk
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
-	if ruo.mutation.ProgramCleared() {
+	if ruo.mutation.ProgramsCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2M,
 			Inverse: true,
-			Table:   risk.ProgramTable,
-			Columns: risk.ProgramPrimaryKey,
+			Table:   risk.ProgramsTable,
+			Columns: risk.ProgramsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(program.FieldID, field.TypeString),
@@ -2137,12 +2281,12 @@ func (ruo *RiskUpdateOne) sqlSave(ctx context.Context) (_node *Risk, err error) 
 		edge.Schema = ruo.schemaConfig.ProgramRisks
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
-	if nodes := ruo.mutation.RemovedProgramIDs(); len(nodes) > 0 && !ruo.mutation.ProgramCleared() {
+	if nodes := ruo.mutation.RemovedProgramsIDs(); len(nodes) > 0 && !ruo.mutation.ProgramsCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2M,
 			Inverse: true,
-			Table:   risk.ProgramTable,
-			Columns: risk.ProgramPrimaryKey,
+			Table:   risk.ProgramsTable,
+			Columns: risk.ProgramsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(program.FieldID, field.TypeString),
@@ -2154,162 +2298,18 @@ func (ruo *RiskUpdateOne) sqlSave(ctx context.Context) (_node *Risk, err error) 
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
-	if nodes := ruo.mutation.ProgramIDs(); len(nodes) > 0 {
+	if nodes := ruo.mutation.ProgramsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2M,
 			Inverse: true,
-			Table:   risk.ProgramTable,
-			Columns: risk.ProgramPrimaryKey,
+			Table:   risk.ProgramsTable,
+			Columns: risk.ProgramsPrimaryKey,
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(program.FieldID, field.TypeString),
 			},
 		}
 		edge.Schema = ruo.schemaConfig.ProgramRisks
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
-	if ruo.mutation.ViewersCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   risk.ViewersTable,
-			Columns: risk.ViewersPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ruo.schemaConfig.RiskViewers
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := ruo.mutation.RemovedViewersIDs(); len(nodes) > 0 && !ruo.mutation.ViewersCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   risk.ViewersTable,
-			Columns: risk.ViewersPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ruo.schemaConfig.RiskViewers
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := ruo.mutation.ViewersIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   risk.ViewersTable,
-			Columns: risk.ViewersPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ruo.schemaConfig.RiskViewers
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
-	if ruo.mutation.EditorsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   risk.EditorsTable,
-			Columns: risk.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ruo.schemaConfig.RiskEditors
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := ruo.mutation.RemovedEditorsIDs(); len(nodes) > 0 && !ruo.mutation.EditorsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   risk.EditorsTable,
-			Columns: risk.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ruo.schemaConfig.RiskEditors
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := ruo.mutation.EditorsIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   risk.EditorsTable,
-			Columns: risk.EditorsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ruo.schemaConfig.RiskEditors
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
-	if ruo.mutation.BlockedGroupsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   risk.BlockedGroupsTable,
-			Columns: risk.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ruo.schemaConfig.RiskBlockedGroups
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := ruo.mutation.RemovedBlockedGroupsIDs(); len(nodes) > 0 && !ruo.mutation.BlockedGroupsCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   risk.BlockedGroupsTable,
-			Columns: risk.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ruo.schemaConfig.RiskBlockedGroups
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := ruo.mutation.BlockedGroupsIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
-			Inverse: false,
-			Table:   risk.BlockedGroupsTable,
-			Columns: risk.BlockedGroupsPrimaryKey,
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(group.FieldID, field.TypeString),
-			},
-		}
-		edge.Schema = ruo.schemaConfig.RiskBlockedGroups
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}

--- a/internal/ent/generated/riskhistory/riskhistory.go
+++ b/internal/ent/generated/riskhistory/riskhistory.go
@@ -40,6 +40,8 @@ const (
 	FieldMappingID = "mapping_id"
 	// FieldTags holds the string denoting the tags field in the database.
 	FieldTags = "tags"
+	// FieldOwnerID holds the string denoting the owner_id field in the database.
+	FieldOwnerID = "owner_id"
 	// FieldName holds the string denoting the name field in the database.
 	FieldName = "name"
 	// FieldDescription holds the string denoting the description field in the database.
@@ -60,8 +62,6 @@ const (
 	FieldSatisfies = "satisfies"
 	// FieldDetails holds the string denoting the details field in the database.
 	FieldDetails = "details"
-	// FieldOwnerID holds the string denoting the owner_id field in the database.
-	FieldOwnerID = "owner_id"
 	// Table holds the table name of the riskhistory in the database.
 	Table = "risk_history"
 )
@@ -80,6 +80,7 @@ var Columns = []string{
 	FieldDeletedBy,
 	FieldMappingID,
 	FieldTags,
+	FieldOwnerID,
 	FieldName,
 	FieldDescription,
 	FieldStatus,
@@ -90,7 +91,6 @@ var Columns = []string{
 	FieldMitigation,
 	FieldSatisfies,
 	FieldDetails,
-	FieldOwnerID,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -220,6 +220,11 @@ func ByMappingID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldMappingID, opts...).ToFunc()
 }
 
+// ByOwnerID orders the results by the owner_id field.
+func ByOwnerID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldOwnerID, opts...).ToFunc()
+}
+
 // ByName orders the results by the name field.
 func ByName(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldName, opts...).ToFunc()
@@ -263,11 +268,6 @@ func ByMitigation(opts ...sql.OrderTermOption) OrderOption {
 // BySatisfies orders the results by the satisfies field.
 func BySatisfies(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldSatisfies, opts...).ToFunc()
-}
-
-// ByOwnerID orders the results by the owner_id field.
-func ByOwnerID(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldOwnerID, opts...).ToFunc()
 }
 
 var (

--- a/internal/ent/generated/riskhistory/where.go
+++ b/internal/ent/generated/riskhistory/where.go
@@ -111,6 +111,11 @@ func MappingID(v string) predicate.RiskHistory {
 	return predicate.RiskHistory(sql.FieldEQ(FieldMappingID, v))
 }
 
+// OwnerID applies equality check predicate on the "owner_id" field. It's identical to OwnerIDEQ.
+func OwnerID(v string) predicate.RiskHistory {
+	return predicate.RiskHistory(sql.FieldEQ(FieldOwnerID, v))
+}
+
 // Name applies equality check predicate on the "name" field. It's identical to NameEQ.
 func Name(v string) predicate.RiskHistory {
 	return predicate.RiskHistory(sql.FieldEQ(FieldName, v))
@@ -144,11 +149,6 @@ func Mitigation(v string) predicate.RiskHistory {
 // Satisfies applies equality check predicate on the "satisfies" field. It's identical to SatisfiesEQ.
 func Satisfies(v string) predicate.RiskHistory {
 	return predicate.RiskHistory(sql.FieldEQ(FieldSatisfies, v))
-}
-
-// OwnerID applies equality check predicate on the "owner_id" field. It's identical to OwnerIDEQ.
-func OwnerID(v string) predicate.RiskHistory {
-	return predicate.RiskHistory(sql.FieldEQ(FieldOwnerID, v))
 }
 
 // HistoryTimeEQ applies the EQ predicate on the "history_time" field.
@@ -734,6 +734,71 @@ func TagsIsNil() predicate.RiskHistory {
 // TagsNotNil applies the NotNil predicate on the "tags" field.
 func TagsNotNil() predicate.RiskHistory {
 	return predicate.RiskHistory(sql.FieldNotNull(FieldTags))
+}
+
+// OwnerIDEQ applies the EQ predicate on the "owner_id" field.
+func OwnerIDEQ(v string) predicate.RiskHistory {
+	return predicate.RiskHistory(sql.FieldEQ(FieldOwnerID, v))
+}
+
+// OwnerIDNEQ applies the NEQ predicate on the "owner_id" field.
+func OwnerIDNEQ(v string) predicate.RiskHistory {
+	return predicate.RiskHistory(sql.FieldNEQ(FieldOwnerID, v))
+}
+
+// OwnerIDIn applies the In predicate on the "owner_id" field.
+func OwnerIDIn(vs ...string) predicate.RiskHistory {
+	return predicate.RiskHistory(sql.FieldIn(FieldOwnerID, vs...))
+}
+
+// OwnerIDNotIn applies the NotIn predicate on the "owner_id" field.
+func OwnerIDNotIn(vs ...string) predicate.RiskHistory {
+	return predicate.RiskHistory(sql.FieldNotIn(FieldOwnerID, vs...))
+}
+
+// OwnerIDGT applies the GT predicate on the "owner_id" field.
+func OwnerIDGT(v string) predicate.RiskHistory {
+	return predicate.RiskHistory(sql.FieldGT(FieldOwnerID, v))
+}
+
+// OwnerIDGTE applies the GTE predicate on the "owner_id" field.
+func OwnerIDGTE(v string) predicate.RiskHistory {
+	return predicate.RiskHistory(sql.FieldGTE(FieldOwnerID, v))
+}
+
+// OwnerIDLT applies the LT predicate on the "owner_id" field.
+func OwnerIDLT(v string) predicate.RiskHistory {
+	return predicate.RiskHistory(sql.FieldLT(FieldOwnerID, v))
+}
+
+// OwnerIDLTE applies the LTE predicate on the "owner_id" field.
+func OwnerIDLTE(v string) predicate.RiskHistory {
+	return predicate.RiskHistory(sql.FieldLTE(FieldOwnerID, v))
+}
+
+// OwnerIDContains applies the Contains predicate on the "owner_id" field.
+func OwnerIDContains(v string) predicate.RiskHistory {
+	return predicate.RiskHistory(sql.FieldContains(FieldOwnerID, v))
+}
+
+// OwnerIDHasPrefix applies the HasPrefix predicate on the "owner_id" field.
+func OwnerIDHasPrefix(v string) predicate.RiskHistory {
+	return predicate.RiskHistory(sql.FieldHasPrefix(FieldOwnerID, v))
+}
+
+// OwnerIDHasSuffix applies the HasSuffix predicate on the "owner_id" field.
+func OwnerIDHasSuffix(v string) predicate.RiskHistory {
+	return predicate.RiskHistory(sql.FieldHasSuffix(FieldOwnerID, v))
+}
+
+// OwnerIDEqualFold applies the EqualFold predicate on the "owner_id" field.
+func OwnerIDEqualFold(v string) predicate.RiskHistory {
+	return predicate.RiskHistory(sql.FieldEqualFold(FieldOwnerID, v))
+}
+
+// OwnerIDContainsFold applies the ContainsFold predicate on the "owner_id" field.
+func OwnerIDContainsFold(v string) predicate.RiskHistory {
+	return predicate.RiskHistory(sql.FieldContainsFold(FieldOwnerID, v))
 }
 
 // NameEQ applies the EQ predicate on the "name" field.
@@ -1339,71 +1404,6 @@ func DetailsIsNil() predicate.RiskHistory {
 // DetailsNotNil applies the NotNil predicate on the "details" field.
 func DetailsNotNil() predicate.RiskHistory {
 	return predicate.RiskHistory(sql.FieldNotNull(FieldDetails))
-}
-
-// OwnerIDEQ applies the EQ predicate on the "owner_id" field.
-func OwnerIDEQ(v string) predicate.RiskHistory {
-	return predicate.RiskHistory(sql.FieldEQ(FieldOwnerID, v))
-}
-
-// OwnerIDNEQ applies the NEQ predicate on the "owner_id" field.
-func OwnerIDNEQ(v string) predicate.RiskHistory {
-	return predicate.RiskHistory(sql.FieldNEQ(FieldOwnerID, v))
-}
-
-// OwnerIDIn applies the In predicate on the "owner_id" field.
-func OwnerIDIn(vs ...string) predicate.RiskHistory {
-	return predicate.RiskHistory(sql.FieldIn(FieldOwnerID, vs...))
-}
-
-// OwnerIDNotIn applies the NotIn predicate on the "owner_id" field.
-func OwnerIDNotIn(vs ...string) predicate.RiskHistory {
-	return predicate.RiskHistory(sql.FieldNotIn(FieldOwnerID, vs...))
-}
-
-// OwnerIDGT applies the GT predicate on the "owner_id" field.
-func OwnerIDGT(v string) predicate.RiskHistory {
-	return predicate.RiskHistory(sql.FieldGT(FieldOwnerID, v))
-}
-
-// OwnerIDGTE applies the GTE predicate on the "owner_id" field.
-func OwnerIDGTE(v string) predicate.RiskHistory {
-	return predicate.RiskHistory(sql.FieldGTE(FieldOwnerID, v))
-}
-
-// OwnerIDLT applies the LT predicate on the "owner_id" field.
-func OwnerIDLT(v string) predicate.RiskHistory {
-	return predicate.RiskHistory(sql.FieldLT(FieldOwnerID, v))
-}
-
-// OwnerIDLTE applies the LTE predicate on the "owner_id" field.
-func OwnerIDLTE(v string) predicate.RiskHistory {
-	return predicate.RiskHistory(sql.FieldLTE(FieldOwnerID, v))
-}
-
-// OwnerIDContains applies the Contains predicate on the "owner_id" field.
-func OwnerIDContains(v string) predicate.RiskHistory {
-	return predicate.RiskHistory(sql.FieldContains(FieldOwnerID, v))
-}
-
-// OwnerIDHasPrefix applies the HasPrefix predicate on the "owner_id" field.
-func OwnerIDHasPrefix(v string) predicate.RiskHistory {
-	return predicate.RiskHistory(sql.FieldHasPrefix(FieldOwnerID, v))
-}
-
-// OwnerIDHasSuffix applies the HasSuffix predicate on the "owner_id" field.
-func OwnerIDHasSuffix(v string) predicate.RiskHistory {
-	return predicate.RiskHistory(sql.FieldHasSuffix(FieldOwnerID, v))
-}
-
-// OwnerIDEqualFold applies the EqualFold predicate on the "owner_id" field.
-func OwnerIDEqualFold(v string) predicate.RiskHistory {
-	return predicate.RiskHistory(sql.FieldEqualFold(FieldOwnerID, v))
-}
-
-// OwnerIDContainsFold applies the ContainsFold predicate on the "owner_id" field.
-func OwnerIDContainsFold(v string) predicate.RiskHistory {
-	return predicate.RiskHistory(sql.FieldContainsFold(FieldOwnerID, v))
 }
 
 // And groups predicates with the AND operator between them.

--- a/internal/ent/generated/riskhistory_create.go
+++ b/internal/ent/generated/riskhistory_create.go
@@ -160,6 +160,12 @@ func (rhc *RiskHistoryCreate) SetTags(s []string) *RiskHistoryCreate {
 	return rhc
 }
 
+// SetOwnerID sets the "owner_id" field.
+func (rhc *RiskHistoryCreate) SetOwnerID(s string) *RiskHistoryCreate {
+	rhc.mutation.SetOwnerID(s)
+	return rhc
+}
+
 // SetName sets the "name" field.
 func (rhc *RiskHistoryCreate) SetName(s string) *RiskHistoryCreate {
 	rhc.mutation.SetName(s)
@@ -284,12 +290,6 @@ func (rhc *RiskHistoryCreate) SetDetails(m map[string]interface{}) *RiskHistoryC
 	return rhc
 }
 
-// SetOwnerID sets the "owner_id" field.
-func (rhc *RiskHistoryCreate) SetOwnerID(s string) *RiskHistoryCreate {
-	rhc.mutation.SetOwnerID(s)
-	return rhc
-}
-
 // SetID sets the "id" field.
 func (rhc *RiskHistoryCreate) SetID(s string) *RiskHistoryCreate {
 	rhc.mutation.SetID(s)
@@ -407,6 +407,9 @@ func (rhc *RiskHistoryCreate) check() error {
 	if _, ok := rhc.mutation.MappingID(); !ok {
 		return &ValidationError{Name: "mapping_id", err: errors.New(`generated: missing required field "RiskHistory.mapping_id"`)}
 	}
+	if _, ok := rhc.mutation.OwnerID(); !ok {
+		return &ValidationError{Name: "owner_id", err: errors.New(`generated: missing required field "RiskHistory.owner_id"`)}
+	}
 	if _, ok := rhc.mutation.Name(); !ok {
 		return &ValidationError{Name: "name", err: errors.New(`generated: missing required field "RiskHistory.name"`)}
 	}
@@ -419,9 +422,6 @@ func (rhc *RiskHistoryCreate) check() error {
 		if err := riskhistory.LikelihoodValidator(v); err != nil {
 			return &ValidationError{Name: "likelihood", err: fmt.Errorf(`generated: validator failed for field "RiskHistory.likelihood": %w`, err)}
 		}
-	}
-	if _, ok := rhc.mutation.OwnerID(); !ok {
-		return &ValidationError{Name: "owner_id", err: errors.New(`generated: missing required field "RiskHistory.owner_id"`)}
 	}
 	return nil
 }
@@ -503,6 +503,10 @@ func (rhc *RiskHistoryCreate) createSpec() (*RiskHistory, *sqlgraph.CreateSpec) 
 		_spec.SetField(riskhistory.FieldTags, field.TypeJSON, value)
 		_node.Tags = value
 	}
+	if value, ok := rhc.mutation.OwnerID(); ok {
+		_spec.SetField(riskhistory.FieldOwnerID, field.TypeString, value)
+		_node.OwnerID = value
+	}
 	if value, ok := rhc.mutation.Name(); ok {
 		_spec.SetField(riskhistory.FieldName, field.TypeString, value)
 		_node.Name = value
@@ -542,10 +546,6 @@ func (rhc *RiskHistoryCreate) createSpec() (*RiskHistory, *sqlgraph.CreateSpec) 
 	if value, ok := rhc.mutation.Details(); ok {
 		_spec.SetField(riskhistory.FieldDetails, field.TypeJSON, value)
 		_node.Details = value
-	}
-	if value, ok := rhc.mutation.OwnerID(); ok {
-		_spec.SetField(riskhistory.FieldOwnerID, field.TypeString, value)
-		_node.OwnerID = value
 	}
 	return _node, _spec
 }

--- a/internal/ent/generated/riskhistory_update.go
+++ b/internal/ent/generated/riskhistory_update.go
@@ -123,6 +123,20 @@ func (rhu *RiskHistoryUpdate) ClearTags() *RiskHistoryUpdate {
 	return rhu
 }
 
+// SetOwnerID sets the "owner_id" field.
+func (rhu *RiskHistoryUpdate) SetOwnerID(s string) *RiskHistoryUpdate {
+	rhu.mutation.SetOwnerID(s)
+	return rhu
+}
+
+// SetNillableOwnerID sets the "owner_id" field if the given value is not nil.
+func (rhu *RiskHistoryUpdate) SetNillableOwnerID(s *string) *RiskHistoryUpdate {
+	if s != nil {
+		rhu.SetOwnerID(*s)
+	}
+	return rhu
+}
+
 // SetName sets the "name" field.
 func (rhu *RiskHistoryUpdate) SetName(s string) *RiskHistoryUpdate {
 	rhu.mutation.SetName(s)
@@ -309,20 +323,6 @@ func (rhu *RiskHistoryUpdate) ClearDetails() *RiskHistoryUpdate {
 	return rhu
 }
 
-// SetOwnerID sets the "owner_id" field.
-func (rhu *RiskHistoryUpdate) SetOwnerID(s string) *RiskHistoryUpdate {
-	rhu.mutation.SetOwnerID(s)
-	return rhu
-}
-
-// SetNillableOwnerID sets the "owner_id" field if the given value is not nil.
-func (rhu *RiskHistoryUpdate) SetNillableOwnerID(s *string) *RiskHistoryUpdate {
-	if s != nil {
-		rhu.SetOwnerID(*s)
-	}
-	return rhu
-}
-
 // Mutation returns the RiskHistoryMutation object of the builder.
 func (rhu *RiskHistoryUpdate) Mutation() *RiskHistoryMutation {
 	return rhu.mutation
@@ -447,6 +447,9 @@ func (rhu *RiskHistoryUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	if rhu.mutation.TagsCleared() {
 		_spec.ClearField(riskhistory.FieldTags, field.TypeJSON)
 	}
+	if value, ok := rhu.mutation.OwnerID(); ok {
+		_spec.SetField(riskhistory.FieldOwnerID, field.TypeString, value)
+	}
 	if value, ok := rhu.mutation.Name(); ok {
 		_spec.SetField(riskhistory.FieldName, field.TypeString, value)
 	}
@@ -503,9 +506,6 @@ func (rhu *RiskHistoryUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if rhu.mutation.DetailsCleared() {
 		_spec.ClearField(riskhistory.FieldDetails, field.TypeJSON)
-	}
-	if value, ok := rhu.mutation.OwnerID(); ok {
-		_spec.SetField(riskhistory.FieldOwnerID, field.TypeString, value)
 	}
 	_spec.Node.Schema = rhu.schemaConfig.RiskHistory
 	ctx = internal.NewSchemaConfigContext(ctx, rhu.schemaConfig)
@@ -618,6 +618,20 @@ func (rhuo *RiskHistoryUpdateOne) AppendTags(s []string) *RiskHistoryUpdateOne {
 // ClearTags clears the value of the "tags" field.
 func (rhuo *RiskHistoryUpdateOne) ClearTags() *RiskHistoryUpdateOne {
 	rhuo.mutation.ClearTags()
+	return rhuo
+}
+
+// SetOwnerID sets the "owner_id" field.
+func (rhuo *RiskHistoryUpdateOne) SetOwnerID(s string) *RiskHistoryUpdateOne {
+	rhuo.mutation.SetOwnerID(s)
+	return rhuo
+}
+
+// SetNillableOwnerID sets the "owner_id" field if the given value is not nil.
+func (rhuo *RiskHistoryUpdateOne) SetNillableOwnerID(s *string) *RiskHistoryUpdateOne {
+	if s != nil {
+		rhuo.SetOwnerID(*s)
+	}
 	return rhuo
 }
 
@@ -807,20 +821,6 @@ func (rhuo *RiskHistoryUpdateOne) ClearDetails() *RiskHistoryUpdateOne {
 	return rhuo
 }
 
-// SetOwnerID sets the "owner_id" field.
-func (rhuo *RiskHistoryUpdateOne) SetOwnerID(s string) *RiskHistoryUpdateOne {
-	rhuo.mutation.SetOwnerID(s)
-	return rhuo
-}
-
-// SetNillableOwnerID sets the "owner_id" field if the given value is not nil.
-func (rhuo *RiskHistoryUpdateOne) SetNillableOwnerID(s *string) *RiskHistoryUpdateOne {
-	if s != nil {
-		rhuo.SetOwnerID(*s)
-	}
-	return rhuo
-}
-
 // Mutation returns the RiskHistoryMutation object of the builder.
 func (rhuo *RiskHistoryUpdateOne) Mutation() *RiskHistoryMutation {
 	return rhuo.mutation
@@ -975,6 +975,9 @@ func (rhuo *RiskHistoryUpdateOne) sqlSave(ctx context.Context) (_node *RiskHisto
 	if rhuo.mutation.TagsCleared() {
 		_spec.ClearField(riskhistory.FieldTags, field.TypeJSON)
 	}
+	if value, ok := rhuo.mutation.OwnerID(); ok {
+		_spec.SetField(riskhistory.FieldOwnerID, field.TypeString, value)
+	}
 	if value, ok := rhuo.mutation.Name(); ok {
 		_spec.SetField(riskhistory.FieldName, field.TypeString, value)
 	}
@@ -1031,9 +1034,6 @@ func (rhuo *RiskHistoryUpdateOne) sqlSave(ctx context.Context) (_node *RiskHisto
 	}
 	if rhuo.mutation.DetailsCleared() {
 		_spec.ClearField(riskhistory.FieldDetails, field.TypeJSON)
-	}
-	if value, ok := rhuo.mutation.OwnerID(); ok {
-		_spec.SetField(riskhistory.FieldOwnerID, field.TypeString, value)
 	}
 	_spec.Node.Schema = rhuo.schemaConfig.RiskHistory
 	ctx = internal.NewSchemaConfigContext(ctx, rhuo.schemaConfig)

--- a/internal/ent/generated/runtime/runtime.go
+++ b/internal/ent/generated/runtime/runtime.go
@@ -426,18 +426,47 @@ func init() {
 	// controlhistory.DefaultID holds the default value on creation for the id field.
 	controlhistory.DefaultID = controlhistoryDescID.Default.(func() string)
 	controlobjectiveMixin := schema.ControlObjective{}.Mixin()
+	controlobjective.Policy = privacy.NewPolicies(schema.ControlObjective{})
+	controlobjective.Hooks[0] = func(next ent.Mutator) ent.Mutator {
+		return ent.MutateFunc(func(ctx context.Context, m ent.Mutation) (ent.Value, error) {
+			if err := controlobjective.Policy.EvalMutation(ctx, m); err != nil {
+				return nil, err
+			}
+			return next.Mutate(ctx, m)
+		})
+	}
 	controlobjectiveMixinHooks0 := controlobjectiveMixin[0].Hooks()
 	controlobjectiveMixinHooks1 := controlobjectiveMixin[1].Hooks()
-	controlobjective.Hooks[0] = controlobjectiveMixinHooks0[0]
-	controlobjective.Hooks[1] = controlobjectiveMixinHooks1[0]
+	controlobjectiveMixinHooks4 := controlobjectiveMixin[4].Hooks()
+	controlobjectiveMixinHooks5 := controlobjectiveMixin[5].Hooks()
+
+	controlobjective.Hooks[1] = controlobjectiveMixinHooks0[0]
+
+	controlobjective.Hooks[2] = controlobjectiveMixinHooks1[0]
+
+	controlobjective.Hooks[3] = controlobjectiveMixinHooks4[0]
+
+	controlobjective.Hooks[4] = controlobjectiveMixinHooks4[1]
+
+	controlobjective.Hooks[5] = controlobjectiveMixinHooks4[2]
+
+	controlobjective.Hooks[6] = controlobjectiveMixinHooks5[0]
+
+	controlobjective.Hooks[7] = controlobjectiveMixinHooks5[1]
+
+	controlobjective.Hooks[8] = controlobjectiveMixinHooks5[2]
 	controlobjectiveMixinInters1 := controlobjectiveMixin[1].Interceptors()
+	controlobjectiveMixinInters4 := controlobjectiveMixin[4].Interceptors()
 	controlobjective.Interceptors[0] = controlobjectiveMixinInters1[0]
+	controlobjective.Interceptors[1] = controlobjectiveMixinInters4[0]
 	controlobjectiveMixinFields0 := controlobjectiveMixin[0].Fields()
 	_ = controlobjectiveMixinFields0
 	controlobjectiveMixinFields2 := controlobjectiveMixin[2].Fields()
 	_ = controlobjectiveMixinFields2
 	controlobjectiveMixinFields3 := controlobjectiveMixin[3].Fields()
 	_ = controlobjectiveMixinFields3
+	controlobjectiveMixinFields4 := controlobjectiveMixin[4].Fields()
+	_ = controlobjectiveMixinFields4
 	controlobjectiveFields := schema.ControlObjective{}.Fields()
 	_ = controlobjectiveFields
 	// controlobjectiveDescCreatedAt is the schema descriptor for created_at field.
@@ -458,10 +487,29 @@ func init() {
 	controlobjectiveDescTags := controlobjectiveMixinFields3[0].Descriptor()
 	// controlobjective.DefaultTags holds the default value on creation for the tags field.
 	controlobjective.DefaultTags = controlobjectiveDescTags.Default.([]string)
+	// controlobjectiveDescOwnerID is the schema descriptor for owner_id field.
+	controlobjectiveDescOwnerID := controlobjectiveMixinFields4[0].Descriptor()
+	// controlobjective.OwnerIDValidator is a validator for the "owner_id" field. It is called by the builders before save.
+	controlobjective.OwnerIDValidator = controlobjectiveDescOwnerID.Validators[0].(func(string) error)
+	// controlobjectiveDescName is the schema descriptor for name field.
+	controlobjectiveDescName := controlobjectiveFields[0].Descriptor()
+	// controlobjective.NameValidator is a validator for the "name" field. It is called by the builders before save.
+	controlobjective.NameValidator = controlobjectiveDescName.Validators[0].(func(string) error)
 	// controlobjectiveDescID is the schema descriptor for id field.
 	controlobjectiveDescID := controlobjectiveMixinFields2[0].Descriptor()
 	// controlobjective.DefaultID holds the default value on creation for the id field.
 	controlobjective.DefaultID = controlobjectiveDescID.Default.(func() string)
+	controlobjectivehistory.Policy = privacy.NewPolicies(schema.ControlObjectiveHistory{})
+	controlobjectivehistory.Hooks[0] = func(next ent.Mutator) ent.Mutator {
+		return ent.MutateFunc(func(ctx context.Context, m ent.Mutation) (ent.Value, error) {
+			if err := controlobjectivehistory.Policy.EvalMutation(ctx, m); err != nil {
+				return nil, err
+			}
+			return next.Mutate(ctx, m)
+		})
+	}
+	controlobjectivehistoryInters := schema.ControlObjectiveHistory{}.Interceptors()
+	controlobjectivehistory.Interceptors[0] = controlobjectivehistoryInters[0]
 	controlobjectivehistoryFields := schema.ControlObjectiveHistory{}.Fields()
 	_ = controlobjectivehistoryFields
 	// controlobjectivehistoryDescHistoryTime is the schema descriptor for history_time field.
@@ -2036,6 +2084,7 @@ func init() {
 	internalpolicyMixinHooks0 := internalpolicyMixin[0].Hooks()
 	internalpolicyMixinHooks1 := internalpolicyMixin[1].Hooks()
 	internalpolicyMixinHooks4 := internalpolicyMixin[4].Hooks()
+	internalpolicyMixinHooks5 := internalpolicyMixin[5].Hooks()
 	internalpolicyHooks := schema.InternalPolicy{}.Hooks()
 
 	internalpolicy.Hooks[1] = internalpolicyMixinHooks0[0]
@@ -2044,17 +2093,15 @@ func init() {
 
 	internalpolicy.Hooks[3] = internalpolicyMixinHooks4[0]
 
-	internalpolicy.Hooks[4] = internalpolicyHooks[0]
+	internalpolicy.Hooks[4] = internalpolicyMixinHooks5[0]
 
-	internalpolicy.Hooks[5] = internalpolicyHooks[1]
+	internalpolicy.Hooks[5] = internalpolicyMixinHooks5[1]
 
-	internalpolicy.Hooks[6] = internalpolicyHooks[2]
+	internalpolicy.Hooks[6] = internalpolicyHooks[0]
 	internalpolicyMixinInters1 := internalpolicyMixin[1].Interceptors()
 	internalpolicyMixinInters4 := internalpolicyMixin[4].Interceptors()
-	internalpolicyInters := schema.InternalPolicy{}.Interceptors()
 	internalpolicy.Interceptors[0] = internalpolicyMixinInters1[0]
 	internalpolicy.Interceptors[1] = internalpolicyMixinInters4[0]
-	internalpolicy.Interceptors[2] = internalpolicyInters[0]
 	internalpolicyMixinFields0 := internalpolicyMixin[0].Fields()
 	_ = internalpolicyMixinFields0
 	internalpolicyMixinFields2 := internalpolicyMixin[2].Fields()
@@ -3041,6 +3088,7 @@ func init() {
 	procedureMixinHooks0 := procedureMixin[0].Hooks()
 	procedureMixinHooks1 := procedureMixin[1].Hooks()
 	procedureMixinHooks4 := procedureMixin[4].Hooks()
+	procedureMixinHooks5 := procedureMixin[5].Hooks()
 	procedureHooks := schema.Procedure{}.Hooks()
 
 	procedure.Hooks[1] = procedureMixinHooks0[0]
@@ -3049,17 +3097,15 @@ func init() {
 
 	procedure.Hooks[3] = procedureMixinHooks4[0]
 
-	procedure.Hooks[4] = procedureHooks[0]
+	procedure.Hooks[4] = procedureMixinHooks5[0]
 
-	procedure.Hooks[5] = procedureHooks[1]
+	procedure.Hooks[5] = procedureMixinHooks5[1]
 
-	procedure.Hooks[6] = procedureHooks[2]
+	procedure.Hooks[6] = procedureHooks[0]
 	procedureMixinInters1 := procedureMixin[1].Interceptors()
 	procedureMixinInters4 := procedureMixin[4].Interceptors()
-	procedureInters := schema.Procedure{}.Interceptors()
 	procedure.Interceptors[0] = procedureMixinInters1[0]
 	procedure.Interceptors[1] = procedureMixinInters4[0]
-	procedure.Interceptors[2] = procedureInters[0]
 	procedureMixinFields0 := procedureMixin[0].Fields()
 	_ = procedureMixinFields0
 	procedureMixinFields2 := procedureMixin[2].Fields()
@@ -3152,6 +3198,7 @@ func init() {
 	programMixinHooks0 := programMixin[0].Hooks()
 	programMixinHooks2 := programMixin[2].Hooks()
 	programMixinHooks4 := programMixin[4].Hooks()
+	programMixinHooks5 := programMixin[5].Hooks()
 	programHooks := schema.Program{}.Hooks()
 
 	program.Hooks[1] = programMixinHooks0[0]
@@ -3160,13 +3207,13 @@ func init() {
 
 	program.Hooks[3] = programMixinHooks4[0]
 
-	program.Hooks[4] = programHooks[0]
+	program.Hooks[4] = programMixinHooks5[0]
 
-	program.Hooks[5] = programHooks[1]
+	program.Hooks[5] = programMixinHooks5[1]
 
-	program.Hooks[6] = programHooks[2]
+	program.Hooks[6] = programMixinHooks5[2]
 
-	program.Hooks[7] = programHooks[3]
+	program.Hooks[7] = programHooks[0]
 	programMixinInters2 := programMixin[2].Interceptors()
 	programMixinInters4 := programMixin[4].Interceptors()
 	programInters := schema.Program{}.Interceptors()
@@ -3369,7 +3416,7 @@ func init() {
 	riskMixinHooks0 := riskMixin[0].Hooks()
 	riskMixinHooks1 := riskMixin[1].Hooks()
 	riskMixinHooks4 := riskMixin[4].Hooks()
-	riskHooks := schema.Risk{}.Hooks()
+	riskMixinHooks5 := riskMixin[5].Hooks()
 
 	risk.Hooks[1] = riskMixinHooks0[0]
 
@@ -3381,23 +3428,23 @@ func init() {
 
 	risk.Hooks[5] = riskMixinHooks4[2]
 
-	risk.Hooks[6] = riskHooks[0]
+	risk.Hooks[6] = riskMixinHooks5[0]
 
-	risk.Hooks[7] = riskHooks[1]
+	risk.Hooks[7] = riskMixinHooks5[1]
 
-	risk.Hooks[8] = riskHooks[2]
+	risk.Hooks[8] = riskMixinHooks5[2]
 	riskMixinInters1 := riskMixin[1].Interceptors()
 	riskMixinInters4 := riskMixin[4].Interceptors()
-	riskInters := schema.Risk{}.Interceptors()
 	risk.Interceptors[0] = riskMixinInters1[0]
 	risk.Interceptors[1] = riskMixinInters4[0]
-	risk.Interceptors[2] = riskInters[0]
 	riskMixinFields0 := riskMixin[0].Fields()
 	_ = riskMixinFields0
 	riskMixinFields2 := riskMixin[2].Fields()
 	_ = riskMixinFields2
 	riskMixinFields3 := riskMixin[3].Fields()
 	_ = riskMixinFields3
+	riskMixinFields4 := riskMixin[4].Fields()
+	_ = riskMixinFields4
 	riskFields := schema.Risk{}.Fields()
 	_ = riskFields
 	// riskDescCreatedAt is the schema descriptor for created_at field.
@@ -3418,14 +3465,14 @@ func init() {
 	riskDescTags := riskMixinFields3[0].Descriptor()
 	// risk.DefaultTags holds the default value on creation for the tags field.
 	risk.DefaultTags = riskDescTags.Default.([]string)
+	// riskDescOwnerID is the schema descriptor for owner_id field.
+	riskDescOwnerID := riskMixinFields4[0].Descriptor()
+	// risk.OwnerIDValidator is a validator for the "owner_id" field. It is called by the builders before save.
+	risk.OwnerIDValidator = riskDescOwnerID.Validators[0].(func(string) error)
 	// riskDescName is the schema descriptor for name field.
 	riskDescName := riskFields[0].Descriptor()
 	// risk.NameValidator is a validator for the "name" field. It is called by the builders before save.
 	risk.NameValidator = riskDescName.Validators[0].(func(string) error)
-	// riskDescOwnerID is the schema descriptor for owner_id field.
-	riskDescOwnerID := riskFields[10].Descriptor()
-	// risk.OwnerIDValidator is a validator for the "owner_id" field. It is called by the builders before save.
-	risk.OwnerIDValidator = riskDescOwnerID.Validators[0].(func(string) error)
 	// riskDescID is the schema descriptor for id field.
 	riskDescID := riskMixinFields2[0].Descriptor()
 	// risk.DefaultID holds the default value on creation for the id field.

--- a/internal/ent/interceptors/user.go
+++ b/internal/ent/interceptors/user.go
@@ -66,6 +66,10 @@ func filterType(ctx context.Context) string {
 			"updateGroup",
 			"createGroupMembership",
 			"updateGroupMembership",
+			"createProgramMembership",
+			"updateProgramMembership",
+			"createProgram",
+			"updateProgram",
 			"organization",
 		}
 
@@ -80,7 +84,7 @@ func filterType(ctx context.Context) string {
 	}
 
 	switch qCtx.Type {
-	case "OrgMembership", "GroupMembership", "Group":
+	case "OrgMembership", "GroupMembership", "Group", "ProgramMembership", "Program":
 		return "org"
 	case "Organization":
 		return "" // no filter because this is filtered at the org level

--- a/internal/ent/privacy/rule/program.go
+++ b/internal/ent/privacy/rule/program.go
@@ -25,8 +25,6 @@ func CanCreateObjectsInProgram() privacy.MutationRuleFunc {
 			return privacy.Skipf("no program set on request, skipping")
 		}
 
-		log.Debug().Msg("checking mutation access")
-
 		relation := fgax.CanEdit
 
 		userID, err := auth.GetUserIDFromContext(ctx)
@@ -34,8 +32,8 @@ func CanCreateObjectsInProgram() privacy.MutationRuleFunc {
 			return err
 		}
 
-		log.Info().Str("relation", relation).
-			Strs("program_id", pIDs).
+		log.Debug().Str("relation", relation).
+			Strs("program_ids", pIDs).
 			Msg("checking relationship tuples")
 
 		for _, pID := range pIDs {
@@ -75,12 +73,16 @@ func CanCreateObjectsInProgram() privacy.MutationRuleFunc {
 	})
 }
 
-// getOwnerIDFromEntMutation extracts the object id from a the mutation
+// getProgramIDFromEntMutation extracts the program id from a the mutation
 // by attempting to cast the mutation to a risk mutation
 // if additional object types are needed, they should be added to this function
 func getProgramIDFromEntMutation(m generated.Mutation) ([]string, error) {
 	if o, ok := m.(*generated.RiskMutation); ok {
-		return o.ProgramIDs(), nil
+		return o.ProgramsIDs(), nil
+	}
+
+	if o, ok := m.(*generated.ControlObjectiveMutation); ok {
+		return o.ProgramsIDs(), nil
 	}
 
 	return nil, nil

--- a/internal/ent/schema/group.go
+++ b/internal/ent/schema/group.go
@@ -114,6 +114,12 @@ func (Group) Edges() []ent.Edge {
 			Ref("editors"),
 		edge.From("risk_blocked_groups", Risk.Type).
 			Ref("blocked_groups"),
+		edge.From("controlobjective_viewers", ControlObjective.Type).
+			Ref("viewers"),
+		edge.From("controlobjective_editors", ControlObjective.Type).
+			Ref("editors"),
+		edge.From("controlobjective_blocked_groups", ControlObjective.Type).
+			Ref("blocked_groups"),
 	}
 }
 

--- a/internal/ent/schema/grouppermissionsmixin.go
+++ b/internal/ent/schema/grouppermissionsmixin.go
@@ -35,7 +35,7 @@ func NewGroupPermissionsMixin(viewPermissions bool) GroupPermissionsMixin {
 	}
 }
 
-// Fields of the ObjectOwnedMixin
+// Edges of the GroupPermissionsMixin
 func (g GroupPermissionsMixin) Edges() []ent.Edge {
 	blockEdge := edge.To("blocked_groups", Group.Type).
 		Comment("groups that are blocked from viewing or editing the risk")
@@ -56,6 +56,7 @@ func (g GroupPermissionsMixin) Edges() []ent.Edge {
 	return edges
 }
 
+// Hooks of the GroupPermissionsMixin
 func (g GroupPermissionsMixin) Hooks() []ent.Hook {
 	var hooks []ent.Hook
 

--- a/internal/ent/schema/grouppermissionsmixin.go
+++ b/internal/ent/schema/grouppermissionsmixin.go
@@ -1,0 +1,101 @@
+package schema
+
+import (
+	"entgo.io/ent"
+	"entgo.io/ent/schema/edge"
+	"entgo.io/ent/schema/mixin"
+	"github.com/theopenlane/core/internal/ent/generated/hook"
+	"github.com/theopenlane/core/internal/ent/hooks"
+	"github.com/theopenlane/iam/fgax"
+)
+
+// GroupPermissionsMixin is a mixin for group permissions on an entity
+// This allows for editor + blocked_groups, and optionally viewer groups
+// to be added as edges to the entity. The hooks are added to create the tuples in
+// FGA for the groups
+// After adding this mixin to a schema, you must also add the other edge to the group schema, e.g.
+//
+//	edge.From("risk_viewers", Risk.Type).
+//	    Ref("viewers"),
+//	edge.From("risk_editors", Risk.Type).
+//		Ref("editors"),
+//	edge.From("risk_blocked_groups", Risk.Type).
+//		Ref("blocked_groups"),
+type GroupPermissionsMixin struct {
+	mixin.Schema
+
+	// ViewPermissions adds view permission for a group
+	ViewPermissions bool
+}
+
+// NewGroupPermissionsMixin creates a new GroupPermissionsMixin with optional viewer permissions
+func NewGroupPermissionsMixin(viewPermissions bool) GroupPermissionsMixin {
+	return GroupPermissionsMixin{
+		ViewPermissions: viewPermissions,
+	}
+}
+
+// Fields of the ObjectOwnedMixin
+func (g GroupPermissionsMixin) Edges() []ent.Edge {
+	blockEdge := edge.To("blocked_groups", Group.Type).
+		Comment("groups that are blocked from viewing or editing the risk")
+
+	editEdge := edge.To("editors", Group.Type).
+		Comment("provides edit access to the risk to members of the group")
+
+	viewEdge := edge.To("viewers", Group.Type).
+		Comment("provides view access to the risk to members of the group")
+
+	edges := []ent.Edge{blockEdge, editEdge}
+
+	// add the view edge if the view permissions are enabled
+	if g.ViewPermissions {
+		edges = append(edges, viewEdge)
+	}
+
+	return edges
+}
+
+func (g GroupPermissionsMixin) Hooks() []ent.Hook {
+	var hooks []ent.Hook
+
+	hooks = append(hooks, groupWriteOnlyHooks...)
+
+	if g.ViewPermissions {
+		hooks = append(hooks, groupReadOnlyHooks...)
+	}
+
+	return hooks
+}
+
+// groupReadWriteHooks are the hooks that are used to add the editor, blocked, and viewer tuples
+// based on a group
+var groupReadWriteHooks = append(groupWriteOnlyHooks, groupReadOnlyHooks...)
+
+// groupReadOnlyHooks are the hooks that are used to add the viewer tuples
+// based on a group
+var groupReadOnlyHooks = []ent.Hook{
+	hook.On(
+		hooks.HookRelationTuples(map[string]string{
+			"viewer_id": "group",
+		}, fgax.ViewerRelation), // add viewer tuples for associated groups
+		ent.OpCreate|ent.OpUpdateOne|ent.OpUpdateOne,
+	),
+}
+
+// groupWriteOnlyHooks are the hooks that are used to add the editor and blocked tuples
+// based on a group
+var groupWriteOnlyHooks = []ent.Hook{
+	hook.On(
+		hooks.HookRelationTuples(map[string]string{
+			"editor_id": "group",
+		}, fgax.EditorRelation), // add editor tuples for associated groups
+		ent.OpCreate|ent.OpUpdateOne|ent.OpUpdateOne,
+	),
+	hook.On(
+		hooks.HookRelationTuples(map[string]string{
+			"blocked_group_id": "group",
+		}, fgax.BlockedRelation), // add block tuples for associated groups
+		ent.OpCreate|ent.OpUpdateOne|ent.OpUpdateOne,
+	),
+}

--- a/internal/ent/schema/internalpolicy.go
+++ b/internal/ent/schema/internalpolicy.go
@@ -15,7 +15,6 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated/hook"
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
 	"github.com/theopenlane/core/internal/ent/hooks"
-	"github.com/theopenlane/core/internal/ent/interceptors"
 	"github.com/theopenlane/core/internal/ent/mixin"
 	"github.com/theopenlane/core/internal/ent/privacy/rule"
 )
@@ -65,10 +64,6 @@ func (InternalPolicy) Edges() []ent.Edge {
 		edge.To("tasks", Task.Type),
 		edge.From("programs", Program.Type).
 			Ref("policies"),
-		edge.To("editors", Group.Type).
-			Comment("provides edit access to the policy to members of the group"),
-		edge.To("blocked_groups", Group.Type).
-			Comment("groups that are blocked from viewing or editing the policy"),
 	}
 }
 
@@ -81,6 +76,8 @@ func (InternalPolicy) Mixin() []ent.Mixin {
 		emixin.TagMixin{},
 		// all policies must be associated to an organization
 		NewOrgOwnMixinWithRef("internalpolicies"),
+		// add group edit permissions to the procedure
+		NewGroupPermissionsMixin(false),
 	}
 }
 
@@ -99,23 +96,17 @@ func (InternalPolicy) Annotations() []schema.Annotation {
 
 // Hooks of the InternalPolicy
 func (InternalPolicy) Hooks() []ent.Hook {
-	hooks := []ent.Hook{
+	return []ent.Hook{
 		hook.On(
 			hooks.HookOrgOwnedTuples(false),
 			ent.OpCreate|ent.OpUpdateOne|ent.OpUpdateOne,
 		),
 	}
-
-	hooks = append(hooks, groupWriteOnlyHooks...)
-
-	return hooks
 }
 
 // Interceptors of the InternalPolicy
 func (InternalPolicy) Interceptors() []ent.Interceptor {
-	return []ent.Interceptor{
-		interceptors.FilterListQuery(),
-	}
+	return []ent.Interceptor{}
 }
 
 // Policy of the InternalPolicy

--- a/internal/ent/schema/organization.go
+++ b/internal/ent/schema/organization.go
@@ -176,6 +176,8 @@ func (Organization) Edges() []ent.Edge {
 			Annotations(entx.CascadeAnnotationField("Owner")),
 		edge.To("risks", Risk.Type).
 			Annotations(entx.CascadeAnnotationField("Owner")),
+		edge.To("controlobjectives", ControlObjective.Type).
+			Annotations(entx.CascadeAnnotationField("Owner")),
 	}
 }
 

--- a/internal/ent/schema/procedure.go
+++ b/internal/ent/schema/procedure.go
@@ -15,7 +15,6 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated/hook"
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
 	"github.com/theopenlane/core/internal/ent/hooks"
-	"github.com/theopenlane/core/internal/ent/interceptors"
 	"github.com/theopenlane/core/internal/ent/mixin"
 	"github.com/theopenlane/core/internal/ent/privacy/rule"
 )
@@ -70,10 +69,6 @@ func (Procedure) Edges() []ent.Edge {
 		edge.To("tasks", Task.Type),
 		edge.From("programs", Program.Type).
 			Ref("procedures"),
-		edge.To("editors", Group.Type).
-			Comment("provides edit access to the procedure to members of the group"),
-		edge.To("blocked_groups", Group.Type).
-			Comment("groups that are blocked from viewing or editing the procedure"),
 	}
 }
 
@@ -85,6 +80,8 @@ func (Procedure) Mixin() []ent.Mixin {
 		emixin.IDMixin{},
 		emixin.TagMixin{},
 		NewOrgOwnMixinWithRef("procedures"),
+		// add group edit permissions to the procedure
+		NewGroupPermissionsMixin(false),
 	}
 }
 
@@ -103,23 +100,17 @@ func (Procedure) Annotations() []schema.Annotation {
 
 // Hooks of the Procedure
 func (Procedure) Hooks() []ent.Hook {
-	hooks := []ent.Hook{
+	return []ent.Hook{
 		hook.On(
 			hooks.HookOrgOwnedTuples(false),
 			ent.OpCreate|ent.OpUpdateOne|ent.OpUpdateOne,
 		),
 	}
-
-	hooks = append(hooks, groupWriteOnlyHooks...)
-
-	return hooks
 }
 
 // Interceptors of the Procedure
 func (Procedure) Interceptors() []ent.Interceptor {
-	return []ent.Interceptor{
-		interceptors.FilterListQuery(),
-	}
+	return []ent.Interceptor{}
 }
 
 // Policy of the Procedure

--- a/internal/ent/schema/program.go
+++ b/internal/ent/schema/program.go
@@ -66,6 +66,8 @@ func (Program) Mixin() []ent.Mixin {
 		emixin.TagMixin{},
 		// all programs must be associated to an organization
 		NewOrgOwnMixinWithRef("programs"),
+		// add group permissions to the program
+		NewGroupPermissionsMixin(true),
 	}
 }
 
@@ -101,12 +103,6 @@ func (Program) Edges() []ent.Edge {
 		edge.From("users", User.Type).
 			Ref("programs").
 			Through("members", ProgramMembership.Type),
-		edge.To("viewers", Group.Type).
-			Comment("provides view access to the program to members of the group"),
-		edge.To("editors", Group.Type).
-			Comment("provides edit access to the program to members of the group"),
-		edge.To("blocked_groups", Group.Type).
-			Comment("groups that are blocked from viewing or editing the program"),
 	}
 }
 
@@ -139,13 +135,9 @@ func (Program) Annotations() []schema.Annotation {
 
 // Hooks of the Program
 func (Program) Hooks() []ent.Hook {
-	hooks := []ent.Hook{
+	return []ent.Hook{
 		hooks.HookProgramAuthz(),
 	}
-
-	hooks = append(hooks, groupReadWriteHooks...)
-
-	return hooks
 }
 
 // Interceptors of the Program

--- a/internal/ent/schema/risk.go
+++ b/internal/ent/schema/risk.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
-	"github.com/theopenlane/core/internal/ent/interceptors"
 	"github.com/theopenlane/core/internal/ent/mixin"
 	"github.com/theopenlane/core/internal/ent/privacy/rule"
 	"github.com/theopenlane/core/pkg/enums"
@@ -61,9 +60,6 @@ func (Risk) Fields() []ent.Field {
 		field.JSON("details", map[string]interface{}{}).
 			Optional().
 			Comment("json data for the risk document"),
-		field.String("owner_id").
-			NotEmpty().
-			Comment("the ID of the organization owner of the risk"),
 	}
 }
 
@@ -75,19 +71,8 @@ func (Risk) Edges() []ent.Edge {
 		edge.From("procedure", Procedure.Type).
 			Ref("risks"),
 		edge.To("actionplans", ActionPlan.Type),
-		edge.From("owner", Organization.Type).
-			Field("owner_id").
-			Required().
-			Unique(). // risk must be associated to a single organization
-			Ref("risks"),
-		edge.From("program", Program.Type).
+		edge.From("programs", Program.Type).
 			Ref("risks"), // risk can be associated to 1:m programs, this allow permission inheritance from the program(s)
-		edge.To("viewers", Group.Type).
-			Comment("provides view access to the risk to members of the group"),
-		edge.To("editors", Group.Type).
-			Comment("provides edit access to the risk to members of the group"),
-		edge.To("blocked_groups", Group.Type).
-			Comment("groups that are blocked from viewing or editing the risk"),
 	}
 }
 
@@ -102,9 +87,13 @@ func (Risk) Mixin() []ent.Mixin {
 		// this mixin will add the owner_id field using the OrgHook but not organization tuples are created
 		// it will also create program parent tuples for the risk when a program is associated to the risk
 		NewObjectOwnedMixin(ObjectOwnedMixin{
-			FieldNames: []string{"program_id"},
-			HookFuncs:  []HookFunc{orgHookCreateFunc, defaultObjectHookFunc, defaultTupleUpdateFunc},
-		})}
+			FieldNames:            []string{"program_id"},
+			WithOrganizationOwner: true,
+			Ref:                   "risks",
+		}),
+		// add groups permissions with viewer, editor, and blocked groups
+		NewGroupPermissionsMixin(true),
+	}
 }
 
 // Annotations of the Risk
@@ -117,22 +106,6 @@ func (Risk) Annotations() []schema.Annotation {
 			ObjectType:   "risk", // check access to the risk for update/delete
 			IncludeHooks: false,
 		},
-	}
-}
-
-// Hooks of the Risk
-func (Risk) Hooks() []ent.Hook {
-	var hooks []ent.Hook
-
-	hooks = append(hooks, groupReadWriteHooks...)
-
-	return hooks
-}
-
-// Interceptors of the Risk
-func (Risk) Interceptors() []ent.Interceptor {
-	return []ent.Interceptor{
-		interceptors.FilterListQuery(),
 	}
 }
 

--- a/internal/ent/schema/risk_history.go
+++ b/internal/ent/schema/risk_history.go
@@ -102,7 +102,7 @@ func (RiskHistory) Indexes() []ent.Index {
 // Interceptors of the RiskHistory
 func (RiskHistory) Interceptors() []ent.Interceptor {
 	return []ent.Interceptor{
-		interceptors.HistoryAccess("audit_log_viewer", false, false),
+		interceptors.HistoryAccess("audit_log_viewer", true, false),
 	}
 }
 

--- a/internal/graphapi/controlobjective_test.go
+++ b/internal/graphapi/controlobjective_test.go
@@ -1,0 +1,610 @@
+package graphapi_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/theopenlane/core/pkg/enums"
+	"github.com/theopenlane/core/pkg/openlaneclient"
+	"github.com/theopenlane/utils/ulids"
+)
+
+func (suite *GraphTestSuite) TestQueryControlObjective() {
+	t := suite.T()
+
+	program := (&ProgramBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+
+	// add adminUser to the program so that they can create a ControlObjective
+	(&ProgramMemberBuilder{client: suite.client, ProgramID: program.ID,
+		UserID: adminUser.ID, Role: enums.RoleAdmin.String()}).
+		MustNew(testUser1.UserCtx, t)
+
+	// add test cases for querying the ControlObjective
+	testCases := []struct {
+		name     string
+		queryID  string
+		client   *openlaneclient.OpenlaneClient
+		ctx      context.Context
+		errorMsg string
+	}{
+		{
+			name:   "happy path",
+			client: suite.client.api,
+			ctx:    testUser1.UserCtx,
+		},
+		{
+			name:     "read only user, same org, no access to the program",
+			client:   suite.client.api,
+			ctx:      viewOnlyUser.UserCtx,
+			errorMsg: notFoundErrorMsg,
+		},
+		{
+			name:   "admin user, access to the program",
+			client: suite.client.api,
+			ctx:    adminUser.UserCtx,
+		},
+		{
+			name:   "happy path using personal access token",
+			client: suite.client.apiWithPAT,
+			ctx:    context.Background(),
+		},
+		{
+			name:     "control objective not found, invalid ID",
+			queryID:  "invalid",
+			client:   suite.client.api,
+			ctx:      testUser1.UserCtx,
+			errorMsg: notFoundErrorMsg,
+		},
+		{
+			name:     "control objective not found, using not authorized user",
+			client:   suite.client.api,
+			ctx:      testUser2.UserCtx,
+			errorMsg: notFoundErrorMsg,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("Get "+tc.name, func(t *testing.T) {
+			// setup the control objective if it is not already created
+			if tc.queryID == "" {
+				resp, err := suite.client.api.CreateControlObjective(testUser1.UserCtx,
+					openlaneclient.CreateControlObjectiveInput{
+						Name:       "ControlObjective",
+						ProgramIDs: []string{program.ID},
+					})
+
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+
+				tc.queryID = resp.CreateControlObjective.ControlObjective.ID
+			}
+
+			resp, err := tc.client.GetControlObjectiveByID(tc.ctx, tc.queryID)
+
+			if tc.errorMsg != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tc.errorMsg)
+				assert.Nil(t, resp)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			require.NotEmpty(t, resp.ControlObjective)
+
+			assert.Equal(t, tc.queryID, resp.ControlObjective.ID)
+			assert.NotEmpty(t, resp.ControlObjective.Name)
+
+			require.Len(t, resp.ControlObjective.Programs, 1)
+			assert.NotEmpty(t, resp.ControlObjective.Programs[0].ID)
+		})
+	}
+}
+
+func (suite *GraphTestSuite) TestQueryControlObjectives() {
+	t := suite.T()
+
+	// create multiple objects to be queried using testUser1
+	(&ControlObjectiveBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	(&ControlObjectiveBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+
+	testCases := []struct {
+		name            string
+		client          *openlaneclient.OpenlaneClient
+		ctx             context.Context
+		expectedResults int
+	}{
+		{
+			name:            "happy path",
+			client:          suite.client.api,
+			ctx:             testUser1.UserCtx,
+			expectedResults: 2,
+		},
+		{
+			name:            "happy path, using read only user of the same org, no programs or groups associated",
+			client:          suite.client.api,
+			ctx:             viewOnlyUser.UserCtx,
+			expectedResults: 0,
+		},
+		{
+			name:            "happy path, no access to the program or group",
+			client:          suite.client.apiWithToken,
+			ctx:             context.Background(),
+			expectedResults: 0,
+		},
+		{
+			name:            "happy path, using pat",
+			client:          suite.client.apiWithPAT,
+			ctx:             context.Background(),
+			expectedResults: 2,
+		},
+		{
+			name:            "another user, no control objectives should be returned",
+			client:          suite.client.api,
+			ctx:             testUser2.UserCtx,
+			expectedResults: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("List "+tc.name, func(t *testing.T) {
+			resp, err := tc.client.GetAllControlObjectives(tc.ctx)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			assert.Len(t, resp.ControlObjectives.Edges, tc.expectedResults)
+		})
+	}
+}
+
+func (suite *GraphTestSuite) TestMutationCreateControlObjective() {
+	t := suite.T()
+
+	program1 := (&ProgramBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	program2 := (&ProgramBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	programAnotherUser := (&ProgramBuilder{client: suite.client}).MustNew(testUser2.UserCtx, t)
+
+	// add adminUser to the program so that they can create a control objective associated with the program1
+	(&ProgramMemberBuilder{client: suite.client, ProgramID: program1.ID,
+		UserID: adminUser.ID, Role: enums.RoleAdmin.String()}).
+		MustNew(testUser1.UserCtx, t)
+
+	// create groups to be associated with the control objective
+	blockedGroup := (&GroupBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	viewerGroup := (&GroupBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+
+	testCases := []struct {
+		name        string
+		request     openlaneclient.CreateControlObjectiveInput
+		client      *openlaneclient.OpenlaneClient
+		ctx         context.Context
+		expectedErr string
+	}{
+		{
+			name: "happy path, minimal input",
+			request: openlaneclient.CreateControlObjectiveInput{
+				Name: "ControlObjective",
+			},
+			client: suite.client.api,
+			ctx:    testUser1.UserCtx,
+		},
+		{
+			name: "happy path, all input",
+			request: openlaneclient.CreateControlObjectiveInput{
+				Name:                 "Another ControlObjective",
+				Description:          lo.ToPtr("A description of the ControlObjective"),
+				Status:               lo.ToPtr("mitigated"),
+				ControlObjectiveType: lo.ToPtr("operational"),
+				Version:              lo.ToPtr("1.0"),
+				ControlNumber:        lo.ToPtr("1.1"),
+				Family:               lo.ToPtr("family"),
+				Class:                lo.ToPtr("class"),
+				Source:               lo.ToPtr("source"),
+				MappedFrameworks:     lo.ToPtr("mapped frameworks"),
+				Details:              map[string]interface{}{"stuff": "things"},
+				ProgramIDs:           []string{program1.ID, program2.ID}, // multiple programs
+			},
+			client: suite.client.api,
+			ctx:    testUser1.UserCtx,
+		},
+		{
+			name: "add groups",
+			request: openlaneclient.CreateControlObjectiveInput{
+				Name:            "Test Procedure",
+				EditorIDs:       []string{testUser1.GroupID},
+				BlockedGroupIDs: []string{blockedGroup.ID},
+				ViewerIDs:       []string{viewerGroup.ID},
+			},
+			client: suite.client.api,
+			ctx:    testUser1.UserCtx,
+		},
+		{
+			name: "happy path, using pat",
+			request: openlaneclient.CreateControlObjectiveInput{
+				Name:    "ControlObjective",
+				OwnerID: testUser1.OrganizationID,
+			},
+			client: suite.client.apiWithPAT,
+			ctx:    context.Background(),
+		},
+		{
+			name: "using api token",
+			request: openlaneclient.CreateControlObjectiveInput{
+				Name: "ControlObjective",
+			},
+			client: suite.client.apiWithToken,
+			ctx:    context.Background(),
+		},
+		{
+			name: "user not authorized, not enough permissions",
+			request: openlaneclient.CreateControlObjectiveInput{
+				Name: "ControlObjective",
+			},
+			client:      suite.client.api,
+			ctx:         viewOnlyUser.UserCtx,
+			expectedErr: notAuthorizedErrorMsg,
+		},
+		{
+			name: "user authorized, they were added to the program",
+			request: openlaneclient.CreateControlObjectiveInput{
+				Name:       "ControlObjective",
+				ProgramIDs: []string{program1.ID},
+			},
+			client: suite.client.api,
+			ctx:    adminUser.UserCtx,
+		},
+		{
+			name: "user not authorized, user not authorized to one of the programs",
+			request: openlaneclient.CreateControlObjectiveInput{
+				Name:       "ControlObjective",
+				ProgramIDs: []string{program1.ID, program2.ID},
+			},
+			client:      suite.client.api,
+			ctx:         adminUser.UserCtx,
+			expectedErr: notAuthorizedErrorMsg,
+		},
+		{
+			name:        "missing required name",
+			request:     openlaneclient.CreateControlObjectiveInput{},
+			client:      suite.client.api,
+			ctx:         testUser1.UserCtx,
+			expectedErr: "value is less than the required length",
+		},
+		{
+			name: "user not authorized, no permissions to one of the programs",
+			request: openlaneclient.CreateControlObjectiveInput{
+				Name:       "ControlObjective",
+				ProgramIDs: []string{programAnotherUser.ID, program1.ID},
+			},
+			client:      suite.client.api,
+			ctx:         testUser1.UserCtx,
+			expectedErr: notAuthorizedErrorMsg,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("Create "+tc.name, func(t *testing.T) {
+			resp, err := tc.client.CreateControlObjective(tc.ctx, tc.request)
+			if tc.expectedErr != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tc.expectedErr)
+				assert.Nil(t, resp)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			// check required fields
+			require.NotEmpty(t, resp.CreateControlObjective.ControlObjective.ID)
+			assert.Equal(t, tc.request.Name, resp.CreateControlObjective.ControlObjective.Name)
+
+			// ensure the program is set
+			if len(tc.request.ProgramIDs) > 0 {
+				require.NotEmpty(t, resp.CreateControlObjective.ControlObjective.Programs)
+				require.Len(t, resp.CreateControlObjective.ControlObjective.Programs, len(tc.request.ProgramIDs))
+
+				for i, p := range resp.CreateControlObjective.ControlObjective.Programs {
+					assert.Equal(t, tc.request.ProgramIDs[i], p.ID)
+				}
+			} else {
+				assert.Empty(t, resp.CreateControlObjective.ControlObjective.Programs)
+			}
+
+			if tc.request.Description != nil {
+				assert.Equal(t, *tc.request.Description, *resp.CreateControlObjective.ControlObjective.Description)
+			} else {
+				assert.Empty(t, resp.CreateControlObjective.ControlObjective.Description)
+			}
+
+			if tc.request.Status != nil {
+				assert.Equal(t, *tc.request.Status, *resp.CreateControlObjective.ControlObjective.Status)
+			} else {
+				assert.Empty(t, resp.CreateControlObjective.ControlObjective.Status)
+			}
+
+			if tc.request.ControlObjectiveType != nil {
+				assert.Equal(t, *tc.request.ControlObjectiveType, *resp.CreateControlObjective.ControlObjective.ControlObjectiveType)
+			} else {
+				assert.Empty(t, resp.CreateControlObjective.ControlObjective.ControlObjectiveType)
+			}
+
+			if tc.request.Version != nil {
+				assert.Equal(t, *tc.request.Version, *resp.CreateControlObjective.ControlObjective.Version)
+			} else {
+				assert.Empty(t, resp.CreateControlObjective.ControlObjective.Version)
+			}
+
+			if tc.request.ControlNumber != nil {
+				assert.Equal(t, *tc.request.ControlNumber, *resp.CreateControlObjective.ControlObjective.ControlNumber)
+			} else {
+				assert.Empty(t, resp.CreateControlObjective.ControlObjective.ControlNumber)
+			}
+
+			if tc.request.Family != nil {
+				assert.Equal(t, *tc.request.Family, *resp.CreateControlObjective.ControlObjective.Family)
+			} else {
+				assert.Empty(t, resp.CreateControlObjective.ControlObjective.Family)
+			}
+
+			if tc.request.Class != nil {
+				assert.Equal(t, *tc.request.Class, *resp.CreateControlObjective.ControlObjective.Class)
+			} else {
+				assert.Empty(t, resp.CreateControlObjective.ControlObjective.Class)
+			}
+
+			if tc.request.Source != nil {
+				assert.Equal(t, *tc.request.Source, *resp.CreateControlObjective.ControlObjective.Source)
+			} else {
+				assert.Empty(t, resp.CreateControlObjective.ControlObjective.Source)
+			}
+
+			if tc.request.MappedFrameworks != nil {
+				assert.Equal(t, *tc.request.MappedFrameworks, *resp.CreateControlObjective.ControlObjective.MappedFrameworks)
+			} else {
+				assert.Empty(t, resp.CreateControlObjective.ControlObjective.MappedFrameworks)
+			}
+
+			if tc.request.Details != nil {
+				assert.Equal(t, tc.request.Details, resp.CreateControlObjective.ControlObjective.Details)
+			} else {
+				assert.Empty(t, resp.CreateControlObjective.ControlObjective.Details)
+			}
+
+			if len(tc.request.EditorIDs) > 0 {
+				require.Len(t, resp.CreateControlObjective.ControlObjective.Editors, 1)
+				for _, edge := range resp.CreateControlObjective.ControlObjective.Editors {
+					assert.Equal(t, testUser1.GroupID, edge.ID)
+				}
+			}
+
+			if len(tc.request.BlockedGroupIDs) > 0 {
+				require.Len(t, resp.CreateControlObjective.ControlObjective.BlockedGroups, 1)
+				for _, edge := range resp.CreateControlObjective.ControlObjective.BlockedGroups {
+					assert.Equal(t, blockedGroup.ID, edge.ID)
+				}
+			}
+
+			if len(tc.request.ViewerIDs) > 0 {
+				require.Len(t, resp.CreateControlObjective.ControlObjective.Viewers, 1)
+				for _, edge := range resp.CreateControlObjective.ControlObjective.Viewers {
+					assert.Equal(t, viewerGroup.ID, edge.ID)
+				}
+			}
+		})
+	}
+}
+
+func (suite *GraphTestSuite) TestMutationUpdateControlObjective() {
+	t := suite.T()
+
+	program := (&ProgramBuilder{client: suite.client, EditorIDs: testUser1.GroupID}).MustNew(testUser1.UserCtx, t)
+	controlObjective := (&ControlObjectiveBuilder{client: suite.client, ProgramID: program.ID}).MustNew(testUser1.UserCtx, t)
+
+	// create another admin user and add them to the same organization and group as testUser1
+	// this will allow us to test the group editor/viewer permissions
+	anotherAdminUser := suite.userBuilder(context.Background())
+	suite.addUserToOrganization(&anotherAdminUser, enums.RoleAdmin, testUser1.OrganizationID)
+
+	(&GroupMemberBuilder{client: suite.client, UserID: anotherAdminUser.ID, GroupID: testUser1.GroupID}).MustNew(testUser1.UserCtx, t)
+
+	// ensure the user does not currently have access to the control objective
+	res, err := suite.client.api.GetControlObjectiveByID(anotherAdminUser.UserCtx, controlObjective.ID)
+	require.Error(t, err)
+	require.Nil(t, res)
+
+	testCases := []struct {
+		name        string
+		request     openlaneclient.UpdateControlObjectiveInput
+		client      *openlaneclient.OpenlaneClient
+		ctx         context.Context
+		expectedErr string
+	}{
+		{
+			name: "happy path, update field",
+			request: openlaneclient.UpdateControlObjectiveInput{
+				Description:  lo.ToPtr("Updated description"),
+				AddViewerIDs: []string{testUser1.GroupID},
+			},
+			client: suite.client.api,
+			ctx:    testUser1.UserCtx,
+		},
+		{
+			name: "happy path, update multiple fields",
+			request: openlaneclient.UpdateControlObjectiveInput{
+				Status:           lo.ToPtr("mitigated"),
+				Tags:             []string{"tag1", "tag2"},
+				Description:      lo.ToPtr("Updated description"),
+				Version:          lo.ToPtr("1.1"),
+				ControlNumber:    lo.ToPtr("1.2"),
+				Family:           lo.ToPtr("family2"),
+				Class:            lo.ToPtr("class2"),
+				Source:           lo.ToPtr("source2"),
+				MappedFrameworks: lo.ToPtr("mapped frameworks2"),
+			},
+			client: suite.client.apiWithPAT,
+			ctx:    context.Background(),
+		},
+		{
+			name: "update not allowed, not permissions in same org",
+			request: openlaneclient.UpdateControlObjectiveInput{
+				Status: lo.ToPtr("testing"),
+			},
+			client:      suite.client.api,
+			ctx:         viewOnlyUser.UserCtx,
+			expectedErr: notFoundErrorMsg,
+		},
+		{
+			name: "update not allowed, no permissions",
+			request: openlaneclient.UpdateControlObjectiveInput{
+				Family: lo.ToPtr("family3"),
+			},
+			client:      suite.client.api,
+			ctx:         testUser2.UserCtx,
+			expectedErr: notFoundErrorMsg,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("Update "+tc.name, func(t *testing.T) {
+			resp, err := tc.client.UpdateControlObjective(tc.ctx, controlObjective.ID, tc.request)
+			if tc.expectedErr != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tc.expectedErr)
+				assert.Nil(t, resp)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			if tc.request.Description != nil {
+				assert.Equal(t, *tc.request.Description, *resp.UpdateControlObjective.ControlObjective.Description)
+			}
+
+			if tc.request.Status != nil {
+				assert.Equal(t, *tc.request.Status, *resp.UpdateControlObjective.ControlObjective.Status)
+			}
+
+			if tc.request.Tags != nil {
+				assert.ElementsMatch(t, tc.request.Tags, resp.UpdateControlObjective.ControlObjective.Tags)
+			}
+
+			if tc.request.Version != nil {
+				assert.Equal(t, *tc.request.Version, *resp.UpdateControlObjective.ControlObjective.Version)
+			}
+
+			if tc.request.ControlNumber != nil {
+				assert.Equal(t, *tc.request.ControlNumber, *resp.UpdateControlObjective.ControlObjective.ControlNumber)
+			}
+
+			if tc.request.Family != nil {
+				assert.Equal(t, *tc.request.Family, *resp.UpdateControlObjective.ControlObjective.Family)
+			}
+
+			if tc.request.Class != nil {
+				assert.Equal(t, *tc.request.Class, *resp.UpdateControlObjective.ControlObjective.Class)
+			}
+
+			if tc.request.Source != nil {
+				assert.Equal(t, *tc.request.Source, *resp.UpdateControlObjective.ControlObjective.Source)
+			}
+
+			if tc.request.MappedFrameworks != nil {
+				assert.Equal(t, *tc.request.MappedFrameworks, *resp.UpdateControlObjective.ControlObjective.MappedFrameworks)
+			}
+
+			if tc.request.Details != nil {
+				assert.Equal(t, tc.request.Details, resp.UpdateControlObjective.ControlObjective.Details)
+			}
+
+			if len(tc.request.AddViewerIDs) > 0 {
+				require.Len(t, resp.UpdateControlObjective.ControlObjective.Viewers, 1)
+				for _, edge := range resp.UpdateControlObjective.ControlObjective.Viewers {
+					assert.Equal(t, testUser1.GroupID, edge.ID)
+				}
+
+				// ensure the user has access to the control objective now
+				res, err := suite.client.api.GetControlObjectiveByID(anotherAdminUser.UserCtx, controlObjective.ID)
+				require.NoError(t, err)
+				require.NotEmpty(t, res)
+				assert.Equal(t, controlObjective.ID, res.ControlObjective.ID)
+			}
+		})
+	}
+}
+
+func (suite *GraphTestSuite) TestMutationDeleteControlObjective() {
+	t := suite.T()
+
+	// create objects to be deleted
+	ControlObjective1 := (&ControlObjectiveBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	ControlObjective2 := (&ControlObjectiveBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+
+	testCases := []struct {
+		name        string
+		idToDelete  string
+		client      *openlaneclient.OpenlaneClient
+		ctx         context.Context
+		expectedErr string
+	}{
+		{
+			name:        "not authorized, delete",
+			idToDelete:  ControlObjective1.ID,
+			client:      suite.client.api,
+			ctx:         testUser2.UserCtx,
+			expectedErr: notFoundErrorMsg,
+		},
+		{
+			name:       "happy path, delete",
+			idToDelete: ControlObjective1.ID,
+			client:     suite.client.api,
+			ctx:        testUser1.UserCtx,
+		},
+		{
+			name:        "already deleted, not found",
+			idToDelete:  ControlObjective1.ID,
+			client:      suite.client.api,
+			ctx:         testUser1.UserCtx,
+			expectedErr: "not found",
+		},
+		{
+			name:       "happy path, delete using personal access token",
+			idToDelete: ControlObjective2.ID,
+			client:     suite.client.apiWithPAT,
+			ctx:        context.Background(),
+		},
+		{
+			name:        "unknown id, not found",
+			idToDelete:  ulids.New().String(),
+			client:      suite.client.api,
+			ctx:         testUser1.UserCtx,
+			expectedErr: notFoundErrorMsg,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("Delete "+tc.name, func(t *testing.T) {
+			resp, err := tc.client.DeleteControlObjective(tc.ctx, tc.idToDelete)
+			if tc.expectedErr != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tc.expectedErr)
+				assert.Nil(t, resp)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			assert.Equal(t, tc.idToDelete, resp.DeleteControlObjective.DeletedID)
+		})
+	}
+}

--- a/internal/graphapi/models_test.go
+++ b/internal/graphapi/models_test.go
@@ -297,6 +297,14 @@ type RiskBuilder struct {
 	ProgramID string
 }
 
+type ControlObjectiveBuilder struct {
+	client *client
+
+	// Fields
+	Name      string
+	ProgramID string
+}
+
 // MustNew organization builder is used to create, without authz checks, orgs in the database
 func (o *OrganizationBuilder) MustNew(ctx context.Context, t *testing.T) *ent.Organization {
 	// no auth, so allow policy
@@ -982,4 +990,28 @@ func (r *RiskBuilder) MustNew(ctx context.Context, t *testing.T) *ent.Risk {
 		SaveX(ctx)
 
 	return risk
+}
+
+// MustNew control objective builder is used to create, without authz checks, control objectives in the database
+func (c *ControlObjectiveBuilder) MustNew(ctx context.Context, t *testing.T) *ent.ControlObjective {
+	ctx = privacy.DecisionContext(ctx, privacy.Allow)
+
+	// add client to context
+	ctx = ent.NewContext(ctx, c.client.db)
+
+	if c.Name == "" {
+		c.Name = gofakeit.AppName()
+	}
+
+	mutation := c.client.db.ControlObjective.Create().
+		SetName(c.Name)
+
+	if c.ProgramID != "" {
+		mutation.AddProgramIDs(c.ProgramID)
+	}
+
+	co := mutation.
+		SaveX(ctx)
+
+	return co
 }

--- a/internal/graphapi/risk_test.go
+++ b/internal/graphapi/risk_test.go
@@ -101,8 +101,8 @@ func (suite *GraphTestSuite) TestQueryRisk() {
 			assert.Equal(t, tc.queryID, resp.Risk.ID)
 			assert.NotEmpty(t, resp.Risk.Name)
 
-			require.Len(t, resp.Risk.Program, 1)
-			assert.NotEmpty(t, resp.Risk.Program[0].ID)
+			require.Len(t, resp.Risk.Programs, 1)
+			assert.NotEmpty(t, resp.Risk.Programs[0].ID)
 		})
 	}
 }
@@ -307,14 +307,14 @@ func (suite *GraphTestSuite) TestMutationCreateRisk() {
 
 			// ensure the program is set
 			if len(tc.request.ProgramIDs) > 0 {
-				require.NotEmpty(t, resp.CreateRisk.Risk.Program)
-				require.Len(t, resp.CreateRisk.Risk.Program, len(tc.request.ProgramIDs))
+				require.NotEmpty(t, resp.CreateRisk.Risk.Programs)
+				require.Len(t, resp.CreateRisk.Risk.Programs, len(tc.request.ProgramIDs))
 
-				for i, p := range resp.CreateRisk.Risk.Program {
+				for i, p := range resp.CreateRisk.Risk.Programs {
 					assert.Equal(t, tc.request.ProgramIDs[i], p.ID)
 				}
 			} else {
-				assert.Empty(t, resp.CreateRisk.Risk.Program)
+				assert.Empty(t, resp.CreateRisk.Risk.Programs)
 			}
 
 			if tc.request.Description != nil {
@@ -429,37 +429,37 @@ func (suite *GraphTestSuite) TestMutationUpdateRisk() {
 			client: suite.client.api,
 			ctx:    testUser1.UserCtx,
 		},
-		// {
-		// 	name: "happy path, update multiple fields",
-		// 	request: openlaneclient.UpdateRiskInput{
-		// 		Satisfies:  lo.ToPtr("Updated controls"),
-		// 		Status:     lo.ToPtr("mitigated"),
-		// 		Tags:       []string{"tag1", "tag2"},
-		// 		Mitigation: lo.ToPtr("Updated mitigation"),
-		// 		Impact:     &enums.RiskImpactModerate,
-		// 		Likelihood: &enums.RiskLikelihoodLow,
-		// 	},
-		// 	client: suite.client.apiWithPAT,
-		// 	ctx:    context.Background(),
-		// },
-		// {
-		// 	name: "update not allowed, not permissions in same org",
-		// 	request: openlaneclient.UpdateRiskInput{
-		// 		Likelihood: &enums.RiskLikelihoodLow,
-		// 	},
-		// 	client:      suite.client.api,
-		// 	ctx:         viewOnlyUser.UserCtx,
-		// 	expectedErr: notFoundErrorMsg,
-		// },
-		// {
-		// 	name: "update not allowed, no permissions",
-		// 	request: openlaneclient.UpdateRiskInput{
-		// 		Likelihood: &enums.RiskLikelihoodLow,
-		// 	},
-		// 	client:      suite.client.api,
-		// 	ctx:         testUser2.UserCtx,
-		// 	expectedErr: notFoundErrorMsg,
-		// },
+		{
+			name: "happy path, update multiple fields",
+			request: openlaneclient.UpdateRiskInput{
+				Satisfies:  lo.ToPtr("Updated controls"),
+				Status:     lo.ToPtr("mitigated"),
+				Tags:       []string{"tag1", "tag2"},
+				Mitigation: lo.ToPtr("Updated mitigation"),
+				Impact:     &enums.RiskImpactModerate,
+				Likelihood: &enums.RiskLikelihoodLow,
+			},
+			client: suite.client.apiWithPAT,
+			ctx:    context.Background(),
+		},
+		{
+			name: "update not allowed, not permissions in same org",
+			request: openlaneclient.UpdateRiskInput{
+				Likelihood: &enums.RiskLikelihoodLow,
+			},
+			client:      suite.client.api,
+			ctx:         viewOnlyUser.UserCtx,
+			expectedErr: notFoundErrorMsg,
+		},
+		{
+			name: "update not allowed, no permissions",
+			request: openlaneclient.UpdateRiskInput{
+				Likelihood: &enums.RiskLikelihoodLow,
+			},
+			client:      suite.client.api,
+			ctx:         testUser2.UserCtx,
+			expectedErr: notFoundErrorMsg,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/graphapi/search.go
+++ b/internal/graphapi/search.go
@@ -226,6 +226,7 @@ func adminSearchControlObjectives(ctx context.Context, query string) ([]*generat
 				likeQuery := "%" + query + "%"
 				s.Where(sql.ExprP("(tags)::text LIKE $3", likeQuery)) // search by Tags
 			},
+			controlobjective.OwnerIDContainsFold(query),              // search by OwnerID
 			controlobjective.NameContainsFold(query),                 // search by Name
 			controlobjective.DescriptionContainsFold(query),          // search by Description
 			controlobjective.StatusContainsFold(query),               // search by Status
@@ -238,7 +239,7 @@ func adminSearchControlObjectives(ctx context.Context, query string) ([]*generat
 			controlobjective.MappedFrameworksContainsFold(query),     // search by MappedFrameworks
 			func(s *sql.Selector) {
 				likeQuery := "%" + query + "%"
-				s.Where(sql.ExprP("(details)::text LIKE $14", likeQuery)) // search by Details
+				s.Where(sql.ExprP("(details)::text LIKE $15", likeQuery)) // search by Details
 			},
 		),
 	).All(ctx)
@@ -998,6 +999,7 @@ func adminSearchRisks(ctx context.Context, query string) ([]*generated.Risk, err
 				likeQuery := "%" + query + "%"
 				s.Where(sql.ExprP("(tags)::text LIKE $3", likeQuery)) // search by Tags
 			},
+			risk.OwnerIDContainsFold(query),       // search by OwnerID
 			risk.NameContainsFold(query),          // search by Name
 			risk.DescriptionContainsFold(query),   // search by Description
 			risk.StatusContainsFold(query),        // search by Status
@@ -1007,9 +1009,8 @@ func adminSearchRisks(ctx context.Context, query string) ([]*generated.Risk, err
 			risk.SatisfiesContainsFold(query),     // search by Satisfies
 			func(s *sql.Selector) {
 				likeQuery := "%" + query + "%"
-				s.Where(sql.ExprP("(details)::text LIKE $11", likeQuery)) // search by Details
+				s.Where(sql.ExprP("(details)::text LIKE $12", likeQuery)) // search by Details
 			},
-			risk.OwnerIDContainsFold(query), // search by OwnerID
 		),
 	).All(ctx)
 }

--- a/pkg/openlaneclient/graphclient.go
+++ b/pkg/openlaneclient/graphclient.go
@@ -1767,6 +1767,7 @@ type AdminSearch_AdminSearch_Nodes_ControlObjectiveSearchResult_ControlObjective
 	DeletedBy            *string                "json:\"deletedBy,omitempty\" graphql:\"deletedBy\""
 	ID                   string                 "json:\"id\" graphql:\"id\""
 	Tags                 []string               "json:\"tags,omitempty\" graphql:\"tags\""
+	OwnerID              string                 "json:\"ownerID\" graphql:\"ownerID\""
 	Name                 string                 "json:\"name\" graphql:\"name\""
 	Description          *string                "json:\"description,omitempty\" graphql:\"description\""
 	Status               *string                "json:\"status,omitempty\" graphql:\"status\""
@@ -1797,6 +1798,12 @@ func (t *AdminSearch_AdminSearch_Nodes_ControlObjectiveSearchResult_ControlObjec
 		t = &AdminSearch_AdminSearch_Nodes_ControlObjectiveSearchResult_ControlObjectives{}
 	}
 	return t.Tags
+}
+func (t *AdminSearch_AdminSearch_Nodes_ControlObjectiveSearchResult_ControlObjectives) GetOwnerID() string {
+	if t == nil {
+		t = &AdminSearch_AdminSearch_Nodes_ControlObjectiveSearchResult_ControlObjectives{}
+	}
+	return t.OwnerID
 }
 func (t *AdminSearch_AdminSearch_Nodes_ControlObjectiveSearchResult_ControlObjectives) GetName() string {
 	if t == nil {
@@ -3441,6 +3448,7 @@ type AdminSearch_AdminSearch_Nodes_RiskSearchResult_Risks struct {
 	DeletedBy     *string                "json:\"deletedBy,omitempty\" graphql:\"deletedBy\""
 	ID            string                 "json:\"id\" graphql:\"id\""
 	Tags          []string               "json:\"tags,omitempty\" graphql:\"tags\""
+	OwnerID       string                 "json:\"ownerID\" graphql:\"ownerID\""
 	Name          string                 "json:\"name\" graphql:\"name\""
 	Description   *string                "json:\"description,omitempty\" graphql:\"description\""
 	Status        *string                "json:\"status,omitempty\" graphql:\"status\""
@@ -3449,7 +3457,6 @@ type AdminSearch_AdminSearch_Nodes_RiskSearchResult_Risks struct {
 	Mitigation    *string                "json:\"mitigation,omitempty\" graphql:\"mitigation\""
 	Satisfies     *string                "json:\"satisfies,omitempty\" graphql:\"satisfies\""
 	Details       map[string]interface{} "json:\"details,omitempty\" graphql:\"details\""
-	OwnerID       string                 "json:\"ownerID\" graphql:\"ownerID\""
 }
 
 func (t *AdminSearch_AdminSearch_Nodes_RiskSearchResult_Risks) GetDeletedBy() *string {
@@ -3469,6 +3476,12 @@ func (t *AdminSearch_AdminSearch_Nodes_RiskSearchResult_Risks) GetTags() []strin
 		t = &AdminSearch_AdminSearch_Nodes_RiskSearchResult_Risks{}
 	}
 	return t.Tags
+}
+func (t *AdminSearch_AdminSearch_Nodes_RiskSearchResult_Risks) GetOwnerID() string {
+	if t == nil {
+		t = &AdminSearch_AdminSearch_Nodes_RiskSearchResult_Risks{}
+	}
+	return t.OwnerID
 }
 func (t *AdminSearch_AdminSearch_Nodes_RiskSearchResult_Risks) GetName() string {
 	if t == nil {
@@ -3517,12 +3530,6 @@ func (t *AdminSearch_AdminSearch_Nodes_RiskSearchResult_Risks) GetDetails() map[
 		t = &AdminSearch_AdminSearch_Nodes_RiskSearchResult_Risks{}
 	}
 	return t.Details
-}
-func (t *AdminSearch_AdminSearch_Nodes_RiskSearchResult_Risks) GetOwnerID() string {
-	if t == nil {
-		t = &AdminSearch_AdminSearch_Nodes_RiskSearchResult_Risks{}
-	}
-	return t.OwnerID
 }
 
 type AdminSearch_AdminSearch_Nodes_RiskSearchResult struct {
@@ -7661,24 +7668,100 @@ func (t *CreateBulkControlObjective_CreateBulkControlObjective) GetControlObject
 	return t.ControlObjectives
 }
 
+type CreateControlObjective_CreateControlObjective_ControlObjective_Programs struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *CreateControlObjective_CreateControlObjective_ControlObjective_Programs) GetID() string {
+	if t == nil {
+		t = &CreateControlObjective_CreateControlObjective_ControlObjective_Programs{}
+	}
+	return t.ID
+}
+func (t *CreateControlObjective_CreateControlObjective_ControlObjective_Programs) GetName() string {
+	if t == nil {
+		t = &CreateControlObjective_CreateControlObjective_ControlObjective_Programs{}
+	}
+	return t.Name
+}
+
+type CreateControlObjective_CreateControlObjective_ControlObjective_Editors struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *CreateControlObjective_CreateControlObjective_ControlObjective_Editors) GetID() string {
+	if t == nil {
+		t = &CreateControlObjective_CreateControlObjective_ControlObjective_Editors{}
+	}
+	return t.ID
+}
+func (t *CreateControlObjective_CreateControlObjective_ControlObjective_Editors) GetName() string {
+	if t == nil {
+		t = &CreateControlObjective_CreateControlObjective_ControlObjective_Editors{}
+	}
+	return t.Name
+}
+
+type CreateControlObjective_CreateControlObjective_ControlObjective_Viewers struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *CreateControlObjective_CreateControlObjective_ControlObjective_Viewers) GetID() string {
+	if t == nil {
+		t = &CreateControlObjective_CreateControlObjective_ControlObjective_Viewers{}
+	}
+	return t.ID
+}
+func (t *CreateControlObjective_CreateControlObjective_ControlObjective_Viewers) GetName() string {
+	if t == nil {
+		t = &CreateControlObjective_CreateControlObjective_ControlObjective_Viewers{}
+	}
+	return t.Name
+}
+
+type CreateControlObjective_CreateControlObjective_ControlObjective_BlockedGroups struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *CreateControlObjective_CreateControlObjective_ControlObjective_BlockedGroups) GetID() string {
+	if t == nil {
+		t = &CreateControlObjective_CreateControlObjective_ControlObjective_BlockedGroups{}
+	}
+	return t.ID
+}
+func (t *CreateControlObjective_CreateControlObjective_ControlObjective_BlockedGroups) GetName() string {
+	if t == nil {
+		t = &CreateControlObjective_CreateControlObjective_ControlObjective_BlockedGroups{}
+	}
+	return t.Name
+}
+
 type CreateControlObjective_CreateControlObjective_ControlObjective struct {
-	Class                *string                "json:\"class,omitempty\" graphql:\"class\""
-	ControlNumber        *string                "json:\"controlNumber,omitempty\" graphql:\"controlNumber\""
-	ControlObjectiveType *string                "json:\"controlObjectiveType,omitempty\" graphql:\"controlObjectiveType\""
-	CreatedAt            *time.Time             "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy            *string                "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description          *string                "json:\"description,omitempty\" graphql:\"description\""
-	Details              map[string]interface{} "json:\"details,omitempty\" graphql:\"details\""
-	Family               *string                "json:\"family,omitempty\" graphql:\"family\""
-	ID                   string                 "json:\"id\" graphql:\"id\""
-	MappedFrameworks     *string                "json:\"mappedFrameworks,omitempty\" graphql:\"mappedFrameworks\""
-	Name                 string                 "json:\"name\" graphql:\"name\""
-	Source               *string                "json:\"source,omitempty\" graphql:\"source\""
-	Status               *string                "json:\"status,omitempty\" graphql:\"status\""
-	Tags                 []string               "json:\"tags,omitempty\" graphql:\"tags\""
-	UpdatedAt            *time.Time             "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy            *string                "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
-	Version              *string                "json:\"version,omitempty\" graphql:\"version\""
+	Class                *string                                                                         "json:\"class,omitempty\" graphql:\"class\""
+	ControlNumber        *string                                                                         "json:\"controlNumber,omitempty\" graphql:\"controlNumber\""
+	ControlObjectiveType *string                                                                         "json:\"controlObjectiveType,omitempty\" graphql:\"controlObjectiveType\""
+	CreatedAt            *time.Time                                                                      "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy            *string                                                                         "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description          *string                                                                         "json:\"description,omitempty\" graphql:\"description\""
+	Details              map[string]interface{}                                                          "json:\"details,omitempty\" graphql:\"details\""
+	Family               *string                                                                         "json:\"family,omitempty\" graphql:\"family\""
+	ID                   string                                                                          "json:\"id\" graphql:\"id\""
+	MappedFrameworks     *string                                                                         "json:\"mappedFrameworks,omitempty\" graphql:\"mappedFrameworks\""
+	Name                 string                                                                          "json:\"name\" graphql:\"name\""
+	Source               *string                                                                         "json:\"source,omitempty\" graphql:\"source\""
+	Status               *string                                                                         "json:\"status,omitempty\" graphql:\"status\""
+	Tags                 []string                                                                        "json:\"tags,omitempty\" graphql:\"tags\""
+	UpdatedAt            *time.Time                                                                      "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy            *string                                                                         "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Version              *string                                                                         "json:\"version,omitempty\" graphql:\"version\""
+	Programs             []*CreateControlObjective_CreateControlObjective_ControlObjective_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
+	Editors              []*CreateControlObjective_CreateControlObjective_ControlObjective_Editors       "json:\"editors,omitempty\" graphql:\"editors\""
+	Viewers              []*CreateControlObjective_CreateControlObjective_ControlObjective_Viewers       "json:\"viewers,omitempty\" graphql:\"viewers\""
+	BlockedGroups        []*CreateControlObjective_CreateControlObjective_ControlObjective_BlockedGroups "json:\"blockedGroups,omitempty\" graphql:\"blockedGroups\""
 }
 
 func (t *CreateControlObjective_CreateControlObjective_ControlObjective) GetClass() *string {
@@ -7783,6 +7866,30 @@ func (t *CreateControlObjective_CreateControlObjective_ControlObjective) GetVers
 	}
 	return t.Version
 }
+func (t *CreateControlObjective_CreateControlObjective_ControlObjective) GetPrograms() []*CreateControlObjective_CreateControlObjective_ControlObjective_Programs {
+	if t == nil {
+		t = &CreateControlObjective_CreateControlObjective_ControlObjective{}
+	}
+	return t.Programs
+}
+func (t *CreateControlObjective_CreateControlObjective_ControlObjective) GetEditors() []*CreateControlObjective_CreateControlObjective_ControlObjective_Editors {
+	if t == nil {
+		t = &CreateControlObjective_CreateControlObjective_ControlObjective{}
+	}
+	return t.Editors
+}
+func (t *CreateControlObjective_CreateControlObjective_ControlObjective) GetViewers() []*CreateControlObjective_CreateControlObjective_ControlObjective_Viewers {
+	if t == nil {
+		t = &CreateControlObjective_CreateControlObjective_ControlObjective{}
+	}
+	return t.Viewers
+}
+func (t *CreateControlObjective_CreateControlObjective_ControlObjective) GetBlockedGroups() []*CreateControlObjective_CreateControlObjective_ControlObjective_BlockedGroups {
+	if t == nil {
+		t = &CreateControlObjective_CreateControlObjective_ControlObjective{}
+	}
+	return t.BlockedGroups
+}
 
 type CreateControlObjective_CreateControlObjective struct {
 	ControlObjective CreateControlObjective_CreateControlObjective_ControlObjective "json:\"controlObjective\" graphql:\"controlObjective\""
@@ -7806,24 +7913,100 @@ func (t *DeleteControlObjective_DeleteControlObjective) GetDeletedID() string {
 	return t.DeletedID
 }
 
+type GetAllControlObjectives_ControlObjectives_Edges_Node_Programs struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *GetAllControlObjectives_ControlObjectives_Edges_Node_Programs) GetID() string {
+	if t == nil {
+		t = &GetAllControlObjectives_ControlObjectives_Edges_Node_Programs{}
+	}
+	return t.ID
+}
+func (t *GetAllControlObjectives_ControlObjectives_Edges_Node_Programs) GetName() string {
+	if t == nil {
+		t = &GetAllControlObjectives_ControlObjectives_Edges_Node_Programs{}
+	}
+	return t.Name
+}
+
+type GetAllControlObjectives_ControlObjectives_Edges_Node_Editors struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *GetAllControlObjectives_ControlObjectives_Edges_Node_Editors) GetID() string {
+	if t == nil {
+		t = &GetAllControlObjectives_ControlObjectives_Edges_Node_Editors{}
+	}
+	return t.ID
+}
+func (t *GetAllControlObjectives_ControlObjectives_Edges_Node_Editors) GetName() string {
+	if t == nil {
+		t = &GetAllControlObjectives_ControlObjectives_Edges_Node_Editors{}
+	}
+	return t.Name
+}
+
+type GetAllControlObjectives_ControlObjectives_Edges_Node_Viewers struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *GetAllControlObjectives_ControlObjectives_Edges_Node_Viewers) GetID() string {
+	if t == nil {
+		t = &GetAllControlObjectives_ControlObjectives_Edges_Node_Viewers{}
+	}
+	return t.ID
+}
+func (t *GetAllControlObjectives_ControlObjectives_Edges_Node_Viewers) GetName() string {
+	if t == nil {
+		t = &GetAllControlObjectives_ControlObjectives_Edges_Node_Viewers{}
+	}
+	return t.Name
+}
+
+type GetAllControlObjectives_ControlObjectives_Edges_Node_BlockedGroups struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *GetAllControlObjectives_ControlObjectives_Edges_Node_BlockedGroups) GetID() string {
+	if t == nil {
+		t = &GetAllControlObjectives_ControlObjectives_Edges_Node_BlockedGroups{}
+	}
+	return t.ID
+}
+func (t *GetAllControlObjectives_ControlObjectives_Edges_Node_BlockedGroups) GetName() string {
+	if t == nil {
+		t = &GetAllControlObjectives_ControlObjectives_Edges_Node_BlockedGroups{}
+	}
+	return t.Name
+}
+
 type GetAllControlObjectives_ControlObjectives_Edges_Node struct {
-	Class                *string                "json:\"class,omitempty\" graphql:\"class\""
-	ControlNumber        *string                "json:\"controlNumber,omitempty\" graphql:\"controlNumber\""
-	ControlObjectiveType *string                "json:\"controlObjectiveType,omitempty\" graphql:\"controlObjectiveType\""
-	CreatedAt            *time.Time             "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy            *string                "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description          *string                "json:\"description,omitempty\" graphql:\"description\""
-	Details              map[string]interface{} "json:\"details,omitempty\" graphql:\"details\""
-	Family               *string                "json:\"family,omitempty\" graphql:\"family\""
-	ID                   string                 "json:\"id\" graphql:\"id\""
-	MappedFrameworks     *string                "json:\"mappedFrameworks,omitempty\" graphql:\"mappedFrameworks\""
-	Name                 string                 "json:\"name\" graphql:\"name\""
-	Source               *string                "json:\"source,omitempty\" graphql:\"source\""
-	Status               *string                "json:\"status,omitempty\" graphql:\"status\""
-	Tags                 []string               "json:\"tags,omitempty\" graphql:\"tags\""
-	UpdatedAt            *time.Time             "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy            *string                "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
-	Version              *string                "json:\"version,omitempty\" graphql:\"version\""
+	Class                *string                                                               "json:\"class,omitempty\" graphql:\"class\""
+	ControlNumber        *string                                                               "json:\"controlNumber,omitempty\" graphql:\"controlNumber\""
+	ControlObjectiveType *string                                                               "json:\"controlObjectiveType,omitempty\" graphql:\"controlObjectiveType\""
+	CreatedAt            *time.Time                                                            "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy            *string                                                               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description          *string                                                               "json:\"description,omitempty\" graphql:\"description\""
+	Details              map[string]interface{}                                                "json:\"details,omitempty\" graphql:\"details\""
+	Family               *string                                                               "json:\"family,omitempty\" graphql:\"family\""
+	ID                   string                                                                "json:\"id\" graphql:\"id\""
+	MappedFrameworks     *string                                                               "json:\"mappedFrameworks,omitempty\" graphql:\"mappedFrameworks\""
+	Name                 string                                                                "json:\"name\" graphql:\"name\""
+	Source               *string                                                               "json:\"source,omitempty\" graphql:\"source\""
+	Status               *string                                                               "json:\"status,omitempty\" graphql:\"status\""
+	Tags                 []string                                                              "json:\"tags,omitempty\" graphql:\"tags\""
+	UpdatedAt            *time.Time                                                            "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy            *string                                                               "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Version              *string                                                               "json:\"version,omitempty\" graphql:\"version\""
+	Programs             []*GetAllControlObjectives_ControlObjectives_Edges_Node_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
+	Editors              []*GetAllControlObjectives_ControlObjectives_Edges_Node_Editors       "json:\"editors,omitempty\" graphql:\"editors\""
+	Viewers              []*GetAllControlObjectives_ControlObjectives_Edges_Node_Viewers       "json:\"viewers,omitempty\" graphql:\"viewers\""
+	BlockedGroups        []*GetAllControlObjectives_ControlObjectives_Edges_Node_BlockedGroups "json:\"blockedGroups,omitempty\" graphql:\"blockedGroups\""
 }
 
 func (t *GetAllControlObjectives_ControlObjectives_Edges_Node) GetClass() *string {
@@ -7928,6 +8111,30 @@ func (t *GetAllControlObjectives_ControlObjectives_Edges_Node) GetVersion() *str
 	}
 	return t.Version
 }
+func (t *GetAllControlObjectives_ControlObjectives_Edges_Node) GetPrograms() []*GetAllControlObjectives_ControlObjectives_Edges_Node_Programs {
+	if t == nil {
+		t = &GetAllControlObjectives_ControlObjectives_Edges_Node{}
+	}
+	return t.Programs
+}
+func (t *GetAllControlObjectives_ControlObjectives_Edges_Node) GetEditors() []*GetAllControlObjectives_ControlObjectives_Edges_Node_Editors {
+	if t == nil {
+		t = &GetAllControlObjectives_ControlObjectives_Edges_Node{}
+	}
+	return t.Editors
+}
+func (t *GetAllControlObjectives_ControlObjectives_Edges_Node) GetViewers() []*GetAllControlObjectives_ControlObjectives_Edges_Node_Viewers {
+	if t == nil {
+		t = &GetAllControlObjectives_ControlObjectives_Edges_Node{}
+	}
+	return t.Viewers
+}
+func (t *GetAllControlObjectives_ControlObjectives_Edges_Node) GetBlockedGroups() []*GetAllControlObjectives_ControlObjectives_Edges_Node_BlockedGroups {
+	if t == nil {
+		t = &GetAllControlObjectives_ControlObjectives_Edges_Node{}
+	}
+	return t.BlockedGroups
+}
 
 type GetAllControlObjectives_ControlObjectives_Edges struct {
 	Node *GetAllControlObjectives_ControlObjectives_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
@@ -7951,24 +8158,100 @@ func (t *GetAllControlObjectives_ControlObjectives) GetEdges() []*GetAllControlO
 	return t.Edges
 }
 
+type GetControlObjectiveByID_ControlObjective_Programs struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *GetControlObjectiveByID_ControlObjective_Programs) GetID() string {
+	if t == nil {
+		t = &GetControlObjectiveByID_ControlObjective_Programs{}
+	}
+	return t.ID
+}
+func (t *GetControlObjectiveByID_ControlObjective_Programs) GetName() string {
+	if t == nil {
+		t = &GetControlObjectiveByID_ControlObjective_Programs{}
+	}
+	return t.Name
+}
+
+type GetControlObjectiveByID_ControlObjective_Editors struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *GetControlObjectiveByID_ControlObjective_Editors) GetID() string {
+	if t == nil {
+		t = &GetControlObjectiveByID_ControlObjective_Editors{}
+	}
+	return t.ID
+}
+func (t *GetControlObjectiveByID_ControlObjective_Editors) GetName() string {
+	if t == nil {
+		t = &GetControlObjectiveByID_ControlObjective_Editors{}
+	}
+	return t.Name
+}
+
+type GetControlObjectiveByID_ControlObjective_Viewers struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *GetControlObjectiveByID_ControlObjective_Viewers) GetID() string {
+	if t == nil {
+		t = &GetControlObjectiveByID_ControlObjective_Viewers{}
+	}
+	return t.ID
+}
+func (t *GetControlObjectiveByID_ControlObjective_Viewers) GetName() string {
+	if t == nil {
+		t = &GetControlObjectiveByID_ControlObjective_Viewers{}
+	}
+	return t.Name
+}
+
+type GetControlObjectiveByID_ControlObjective_BlockedGroups struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *GetControlObjectiveByID_ControlObjective_BlockedGroups) GetID() string {
+	if t == nil {
+		t = &GetControlObjectiveByID_ControlObjective_BlockedGroups{}
+	}
+	return t.ID
+}
+func (t *GetControlObjectiveByID_ControlObjective_BlockedGroups) GetName() string {
+	if t == nil {
+		t = &GetControlObjectiveByID_ControlObjective_BlockedGroups{}
+	}
+	return t.Name
+}
+
 type GetControlObjectiveByID_ControlObjective struct {
-	Class                *string                "json:\"class,omitempty\" graphql:\"class\""
-	ControlNumber        *string                "json:\"controlNumber,omitempty\" graphql:\"controlNumber\""
-	ControlObjectiveType *string                "json:\"controlObjectiveType,omitempty\" graphql:\"controlObjectiveType\""
-	CreatedAt            *time.Time             "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy            *string                "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description          *string                "json:\"description,omitempty\" graphql:\"description\""
-	Details              map[string]interface{} "json:\"details,omitempty\" graphql:\"details\""
-	Family               *string                "json:\"family,omitempty\" graphql:\"family\""
-	ID                   string                 "json:\"id\" graphql:\"id\""
-	MappedFrameworks     *string                "json:\"mappedFrameworks,omitempty\" graphql:\"mappedFrameworks\""
-	Name                 string                 "json:\"name\" graphql:\"name\""
-	Source               *string                "json:\"source,omitempty\" graphql:\"source\""
-	Status               *string                "json:\"status,omitempty\" graphql:\"status\""
-	Tags                 []string               "json:\"tags,omitempty\" graphql:\"tags\""
-	UpdatedAt            *time.Time             "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy            *string                "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
-	Version              *string                "json:\"version,omitempty\" graphql:\"version\""
+	Class                *string                                                   "json:\"class,omitempty\" graphql:\"class\""
+	ControlNumber        *string                                                   "json:\"controlNumber,omitempty\" graphql:\"controlNumber\""
+	ControlObjectiveType *string                                                   "json:\"controlObjectiveType,omitempty\" graphql:\"controlObjectiveType\""
+	CreatedAt            *time.Time                                                "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy            *string                                                   "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description          *string                                                   "json:\"description,omitempty\" graphql:\"description\""
+	Details              map[string]interface{}                                    "json:\"details,omitempty\" graphql:\"details\""
+	Family               *string                                                   "json:\"family,omitempty\" graphql:\"family\""
+	ID                   string                                                    "json:\"id\" graphql:\"id\""
+	MappedFrameworks     *string                                                   "json:\"mappedFrameworks,omitempty\" graphql:\"mappedFrameworks\""
+	Name                 string                                                    "json:\"name\" graphql:\"name\""
+	Source               *string                                                   "json:\"source,omitempty\" graphql:\"source\""
+	Status               *string                                                   "json:\"status,omitempty\" graphql:\"status\""
+	Tags                 []string                                                  "json:\"tags,omitempty\" graphql:\"tags\""
+	UpdatedAt            *time.Time                                                "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy            *string                                                   "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Version              *string                                                   "json:\"version,omitempty\" graphql:\"version\""
+	Programs             []*GetControlObjectiveByID_ControlObjective_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
+	Editors              []*GetControlObjectiveByID_ControlObjective_Editors       "json:\"editors,omitempty\" graphql:\"editors\""
+	Viewers              []*GetControlObjectiveByID_ControlObjective_Viewers       "json:\"viewers,omitempty\" graphql:\"viewers\""
+	BlockedGroups        []*GetControlObjectiveByID_ControlObjective_BlockedGroups "json:\"blockedGroups,omitempty\" graphql:\"blockedGroups\""
 }
 
 func (t *GetControlObjectiveByID_ControlObjective) GetClass() *string {
@@ -8073,25 +8356,125 @@ func (t *GetControlObjectiveByID_ControlObjective) GetVersion() *string {
 	}
 	return t.Version
 }
+func (t *GetControlObjectiveByID_ControlObjective) GetPrograms() []*GetControlObjectiveByID_ControlObjective_Programs {
+	if t == nil {
+		t = &GetControlObjectiveByID_ControlObjective{}
+	}
+	return t.Programs
+}
+func (t *GetControlObjectiveByID_ControlObjective) GetEditors() []*GetControlObjectiveByID_ControlObjective_Editors {
+	if t == nil {
+		t = &GetControlObjectiveByID_ControlObjective{}
+	}
+	return t.Editors
+}
+func (t *GetControlObjectiveByID_ControlObjective) GetViewers() []*GetControlObjectiveByID_ControlObjective_Viewers {
+	if t == nil {
+		t = &GetControlObjectiveByID_ControlObjective{}
+	}
+	return t.Viewers
+}
+func (t *GetControlObjectiveByID_ControlObjective) GetBlockedGroups() []*GetControlObjectiveByID_ControlObjective_BlockedGroups {
+	if t == nil {
+		t = &GetControlObjectiveByID_ControlObjective{}
+	}
+	return t.BlockedGroups
+}
+
+type GetControlObjectives_ControlObjectives_Edges_Node_Programs struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *GetControlObjectives_ControlObjectives_Edges_Node_Programs) GetID() string {
+	if t == nil {
+		t = &GetControlObjectives_ControlObjectives_Edges_Node_Programs{}
+	}
+	return t.ID
+}
+func (t *GetControlObjectives_ControlObjectives_Edges_Node_Programs) GetName() string {
+	if t == nil {
+		t = &GetControlObjectives_ControlObjectives_Edges_Node_Programs{}
+	}
+	return t.Name
+}
+
+type GetControlObjectives_ControlObjectives_Edges_Node_Editors struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *GetControlObjectives_ControlObjectives_Edges_Node_Editors) GetID() string {
+	if t == nil {
+		t = &GetControlObjectives_ControlObjectives_Edges_Node_Editors{}
+	}
+	return t.ID
+}
+func (t *GetControlObjectives_ControlObjectives_Edges_Node_Editors) GetName() string {
+	if t == nil {
+		t = &GetControlObjectives_ControlObjectives_Edges_Node_Editors{}
+	}
+	return t.Name
+}
+
+type GetControlObjectives_ControlObjectives_Edges_Node_Viewers struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *GetControlObjectives_ControlObjectives_Edges_Node_Viewers) GetID() string {
+	if t == nil {
+		t = &GetControlObjectives_ControlObjectives_Edges_Node_Viewers{}
+	}
+	return t.ID
+}
+func (t *GetControlObjectives_ControlObjectives_Edges_Node_Viewers) GetName() string {
+	if t == nil {
+		t = &GetControlObjectives_ControlObjectives_Edges_Node_Viewers{}
+	}
+	return t.Name
+}
+
+type GetControlObjectives_ControlObjectives_Edges_Node_BlockedGroups struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *GetControlObjectives_ControlObjectives_Edges_Node_BlockedGroups) GetID() string {
+	if t == nil {
+		t = &GetControlObjectives_ControlObjectives_Edges_Node_BlockedGroups{}
+	}
+	return t.ID
+}
+func (t *GetControlObjectives_ControlObjectives_Edges_Node_BlockedGroups) GetName() string {
+	if t == nil {
+		t = &GetControlObjectives_ControlObjectives_Edges_Node_BlockedGroups{}
+	}
+	return t.Name
+}
 
 type GetControlObjectives_ControlObjectives_Edges_Node struct {
-	Class                *string                "json:\"class,omitempty\" graphql:\"class\""
-	ControlNumber        *string                "json:\"controlNumber,omitempty\" graphql:\"controlNumber\""
-	ControlObjectiveType *string                "json:\"controlObjectiveType,omitempty\" graphql:\"controlObjectiveType\""
-	CreatedAt            *time.Time             "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy            *string                "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description          *string                "json:\"description,omitempty\" graphql:\"description\""
-	Details              map[string]interface{} "json:\"details,omitempty\" graphql:\"details\""
-	Family               *string                "json:\"family,omitempty\" graphql:\"family\""
-	ID                   string                 "json:\"id\" graphql:\"id\""
-	MappedFrameworks     *string                "json:\"mappedFrameworks,omitempty\" graphql:\"mappedFrameworks\""
-	Name                 string                 "json:\"name\" graphql:\"name\""
-	Source               *string                "json:\"source,omitempty\" graphql:\"source\""
-	Status               *string                "json:\"status,omitempty\" graphql:\"status\""
-	Tags                 []string               "json:\"tags,omitempty\" graphql:\"tags\""
-	UpdatedAt            *time.Time             "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy            *string                "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
-	Version              *string                "json:\"version,omitempty\" graphql:\"version\""
+	Class                *string                                                            "json:\"class,omitempty\" graphql:\"class\""
+	ControlNumber        *string                                                            "json:\"controlNumber,omitempty\" graphql:\"controlNumber\""
+	ControlObjectiveType *string                                                            "json:\"controlObjectiveType,omitempty\" graphql:\"controlObjectiveType\""
+	CreatedAt            *time.Time                                                         "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy            *string                                                            "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description          *string                                                            "json:\"description,omitempty\" graphql:\"description\""
+	Details              map[string]interface{}                                             "json:\"details,omitempty\" graphql:\"details\""
+	Family               *string                                                            "json:\"family,omitempty\" graphql:\"family\""
+	ID                   string                                                             "json:\"id\" graphql:\"id\""
+	MappedFrameworks     *string                                                            "json:\"mappedFrameworks,omitempty\" graphql:\"mappedFrameworks\""
+	Name                 string                                                             "json:\"name\" graphql:\"name\""
+	Source               *string                                                            "json:\"source,omitempty\" graphql:\"source\""
+	Status               *string                                                            "json:\"status,omitempty\" graphql:\"status\""
+	Tags                 []string                                                           "json:\"tags,omitempty\" graphql:\"tags\""
+	UpdatedAt            *time.Time                                                         "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy            *string                                                            "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Version              *string                                                            "json:\"version,omitempty\" graphql:\"version\""
+	Programs             []*GetControlObjectives_ControlObjectives_Edges_Node_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
+	Editors              []*GetControlObjectives_ControlObjectives_Edges_Node_Editors       "json:\"editors,omitempty\" graphql:\"editors\""
+	Viewers              []*GetControlObjectives_ControlObjectives_Edges_Node_Viewers       "json:\"viewers,omitempty\" graphql:\"viewers\""
+	BlockedGroups        []*GetControlObjectives_ControlObjectives_Edges_Node_BlockedGroups "json:\"blockedGroups,omitempty\" graphql:\"blockedGroups\""
 }
 
 func (t *GetControlObjectives_ControlObjectives_Edges_Node) GetClass() *string {
@@ -8196,6 +8579,30 @@ func (t *GetControlObjectives_ControlObjectives_Edges_Node) GetVersion() *string
 	}
 	return t.Version
 }
+func (t *GetControlObjectives_ControlObjectives_Edges_Node) GetPrograms() []*GetControlObjectives_ControlObjectives_Edges_Node_Programs {
+	if t == nil {
+		t = &GetControlObjectives_ControlObjectives_Edges_Node{}
+	}
+	return t.Programs
+}
+func (t *GetControlObjectives_ControlObjectives_Edges_Node) GetEditors() []*GetControlObjectives_ControlObjectives_Edges_Node_Editors {
+	if t == nil {
+		t = &GetControlObjectives_ControlObjectives_Edges_Node{}
+	}
+	return t.Editors
+}
+func (t *GetControlObjectives_ControlObjectives_Edges_Node) GetViewers() []*GetControlObjectives_ControlObjectives_Edges_Node_Viewers {
+	if t == nil {
+		t = &GetControlObjectives_ControlObjectives_Edges_Node{}
+	}
+	return t.Viewers
+}
+func (t *GetControlObjectives_ControlObjectives_Edges_Node) GetBlockedGroups() []*GetControlObjectives_ControlObjectives_Edges_Node_BlockedGroups {
+	if t == nil {
+		t = &GetControlObjectives_ControlObjectives_Edges_Node{}
+	}
+	return t.BlockedGroups
+}
 
 type GetControlObjectives_ControlObjectives_Edges struct {
 	Node *GetControlObjectives_ControlObjectives_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
@@ -8219,24 +8626,100 @@ func (t *GetControlObjectives_ControlObjectives) GetEdges() []*GetControlObjecti
 	return t.Edges
 }
 
+type UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs) GetID() string {
+	if t == nil {
+		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs{}
+	}
+	return t.ID
+}
+func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs) GetName() string {
+	if t == nil {
+		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs{}
+	}
+	return t.Name
+}
+
+type UpdateControlObjective_UpdateControlObjective_ControlObjective_Editors struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective_Editors) GetID() string {
+	if t == nil {
+		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective_Editors{}
+	}
+	return t.ID
+}
+func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective_Editors) GetName() string {
+	if t == nil {
+		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective_Editors{}
+	}
+	return t.Name
+}
+
+type UpdateControlObjective_UpdateControlObjective_ControlObjective_Viewers struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective_Viewers) GetID() string {
+	if t == nil {
+		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective_Viewers{}
+	}
+	return t.ID
+}
+func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective_Viewers) GetName() string {
+	if t == nil {
+		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective_Viewers{}
+	}
+	return t.Name
+}
+
+type UpdateControlObjective_UpdateControlObjective_ControlObjective_BlockedGroups struct {
+	ID   string "json:\"id\" graphql:\"id\""
+	Name string "json:\"name\" graphql:\"name\""
+}
+
+func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective_BlockedGroups) GetID() string {
+	if t == nil {
+		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective_BlockedGroups{}
+	}
+	return t.ID
+}
+func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective_BlockedGroups) GetName() string {
+	if t == nil {
+		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective_BlockedGroups{}
+	}
+	return t.Name
+}
+
 type UpdateControlObjective_UpdateControlObjective_ControlObjective struct {
-	Class                *string                "json:\"class,omitempty\" graphql:\"class\""
-	ControlNumber        *string                "json:\"controlNumber,omitempty\" graphql:\"controlNumber\""
-	ControlObjectiveType *string                "json:\"controlObjectiveType,omitempty\" graphql:\"controlObjectiveType\""
-	CreatedAt            *time.Time             "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy            *string                "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description          *string                "json:\"description,omitempty\" graphql:\"description\""
-	Details              map[string]interface{} "json:\"details,omitempty\" graphql:\"details\""
-	Family               *string                "json:\"family,omitempty\" graphql:\"family\""
-	ID                   string                 "json:\"id\" graphql:\"id\""
-	MappedFrameworks     *string                "json:\"mappedFrameworks,omitempty\" graphql:\"mappedFrameworks\""
-	Name                 string                 "json:\"name\" graphql:\"name\""
-	Source               *string                "json:\"source,omitempty\" graphql:\"source\""
-	Status               *string                "json:\"status,omitempty\" graphql:\"status\""
-	Tags                 []string               "json:\"tags,omitempty\" graphql:\"tags\""
-	UpdatedAt            *time.Time             "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy            *string                "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
-	Version              *string                "json:\"version,omitempty\" graphql:\"version\""
+	Class                *string                                                                         "json:\"class,omitempty\" graphql:\"class\""
+	ControlNumber        *string                                                                         "json:\"controlNumber,omitempty\" graphql:\"controlNumber\""
+	ControlObjectiveType *string                                                                         "json:\"controlObjectiveType,omitempty\" graphql:\"controlObjectiveType\""
+	CreatedAt            *time.Time                                                                      "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy            *string                                                                         "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description          *string                                                                         "json:\"description,omitempty\" graphql:\"description\""
+	Details              map[string]interface{}                                                          "json:\"details,omitempty\" graphql:\"details\""
+	Family               *string                                                                         "json:\"family,omitempty\" graphql:\"family\""
+	ID                   string                                                                          "json:\"id\" graphql:\"id\""
+	MappedFrameworks     *string                                                                         "json:\"mappedFrameworks,omitempty\" graphql:\"mappedFrameworks\""
+	Name                 string                                                                          "json:\"name\" graphql:\"name\""
+	Source               *string                                                                         "json:\"source,omitempty\" graphql:\"source\""
+	Status               *string                                                                         "json:\"status,omitempty\" graphql:\"status\""
+	Tags                 []string                                                                        "json:\"tags,omitempty\" graphql:\"tags\""
+	UpdatedAt            *time.Time                                                                      "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy            *string                                                                         "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Version              *string                                                                         "json:\"version,omitempty\" graphql:\"version\""
+	Programs             []*UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
+	Editors              []*UpdateControlObjective_UpdateControlObjective_ControlObjective_Editors       "json:\"editors,omitempty\" graphql:\"editors\""
+	Viewers              []*UpdateControlObjective_UpdateControlObjective_ControlObjective_Viewers       "json:\"viewers,omitempty\" graphql:\"viewers\""
+	BlockedGroups        []*UpdateControlObjective_UpdateControlObjective_ControlObjective_BlockedGroups "json:\"blockedGroups,omitempty\" graphql:\"blockedGroups\""
 }
 
 func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective) GetClass() *string {
@@ -8340,6 +8823,30 @@ func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective) GetVers
 		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective{}
 	}
 	return t.Version
+}
+func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective) GetPrograms() []*UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs {
+	if t == nil {
+		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective{}
+	}
+	return t.Programs
+}
+func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective) GetEditors() []*UpdateControlObjective_UpdateControlObjective_ControlObjective_Editors {
+	if t == nil {
+		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective{}
+	}
+	return t.Editors
+}
+func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective) GetViewers() []*UpdateControlObjective_UpdateControlObjective_ControlObjective_Viewers {
+	if t == nil {
+		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective{}
+	}
+	return t.Viewers
+}
+func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective) GetBlockedGroups() []*UpdateControlObjective_UpdateControlObjective_ControlObjective_BlockedGroups {
+	if t == nil {
+		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective{}
+	}
+	return t.BlockedGroups
 }
 
 type UpdateControlObjective_UpdateControlObjective struct {
@@ -38459,20 +38966,20 @@ func (t *CreateBulkRisk_CreateBulkRisk) GetRisks() []*CreateBulkRisk_CreateBulkR
 	return t.Risks
 }
 
-type CreateRisk_CreateRisk_Risk_Program struct {
+type CreateRisk_CreateRisk_Risk_Programs struct {
 	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
-func (t *CreateRisk_CreateRisk_Risk_Program) GetID() string {
+func (t *CreateRisk_CreateRisk_Risk_Programs) GetID() string {
 	if t == nil {
-		t = &CreateRisk_CreateRisk_Risk_Program{}
+		t = &CreateRisk_CreateRisk_Risk_Programs{}
 	}
 	return t.ID
 }
-func (t *CreateRisk_CreateRisk_Risk_Program) GetName() string {
+func (t *CreateRisk_CreateRisk_Risk_Programs) GetName() string {
 	if t == nil {
-		t = &CreateRisk_CreateRisk_Risk_Program{}
+		t = &CreateRisk_CreateRisk_Risk_Programs{}
 	}
 	return t.Name
 }
@@ -38548,7 +39055,7 @@ type CreateRisk_CreateRisk_Risk struct {
 	Tags          []string                                    "json:\"tags,omitempty\" graphql:\"tags\""
 	UpdatedAt     *time.Time                                  "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
 	UpdatedBy     *string                                     "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
-	Program       []*CreateRisk_CreateRisk_Risk_Program       "json:\"program,omitempty\" graphql:\"program\""
+	Programs      []*CreateRisk_CreateRisk_Risk_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
 	Editors       []*CreateRisk_CreateRisk_Risk_Editors       "json:\"editors,omitempty\" graphql:\"editors\""
 	Viewers       []*CreateRisk_CreateRisk_Risk_Viewers       "json:\"viewers,omitempty\" graphql:\"viewers\""
 	BlockedGroups []*CreateRisk_CreateRisk_Risk_BlockedGroups "json:\"blockedGroups,omitempty\" graphql:\"blockedGroups\""
@@ -38650,11 +39157,11 @@ func (t *CreateRisk_CreateRisk_Risk) GetUpdatedBy() *string {
 	}
 	return t.UpdatedBy
 }
-func (t *CreateRisk_CreateRisk_Risk) GetProgram() []*CreateRisk_CreateRisk_Risk_Program {
+func (t *CreateRisk_CreateRisk_Risk) GetPrograms() []*CreateRisk_CreateRisk_Risk_Programs {
 	if t == nil {
 		t = &CreateRisk_CreateRisk_Risk{}
 	}
-	return t.Program
+	return t.Programs
 }
 func (t *CreateRisk_CreateRisk_Risk) GetEditors() []*CreateRisk_CreateRisk_Risk_Editors {
 	if t == nil {
@@ -38697,20 +39204,20 @@ func (t *DeleteRisk_DeleteRisk) GetDeletedID() string {
 	return t.DeletedID
 }
 
-type GetAllRisks_Risks_Edges_Node_Program struct {
+type GetAllRisks_Risks_Edges_Node_Programs struct {
 	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
-func (t *GetAllRisks_Risks_Edges_Node_Program) GetID() string {
+func (t *GetAllRisks_Risks_Edges_Node_Programs) GetID() string {
 	if t == nil {
-		t = &GetAllRisks_Risks_Edges_Node_Program{}
+		t = &GetAllRisks_Risks_Edges_Node_Programs{}
 	}
 	return t.ID
 }
-func (t *GetAllRisks_Risks_Edges_Node_Program) GetName() string {
+func (t *GetAllRisks_Risks_Edges_Node_Programs) GetName() string {
 	if t == nil {
-		t = &GetAllRisks_Risks_Edges_Node_Program{}
+		t = &GetAllRisks_Risks_Edges_Node_Programs{}
 	}
 	return t.Name
 }
@@ -38786,7 +39293,7 @@ type GetAllRisks_Risks_Edges_Node struct {
 	Tags          []string                                      "json:\"tags,omitempty\" graphql:\"tags\""
 	UpdatedAt     *time.Time                                    "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
 	UpdatedBy     *string                                       "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
-	Program       []*GetAllRisks_Risks_Edges_Node_Program       "json:\"program,omitempty\" graphql:\"program\""
+	Programs      []*GetAllRisks_Risks_Edges_Node_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
 	Editors       []*GetAllRisks_Risks_Edges_Node_Editors       "json:\"editors,omitempty\" graphql:\"editors\""
 	Viewers       []*GetAllRisks_Risks_Edges_Node_Viewers       "json:\"viewers,omitempty\" graphql:\"viewers\""
 	BlockedGroups []*GetAllRisks_Risks_Edges_Node_BlockedGroups "json:\"blockedGroups,omitempty\" graphql:\"blockedGroups\""
@@ -38888,11 +39395,11 @@ func (t *GetAllRisks_Risks_Edges_Node) GetUpdatedBy() *string {
 	}
 	return t.UpdatedBy
 }
-func (t *GetAllRisks_Risks_Edges_Node) GetProgram() []*GetAllRisks_Risks_Edges_Node_Program {
+func (t *GetAllRisks_Risks_Edges_Node) GetPrograms() []*GetAllRisks_Risks_Edges_Node_Programs {
 	if t == nil {
 		t = &GetAllRisks_Risks_Edges_Node{}
 	}
-	return t.Program
+	return t.Programs
 }
 func (t *GetAllRisks_Risks_Edges_Node) GetEditors() []*GetAllRisks_Risks_Edges_Node_Editors {
 	if t == nil {
@@ -38935,20 +39442,20 @@ func (t *GetAllRisks_Risks) GetEdges() []*GetAllRisks_Risks_Edges {
 	return t.Edges
 }
 
-type GetRiskByID_Risk_Program struct {
+type GetRiskByID_Risk_Programs struct {
 	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
-func (t *GetRiskByID_Risk_Program) GetID() string {
+func (t *GetRiskByID_Risk_Programs) GetID() string {
 	if t == nil {
-		t = &GetRiskByID_Risk_Program{}
+		t = &GetRiskByID_Risk_Programs{}
 	}
 	return t.ID
 }
-func (t *GetRiskByID_Risk_Program) GetName() string {
+func (t *GetRiskByID_Risk_Programs) GetName() string {
 	if t == nil {
-		t = &GetRiskByID_Risk_Program{}
+		t = &GetRiskByID_Risk_Programs{}
 	}
 	return t.Name
 }
@@ -39024,7 +39531,7 @@ type GetRiskByID_Risk struct {
 	Tags          []string                          "json:\"tags,omitempty\" graphql:\"tags\""
 	UpdatedAt     *time.Time                        "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
 	UpdatedBy     *string                           "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
-	Program       []*GetRiskByID_Risk_Program       "json:\"program,omitempty\" graphql:\"program\""
+	Programs      []*GetRiskByID_Risk_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
 	Editors       []*GetRiskByID_Risk_Editors       "json:\"editors,omitempty\" graphql:\"editors\""
 	Viewers       []*GetRiskByID_Risk_Viewers       "json:\"viewers,omitempty\" graphql:\"viewers\""
 	BlockedGroups []*GetRiskByID_Risk_BlockedGroups "json:\"blockedGroups,omitempty\" graphql:\"blockedGroups\""
@@ -39126,11 +39633,11 @@ func (t *GetRiskByID_Risk) GetUpdatedBy() *string {
 	}
 	return t.UpdatedBy
 }
-func (t *GetRiskByID_Risk) GetProgram() []*GetRiskByID_Risk_Program {
+func (t *GetRiskByID_Risk) GetPrograms() []*GetRiskByID_Risk_Programs {
 	if t == nil {
 		t = &GetRiskByID_Risk{}
 	}
-	return t.Program
+	return t.Programs
 }
 func (t *GetRiskByID_Risk) GetEditors() []*GetRiskByID_Risk_Editors {
 	if t == nil {
@@ -39151,20 +39658,20 @@ func (t *GetRiskByID_Risk) GetBlockedGroups() []*GetRiskByID_Risk_BlockedGroups 
 	return t.BlockedGroups
 }
 
-type GetRisks_Risks_Edges_Node_Program struct {
+type GetRisks_Risks_Edges_Node_Programs struct {
 	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
-func (t *GetRisks_Risks_Edges_Node_Program) GetID() string {
+func (t *GetRisks_Risks_Edges_Node_Programs) GetID() string {
 	if t == nil {
-		t = &GetRisks_Risks_Edges_Node_Program{}
+		t = &GetRisks_Risks_Edges_Node_Programs{}
 	}
 	return t.ID
 }
-func (t *GetRisks_Risks_Edges_Node_Program) GetName() string {
+func (t *GetRisks_Risks_Edges_Node_Programs) GetName() string {
 	if t == nil {
-		t = &GetRisks_Risks_Edges_Node_Program{}
+		t = &GetRisks_Risks_Edges_Node_Programs{}
 	}
 	return t.Name
 }
@@ -39240,7 +39747,7 @@ type GetRisks_Risks_Edges_Node struct {
 	Tags          []string                                   "json:\"tags,omitempty\" graphql:\"tags\""
 	UpdatedAt     *time.Time                                 "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
 	UpdatedBy     *string                                    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
-	Program       []*GetRisks_Risks_Edges_Node_Program       "json:\"program,omitempty\" graphql:\"program\""
+	Programs      []*GetRisks_Risks_Edges_Node_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
 	Editors       []*GetRisks_Risks_Edges_Node_Editors       "json:\"editors,omitempty\" graphql:\"editors\""
 	Viewers       []*GetRisks_Risks_Edges_Node_Viewers       "json:\"viewers,omitempty\" graphql:\"viewers\""
 	BlockedGroups []*GetRisks_Risks_Edges_Node_BlockedGroups "json:\"blockedGroups,omitempty\" graphql:\"blockedGroups\""
@@ -39342,11 +39849,11 @@ func (t *GetRisks_Risks_Edges_Node) GetUpdatedBy() *string {
 	}
 	return t.UpdatedBy
 }
-func (t *GetRisks_Risks_Edges_Node) GetProgram() []*GetRisks_Risks_Edges_Node_Program {
+func (t *GetRisks_Risks_Edges_Node) GetPrograms() []*GetRisks_Risks_Edges_Node_Programs {
 	if t == nil {
 		t = &GetRisks_Risks_Edges_Node{}
 	}
-	return t.Program
+	return t.Programs
 }
 func (t *GetRisks_Risks_Edges_Node) GetEditors() []*GetRisks_Risks_Edges_Node_Editors {
 	if t == nil {
@@ -39389,20 +39896,20 @@ func (t *GetRisks_Risks) GetEdges() []*GetRisks_Risks_Edges {
 	return t.Edges
 }
 
-type UpdateRisk_UpdateRisk_Risk_Program struct {
+type UpdateRisk_UpdateRisk_Risk_Programs struct {
 	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
-func (t *UpdateRisk_UpdateRisk_Risk_Program) GetID() string {
+func (t *UpdateRisk_UpdateRisk_Risk_Programs) GetID() string {
 	if t == nil {
-		t = &UpdateRisk_UpdateRisk_Risk_Program{}
+		t = &UpdateRisk_UpdateRisk_Risk_Programs{}
 	}
 	return t.ID
 }
-func (t *UpdateRisk_UpdateRisk_Risk_Program) GetName() string {
+func (t *UpdateRisk_UpdateRisk_Risk_Programs) GetName() string {
 	if t == nil {
-		t = &UpdateRisk_UpdateRisk_Risk_Program{}
+		t = &UpdateRisk_UpdateRisk_Risk_Programs{}
 	}
 	return t.Name
 }
@@ -39478,7 +39985,7 @@ type UpdateRisk_UpdateRisk_Risk struct {
 	Tags          []string                                    "json:\"tags,omitempty\" graphql:\"tags\""
 	UpdatedAt     *time.Time                                  "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
 	UpdatedBy     *string                                     "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
-	Program       []*UpdateRisk_UpdateRisk_Risk_Program       "json:\"program,omitempty\" graphql:\"program\""
+	Programs      []*UpdateRisk_UpdateRisk_Risk_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
 	Editors       []*UpdateRisk_UpdateRisk_Risk_Editors       "json:\"editors,omitempty\" graphql:\"editors\""
 	Viewers       []*UpdateRisk_UpdateRisk_Risk_Viewers       "json:\"viewers,omitempty\" graphql:\"viewers\""
 	BlockedGroups []*UpdateRisk_UpdateRisk_Risk_BlockedGroups "json:\"blockedGroups,omitempty\" graphql:\"blockedGroups\""
@@ -39580,11 +40087,11 @@ func (t *UpdateRisk_UpdateRisk_Risk) GetUpdatedBy() *string {
 	}
 	return t.UpdatedBy
 }
-func (t *UpdateRisk_UpdateRisk_Risk) GetProgram() []*UpdateRisk_UpdateRisk_Risk_Program {
+func (t *UpdateRisk_UpdateRisk_Risk) GetPrograms() []*UpdateRisk_UpdateRisk_Risk_Programs {
 	if t == nil {
 		t = &UpdateRisk_UpdateRisk_Risk{}
 	}
-	return t.Program
+	return t.Programs
 }
 func (t *UpdateRisk_UpdateRisk_Risk) GetEditors() []*UpdateRisk_UpdateRisk_Risk_Editors {
 	if t == nil {
@@ -54820,6 +55327,7 @@ const AdminSearchDocument = `query AdminSearch ($query: String!) {
 					deletedBy
 					id
 					tags
+					ownerID
 					name
 					description
 					status
@@ -55100,6 +55608,7 @@ const AdminSearchDocument = `query AdminSearch ($query: String!) {
 					deletedBy
 					id
 					tags
+					ownerID
 					name
 					description
 					status
@@ -55108,7 +55617,6 @@ const AdminSearchDocument = `query AdminSearch ($query: String!) {
 					mitigation
 					satisfies
 					details
-					ownerID
 				}
 			}
 			... on StandardSearchResult {
@@ -56334,6 +56842,22 @@ const CreateControlObjectiveDocument = `mutation CreateControlObjective ($input:
 			updatedAt
 			updatedBy
 			version
+			programs {
+				id
+				name
+			}
+			editors {
+				id
+				name
+			}
+			viewers {
+				id
+				name
+			}
+			blockedGroups {
+				id
+				name
+			}
 		}
 	}
 }
@@ -56401,6 +56925,22 @@ const GetAllControlObjectivesDocument = `query GetAllControlObjectives {
 				updatedAt
 				updatedBy
 				version
+				programs {
+					id
+					name
+				}
+				editors {
+					id
+					name
+				}
+				viewers {
+					id
+					name
+				}
+				blockedGroups {
+					id
+					name
+				}
 			}
 		}
 	}
@@ -56441,6 +56981,22 @@ const GetControlObjectiveByIDDocument = `query GetControlObjectiveByID ($control
 		updatedAt
 		updatedBy
 		version
+		programs {
+			id
+			name
+		}
+		editors {
+			id
+			name
+		}
+		viewers {
+			id
+			name
+		}
+		blockedGroups {
+			id
+			name
+		}
 	}
 }
 `
@@ -56483,6 +57039,22 @@ const GetControlObjectivesDocument = `query GetControlObjectives ($where: Contro
 				updatedAt
 				updatedBy
 				version
+				programs {
+					id
+					name
+				}
+				editors {
+					id
+					name
+				}
+				viewers {
+					id
+					name
+				}
+				blockedGroups {
+					id
+					name
+				}
 			}
 		}
 	}
@@ -56526,6 +57098,22 @@ const UpdateControlObjectiveDocument = `mutation UpdateControlObjective ($update
 			updatedAt
 			updatedBy
 			version
+			programs {
+				id
+				name
+			}
+			editors {
+				id
+				name
+			}
+			viewers {
+				id
+				name
+			}
+			blockedGroups {
+				id
+				name
+			}
 		}
 	}
 }
@@ -66292,7 +66880,7 @@ const CreateRiskDocument = `mutation CreateRisk ($input: CreateRiskInput!) {
 			tags
 			updatedAt
 			updatedBy
-			program {
+			programs {
 				id
 				name
 			}
@@ -66374,7 +66962,7 @@ const GetAllRisksDocument = `query GetAllRisks {
 				tags
 				updatedAt
 				updatedBy
-				program {
+				programs {
 					id
 					name
 				}
@@ -66429,7 +67017,7 @@ const GetRiskByIDDocument = `query GetRiskByID ($riskId: ID!) {
 		tags
 		updatedAt
 		updatedBy
-		program {
+		programs {
 			id
 			name
 		}
@@ -66486,7 +67074,7 @@ const GetRisksDocument = `query GetRisks ($where: RiskWhereInput) {
 				tags
 				updatedAt
 				updatedBy
-				program {
+				programs {
 					id
 					name
 				}
@@ -66544,7 +67132,7 @@ const UpdateRiskDocument = `mutation UpdateRisk ($updateRiskId: ID!, $input: Upd
 			tags
 			updatedAt
 			updatedBy
-			program {
+			programs {
 				id
 				name
 			}

--- a/pkg/openlaneclient/models.go
+++ b/pkg/openlaneclient/models.go
@@ -1894,6 +1894,8 @@ type ControlObjective struct {
 	DeletedBy *string    `json:"deletedBy,omitempty"`
 	// tags associated with the object
 	Tags []string `json:"tags,omitempty"`
+	// the ID of the organization owner of the object
+	OwnerID string `json:"ownerID"`
 	// the name of the control objective
 	Name string `json:"name"`
 	// description of the control objective
@@ -1915,16 +1917,23 @@ type ControlObjective struct {
 	// mapped frameworks
 	MappedFrameworks *string `json:"mappedFrameworks,omitempty"`
 	// json data including details of the control objective
-	Details     map[string]interface{} `json:"details,omitempty"`
-	Policy      []*InternalPolicy      `json:"policy,omitempty"`
-	Controls    []*Control             `json:"controls,omitempty"`
-	Procedures  []*Procedure           `json:"procedures,omitempty"`
-	Risks       []*Risk                `json:"risks,omitempty"`
-	Subcontrols []*Subcontrol          `json:"subcontrols,omitempty"`
-	Standard    []*Standard            `json:"standard,omitempty"`
-	Narratives  []*Narrative           `json:"narratives,omitempty"`
-	Tasks       []*Task                `json:"tasks,omitempty"`
-	Programs    []*Program             `json:"programs,omitempty"`
+	Details map[string]interface{} `json:"details,omitempty"`
+	Owner   *Organization          `json:"owner"`
+	// groups that are blocked from viewing or editing the risk
+	BlockedGroups []*Group `json:"blockedGroups,omitempty"`
+	// provides edit access to the risk to members of the group
+	Editors []*Group `json:"editors,omitempty"`
+	// provides view access to the risk to members of the group
+	Viewers     []*Group          `json:"viewers,omitempty"`
+	Policy      []*InternalPolicy `json:"policy,omitempty"`
+	Controls    []*Control        `json:"controls,omitempty"`
+	Procedures  []*Procedure      `json:"procedures,omitempty"`
+	Risks       []*Risk           `json:"risks,omitempty"`
+	Subcontrols []*Subcontrol     `json:"subcontrols,omitempty"`
+	Standard    []*Standard       `json:"standard,omitempty"`
+	Narratives  []*Narrative      `json:"narratives,omitempty"`
+	Tasks       []*Task           `json:"tasks,omitempty"`
+	Programs    []*Program        `json:"programs,omitempty"`
 }
 
 func (ControlObjective) IsNode() {}
@@ -1978,6 +1987,8 @@ type ControlObjectiveHistory struct {
 	DeletedBy   *string        `json:"deletedBy,omitempty"`
 	// tags associated with the object
 	Tags []string `json:"tags,omitempty"`
+	// the ID of the organization owner of the object
+	OwnerID string `json:"ownerID"`
 	// the name of the control objective
 	Name string `json:"name"`
 	// description of the control objective
@@ -2150,6 +2161,20 @@ type ControlObjectiveHistoryWhereInput struct {
 	DeletedByNotNil       *bool    `json:"deletedByNotNil,omitempty"`
 	DeletedByEqualFold    *string  `json:"deletedByEqualFold,omitempty"`
 	DeletedByContainsFold *string  `json:"deletedByContainsFold,omitempty"`
+	// owner_id field predicates
+	OwnerID             *string  `json:"ownerID,omitempty"`
+	OwnerIdneq          *string  `json:"ownerIDNEQ,omitempty"`
+	OwnerIDIn           []string `json:"ownerIDIn,omitempty"`
+	OwnerIDNotIn        []string `json:"ownerIDNotIn,omitempty"`
+	OwnerIdgt           *string  `json:"ownerIDGT,omitempty"`
+	OwnerIdgte          *string  `json:"ownerIDGTE,omitempty"`
+	OwnerIdlt           *string  `json:"ownerIDLT,omitempty"`
+	OwnerIdlte          *string  `json:"ownerIDLTE,omitempty"`
+	OwnerIDContains     *string  `json:"ownerIDContains,omitempty"`
+	OwnerIDHasPrefix    *string  `json:"ownerIDHasPrefix,omitempty"`
+	OwnerIDHasSuffix    *string  `json:"ownerIDHasSuffix,omitempty"`
+	OwnerIDEqualFold    *string  `json:"ownerIDEqualFold,omitempty"`
+	OwnerIDContainsFold *string  `json:"ownerIDContainsFold,omitempty"`
 	// name field predicates
 	Name             *string  `json:"name,omitempty"`
 	NameNeq          *string  `json:"nameNEQ,omitempty"`
@@ -2420,6 +2445,20 @@ type ControlObjectiveWhereInput struct {
 	DeletedByNotNil       *bool    `json:"deletedByNotNil,omitempty"`
 	DeletedByEqualFold    *string  `json:"deletedByEqualFold,omitempty"`
 	DeletedByContainsFold *string  `json:"deletedByContainsFold,omitempty"`
+	// owner_id field predicates
+	OwnerID             *string  `json:"ownerID,omitempty"`
+	OwnerIdneq          *string  `json:"ownerIDNEQ,omitempty"`
+	OwnerIDIn           []string `json:"ownerIDIn,omitempty"`
+	OwnerIDNotIn        []string `json:"ownerIDNotIn,omitempty"`
+	OwnerIdgt           *string  `json:"ownerIDGT,omitempty"`
+	OwnerIdgte          *string  `json:"ownerIDGTE,omitempty"`
+	OwnerIdlt           *string  `json:"ownerIDLT,omitempty"`
+	OwnerIdlte          *string  `json:"ownerIDLTE,omitempty"`
+	OwnerIDContains     *string  `json:"ownerIDContains,omitempty"`
+	OwnerIDHasPrefix    *string  `json:"ownerIDHasPrefix,omitempty"`
+	OwnerIDHasSuffix    *string  `json:"ownerIDHasSuffix,omitempty"`
+	OwnerIDEqualFold    *string  `json:"ownerIDEqualFold,omitempty"`
+	OwnerIDContainsFold *string  `json:"ownerIDContainsFold,omitempty"`
 	// name field predicates
 	Name             *string  `json:"name,omitempty"`
 	NameNeq          *string  `json:"nameNEQ,omitempty"`
@@ -2578,6 +2617,18 @@ type ControlObjectiveWhereInput struct {
 	MappedFrameworksNotNil       *bool    `json:"mappedFrameworksNotNil,omitempty"`
 	MappedFrameworksEqualFold    *string  `json:"mappedFrameworksEqualFold,omitempty"`
 	MappedFrameworksContainsFold *string  `json:"mappedFrameworksContainsFold,omitempty"`
+	// owner edge predicates
+	HasOwner     *bool                     `json:"hasOwner,omitempty"`
+	HasOwnerWith []*OrganizationWhereInput `json:"hasOwnerWith,omitempty"`
+	// blocked_groups edge predicates
+	HasBlockedGroups     *bool              `json:"hasBlockedGroups,omitempty"`
+	HasBlockedGroupsWith []*GroupWhereInput `json:"hasBlockedGroupsWith,omitempty"`
+	// editors edge predicates
+	HasEditors     *bool              `json:"hasEditors,omitempty"`
+	HasEditorsWith []*GroupWhereInput `json:"hasEditorsWith,omitempty"`
+	// viewers edge predicates
+	HasViewers     *bool              `json:"hasViewers,omitempty"`
+	HasViewersWith []*GroupWhereInput `json:"hasViewersWith,omitempty"`
 	// policy edge predicates
 	HasPolicy     *bool                       `json:"hasPolicy,omitempty"`
 	HasPolicyWith []*InternalPolicyWhereInput `json:"hasPolicyWith,omitempty"`
@@ -3052,16 +3103,20 @@ type CreateControlObjectiveInput struct {
 	// mapped frameworks
 	MappedFrameworks *string `json:"mappedFrameworks,omitempty"`
 	// json data including details of the control objective
-	Details       map[string]interface{} `json:"details,omitempty"`
-	PolicyIDs     []string               `json:"policyIDs,omitempty"`
-	ControlIDs    []string               `json:"controlIDs,omitempty"`
-	ProcedureIDs  []string               `json:"procedureIDs,omitempty"`
-	RiskIDs       []string               `json:"riskIDs,omitempty"`
-	SubcontrolIDs []string               `json:"subcontrolIDs,omitempty"`
-	StandardIDs   []string               `json:"standardIDs,omitempty"`
-	NarrativeIDs  []string               `json:"narrativeIDs,omitempty"`
-	TaskIDs       []string               `json:"taskIDs,omitempty"`
-	ProgramIDs    []string               `json:"programIDs,omitempty"`
+	Details         map[string]interface{} `json:"details,omitempty"`
+	OwnerID         string                 `json:"ownerID"`
+	BlockedGroupIDs []string               `json:"blockedGroupIDs,omitempty"`
+	EditorIDs       []string               `json:"editorIDs,omitempty"`
+	ViewerIDs       []string               `json:"viewerIDs,omitempty"`
+	PolicyIDs       []string               `json:"policyIDs,omitempty"`
+	ControlIDs      []string               `json:"controlIDs,omitempty"`
+	ProcedureIDs    []string               `json:"procedureIDs,omitempty"`
+	RiskIDs         []string               `json:"riskIDs,omitempty"`
+	SubcontrolIDs   []string               `json:"subcontrolIDs,omitempty"`
+	StandardIDs     []string               `json:"standardIDs,omitempty"`
+	NarrativeIDs    []string               `json:"narrativeIDs,omitempty"`
+	TaskIDs         []string               `json:"taskIDs,omitempty"`
+	ProgramIDs      []string               `json:"programIDs,omitempty"`
 }
 
 // CreateDocumentDataInput is used for create DocumentData object.
@@ -3283,25 +3338,28 @@ type CreateGroupInput struct {
 	// the URL to an image uploaded by the customer for the groups avatar image
 	LogoURL *string `json:"logoURL,omitempty"`
 	// The group's displayed 'friendly' name
-	DisplayName                   *string                  `json:"displayName,omitempty"`
-	OwnerID                       *string                  `json:"ownerID,omitempty"`
-	SettingID                     string                   `json:"settingID"`
-	UserIDs                       []string                 `json:"userIDs,omitempty"`
-	EventIDs                      []string                 `json:"eventIDs,omitempty"`
-	IntegrationIDs                []string                 `json:"integrationIDs,omitempty"`
-	FileIDs                       []string                 `json:"fileIDs,omitempty"`
-	TaskIDs                       []string                 `json:"taskIDs,omitempty"`
-	ProcedureEditorIDs            []string                 `json:"procedureEditorIDs,omitempty"`
-	ProcedureBlockedGroupIDs      []string                 `json:"procedureBlockedGroupIDs,omitempty"`
-	InternalpolicyEditorIDs       []string                 `json:"internalpolicyEditorIDs,omitempty"`
-	InternalpolicyBlockedGroupIDs []string                 `json:"internalpolicyBlockedGroupIDs,omitempty"`
-	ProgramViewerIDs              []string                 `json:"programViewerIDs,omitempty"`
-	ProgramEditorIDs              []string                 `json:"programEditorIDs,omitempty"`
-	ProgramBlockedGroupIDs        []string                 `json:"programBlockedGroupIDs,omitempty"`
-	RiskViewerIDs                 []string                 `json:"riskViewerIDs,omitempty"`
-	RiskEditorIDs                 []string                 `json:"riskEditorIDs,omitempty"`
-	RiskBlockedGroupIDs           []string                 `json:"riskBlockedGroupIDs,omitempty"`
-	CreateGroupSettings           *CreateGroupSettingInput `json:"createGroupSettings,omitempty"`
+	DisplayName                     *string                  `json:"displayName,omitempty"`
+	OwnerID                         *string                  `json:"ownerID,omitempty"`
+	SettingID                       string                   `json:"settingID"`
+	UserIDs                         []string                 `json:"userIDs,omitempty"`
+	EventIDs                        []string                 `json:"eventIDs,omitempty"`
+	IntegrationIDs                  []string                 `json:"integrationIDs,omitempty"`
+	FileIDs                         []string                 `json:"fileIDs,omitempty"`
+	TaskIDs                         []string                 `json:"taskIDs,omitempty"`
+	ProcedureEditorIDs              []string                 `json:"procedureEditorIDs,omitempty"`
+	ProcedureBlockedGroupIDs        []string                 `json:"procedureBlockedGroupIDs,omitempty"`
+	InternalpolicyEditorIDs         []string                 `json:"internalpolicyEditorIDs,omitempty"`
+	InternalpolicyBlockedGroupIDs   []string                 `json:"internalpolicyBlockedGroupIDs,omitempty"`
+	ProgramViewerIDs                []string                 `json:"programViewerIDs,omitempty"`
+	ProgramEditorIDs                []string                 `json:"programEditorIDs,omitempty"`
+	ProgramBlockedGroupIDs          []string                 `json:"programBlockedGroupIDs,omitempty"`
+	RiskViewerIDs                   []string                 `json:"riskViewerIDs,omitempty"`
+	RiskEditorIDs                   []string                 `json:"riskEditorIDs,omitempty"`
+	RiskBlockedGroupIDs             []string                 `json:"riskBlockedGroupIDs,omitempty"`
+	ControlobjectiveViewerIDs       []string                 `json:"controlobjectiveViewerIDs,omitempty"`
+	ControlobjectiveEditorIDs       []string                 `json:"controlobjectiveEditorIDs,omitempty"`
+	ControlobjectiveBlockedGroupIDs []string                 `json:"controlobjectiveBlockedGroupIDs,omitempty"`
+	CreateGroupSettings             *CreateGroupSettingInput `json:"createGroupSettings,omitempty"`
 }
 
 // CreateGroupMembershipInput is used for create GroupMembership object.
@@ -3386,14 +3444,14 @@ type CreateInternalPolicyInput struct {
 	// json data for the policy document
 	Details             map[string]interface{} `json:"details,omitempty"`
 	OwnerID             *string                `json:"ownerID,omitempty"`
+	BlockedGroupIDs     []string               `json:"blockedGroupIDs,omitempty"`
+	EditorIDs           []string               `json:"editorIDs,omitempty"`
 	ControlobjectiveIDs []string               `json:"controlobjectiveIDs,omitempty"`
 	ControlIDs          []string               `json:"controlIDs,omitempty"`
 	ProcedureIDs        []string               `json:"procedureIDs,omitempty"`
 	NarrativeIDs        []string               `json:"narrativeIDs,omitempty"`
 	TaskIDs             []string               `json:"taskIDs,omitempty"`
 	ProgramIDs          []string               `json:"programIDs,omitempty"`
-	EditorIDs           []string               `json:"editorIDs,omitempty"`
-	BlockedGroupIDs     []string               `json:"blockedGroupIDs,omitempty"`
 }
 
 // CreateInviteInput is used for create Invite object.
@@ -3549,6 +3607,7 @@ type CreateOrganizationInput struct {
 	ProcedureIDs               []string                        `json:"procedureIDs,omitempty"`
 	InternalpolicyIDs          []string                        `json:"internalpolicyIDs,omitempty"`
 	RiskIDs                    []string                        `json:"riskIDs,omitempty"`
+	ControlobjectiveIDs        []string                        `json:"controlobjectiveIDs,omitempty"`
 	CreateOrgSettings          *CreateOrganizationSettingInput `json:"createOrgSettings,omitempty"`
 }
 
@@ -3619,14 +3678,14 @@ type CreateProcedureInput struct {
 	// json data for the procedure document
 	Details           map[string]interface{} `json:"details,omitempty"`
 	OwnerID           *string                `json:"ownerID,omitempty"`
+	BlockedGroupIDs   []string               `json:"blockedGroupIDs,omitempty"`
+	EditorIDs         []string               `json:"editorIDs,omitempty"`
 	ControlIDs        []string               `json:"controlIDs,omitempty"`
 	InternalpolicyIDs []string               `json:"internalpolicyIDs,omitempty"`
 	NarrativeIDs      []string               `json:"narrativeIDs,omitempty"`
 	RiskIDs           []string               `json:"riskIDs,omitempty"`
 	TaskIDs           []string               `json:"taskIDs,omitempty"`
 	ProgramIDs        []string               `json:"programIDs,omitempty"`
-	EditorIDs         []string               `json:"editorIDs,omitempty"`
-	BlockedGroupIDs   []string               `json:"blockedGroupIDs,omitempty"`
 }
 
 // CreateProgramInput is used for create Program object.
@@ -3651,6 +3710,9 @@ type CreateProgramInput struct {
 	// can the auditor read comments
 	AuditorReadComments *bool    `json:"auditorReadComments,omitempty"`
 	OwnerID             *string  `json:"ownerID,omitempty"`
+	BlockedGroupIDs     []string `json:"blockedGroupIDs,omitempty"`
+	EditorIDs           []string `json:"editorIDs,omitempty"`
+	ViewerIDs           []string `json:"viewerIDs,omitempty"`
 	ControlIDs          []string `json:"controlIDs,omitempty"`
 	SubcontrolIDs       []string `json:"subcontrolIDs,omitempty"`
 	ControlobjectiveIDs []string `json:"controlobjectiveIDs,omitempty"`
@@ -3664,9 +3726,6 @@ type CreateProgramInput struct {
 	ActionplanIDs       []string `json:"actionplanIDs,omitempty"`
 	StandardIDs         []string `json:"standardIDs,omitempty"`
 	UserIDs             []string `json:"userIDs,omitempty"`
-	ViewerIDs           []string `json:"viewerIDs,omitempty"`
-	EditorIDs           []string `json:"editorIDs,omitempty"`
-	BlockedGroupIDs     []string `json:"blockedGroupIDs,omitempty"`
 }
 
 // CreateProgramMembershipInput is used for create ProgramMembership object.
@@ -3702,14 +3761,14 @@ type CreateRiskInput struct {
 	Satisfies *string `json:"satisfies,omitempty"`
 	// json data for the risk document
 	Details         map[string]interface{} `json:"details,omitempty"`
+	OwnerID         string                 `json:"ownerID"`
+	BlockedGroupIDs []string               `json:"blockedGroupIDs,omitempty"`
+	EditorIDs       []string               `json:"editorIDs,omitempty"`
+	ViewerIDs       []string               `json:"viewerIDs,omitempty"`
 	ControlIDs      []string               `json:"controlIDs,omitempty"`
 	ProcedureIDs    []string               `json:"procedureIDs,omitempty"`
 	ActionplanIDs   []string               `json:"actionplanIDs,omitempty"`
-	OwnerID         string                 `json:"ownerID"`
 	ProgramIDs      []string               `json:"programIDs,omitempty"`
-	ViewerIDs       []string               `json:"viewerIDs,omitempty"`
-	EditorIDs       []string               `json:"editorIDs,omitempty"`
-	BlockedGroupIDs []string               `json:"blockedGroupIDs,omitempty"`
 }
 
 // CreateStandardInput is used for create Standard object.
@@ -8792,25 +8851,28 @@ type Group struct {
 	// the URL to an image uploaded by the customer for the groups avatar image
 	LogoURL *string `json:"logoURL,omitempty"`
 	// The group's displayed 'friendly' name
-	DisplayName                 string             `json:"displayName"`
-	Owner                       *Organization      `json:"owner,omitempty"`
-	Setting                     *GroupSetting      `json:"setting"`
-	Users                       []*User            `json:"users,omitempty"`
-	Events                      []*Event           `json:"events,omitempty"`
-	Integrations                []*Integration     `json:"integrations,omitempty"`
-	Files                       []*File            `json:"files,omitempty"`
-	Tasks                       []*Task            `json:"tasks,omitempty"`
-	ProcedureEditors            []*Procedure       `json:"procedureEditors,omitempty"`
-	ProcedureBlockedGroups      []*Procedure       `json:"procedureBlockedGroups,omitempty"`
-	InternalpolicyEditors       []*InternalPolicy  `json:"internalpolicyEditors,omitempty"`
-	InternalpolicyBlockedGroups []*InternalPolicy  `json:"internalpolicyBlockedGroups,omitempty"`
-	ProgramViewers              []*Program         `json:"programViewers,omitempty"`
-	ProgramEditors              []*Program         `json:"programEditors,omitempty"`
-	ProgramBlockedGroups        []*Program         `json:"programBlockedGroups,omitempty"`
-	RiskViewers                 []*Risk            `json:"riskViewers,omitempty"`
-	RiskEditors                 []*Risk            `json:"riskEditors,omitempty"`
-	RiskBlockedGroups           []*Risk            `json:"riskBlockedGroups,omitempty"`
-	Members                     []*GroupMembership `json:"members,omitempty"`
+	DisplayName                   string              `json:"displayName"`
+	Owner                         *Organization       `json:"owner,omitempty"`
+	Setting                       *GroupSetting       `json:"setting"`
+	Users                         []*User             `json:"users,omitempty"`
+	Events                        []*Event            `json:"events,omitempty"`
+	Integrations                  []*Integration      `json:"integrations,omitempty"`
+	Files                         []*File             `json:"files,omitempty"`
+	Tasks                         []*Task             `json:"tasks,omitempty"`
+	ProcedureEditors              []*Procedure        `json:"procedureEditors,omitempty"`
+	ProcedureBlockedGroups        []*Procedure        `json:"procedureBlockedGroups,omitempty"`
+	InternalpolicyEditors         []*InternalPolicy   `json:"internalpolicyEditors,omitempty"`
+	InternalpolicyBlockedGroups   []*InternalPolicy   `json:"internalpolicyBlockedGroups,omitempty"`
+	ProgramViewers                []*Program          `json:"programViewers,omitempty"`
+	ProgramEditors                []*Program          `json:"programEditors,omitempty"`
+	ProgramBlockedGroups          []*Program          `json:"programBlockedGroups,omitempty"`
+	RiskViewers                   []*Risk             `json:"riskViewers,omitempty"`
+	RiskEditors                   []*Risk             `json:"riskEditors,omitempty"`
+	RiskBlockedGroups             []*Risk             `json:"riskBlockedGroups,omitempty"`
+	ControlobjectiveViewers       []*ControlObjective `json:"controlobjectiveViewers,omitempty"`
+	ControlobjectiveEditors       []*ControlObjective `json:"controlobjectiveEditors,omitempty"`
+	ControlobjectiveBlockedGroups []*ControlObjective `json:"controlobjectiveBlockedGroups,omitempty"`
+	Members                       []*GroupMembership  `json:"members,omitempty"`
 }
 
 func (Group) IsNode() {}
@@ -10082,6 +10144,15 @@ type GroupWhereInput struct {
 	// risk_blocked_groups edge predicates
 	HasRiskBlockedGroups     *bool             `json:"hasRiskBlockedGroups,omitempty"`
 	HasRiskBlockedGroupsWith []*RiskWhereInput `json:"hasRiskBlockedGroupsWith,omitempty"`
+	// controlobjective_viewers edge predicates
+	HasControlobjectiveViewers     *bool                         `json:"hasControlobjectiveViewers,omitempty"`
+	HasControlobjectiveViewersWith []*ControlObjectiveWhereInput `json:"hasControlobjectiveViewersWith,omitempty"`
+	// controlobjective_editors edge predicates
+	HasControlobjectiveEditors     *bool                         `json:"hasControlobjectiveEditors,omitempty"`
+	HasControlobjectiveEditorsWith []*ControlObjectiveWhereInput `json:"hasControlobjectiveEditorsWith,omitempty"`
+	// controlobjective_blocked_groups edge predicates
+	HasControlobjectiveBlockedGroups     *bool                         `json:"hasControlobjectiveBlockedGroups,omitempty"`
+	HasControlobjectiveBlockedGroupsWith []*ControlObjectiveWhereInput `json:"hasControlobjectiveBlockedGroupsWith,omitempty"`
 	// members edge predicates
 	HasMembers     *bool                        `json:"hasMembers,omitempty"`
 	HasMembersWith []*GroupMembershipWhereInput `json:"hasMembersWith,omitempty"`
@@ -11039,18 +11110,18 @@ type InternalPolicy struct {
 	// background of the policy
 	Background *string `json:"background,omitempty"`
 	// json data for the policy document
-	Details           map[string]interface{} `json:"details,omitempty"`
-	Owner             *Organization          `json:"owner,omitempty"`
-	Controlobjectives []*ControlObjective    `json:"controlobjectives,omitempty"`
-	Controls          []*Control             `json:"controls,omitempty"`
-	Procedures        []*Procedure           `json:"procedures,omitempty"`
-	Narratives        []*Narrative           `json:"narratives,omitempty"`
-	Tasks             []*Task                `json:"tasks,omitempty"`
-	Programs          []*Program             `json:"programs,omitempty"`
-	// provides edit access to the policy to members of the group
-	Editors []*Group `json:"editors,omitempty"`
-	// groups that are blocked from viewing or editing the policy
+	Details map[string]interface{} `json:"details,omitempty"`
+	Owner   *Organization          `json:"owner,omitempty"`
+	// groups that are blocked from viewing or editing the risk
 	BlockedGroups []*Group `json:"blockedGroups,omitempty"`
+	// provides edit access to the risk to members of the group
+	Editors           []*Group            `json:"editors,omitempty"`
+	Controlobjectives []*ControlObjective `json:"controlobjectives,omitempty"`
+	Controls          []*Control          `json:"controls,omitempty"`
+	Procedures        []*Procedure        `json:"procedures,omitempty"`
+	Narratives        []*Narrative        `json:"narratives,omitempty"`
+	Tasks             []*Task             `json:"tasks,omitempty"`
+	Programs          []*Program          `json:"programs,omitempty"`
 }
 
 func (InternalPolicy) IsNode() {}
@@ -11639,6 +11710,12 @@ type InternalPolicyWhereInput struct {
 	// owner edge predicates
 	HasOwner     *bool                     `json:"hasOwner,omitempty"`
 	HasOwnerWith []*OrganizationWhereInput `json:"hasOwnerWith,omitempty"`
+	// blocked_groups edge predicates
+	HasBlockedGroups     *bool              `json:"hasBlockedGroups,omitempty"`
+	HasBlockedGroupsWith []*GroupWhereInput `json:"hasBlockedGroupsWith,omitempty"`
+	// editors edge predicates
+	HasEditors     *bool              `json:"hasEditors,omitempty"`
+	HasEditorsWith []*GroupWhereInput `json:"hasEditorsWith,omitempty"`
 	// controlobjectives edge predicates
 	HasControlobjectives     *bool                         `json:"hasControlobjectives,omitempty"`
 	HasControlobjectivesWith []*ControlObjectiveWhereInput `json:"hasControlobjectivesWith,omitempty"`
@@ -11657,12 +11734,6 @@ type InternalPolicyWhereInput struct {
 	// programs edge predicates
 	HasPrograms     *bool                `json:"hasPrograms,omitempty"`
 	HasProgramsWith []*ProgramWhereInput `json:"hasProgramsWith,omitempty"`
-	// editors edge predicates
-	HasEditors     *bool              `json:"hasEditors,omitempty"`
-	HasEditorsWith []*GroupWhereInput `json:"hasEditorsWith,omitempty"`
-	// blocked_groups edge predicates
-	HasBlockedGroups     *bool              `json:"hasBlockedGroups,omitempty"`
-	HasBlockedGroupsWith []*GroupWhereInput `json:"hasBlockedGroupsWith,omitempty"`
 }
 
 type Invite struct {
@@ -14024,6 +14095,7 @@ type Organization struct {
 	Procedures              []*Procedure              `json:"procedures,omitempty"`
 	Internalpolicies        []*InternalPolicy         `json:"internalpolicies,omitempty"`
 	Risks                   []*Risk                   `json:"risks,omitempty"`
+	Controlobjectives       []*ControlObjective       `json:"controlobjectives,omitempty"`
 	Members                 []*OrgMembership          `json:"members,omitempty"`
 }
 
@@ -15172,6 +15244,9 @@ type OrganizationWhereInput struct {
 	// risks edge predicates
 	HasRisks     *bool             `json:"hasRisks,omitempty"`
 	HasRisksWith []*RiskWhereInput `json:"hasRisksWith,omitempty"`
+	// controlobjectives edge predicates
+	HasControlobjectives     *bool                         `json:"hasControlobjectives,omitempty"`
+	HasControlobjectivesWith []*ControlObjectiveWhereInput `json:"hasControlobjectivesWith,omitempty"`
 	// members edge predicates
 	HasMembers     *bool                      `json:"hasMembers,omitempty"`
 	HasMembersWith []*OrgMembershipWhereInput `json:"hasMembersWith,omitempty"`
@@ -15439,18 +15514,18 @@ type Procedure struct {
 	// which controls are satisfied by the procedure
 	Satisfies *string `json:"satisfies,omitempty"`
 	// json data for the procedure document
-	Details        map[string]interface{} `json:"details,omitempty"`
-	Owner          *Organization          `json:"owner,omitempty"`
-	Control        []*Control             `json:"control,omitempty"`
-	Internalpolicy []*InternalPolicy      `json:"internalpolicy,omitempty"`
-	Narratives     []*Narrative           `json:"narratives,omitempty"`
-	Risks          []*Risk                `json:"risks,omitempty"`
-	Tasks          []*Task                `json:"tasks,omitempty"`
-	Programs       []*Program             `json:"programs,omitempty"`
-	// provides edit access to the procedure to members of the group
-	Editors []*Group `json:"editors,omitempty"`
-	// groups that are blocked from viewing or editing the procedure
+	Details map[string]interface{} `json:"details,omitempty"`
+	Owner   *Organization          `json:"owner,omitempty"`
+	// groups that are blocked from viewing or editing the risk
 	BlockedGroups []*Group `json:"blockedGroups,omitempty"`
+	// provides edit access to the risk to members of the group
+	Editors        []*Group          `json:"editors,omitempty"`
+	Control        []*Control        `json:"control,omitempty"`
+	Internalpolicy []*InternalPolicy `json:"internalpolicy,omitempty"`
+	Narratives     []*Narrative      `json:"narratives,omitempty"`
+	Risks          []*Risk           `json:"risks,omitempty"`
+	Tasks          []*Task           `json:"tasks,omitempty"`
+	Programs       []*Program        `json:"programs,omitempty"`
 }
 
 func (Procedure) IsNode() {}
@@ -16073,6 +16148,12 @@ type ProcedureWhereInput struct {
 	// owner edge predicates
 	HasOwner     *bool                     `json:"hasOwner,omitempty"`
 	HasOwnerWith []*OrganizationWhereInput `json:"hasOwnerWith,omitempty"`
+	// blocked_groups edge predicates
+	HasBlockedGroups     *bool              `json:"hasBlockedGroups,omitempty"`
+	HasBlockedGroupsWith []*GroupWhereInput `json:"hasBlockedGroupsWith,omitempty"`
+	// editors edge predicates
+	HasEditors     *bool              `json:"hasEditors,omitempty"`
+	HasEditorsWith []*GroupWhereInput `json:"hasEditorsWith,omitempty"`
 	// control edge predicates
 	HasControl     *bool                `json:"hasControl,omitempty"`
 	HasControlWith []*ControlWhereInput `json:"hasControlWith,omitempty"`
@@ -16091,12 +16172,6 @@ type ProcedureWhereInput struct {
 	// programs edge predicates
 	HasPrograms     *bool                `json:"hasPrograms,omitempty"`
 	HasProgramsWith []*ProgramWhereInput `json:"hasProgramsWith,omitempty"`
-	// editors edge predicates
-	HasEditors     *bool              `json:"hasEditors,omitempty"`
-	HasEditorsWith []*GroupWhereInput `json:"hasEditorsWith,omitempty"`
-	// blocked_groups edge predicates
-	HasBlockedGroups     *bool              `json:"hasBlockedGroups,omitempty"`
-	HasBlockedGroupsWith []*GroupWhereInput `json:"hasBlockedGroupsWith,omitempty"`
 }
 
 type Program struct {
@@ -16126,29 +16201,29 @@ type Program struct {
 	// can the auditor write comments
 	AuditorWriteComments bool `json:"auditorWriteComments"`
 	// can the auditor read comments
-	AuditorReadComments bool                `json:"auditorReadComments"`
-	Owner               *Organization       `json:"owner,omitempty"`
-	Controls            []*Control          `json:"controls,omitempty"`
-	Subcontrols         []*Subcontrol       `json:"subcontrols,omitempty"`
-	Controlobjectives   []*ControlObjective `json:"controlobjectives,omitempty"`
-	Policies            []*InternalPolicy   `json:"policies,omitempty"`
-	Procedures          []*Procedure        `json:"procedures,omitempty"`
-	Risks               []*Risk             `json:"risks,omitempty"`
-	Tasks               []*Task             `json:"tasks,omitempty"`
-	Notes               []*Note             `json:"notes,omitempty"`
-	Files               []*File             `json:"files,omitempty"`
-	Narratives          []*Narrative        `json:"narratives,omitempty"`
-	Actionplans         []*ActionPlan       `json:"actionplans,omitempty"`
-	// the framework(s) that the program is based on
-	Standards []*Standard `json:"standards,omitempty"`
-	Users     []*User     `json:"users,omitempty"`
-	// provides view access to the program to members of the group
-	Viewers []*Group `json:"viewers,omitempty"`
-	// provides edit access to the program to members of the group
+	AuditorReadComments bool          `json:"auditorReadComments"`
+	Owner               *Organization `json:"owner,omitempty"`
+	// groups that are blocked from viewing or editing the risk
+	BlockedGroups []*Group `json:"blockedGroups,omitempty"`
+	// provides edit access to the risk to members of the group
 	Editors []*Group `json:"editors,omitempty"`
-	// groups that are blocked from viewing or editing the program
-	BlockedGroups []*Group             `json:"blockedGroups,omitempty"`
-	Members       []*ProgramMembership `json:"members,omitempty"`
+	// provides view access to the risk to members of the group
+	Viewers           []*Group            `json:"viewers,omitempty"`
+	Controls          []*Control          `json:"controls,omitempty"`
+	Subcontrols       []*Subcontrol       `json:"subcontrols,omitempty"`
+	Controlobjectives []*ControlObjective `json:"controlobjectives,omitempty"`
+	Policies          []*InternalPolicy   `json:"policies,omitempty"`
+	Procedures        []*Procedure        `json:"procedures,omitempty"`
+	Risks             []*Risk             `json:"risks,omitempty"`
+	Tasks             []*Task             `json:"tasks,omitempty"`
+	Notes             []*Note             `json:"notes,omitempty"`
+	Files             []*File             `json:"files,omitempty"`
+	Narratives        []*Narrative        `json:"narratives,omitempty"`
+	Actionplans       []*ActionPlan       `json:"actionplans,omitempty"`
+	// the framework(s) that the program is based on
+	Standards []*Standard          `json:"standards,omitempty"`
+	Users     []*User              `json:"users,omitempty"`
+	Members   []*ProgramMembership `json:"members,omitempty"`
 }
 
 func (Program) IsNode() {}
@@ -17014,6 +17089,15 @@ type ProgramWhereInput struct {
 	// owner edge predicates
 	HasOwner     *bool                     `json:"hasOwner,omitempty"`
 	HasOwnerWith []*OrganizationWhereInput `json:"hasOwnerWith,omitempty"`
+	// blocked_groups edge predicates
+	HasBlockedGroups     *bool              `json:"hasBlockedGroups,omitempty"`
+	HasBlockedGroupsWith []*GroupWhereInput `json:"hasBlockedGroupsWith,omitempty"`
+	// editors edge predicates
+	HasEditors     *bool              `json:"hasEditors,omitempty"`
+	HasEditorsWith []*GroupWhereInput `json:"hasEditorsWith,omitempty"`
+	// viewers edge predicates
+	HasViewers     *bool              `json:"hasViewers,omitempty"`
+	HasViewersWith []*GroupWhereInput `json:"hasViewersWith,omitempty"`
 	// controls edge predicates
 	HasControls     *bool                `json:"hasControls,omitempty"`
 	HasControlsWith []*ControlWhereInput `json:"hasControlsWith,omitempty"`
@@ -17053,15 +17137,6 @@ type ProgramWhereInput struct {
 	// users edge predicates
 	HasUsers     *bool             `json:"hasUsers,omitempty"`
 	HasUsersWith []*UserWhereInput `json:"hasUsersWith,omitempty"`
-	// viewers edge predicates
-	HasViewers     *bool              `json:"hasViewers,omitempty"`
-	HasViewersWith []*GroupWhereInput `json:"hasViewersWith,omitempty"`
-	// editors edge predicates
-	HasEditors     *bool              `json:"hasEditors,omitempty"`
-	HasEditorsWith []*GroupWhereInput `json:"hasEditorsWith,omitempty"`
-	// blocked_groups edge predicates
-	HasBlockedGroups     *bool              `json:"hasBlockedGroups,omitempty"`
-	HasBlockedGroupsWith []*GroupWhereInput `json:"hasBlockedGroupsWith,omitempty"`
 	// members edge predicates
 	HasMembers     *bool                          `json:"hasMembers,omitempty"`
 	HasMembersWith []*ProgramMembershipWhereInput `json:"hasMembersWith,omitempty"`
@@ -17080,6 +17155,8 @@ type Risk struct {
 	DeletedBy *string    `json:"deletedBy,omitempty"`
 	// tags associated with the object
 	Tags []string `json:"tags,omitempty"`
+	// the ID of the organization owner of the object
+	OwnerID string `json:"ownerID"`
 	// the name of the risk
 	Name string `json:"name"`
 	// description of the risk
@@ -17100,19 +17177,17 @@ type Risk struct {
 	Satisfies *string `json:"satisfies,omitempty"`
 	// json data for the risk document
 	Details map[string]interface{} `json:"details,omitempty"`
-	// the ID of the organization owner of the risk
-	OwnerID     string        `json:"ownerID"`
+	Owner   *Organization          `json:"owner"`
+	// groups that are blocked from viewing or editing the risk
+	BlockedGroups []*Group `json:"blockedGroups,omitempty"`
+	// provides edit access to the risk to members of the group
+	Editors []*Group `json:"editors,omitempty"`
+	// provides view access to the risk to members of the group
+	Viewers     []*Group      `json:"viewers,omitempty"`
 	Control     []*Control    `json:"control,omitempty"`
 	Procedure   []*Procedure  `json:"procedure,omitempty"`
 	Actionplans []*ActionPlan `json:"actionplans,omitempty"`
-	Owner       *Organization `json:"owner"`
-	Program     []*Program    `json:"program,omitempty"`
-	// provides view access to the risk to members of the group
-	Viewers []*Group `json:"viewers,omitempty"`
-	// provides edit access to the risk to members of the group
-	Editors []*Group `json:"editors,omitempty"`
-	// groups that are blocked from viewing or editing the risk
-	BlockedGroups []*Group `json:"blockedGroups,omitempty"`
+	Programs    []*Program    `json:"programs,omitempty"`
 }
 
 func (Risk) IsNode() {}
@@ -17166,6 +17241,8 @@ type RiskHistory struct {
 	DeletedBy   *string        `json:"deletedBy,omitempty"`
 	// tags associated with the object
 	Tags []string `json:"tags,omitempty"`
+	// the ID of the organization owner of the object
+	OwnerID string `json:"ownerID"`
 	// the name of the risk
 	Name string `json:"name"`
 	// description of the risk
@@ -17186,8 +17263,6 @@ type RiskHistory struct {
 	Satisfies *string `json:"satisfies,omitempty"`
 	// json data for the risk document
 	Details map[string]interface{} `json:"details,omitempty"`
-	// the ID of the organization owner of the risk
-	OwnerID string `json:"ownerID"`
 }
 
 func (RiskHistory) IsNode() {}
@@ -17338,6 +17413,20 @@ type RiskHistoryWhereInput struct {
 	DeletedByNotNil       *bool    `json:"deletedByNotNil,omitempty"`
 	DeletedByEqualFold    *string  `json:"deletedByEqualFold,omitempty"`
 	DeletedByContainsFold *string  `json:"deletedByContainsFold,omitempty"`
+	// owner_id field predicates
+	OwnerID             *string  `json:"ownerID,omitempty"`
+	OwnerIdneq          *string  `json:"ownerIDNEQ,omitempty"`
+	OwnerIDIn           []string `json:"ownerIDIn,omitempty"`
+	OwnerIDNotIn        []string `json:"ownerIDNotIn,omitempty"`
+	OwnerIdgt           *string  `json:"ownerIDGT,omitempty"`
+	OwnerIdgte          *string  `json:"ownerIDGTE,omitempty"`
+	OwnerIdlt           *string  `json:"ownerIDLT,omitempty"`
+	OwnerIdlte          *string  `json:"ownerIDLTE,omitempty"`
+	OwnerIDContains     *string  `json:"ownerIDContains,omitempty"`
+	OwnerIDHasPrefix    *string  `json:"ownerIDHasPrefix,omitempty"`
+	OwnerIDHasSuffix    *string  `json:"ownerIDHasSuffix,omitempty"`
+	OwnerIDEqualFold    *string  `json:"ownerIDEqualFold,omitempty"`
+	OwnerIDContainsFold *string  `json:"ownerIDContainsFold,omitempty"`
 	// name field predicates
 	Name             *string  `json:"name,omitempty"`
 	NameNeq          *string  `json:"nameNEQ,omitempty"`
@@ -17462,20 +17551,6 @@ type RiskHistoryWhereInput struct {
 	SatisfiesNotNil       *bool    `json:"satisfiesNotNil,omitempty"`
 	SatisfiesEqualFold    *string  `json:"satisfiesEqualFold,omitempty"`
 	SatisfiesContainsFold *string  `json:"satisfiesContainsFold,omitempty"`
-	// owner_id field predicates
-	OwnerID             *string  `json:"ownerID,omitempty"`
-	OwnerIdneq          *string  `json:"ownerIDNEQ,omitempty"`
-	OwnerIDIn           []string `json:"ownerIDIn,omitempty"`
-	OwnerIDNotIn        []string `json:"ownerIDNotIn,omitempty"`
-	OwnerIdgt           *string  `json:"ownerIDGT,omitempty"`
-	OwnerIdgte          *string  `json:"ownerIDGTE,omitempty"`
-	OwnerIdlt           *string  `json:"ownerIDLT,omitempty"`
-	OwnerIdlte          *string  `json:"ownerIDLTE,omitempty"`
-	OwnerIDContains     *string  `json:"ownerIDContains,omitempty"`
-	OwnerIDHasPrefix    *string  `json:"ownerIDHasPrefix,omitempty"`
-	OwnerIDHasSuffix    *string  `json:"ownerIDHasSuffix,omitempty"`
-	OwnerIDEqualFold    *string  `json:"ownerIDEqualFold,omitempty"`
-	OwnerIDContainsFold *string  `json:"ownerIDContainsFold,omitempty"`
 }
 
 type RiskSearchResult struct {
@@ -17588,6 +17663,20 @@ type RiskWhereInput struct {
 	DeletedByNotNil       *bool    `json:"deletedByNotNil,omitempty"`
 	DeletedByEqualFold    *string  `json:"deletedByEqualFold,omitempty"`
 	DeletedByContainsFold *string  `json:"deletedByContainsFold,omitempty"`
+	// owner_id field predicates
+	OwnerID             *string  `json:"ownerID,omitempty"`
+	OwnerIdneq          *string  `json:"ownerIDNEQ,omitempty"`
+	OwnerIDIn           []string `json:"ownerIDIn,omitempty"`
+	OwnerIDNotIn        []string `json:"ownerIDNotIn,omitempty"`
+	OwnerIdgt           *string  `json:"ownerIDGT,omitempty"`
+	OwnerIdgte          *string  `json:"ownerIDGTE,omitempty"`
+	OwnerIdlt           *string  `json:"ownerIDLT,omitempty"`
+	OwnerIdlte          *string  `json:"ownerIDLTE,omitempty"`
+	OwnerIDContains     *string  `json:"ownerIDContains,omitempty"`
+	OwnerIDHasPrefix    *string  `json:"ownerIDHasPrefix,omitempty"`
+	OwnerIDHasSuffix    *string  `json:"ownerIDHasSuffix,omitempty"`
+	OwnerIDEqualFold    *string  `json:"ownerIDEqualFold,omitempty"`
+	OwnerIDContainsFold *string  `json:"ownerIDContainsFold,omitempty"`
 	// name field predicates
 	Name             *string  `json:"name,omitempty"`
 	NameNeq          *string  `json:"nameNEQ,omitempty"`
@@ -17712,20 +17801,18 @@ type RiskWhereInput struct {
 	SatisfiesNotNil       *bool    `json:"satisfiesNotNil,omitempty"`
 	SatisfiesEqualFold    *string  `json:"satisfiesEqualFold,omitempty"`
 	SatisfiesContainsFold *string  `json:"satisfiesContainsFold,omitempty"`
-	// owner_id field predicates
-	OwnerID             *string  `json:"ownerID,omitempty"`
-	OwnerIdneq          *string  `json:"ownerIDNEQ,omitempty"`
-	OwnerIDIn           []string `json:"ownerIDIn,omitempty"`
-	OwnerIDNotIn        []string `json:"ownerIDNotIn,omitempty"`
-	OwnerIdgt           *string  `json:"ownerIDGT,omitempty"`
-	OwnerIdgte          *string  `json:"ownerIDGTE,omitempty"`
-	OwnerIdlt           *string  `json:"ownerIDLT,omitempty"`
-	OwnerIdlte          *string  `json:"ownerIDLTE,omitempty"`
-	OwnerIDContains     *string  `json:"ownerIDContains,omitempty"`
-	OwnerIDHasPrefix    *string  `json:"ownerIDHasPrefix,omitempty"`
-	OwnerIDHasSuffix    *string  `json:"ownerIDHasSuffix,omitempty"`
-	OwnerIDEqualFold    *string  `json:"ownerIDEqualFold,omitempty"`
-	OwnerIDContainsFold *string  `json:"ownerIDContainsFold,omitempty"`
+	// owner edge predicates
+	HasOwner     *bool                     `json:"hasOwner,omitempty"`
+	HasOwnerWith []*OrganizationWhereInput `json:"hasOwnerWith,omitempty"`
+	// blocked_groups edge predicates
+	HasBlockedGroups     *bool              `json:"hasBlockedGroups,omitempty"`
+	HasBlockedGroupsWith []*GroupWhereInput `json:"hasBlockedGroupsWith,omitempty"`
+	// editors edge predicates
+	HasEditors     *bool              `json:"hasEditors,omitempty"`
+	HasEditorsWith []*GroupWhereInput `json:"hasEditorsWith,omitempty"`
+	// viewers edge predicates
+	HasViewers     *bool              `json:"hasViewers,omitempty"`
+	HasViewersWith []*GroupWhereInput `json:"hasViewersWith,omitempty"`
 	// control edge predicates
 	HasControl     *bool                `json:"hasControl,omitempty"`
 	HasControlWith []*ControlWhereInput `json:"hasControlWith,omitempty"`
@@ -17735,21 +17822,9 @@ type RiskWhereInput struct {
 	// actionplans edge predicates
 	HasActionplans     *bool                   `json:"hasActionplans,omitempty"`
 	HasActionplansWith []*ActionPlanWhereInput `json:"hasActionplansWith,omitempty"`
-	// owner edge predicates
-	HasOwner     *bool                     `json:"hasOwner,omitempty"`
-	HasOwnerWith []*OrganizationWhereInput `json:"hasOwnerWith,omitempty"`
-	// program edge predicates
-	HasProgram     *bool                `json:"hasProgram,omitempty"`
-	HasProgramWith []*ProgramWhereInput `json:"hasProgramWith,omitempty"`
-	// viewers edge predicates
-	HasViewers     *bool              `json:"hasViewers,omitempty"`
-	HasViewersWith []*GroupWhereInput `json:"hasViewersWith,omitempty"`
-	// editors edge predicates
-	HasEditors     *bool              `json:"hasEditors,omitempty"`
-	HasEditorsWith []*GroupWhereInput `json:"hasEditorsWith,omitempty"`
-	// blocked_groups edge predicates
-	HasBlockedGroups     *bool              `json:"hasBlockedGroups,omitempty"`
-	HasBlockedGroupsWith []*GroupWhereInput `json:"hasBlockedGroupsWith,omitempty"`
+	// programs edge predicates
+	HasPrograms     *bool                `json:"hasPrograms,omitempty"`
+	HasProgramsWith []*ProgramWhereInput `json:"hasProgramsWith,omitempty"`
 }
 
 type SearchResultConnection struct {
@@ -20913,35 +20988,45 @@ type UpdateControlObjectiveInput struct {
 	MappedFrameworks      *string `json:"mappedFrameworks,omitempty"`
 	ClearMappedFrameworks *bool   `json:"clearMappedFrameworks,omitempty"`
 	// json data including details of the control objective
-	Details             map[string]interface{} `json:"details,omitempty"`
-	ClearDetails        *bool                  `json:"clearDetails,omitempty"`
-	AddPolicyIDs        []string               `json:"addPolicyIDs,omitempty"`
-	RemovePolicyIDs     []string               `json:"removePolicyIDs,omitempty"`
-	ClearPolicy         *bool                  `json:"clearPolicy,omitempty"`
-	AddControlIDs       []string               `json:"addControlIDs,omitempty"`
-	RemoveControlIDs    []string               `json:"removeControlIDs,omitempty"`
-	ClearControls       *bool                  `json:"clearControls,omitempty"`
-	AddProcedureIDs     []string               `json:"addProcedureIDs,omitempty"`
-	RemoveProcedureIDs  []string               `json:"removeProcedureIDs,omitempty"`
-	ClearProcedures     *bool                  `json:"clearProcedures,omitempty"`
-	AddRiskIDs          []string               `json:"addRiskIDs,omitempty"`
-	RemoveRiskIDs       []string               `json:"removeRiskIDs,omitempty"`
-	ClearRisks          *bool                  `json:"clearRisks,omitempty"`
-	AddSubcontrolIDs    []string               `json:"addSubcontrolIDs,omitempty"`
-	RemoveSubcontrolIDs []string               `json:"removeSubcontrolIDs,omitempty"`
-	ClearSubcontrols    *bool                  `json:"clearSubcontrols,omitempty"`
-	AddStandardIDs      []string               `json:"addStandardIDs,omitempty"`
-	RemoveStandardIDs   []string               `json:"removeStandardIDs,omitempty"`
-	ClearStandard       *bool                  `json:"clearStandard,omitempty"`
-	AddNarrativeIDs     []string               `json:"addNarrativeIDs,omitempty"`
-	RemoveNarrativeIDs  []string               `json:"removeNarrativeIDs,omitempty"`
-	ClearNarratives     *bool                  `json:"clearNarratives,omitempty"`
-	AddTaskIDs          []string               `json:"addTaskIDs,omitempty"`
-	RemoveTaskIDs       []string               `json:"removeTaskIDs,omitempty"`
-	ClearTasks          *bool                  `json:"clearTasks,omitempty"`
-	AddProgramIDs       []string               `json:"addProgramIDs,omitempty"`
-	RemoveProgramIDs    []string               `json:"removeProgramIDs,omitempty"`
-	ClearPrograms       *bool                  `json:"clearPrograms,omitempty"`
+	Details               map[string]interface{} `json:"details,omitempty"`
+	ClearDetails          *bool                  `json:"clearDetails,omitempty"`
+	OwnerID               *string                `json:"ownerID,omitempty"`
+	AddBlockedGroupIDs    []string               `json:"addBlockedGroupIDs,omitempty"`
+	RemoveBlockedGroupIDs []string               `json:"removeBlockedGroupIDs,omitempty"`
+	ClearBlockedGroups    *bool                  `json:"clearBlockedGroups,omitempty"`
+	AddEditorIDs          []string               `json:"addEditorIDs,omitempty"`
+	RemoveEditorIDs       []string               `json:"removeEditorIDs,omitempty"`
+	ClearEditors          *bool                  `json:"clearEditors,omitempty"`
+	AddViewerIDs          []string               `json:"addViewerIDs,omitempty"`
+	RemoveViewerIDs       []string               `json:"removeViewerIDs,omitempty"`
+	ClearViewers          *bool                  `json:"clearViewers,omitempty"`
+	AddPolicyIDs          []string               `json:"addPolicyIDs,omitempty"`
+	RemovePolicyIDs       []string               `json:"removePolicyIDs,omitempty"`
+	ClearPolicy           *bool                  `json:"clearPolicy,omitempty"`
+	AddControlIDs         []string               `json:"addControlIDs,omitempty"`
+	RemoveControlIDs      []string               `json:"removeControlIDs,omitempty"`
+	ClearControls         *bool                  `json:"clearControls,omitempty"`
+	AddProcedureIDs       []string               `json:"addProcedureIDs,omitempty"`
+	RemoveProcedureIDs    []string               `json:"removeProcedureIDs,omitempty"`
+	ClearProcedures       *bool                  `json:"clearProcedures,omitempty"`
+	AddRiskIDs            []string               `json:"addRiskIDs,omitempty"`
+	RemoveRiskIDs         []string               `json:"removeRiskIDs,omitempty"`
+	ClearRisks            *bool                  `json:"clearRisks,omitempty"`
+	AddSubcontrolIDs      []string               `json:"addSubcontrolIDs,omitempty"`
+	RemoveSubcontrolIDs   []string               `json:"removeSubcontrolIDs,omitempty"`
+	ClearSubcontrols      *bool                  `json:"clearSubcontrols,omitempty"`
+	AddStandardIDs        []string               `json:"addStandardIDs,omitempty"`
+	RemoveStandardIDs     []string               `json:"removeStandardIDs,omitempty"`
+	ClearStandard         *bool                  `json:"clearStandard,omitempty"`
+	AddNarrativeIDs       []string               `json:"addNarrativeIDs,omitempty"`
+	RemoveNarrativeIDs    []string               `json:"removeNarrativeIDs,omitempty"`
+	ClearNarratives       *bool                  `json:"clearNarratives,omitempty"`
+	AddTaskIDs            []string               `json:"addTaskIDs,omitempty"`
+	RemoveTaskIDs         []string               `json:"removeTaskIDs,omitempty"`
+	ClearTasks            *bool                  `json:"clearTasks,omitempty"`
+	AddProgramIDs         []string               `json:"addProgramIDs,omitempty"`
+	RemoveProgramIDs      []string               `json:"removeProgramIDs,omitempty"`
+	ClearPrograms         *bool                  `json:"clearPrograms,omitempty"`
 }
 
 // UpdateDocumentDataInput is used for update DocumentData object.
@@ -21297,57 +21382,66 @@ type UpdateGroupInput struct {
 	LogoURL      *string `json:"logoURL,omitempty"`
 	ClearLogoURL *bool   `json:"clearLogoURL,omitempty"`
 	// The group's displayed 'friendly' name
-	DisplayName                         *string                       `json:"displayName,omitempty"`
-	OwnerID                             *string                       `json:"ownerID,omitempty"`
-	ClearOwner                          *bool                         `json:"clearOwner,omitempty"`
-	SettingID                           *string                       `json:"settingID,omitempty"`
-	AddUserIDs                          []string                      `json:"addUserIDs,omitempty"`
-	RemoveUserIDs                       []string                      `json:"removeUserIDs,omitempty"`
-	ClearUsers                          *bool                         `json:"clearUsers,omitempty"`
-	AddEventIDs                         []string                      `json:"addEventIDs,omitempty"`
-	RemoveEventIDs                      []string                      `json:"removeEventIDs,omitempty"`
-	ClearEvents                         *bool                         `json:"clearEvents,omitempty"`
-	AddIntegrationIDs                   []string                      `json:"addIntegrationIDs,omitempty"`
-	RemoveIntegrationIDs                []string                      `json:"removeIntegrationIDs,omitempty"`
-	ClearIntegrations                   *bool                         `json:"clearIntegrations,omitempty"`
-	AddFileIDs                          []string                      `json:"addFileIDs,omitempty"`
-	RemoveFileIDs                       []string                      `json:"removeFileIDs,omitempty"`
-	ClearFiles                          *bool                         `json:"clearFiles,omitempty"`
-	AddTaskIDs                          []string                      `json:"addTaskIDs,omitempty"`
-	RemoveTaskIDs                       []string                      `json:"removeTaskIDs,omitempty"`
-	ClearTasks                          *bool                         `json:"clearTasks,omitempty"`
-	AddProcedureEditorIDs               []string                      `json:"addProcedureEditorIDs,omitempty"`
-	RemoveProcedureEditorIDs            []string                      `json:"removeProcedureEditorIDs,omitempty"`
-	ClearProcedureEditors               *bool                         `json:"clearProcedureEditors,omitempty"`
-	AddProcedureBlockedGroupIDs         []string                      `json:"addProcedureBlockedGroupIDs,omitempty"`
-	RemoveProcedureBlockedGroupIDs      []string                      `json:"removeProcedureBlockedGroupIDs,omitempty"`
-	ClearProcedureBlockedGroups         *bool                         `json:"clearProcedureBlockedGroups,omitempty"`
-	AddInternalpolicyEditorIDs          []string                      `json:"addInternalpolicyEditorIDs,omitempty"`
-	RemoveInternalpolicyEditorIDs       []string                      `json:"removeInternalpolicyEditorIDs,omitempty"`
-	ClearInternalpolicyEditors          *bool                         `json:"clearInternalpolicyEditors,omitempty"`
-	AddInternalpolicyBlockedGroupIDs    []string                      `json:"addInternalpolicyBlockedGroupIDs,omitempty"`
-	RemoveInternalpolicyBlockedGroupIDs []string                      `json:"removeInternalpolicyBlockedGroupIDs,omitempty"`
-	ClearInternalpolicyBlockedGroups    *bool                         `json:"clearInternalpolicyBlockedGroups,omitempty"`
-	AddProgramViewerIDs                 []string                      `json:"addProgramViewerIDs,omitempty"`
-	RemoveProgramViewerIDs              []string                      `json:"removeProgramViewerIDs,omitempty"`
-	ClearProgramViewers                 *bool                         `json:"clearProgramViewers,omitempty"`
-	AddProgramEditorIDs                 []string                      `json:"addProgramEditorIDs,omitempty"`
-	RemoveProgramEditorIDs              []string                      `json:"removeProgramEditorIDs,omitempty"`
-	ClearProgramEditors                 *bool                         `json:"clearProgramEditors,omitempty"`
-	AddProgramBlockedGroupIDs           []string                      `json:"addProgramBlockedGroupIDs,omitempty"`
-	RemoveProgramBlockedGroupIDs        []string                      `json:"removeProgramBlockedGroupIDs,omitempty"`
-	ClearProgramBlockedGroups           *bool                         `json:"clearProgramBlockedGroups,omitempty"`
-	AddRiskViewerIDs                    []string                      `json:"addRiskViewerIDs,omitempty"`
-	RemoveRiskViewerIDs                 []string                      `json:"removeRiskViewerIDs,omitempty"`
-	ClearRiskViewers                    *bool                         `json:"clearRiskViewers,omitempty"`
-	AddRiskEditorIDs                    []string                      `json:"addRiskEditorIDs,omitempty"`
-	RemoveRiskEditorIDs                 []string                      `json:"removeRiskEditorIDs,omitempty"`
-	ClearRiskEditors                    *bool                         `json:"clearRiskEditors,omitempty"`
-	AddRiskBlockedGroupIDs              []string                      `json:"addRiskBlockedGroupIDs,omitempty"`
-	RemoveRiskBlockedGroupIDs           []string                      `json:"removeRiskBlockedGroupIDs,omitempty"`
-	ClearRiskBlockedGroups              *bool                         `json:"clearRiskBlockedGroups,omitempty"`
-	AddGroupMembers                     []*CreateGroupMembershipInput `json:"addGroupMembers,omitempty"`
-	UpdateGroupSettings                 *UpdateGroupSettingInput      `json:"updateGroupSettings,omitempty"`
+	DisplayName                           *string                       `json:"displayName,omitempty"`
+	OwnerID                               *string                       `json:"ownerID,omitempty"`
+	ClearOwner                            *bool                         `json:"clearOwner,omitempty"`
+	SettingID                             *string                       `json:"settingID,omitempty"`
+	AddUserIDs                            []string                      `json:"addUserIDs,omitempty"`
+	RemoveUserIDs                         []string                      `json:"removeUserIDs,omitempty"`
+	ClearUsers                            *bool                         `json:"clearUsers,omitempty"`
+	AddEventIDs                           []string                      `json:"addEventIDs,omitempty"`
+	RemoveEventIDs                        []string                      `json:"removeEventIDs,omitempty"`
+	ClearEvents                           *bool                         `json:"clearEvents,omitempty"`
+	AddIntegrationIDs                     []string                      `json:"addIntegrationIDs,omitempty"`
+	RemoveIntegrationIDs                  []string                      `json:"removeIntegrationIDs,omitempty"`
+	ClearIntegrations                     *bool                         `json:"clearIntegrations,omitempty"`
+	AddFileIDs                            []string                      `json:"addFileIDs,omitempty"`
+	RemoveFileIDs                         []string                      `json:"removeFileIDs,omitempty"`
+	ClearFiles                            *bool                         `json:"clearFiles,omitempty"`
+	AddTaskIDs                            []string                      `json:"addTaskIDs,omitempty"`
+	RemoveTaskIDs                         []string                      `json:"removeTaskIDs,omitempty"`
+	ClearTasks                            *bool                         `json:"clearTasks,omitempty"`
+	AddProcedureEditorIDs                 []string                      `json:"addProcedureEditorIDs,omitempty"`
+	RemoveProcedureEditorIDs              []string                      `json:"removeProcedureEditorIDs,omitempty"`
+	ClearProcedureEditors                 *bool                         `json:"clearProcedureEditors,omitempty"`
+	AddProcedureBlockedGroupIDs           []string                      `json:"addProcedureBlockedGroupIDs,omitempty"`
+	RemoveProcedureBlockedGroupIDs        []string                      `json:"removeProcedureBlockedGroupIDs,omitempty"`
+	ClearProcedureBlockedGroups           *bool                         `json:"clearProcedureBlockedGroups,omitempty"`
+	AddInternalpolicyEditorIDs            []string                      `json:"addInternalpolicyEditorIDs,omitempty"`
+	RemoveInternalpolicyEditorIDs         []string                      `json:"removeInternalpolicyEditorIDs,omitempty"`
+	ClearInternalpolicyEditors            *bool                         `json:"clearInternalpolicyEditors,omitempty"`
+	AddInternalpolicyBlockedGroupIDs      []string                      `json:"addInternalpolicyBlockedGroupIDs,omitempty"`
+	RemoveInternalpolicyBlockedGroupIDs   []string                      `json:"removeInternalpolicyBlockedGroupIDs,omitempty"`
+	ClearInternalpolicyBlockedGroups      *bool                         `json:"clearInternalpolicyBlockedGroups,omitempty"`
+	AddProgramViewerIDs                   []string                      `json:"addProgramViewerIDs,omitempty"`
+	RemoveProgramViewerIDs                []string                      `json:"removeProgramViewerIDs,omitempty"`
+	ClearProgramViewers                   *bool                         `json:"clearProgramViewers,omitempty"`
+	AddProgramEditorIDs                   []string                      `json:"addProgramEditorIDs,omitempty"`
+	RemoveProgramEditorIDs                []string                      `json:"removeProgramEditorIDs,omitempty"`
+	ClearProgramEditors                   *bool                         `json:"clearProgramEditors,omitempty"`
+	AddProgramBlockedGroupIDs             []string                      `json:"addProgramBlockedGroupIDs,omitempty"`
+	RemoveProgramBlockedGroupIDs          []string                      `json:"removeProgramBlockedGroupIDs,omitempty"`
+	ClearProgramBlockedGroups             *bool                         `json:"clearProgramBlockedGroups,omitempty"`
+	AddRiskViewerIDs                      []string                      `json:"addRiskViewerIDs,omitempty"`
+	RemoveRiskViewerIDs                   []string                      `json:"removeRiskViewerIDs,omitempty"`
+	ClearRiskViewers                      *bool                         `json:"clearRiskViewers,omitempty"`
+	AddRiskEditorIDs                      []string                      `json:"addRiskEditorIDs,omitempty"`
+	RemoveRiskEditorIDs                   []string                      `json:"removeRiskEditorIDs,omitempty"`
+	ClearRiskEditors                      *bool                         `json:"clearRiskEditors,omitempty"`
+	AddRiskBlockedGroupIDs                []string                      `json:"addRiskBlockedGroupIDs,omitempty"`
+	RemoveRiskBlockedGroupIDs             []string                      `json:"removeRiskBlockedGroupIDs,omitempty"`
+	ClearRiskBlockedGroups                *bool                         `json:"clearRiskBlockedGroups,omitempty"`
+	AddControlobjectiveViewerIDs          []string                      `json:"addControlobjectiveViewerIDs,omitempty"`
+	RemoveControlobjectiveViewerIDs       []string                      `json:"removeControlobjectiveViewerIDs,omitempty"`
+	ClearControlobjectiveViewers          *bool                         `json:"clearControlobjectiveViewers,omitempty"`
+	AddControlobjectiveEditorIDs          []string                      `json:"addControlobjectiveEditorIDs,omitempty"`
+	RemoveControlobjectiveEditorIDs       []string                      `json:"removeControlobjectiveEditorIDs,omitempty"`
+	ClearControlobjectiveEditors          *bool                         `json:"clearControlobjectiveEditors,omitempty"`
+	AddControlobjectiveBlockedGroupIDs    []string                      `json:"addControlobjectiveBlockedGroupIDs,omitempty"`
+	RemoveControlobjectiveBlockedGroupIDs []string                      `json:"removeControlobjectiveBlockedGroupIDs,omitempty"`
+	ClearControlobjectiveBlockedGroups    *bool                         `json:"clearControlobjectiveBlockedGroups,omitempty"`
+	AddGroupMembers                       []*CreateGroupMembershipInput `json:"addGroupMembers,omitempty"`
+	UpdateGroupSettings                   *UpdateGroupSettingInput      `json:"updateGroupSettings,omitempty"`
 }
 
 // UpdateGroupMembershipInput is used for update GroupMembership object.
@@ -21464,6 +21558,12 @@ type UpdateInternalPolicyInput struct {
 	ClearDetails              *bool                  `json:"clearDetails,omitempty"`
 	OwnerID                   *string                `json:"ownerID,omitempty"`
 	ClearOwner                *bool                  `json:"clearOwner,omitempty"`
+	AddBlockedGroupIDs        []string               `json:"addBlockedGroupIDs,omitempty"`
+	RemoveBlockedGroupIDs     []string               `json:"removeBlockedGroupIDs,omitempty"`
+	ClearBlockedGroups        *bool                  `json:"clearBlockedGroups,omitempty"`
+	AddEditorIDs              []string               `json:"addEditorIDs,omitempty"`
+	RemoveEditorIDs           []string               `json:"removeEditorIDs,omitempty"`
+	ClearEditors              *bool                  `json:"clearEditors,omitempty"`
 	AddControlobjectiveIDs    []string               `json:"addControlobjectiveIDs,omitempty"`
 	RemoveControlobjectiveIDs []string               `json:"removeControlobjectiveIDs,omitempty"`
 	ClearControlobjectives    *bool                  `json:"clearControlobjectives,omitempty"`
@@ -21482,12 +21582,6 @@ type UpdateInternalPolicyInput struct {
 	AddProgramIDs             []string               `json:"addProgramIDs,omitempty"`
 	RemoveProgramIDs          []string               `json:"removeProgramIDs,omitempty"`
 	ClearPrograms             *bool                  `json:"clearPrograms,omitempty"`
-	AddEditorIDs              []string               `json:"addEditorIDs,omitempty"`
-	RemoveEditorIDs           []string               `json:"removeEditorIDs,omitempty"`
-	ClearEditors              *bool                  `json:"clearEditors,omitempty"`
-	AddBlockedGroupIDs        []string               `json:"addBlockedGroupIDs,omitempty"`
-	RemoveBlockedGroupIDs     []string               `json:"removeBlockedGroupIDs,omitempty"`
-	ClearBlockedGroups        *bool                  `json:"clearBlockedGroups,omitempty"`
 }
 
 // UpdateInviteInput is used for update Invite object.
@@ -21735,6 +21829,9 @@ type UpdateOrganizationInput struct {
 	AddRiskIDs                       []string                        `json:"addRiskIDs,omitempty"`
 	RemoveRiskIDs                    []string                        `json:"removeRiskIDs,omitempty"`
 	ClearRisks                       *bool                           `json:"clearRisks,omitempty"`
+	AddControlobjectiveIDs           []string                        `json:"addControlobjectiveIDs,omitempty"`
+	RemoveControlobjectiveIDs        []string                        `json:"removeControlobjectiveIDs,omitempty"`
+	ClearControlobjectives           *bool                           `json:"clearControlobjectives,omitempty"`
 	AddOrgMembers                    []*CreateOrgMembershipInput     `json:"addOrgMembers,omitempty"`
 	UpdateOrgSettings                *UpdateOrganizationSettingInput `json:"updateOrgSettings,omitempty"`
 }
@@ -21838,6 +21935,12 @@ type UpdateProcedureInput struct {
 	ClearDetails            *bool                  `json:"clearDetails,omitempty"`
 	OwnerID                 *string                `json:"ownerID,omitempty"`
 	ClearOwner              *bool                  `json:"clearOwner,omitempty"`
+	AddBlockedGroupIDs      []string               `json:"addBlockedGroupIDs,omitempty"`
+	RemoveBlockedGroupIDs   []string               `json:"removeBlockedGroupIDs,omitempty"`
+	ClearBlockedGroups      *bool                  `json:"clearBlockedGroups,omitempty"`
+	AddEditorIDs            []string               `json:"addEditorIDs,omitempty"`
+	RemoveEditorIDs         []string               `json:"removeEditorIDs,omitempty"`
+	ClearEditors            *bool                  `json:"clearEditors,omitempty"`
 	AddControlIDs           []string               `json:"addControlIDs,omitempty"`
 	RemoveControlIDs        []string               `json:"removeControlIDs,omitempty"`
 	ClearControl            *bool                  `json:"clearControl,omitempty"`
@@ -21856,12 +21959,6 @@ type UpdateProcedureInput struct {
 	AddProgramIDs           []string               `json:"addProgramIDs,omitempty"`
 	RemoveProgramIDs        []string               `json:"removeProgramIDs,omitempty"`
 	ClearPrograms           *bool                  `json:"clearPrograms,omitempty"`
-	AddEditorIDs            []string               `json:"addEditorIDs,omitempty"`
-	RemoveEditorIDs         []string               `json:"removeEditorIDs,omitempty"`
-	ClearEditors            *bool                  `json:"clearEditors,omitempty"`
-	AddBlockedGroupIDs      []string               `json:"addBlockedGroupIDs,omitempty"`
-	RemoveBlockedGroupIDs   []string               `json:"removeBlockedGroupIDs,omitempty"`
-	ClearBlockedGroups      *bool                  `json:"clearBlockedGroups,omitempty"`
 }
 
 // UpdateProgramInput is used for update Program object.
@@ -21892,6 +21989,15 @@ type UpdateProgramInput struct {
 	AuditorReadComments       *bool                           `json:"auditorReadComments,omitempty"`
 	OwnerID                   *string                         `json:"ownerID,omitempty"`
 	ClearOwner                *bool                           `json:"clearOwner,omitempty"`
+	AddBlockedGroupIDs        []string                        `json:"addBlockedGroupIDs,omitempty"`
+	RemoveBlockedGroupIDs     []string                        `json:"removeBlockedGroupIDs,omitempty"`
+	ClearBlockedGroups        *bool                           `json:"clearBlockedGroups,omitempty"`
+	AddEditorIDs              []string                        `json:"addEditorIDs,omitempty"`
+	RemoveEditorIDs           []string                        `json:"removeEditorIDs,omitempty"`
+	ClearEditors              *bool                           `json:"clearEditors,omitempty"`
+	AddViewerIDs              []string                        `json:"addViewerIDs,omitempty"`
+	RemoveViewerIDs           []string                        `json:"removeViewerIDs,omitempty"`
+	ClearViewers              *bool                           `json:"clearViewers,omitempty"`
 	AddControlIDs             []string                        `json:"addControlIDs,omitempty"`
 	RemoveControlIDs          []string                        `json:"removeControlIDs,omitempty"`
 	ClearControls             *bool                           `json:"clearControls,omitempty"`
@@ -21931,15 +22037,6 @@ type UpdateProgramInput struct {
 	AddUserIDs                []string                        `json:"addUserIDs,omitempty"`
 	RemoveUserIDs             []string                        `json:"removeUserIDs,omitempty"`
 	ClearUsers                *bool                           `json:"clearUsers,omitempty"`
-	AddViewerIDs              []string                        `json:"addViewerIDs,omitempty"`
-	RemoveViewerIDs           []string                        `json:"removeViewerIDs,omitempty"`
-	ClearViewers              *bool                           `json:"clearViewers,omitempty"`
-	AddEditorIDs              []string                        `json:"addEditorIDs,omitempty"`
-	RemoveEditorIDs           []string                        `json:"removeEditorIDs,omitempty"`
-	ClearEditors              *bool                           `json:"clearEditors,omitempty"`
-	AddBlockedGroupIDs        []string                        `json:"addBlockedGroupIDs,omitempty"`
-	RemoveBlockedGroupIDs     []string                        `json:"removeBlockedGroupIDs,omitempty"`
-	ClearBlockedGroups        *bool                           `json:"clearBlockedGroups,omitempty"`
 	AddProgramMembers         []*CreateProgramMembershipInput `json:"addProgramMembers,omitempty"`
 }
 
@@ -21985,6 +22082,16 @@ type UpdateRiskInput struct {
 	// json data for the risk document
 	Details               map[string]interface{} `json:"details,omitempty"`
 	ClearDetails          *bool                  `json:"clearDetails,omitempty"`
+	OwnerID               *string                `json:"ownerID,omitempty"`
+	AddBlockedGroupIDs    []string               `json:"addBlockedGroupIDs,omitempty"`
+	RemoveBlockedGroupIDs []string               `json:"removeBlockedGroupIDs,omitempty"`
+	ClearBlockedGroups    *bool                  `json:"clearBlockedGroups,omitempty"`
+	AddEditorIDs          []string               `json:"addEditorIDs,omitempty"`
+	RemoveEditorIDs       []string               `json:"removeEditorIDs,omitempty"`
+	ClearEditors          *bool                  `json:"clearEditors,omitempty"`
+	AddViewerIDs          []string               `json:"addViewerIDs,omitempty"`
+	RemoveViewerIDs       []string               `json:"removeViewerIDs,omitempty"`
+	ClearViewers          *bool                  `json:"clearViewers,omitempty"`
 	AddControlIDs         []string               `json:"addControlIDs,omitempty"`
 	RemoveControlIDs      []string               `json:"removeControlIDs,omitempty"`
 	ClearControl          *bool                  `json:"clearControl,omitempty"`
@@ -21994,19 +22101,9 @@ type UpdateRiskInput struct {
 	AddActionplanIDs      []string               `json:"addActionplanIDs,omitempty"`
 	RemoveActionplanIDs   []string               `json:"removeActionplanIDs,omitempty"`
 	ClearActionplans      *bool                  `json:"clearActionplans,omitempty"`
-	OwnerID               *string                `json:"ownerID,omitempty"`
 	AddProgramIDs         []string               `json:"addProgramIDs,omitempty"`
 	RemoveProgramIDs      []string               `json:"removeProgramIDs,omitempty"`
-	ClearProgram          *bool                  `json:"clearProgram,omitempty"`
-	AddViewerIDs          []string               `json:"addViewerIDs,omitempty"`
-	RemoveViewerIDs       []string               `json:"removeViewerIDs,omitempty"`
-	ClearViewers          *bool                  `json:"clearViewers,omitempty"`
-	AddEditorIDs          []string               `json:"addEditorIDs,omitempty"`
-	RemoveEditorIDs       []string               `json:"removeEditorIDs,omitempty"`
-	ClearEditors          *bool                  `json:"clearEditors,omitempty"`
-	AddBlockedGroupIDs    []string               `json:"addBlockedGroupIDs,omitempty"`
-	RemoveBlockedGroupIDs []string               `json:"removeBlockedGroupIDs,omitempty"`
-	ClearBlockedGroups    *bool                  `json:"clearBlockedGroups,omitempty"`
+	ClearPrograms         *bool                  `json:"clearPrograms,omitempty"`
 }
 
 // UpdateStandardInput is used for update Standard object.

--- a/query/adminsearch.graphql
+++ b/query/adminsearch.graphql
@@ -62,6 +62,7 @@ query AdminSearch($query: String!) {
           deletedBy
           id
           tags
+          ownerID
           name
           description
           status
@@ -342,6 +343,7 @@ query AdminSearch($query: String!) {
           deletedBy
           id
           tags
+          ownerID
           name
           description
           status
@@ -350,7 +352,6 @@ query AdminSearch($query: String!) {
           mitigation
           satisfies
           details
-          ownerID
         }
       }
       ... on StandardSearchResult {

--- a/query/controlobjective.graphql
+++ b/query/controlobjective.graphql
@@ -67,6 +67,22 @@ mutation CreateControlObjective($input: CreateControlObjectiveInput!) {
       updatedAt
       updatedBy
       version
+      programs {
+        id
+        name
+      }
+      editors {
+        id
+        name
+      }
+      viewers {
+        id
+        name
+      }
+      blockedGroups {
+        id
+        name
+      }
     }
   }
 }
@@ -98,6 +114,22 @@ query GetAllControlObjectives {
         updatedAt
         updatedBy
         version
+        programs {
+          id
+          name
+        }
+        editors {
+          id
+          name
+        }
+        viewers {
+          id
+          name
+        }
+        blockedGroups {
+          id
+          name
+        }
       }
     }
   }
@@ -121,6 +153,22 @@ query GetControlObjectiveByID($controlObjectiveId: ID!) {
     updatedAt
     updatedBy
     version
+    programs {
+      id
+      name
+    }
+    editors {
+      id
+      name
+    }
+    viewers {
+      id
+      name
+    }
+    blockedGroups {
+      id
+      name
+    }
   }
 }
 
@@ -145,6 +193,22 @@ query GetControlObjectives($where: ControlObjectiveWhereInput) {
         updatedAt
         updatedBy
         version
+        programs {
+          id
+          name
+        }
+        editors {
+          id
+          name
+        }
+        viewers {
+          id
+          name
+        }
+        blockedGroups {
+          id
+          name
+        }
       }
     }
   }
@@ -169,6 +233,22 @@ mutation UpdateControlObjective($updateControlObjectiveId: ID!, $input: UpdateCo
       updatedAt
       updatedBy
       version
+      programs {
+        id
+        name
+      }
+      editors {
+        id
+        name
+      }
+      viewers {
+        id
+        name
+      }
+      blockedGroups {
+        id
+        name
+      }
     }
   }
 }

--- a/query/risk.graphql
+++ b/query/risk.graphql
@@ -63,7 +63,7 @@ mutation CreateRisk($input: CreateRiskInput!) {
       tags
       updatedAt
       updatedBy
-      program {
+      programs {
         id
         name
       }
@@ -109,7 +109,7 @@ query GetAllRisks {
         tags
         updatedAt
         updatedBy
-        program {
+        programs {
           id
           name
         }
@@ -148,7 +148,7 @@ query GetRiskByID($riskId: ID!) {
     tags
     updatedAt
     updatedBy
-    program {
+    programs {
       id
       name
     }
@@ -187,7 +187,7 @@ query GetRisks($where: RiskWhereInput) {
         tags
         updatedAt
         updatedBy
-        program {
+        programs {
           id
           name
         }
@@ -227,7 +227,7 @@ mutation UpdateRisk($updateRiskId: ID!, $input: UpdateRiskInput!) {
       tags
       updatedAt
       updatedBy
-      program {
+      programs {
         id
         name
       }

--- a/schema.graphql
+++ b/schema.graphql
@@ -2373,6 +2373,10 @@ type ControlObjective implements Node {
 	"""
 	tags: [String!]
 	"""
+	the ID of the organization owner of the object
+	"""
+	ownerID: ID!
+	"""
 	the name of the control objective
 	"""
 	name: String!
@@ -2416,6 +2420,19 @@ type ControlObjective implements Node {
 	json data including details of the control objective
 	"""
 	details: Map
+	owner: Organization!
+	"""
+	groups that are blocked from viewing or editing the risk
+	"""
+	blockedGroups: [Group!]
+	"""
+	provides edit access to the risk to members of the group
+	"""
+	editors: [Group!]
+	"""
+	provides view access to the risk to members of the group
+	"""
+	viewers: [Group!]
 	policy: [InternalPolicy!]
 	controls: [Control!]
 	procedures: [Procedure!]
@@ -2498,6 +2515,10 @@ type ControlObjectiveHistory implements Node {
 	tags associated with the object
 	"""
 	tags: [String!]
+	"""
+	the ID of the organization owner of the object
+	"""
+	ownerID: String!
 	"""
 	the name of the control objective
 	"""
@@ -2731,6 +2752,22 @@ input ControlObjectiveHistoryWhereInput {
 	deletedByNotNil: Boolean
 	deletedByEqualFold: String
 	deletedByContainsFold: String
+	"""
+	owner_id field predicates
+	"""
+	ownerID: String
+	ownerIDNEQ: String
+	ownerIDIn: [String!]
+	ownerIDNotIn: [String!]
+	ownerIDGT: String
+	ownerIDGTE: String
+	ownerIDLT: String
+	ownerIDLTE: String
+	ownerIDContains: String
+	ownerIDHasPrefix: String
+	ownerIDHasSuffix: String
+	ownerIDEqualFold: String
+	ownerIDContainsFold: String
 	"""
 	name field predicates
 	"""
@@ -3037,6 +3074,22 @@ input ControlObjectiveWhereInput {
 	deletedByEqualFold: String
 	deletedByContainsFold: String
 	"""
+	owner_id field predicates
+	"""
+	ownerID: ID
+	ownerIDNEQ: ID
+	ownerIDIn: [ID!]
+	ownerIDNotIn: [ID!]
+	ownerIDGT: ID
+	ownerIDGTE: ID
+	ownerIDLT: ID
+	ownerIDLTE: ID
+	ownerIDContains: ID
+	ownerIDHasPrefix: ID
+	ownerIDHasSuffix: ID
+	ownerIDEqualFold: ID
+	ownerIDContainsFold: ID
+	"""
 	name field predicates
 	"""
 	name: String
@@ -3214,6 +3267,26 @@ input ControlObjectiveWhereInput {
 	mappedFrameworksNotNil: Boolean
 	mappedFrameworksEqualFold: String
 	mappedFrameworksContainsFold: String
+	"""
+	owner edge predicates
+	"""
+	hasOwner: Boolean
+	hasOwnerWith: [OrganizationWhereInput!]
+	"""
+	blocked_groups edge predicates
+	"""
+	hasBlockedGroups: Boolean
+	hasBlockedGroupsWith: [GroupWhereInput!]
+	"""
+	editors edge predicates
+	"""
+	hasEditors: Boolean
+	hasEditorsWith: [GroupWhereInput!]
+	"""
+	viewers edge predicates
+	"""
+	hasViewers: Boolean
+	hasViewersWith: [GroupWhereInput!]
 	"""
 	policy edge predicates
 	"""
@@ -3857,6 +3930,10 @@ input CreateControlObjectiveInput {
 	json data including details of the control objective
 	"""
 	details: Map
+	ownerID: ID!
+	blockedGroupIDs: [ID!]
+	editorIDs: [ID!]
+	viewerIDs: [ID!]
 	policyIDs: [ID!]
 	controlIDs: [ID!]
 	procedureIDs: [ID!]
@@ -4229,6 +4306,9 @@ input CreateGroupInput {
 	riskViewerIDs: [ID!]
 	riskEditorIDs: [ID!]
 	riskBlockedGroupIDs: [ID!]
+	controlobjectiveViewerIDs: [ID!]
+	controlobjectiveEditorIDs: [ID!]
+	controlobjectiveBlockedGroupIDs: [ID!]
 	createGroupSettings: CreateGroupSettingInput
 }
 """
@@ -4363,14 +4443,14 @@ input CreateInternalPolicyInput {
 	"""
 	details: Map
 	ownerID: ID
+	blockedGroupIDs: [ID!]
+	editorIDs: [ID!]
 	controlobjectiveIDs: [ID!]
 	controlIDs: [ID!]
 	procedureIDs: [ID!]
 	narrativeIDs: [ID!]
 	taskIDs: [ID!]
 	programIDs: [ID!]
-	editorIDs: [ID!]
-	blockedGroupIDs: [ID!]
 }
 """
 CreateInviteInput is used for create Invite object.
@@ -4593,6 +4673,7 @@ input CreateOrganizationInput {
 	procedureIDs: [ID!]
 	internalpolicyIDs: [ID!]
 	riskIDs: [ID!]
+	controlobjectiveIDs: [ID!]
 	createOrgSettings: CreateOrganizationSettingInput
 }
 """
@@ -4712,14 +4793,14 @@ input CreateProcedureInput {
 	"""
 	details: Map
 	ownerID: ID
+	blockedGroupIDs: [ID!]
+	editorIDs: [ID!]
 	controlIDs: [ID!]
 	internalpolicyIDs: [ID!]
 	narrativeIDs: [ID!]
 	riskIDs: [ID!]
 	taskIDs: [ID!]
 	programIDs: [ID!]
-	editorIDs: [ID!]
-	blockedGroupIDs: [ID!]
 }
 """
 CreateProgramInput is used for create Program object.
@@ -4763,6 +4844,9 @@ input CreateProgramInput {
 	"""
 	auditorReadComments: Boolean
 	ownerID: ID
+	blockedGroupIDs: [ID!]
+	editorIDs: [ID!]
+	viewerIDs: [ID!]
 	controlIDs: [ID!]
 	subcontrolIDs: [ID!]
 	controlobjectiveIDs: [ID!]
@@ -4776,9 +4860,6 @@ input CreateProgramInput {
 	actionplanIDs: [ID!]
 	standardIDs: [ID!]
 	userIDs: [ID!]
-	viewerIDs: [ID!]
-	editorIDs: [ID!]
-	blockedGroupIDs: [ID!]
 }
 """
 CreateProgramMembershipInput is used for create ProgramMembership object.
@@ -4838,14 +4919,14 @@ input CreateRiskInput {
 	json data for the risk document
 	"""
 	details: Map
+	ownerID: ID!
+	blockedGroupIDs: [ID!]
+	editorIDs: [ID!]
+	viewerIDs: [ID!]
 	controlIDs: [ID!]
 	procedureIDs: [ID!]
 	actionplanIDs: [ID!]
-	ownerID: ID!
 	programIDs: [ID!]
-	viewerIDs: [ID!]
-	editorIDs: [ID!]
-	blockedGroupIDs: [ID!]
 }
 """
 CreateStandardInput is used for create Standard object.
@@ -11353,6 +11434,9 @@ type Group implements Node {
 	riskViewers: [Risk!]
 	riskEditors: [Risk!]
 	riskBlockedGroups: [Risk!]
+	controlobjectiveViewers: [ControlObjective!]
+	controlobjectiveEditors: [ControlObjective!]
+	controlobjectiveBlockedGroups: [ControlObjective!]
 	members: [GroupMembership!]
 }
 """
@@ -13027,6 +13111,21 @@ input GroupWhereInput {
 	hasRiskBlockedGroups: Boolean
 	hasRiskBlockedGroupsWith: [RiskWhereInput!]
 	"""
+	controlobjective_viewers edge predicates
+	"""
+	hasControlobjectiveViewers: Boolean
+	hasControlobjectiveViewersWith: [ControlObjectiveWhereInput!]
+	"""
+	controlobjective_editors edge predicates
+	"""
+	hasControlobjectiveEditors: Boolean
+	hasControlobjectiveEditorsWith: [ControlObjectiveWhereInput!]
+	"""
+	controlobjective_blocked_groups edge predicates
+	"""
+	hasControlobjectiveBlockedGroups: Boolean
+	hasControlobjectiveBlockedGroupsWith: [ControlObjectiveWhereInput!]
+	"""
 	members edge predicates
 	"""
 	hasMembers: Boolean
@@ -14277,20 +14376,20 @@ type InternalPolicy implements Node {
 	"""
 	details: Map
 	owner: Organization
+	"""
+	groups that are blocked from viewing or editing the risk
+	"""
+	blockedGroups: [Group!]
+	"""
+	provides edit access to the risk to members of the group
+	"""
+	editors: [Group!]
 	controlobjectives: [ControlObjective!]
 	controls: [Control!]
 	procedures: [Procedure!]
 	narratives: [Narrative!]
 	tasks: [Task!]
 	programs: [Program!]
-	"""
-	provides edit access to the policy to members of the group
-	"""
-	editors: [Group!]
-	"""
-	groups that are blocked from viewing or editing the policy
-	"""
-	blockedGroups: [Group!]
 }
 """
 Return response for createBulkInternalPolicy mutation
@@ -15006,6 +15105,16 @@ input InternalPolicyWhereInput {
 	hasOwner: Boolean
 	hasOwnerWith: [OrganizationWhereInput!]
 	"""
+	blocked_groups edge predicates
+	"""
+	hasBlockedGroups: Boolean
+	hasBlockedGroupsWith: [GroupWhereInput!]
+	"""
+	editors edge predicates
+	"""
+	hasEditors: Boolean
+	hasEditorsWith: [GroupWhereInput!]
+	"""
 	controlobjectives edge predicates
 	"""
 	hasControlobjectives: Boolean
@@ -15035,16 +15144,6 @@ input InternalPolicyWhereInput {
 	"""
 	hasPrograms: Boolean
 	hasProgramsWith: [ProgramWhereInput!]
-	"""
-	editors edge predicates
-	"""
-	hasEditors: Boolean
-	hasEditorsWith: [GroupWhereInput!]
-	"""
-	blocked_groups edge predicates
-	"""
-	hasBlockedGroups: Boolean
-	hasBlockedGroupsWith: [GroupWhereInput!]
 }
 type Invite implements Node {
 	id: ID!
@@ -20019,6 +20118,7 @@ type Organization implements Node {
 	procedures: [Procedure!]
 	internalpolicies: [InternalPolicy!]
 	risks: [Risk!]
+	controlobjectives: [ControlObjective!]
 	members: [OrgMembership!]
 }
 """
@@ -21519,6 +21619,11 @@ input OrganizationWhereInput {
 	hasRisks: Boolean
 	hasRisksWith: [RiskWhereInput!]
 	"""
+	controlobjectives edge predicates
+	"""
+	hasControlobjectives: Boolean
+	hasControlobjectivesWith: [ControlObjectiveWhereInput!]
+	"""
 	members edge predicates
 	"""
 	hasMembers: Boolean
@@ -21874,20 +21979,20 @@ type Procedure implements Node {
 	"""
 	details: Map
 	owner: Organization
+	"""
+	groups that are blocked from viewing or editing the risk
+	"""
+	blockedGroups: [Group!]
+	"""
+	provides edit access to the risk to members of the group
+	"""
+	editors: [Group!]
 	control: [Control!]
 	internalpolicy: [InternalPolicy!]
 	narratives: [Narrative!]
 	risks: [Risk!]
 	tasks: [Task!]
 	programs: [Program!]
-	"""
-	provides edit access to the procedure to members of the group
-	"""
-	editors: [Group!]
-	"""
-	groups that are blocked from viewing or editing the procedure
-	"""
-	blockedGroups: [Group!]
 }
 """
 Return response for createBulkProcedure mutation
@@ -22643,6 +22748,16 @@ input ProcedureWhereInput {
 	hasOwner: Boolean
 	hasOwnerWith: [OrganizationWhereInput!]
 	"""
+	blocked_groups edge predicates
+	"""
+	hasBlockedGroups: Boolean
+	hasBlockedGroupsWith: [GroupWhereInput!]
+	"""
+	editors edge predicates
+	"""
+	hasEditors: Boolean
+	hasEditorsWith: [GroupWhereInput!]
+	"""
 	control edge predicates
 	"""
 	hasControl: Boolean
@@ -22672,16 +22787,6 @@ input ProcedureWhereInput {
 	"""
 	hasPrograms: Boolean
 	hasProgramsWith: [ProgramWhereInput!]
-	"""
-	editors edge predicates
-	"""
-	hasEditors: Boolean
-	hasEditorsWith: [GroupWhereInput!]
-	"""
-	blocked_groups edge predicates
-	"""
-	hasBlockedGroups: Boolean
-	hasBlockedGroupsWith: [GroupWhereInput!]
 }
 type Program implements Node {
 	id: ID!
@@ -22732,6 +22837,18 @@ type Program implements Node {
 	"""
 	auditorReadComments: Boolean!
 	owner: Organization
+	"""
+	groups that are blocked from viewing or editing the risk
+	"""
+	blockedGroups: [Group!]
+	"""
+	provides edit access to the risk to members of the group
+	"""
+	editors: [Group!]
+	"""
+	provides view access to the risk to members of the group
+	"""
+	viewers: [Group!]
 	controls: [Control!]
 	subcontrols: [Subcontrol!]
 	controlobjectives: [ControlObjective!]
@@ -22748,18 +22865,6 @@ type Program implements Node {
 	"""
 	standards: [Standard!]
 	users: [User!]
-	"""
-	provides view access to the program to members of the group
-	"""
-	viewers: [Group!]
-	"""
-	provides edit access to the program to members of the group
-	"""
-	editors: [Group!]
-	"""
-	groups that are blocked from viewing or editing the program
-	"""
-	blockedGroups: [Group!]
 	members: [ProgramMembership!]
 }
 """
@@ -23873,6 +23978,21 @@ input ProgramWhereInput {
 	hasOwner: Boolean
 	hasOwnerWith: [OrganizationWhereInput!]
 	"""
+	blocked_groups edge predicates
+	"""
+	hasBlockedGroups: Boolean
+	hasBlockedGroupsWith: [GroupWhereInput!]
+	"""
+	editors edge predicates
+	"""
+	hasEditors: Boolean
+	hasEditorsWith: [GroupWhereInput!]
+	"""
+	viewers edge predicates
+	"""
+	hasViewers: Boolean
+	hasViewersWith: [GroupWhereInput!]
+	"""
 	controls edge predicates
 	"""
 	hasControls: Boolean
@@ -23937,21 +24057,6 @@ input ProgramWhereInput {
 	"""
 	hasUsers: Boolean
 	hasUsersWith: [UserWhereInput!]
-	"""
-	viewers edge predicates
-	"""
-	hasViewers: Boolean
-	hasViewersWith: [GroupWhereInput!]
-	"""
-	editors edge predicates
-	"""
-	hasEditors: Boolean
-	hasEditorsWith: [GroupWhereInput!]
-	"""
-	blocked_groups edge predicates
-	"""
-	hasBlockedGroups: Boolean
-	hasBlockedGroupsWith: [GroupWhereInput!]
 	"""
 	members edge predicates
 	"""
@@ -27170,6 +27275,10 @@ type Risk implements Node {
 	"""
 	tags: [String!]
 	"""
+	the ID of the organization owner of the object
+	"""
+	ownerID: ID!
+	"""
 	the name of the risk
 	"""
 	name: String!
@@ -27209,27 +27318,23 @@ type Risk implements Node {
 	json data for the risk document
 	"""
 	details: Map
-	"""
-	the ID of the organization owner of the risk
-	"""
-	ownerID: ID!
-	control: [Control!]
-	procedure: [Procedure!]
-	actionplans: [ActionPlan!]
 	owner: Organization!
-	program: [Program!]
 	"""
-	provides view access to the risk to members of the group
+	groups that are blocked from viewing or editing the risk
 	"""
-	viewers: [Group!]
+	blockedGroups: [Group!]
 	"""
 	provides edit access to the risk to members of the group
 	"""
 	editors: [Group!]
 	"""
-	groups that are blocked from viewing or editing the risk
+	provides view access to the risk to members of the group
 	"""
-	blockedGroups: [Group!]
+	viewers: [Group!]
+	control: [Control!]
+	procedure: [Procedure!]
+	actionplans: [ActionPlan!]
+	programs: [Program!]
 }
 """
 Return response for createBulkRisk mutation
@@ -27304,6 +27409,10 @@ type RiskHistory implements Node {
 	"""
 	tags: [String!]
 	"""
+	the ID of the organization owner of the object
+	"""
+	ownerID: String!
+	"""
 	the name of the risk
 	"""
 	name: String!
@@ -27343,10 +27452,6 @@ type RiskHistory implements Node {
 	json data for the risk document
 	"""
 	details: Map
-	"""
-	the ID of the organization owner of the risk
-	"""
-	ownerID: String!
 }
 """
 A connection to a list of items.
@@ -27553,6 +27658,22 @@ input RiskHistoryWhereInput {
 	deletedByEqualFold: String
 	deletedByContainsFold: String
 	"""
+	owner_id field predicates
+	"""
+	ownerID: String
+	ownerIDNEQ: String
+	ownerIDIn: [String!]
+	ownerIDNotIn: [String!]
+	ownerIDGT: String
+	ownerIDGTE: String
+	ownerIDLT: String
+	ownerIDLTE: String
+	ownerIDContains: String
+	ownerIDHasPrefix: String
+	ownerIDHasSuffix: String
+	ownerIDEqualFold: String
+	ownerIDContainsFold: String
+	"""
 	name field predicates
 	"""
 	name: String
@@ -27694,22 +27815,6 @@ input RiskHistoryWhereInput {
 	satisfiesNotNil: Boolean
 	satisfiesEqualFold: String
 	satisfiesContainsFold: String
-	"""
-	owner_id field predicates
-	"""
-	ownerID: String
-	ownerIDNEQ: String
-	ownerIDIn: [String!]
-	ownerIDNotIn: [String!]
-	ownerIDGT: String
-	ownerIDGTE: String
-	ownerIDLT: String
-	ownerIDLTE: String
-	ownerIDContains: String
-	ownerIDHasPrefix: String
-	ownerIDHasSuffix: String
-	ownerIDEqualFold: String
-	ownerIDContainsFold: String
 }
 """
 RiskRiskImpact is enum for the field impact
@@ -27854,6 +27959,22 @@ input RiskWhereInput {
 	deletedByEqualFold: String
 	deletedByContainsFold: String
 	"""
+	owner_id field predicates
+	"""
+	ownerID: ID
+	ownerIDNEQ: ID
+	ownerIDIn: [ID!]
+	ownerIDNotIn: [ID!]
+	ownerIDGT: ID
+	ownerIDGTE: ID
+	ownerIDLT: ID
+	ownerIDLTE: ID
+	ownerIDContains: ID
+	ownerIDHasPrefix: ID
+	ownerIDHasSuffix: ID
+	ownerIDEqualFold: ID
+	ownerIDContainsFold: ID
+	"""
 	name field predicates
 	"""
 	name: String
@@ -27996,21 +28117,25 @@ input RiskWhereInput {
 	satisfiesEqualFold: String
 	satisfiesContainsFold: String
 	"""
-	owner_id field predicates
+	owner edge predicates
 	"""
-	ownerID: ID
-	ownerIDNEQ: ID
-	ownerIDIn: [ID!]
-	ownerIDNotIn: [ID!]
-	ownerIDGT: ID
-	ownerIDGTE: ID
-	ownerIDLT: ID
-	ownerIDLTE: ID
-	ownerIDContains: ID
-	ownerIDHasPrefix: ID
-	ownerIDHasSuffix: ID
-	ownerIDEqualFold: ID
-	ownerIDContainsFold: ID
+	hasOwner: Boolean
+	hasOwnerWith: [OrganizationWhereInput!]
+	"""
+	blocked_groups edge predicates
+	"""
+	hasBlockedGroups: Boolean
+	hasBlockedGroupsWith: [GroupWhereInput!]
+	"""
+	editors edge predicates
+	"""
+	hasEditors: Boolean
+	hasEditorsWith: [GroupWhereInput!]
+	"""
+	viewers edge predicates
+	"""
+	hasViewers: Boolean
+	hasViewersWith: [GroupWhereInput!]
 	"""
 	control edge predicates
 	"""
@@ -28027,30 +28152,10 @@ input RiskWhereInput {
 	hasActionplans: Boolean
 	hasActionplansWith: [ActionPlanWhereInput!]
 	"""
-	owner edge predicates
+	programs edge predicates
 	"""
-	hasOwner: Boolean
-	hasOwnerWith: [OrganizationWhereInput!]
-	"""
-	program edge predicates
-	"""
-	hasProgram: Boolean
-	hasProgramWith: [ProgramWhereInput!]
-	"""
-	viewers edge predicates
-	"""
-	hasViewers: Boolean
-	hasViewersWith: [GroupWhereInput!]
-	"""
-	editors edge predicates
-	"""
-	hasEditors: Boolean
-	hasEditorsWith: [GroupWhereInput!]
-	"""
-	blocked_groups edge predicates
-	"""
-	hasBlockedGroups: Boolean
-	hasBlockedGroupsWith: [GroupWhereInput!]
+	hasPrograms: Boolean
+	hasProgramsWith: [ProgramWhereInput!]
 }
 union SearchResult = APITokenSearchResult | ActionPlanSearchResult | ContactSearchResult | ControlSearchResult | ControlObjectiveSearchResult | DocumentDataSearchResult | EntitlementSearchResult | EntitlementPlanSearchResult | EntitlementPlanFeatureSearchResult | EntitySearchResult | EntityTypeSearchResult | EventSearchResult | FeatureSearchResult | FileSearchResult | GroupSearchResult | GroupSettingSearchResult | IntegrationSearchResult | InternalPolicySearchResult | NarrativeSearchResult | OauthProviderSearchResult | OhAuthTooTokenSearchResult | OrganizationSearchResult | OrganizationSettingSearchResult | PersonalAccessTokenSearchResult | ProcedureSearchResult | ProgramSearchResult | RiskSearchResult | StandardSearchResult | SubcontrolSearchResult | SubscriberSearchResult | TFASettingSearchResult | TaskSearchResult | TemplateSearchResult | UserSearchResult | UserSettingSearchResult | WebhookSearchResult
 type SearchResultConnection {
@@ -32111,6 +32216,16 @@ input UpdateControlObjectiveInput {
 	"""
 	details: Map
 	clearDetails: Boolean
+	ownerID: ID
+	addBlockedGroupIDs: [ID!]
+	removeBlockedGroupIDs: [ID!]
+	clearBlockedGroups: Boolean
+	addEditorIDs: [ID!]
+	removeEditorIDs: [ID!]
+	clearEditors: Boolean
+	addViewerIDs: [ID!]
+	removeViewerIDs: [ID!]
+	clearViewers: Boolean
 	addPolicyIDs: [ID!]
 	removePolicyIDs: [ID!]
 	clearPolicy: Boolean
@@ -32660,6 +32775,15 @@ input UpdateGroupInput {
 	addRiskBlockedGroupIDs: [ID!]
 	removeRiskBlockedGroupIDs: [ID!]
 	clearRiskBlockedGroups: Boolean
+	addControlobjectiveViewerIDs: [ID!]
+	removeControlobjectiveViewerIDs: [ID!]
+	clearControlobjectiveViewers: Boolean
+	addControlobjectiveEditorIDs: [ID!]
+	removeControlobjectiveEditorIDs: [ID!]
+	clearControlobjectiveEditors: Boolean
+	addControlobjectiveBlockedGroupIDs: [ID!]
+	removeControlobjectiveBlockedGroupIDs: [ID!]
+	clearControlobjectiveBlockedGroups: Boolean
 	addGroupMembers: [CreateGroupMembershipInput!]
 	updateGroupSettings: UpdateGroupSettingInput
 }
@@ -32823,6 +32947,12 @@ input UpdateInternalPolicyInput {
 	clearDetails: Boolean
 	ownerID: ID
 	clearOwner: Boolean
+	addBlockedGroupIDs: [ID!]
+	removeBlockedGroupIDs: [ID!]
+	clearBlockedGroups: Boolean
+	addEditorIDs: [ID!]
+	removeEditorIDs: [ID!]
+	clearEditors: Boolean
 	addControlobjectiveIDs: [ID!]
 	removeControlobjectiveIDs: [ID!]
 	clearControlobjectives: Boolean
@@ -32841,12 +32971,6 @@ input UpdateInternalPolicyInput {
 	addProgramIDs: [ID!]
 	removeProgramIDs: [ID!]
 	clearPrograms: Boolean
-	addEditorIDs: [ID!]
-	removeEditorIDs: [ID!]
-	clearEditors: Boolean
-	addBlockedGroupIDs: [ID!]
-	removeBlockedGroupIDs: [ID!]
-	clearBlockedGroups: Boolean
 }
 """
 UpdateInviteInput is used for update Invite object.
@@ -33153,6 +33277,9 @@ input UpdateOrganizationInput {
 	addRiskIDs: [ID!]
 	removeRiskIDs: [ID!]
 	clearRisks: Boolean
+	addControlobjectiveIDs: [ID!]
+	removeControlobjectiveIDs: [ID!]
+	clearControlobjectives: Boolean
 	addOrgMembers: [CreateOrgMembershipInput!]
 	updateOrgSettings: UpdateOrganizationSettingInput
 }
@@ -33303,6 +33430,12 @@ input UpdateProcedureInput {
 	clearDetails: Boolean
 	ownerID: ID
 	clearOwner: Boolean
+	addBlockedGroupIDs: [ID!]
+	removeBlockedGroupIDs: [ID!]
+	clearBlockedGroups: Boolean
+	addEditorIDs: [ID!]
+	removeEditorIDs: [ID!]
+	clearEditors: Boolean
 	addControlIDs: [ID!]
 	removeControlIDs: [ID!]
 	clearControl: Boolean
@@ -33321,12 +33454,6 @@ input UpdateProcedureInput {
 	addProgramIDs: [ID!]
 	removeProgramIDs: [ID!]
 	clearPrograms: Boolean
-	addEditorIDs: [ID!]
-	removeEditorIDs: [ID!]
-	clearEditors: Boolean
-	addBlockedGroupIDs: [ID!]
-	removeBlockedGroupIDs: [ID!]
-	clearBlockedGroups: Boolean
 }
 """
 UpdateProgramInput is used for update Program object.
@@ -33376,6 +33503,15 @@ input UpdateProgramInput {
 	auditorReadComments: Boolean
 	ownerID: ID
 	clearOwner: Boolean
+	addBlockedGroupIDs: [ID!]
+	removeBlockedGroupIDs: [ID!]
+	clearBlockedGroups: Boolean
+	addEditorIDs: [ID!]
+	removeEditorIDs: [ID!]
+	clearEditors: Boolean
+	addViewerIDs: [ID!]
+	removeViewerIDs: [ID!]
+	clearViewers: Boolean
 	addControlIDs: [ID!]
 	removeControlIDs: [ID!]
 	clearControls: Boolean
@@ -33415,15 +33551,6 @@ input UpdateProgramInput {
 	addUserIDs: [ID!]
 	removeUserIDs: [ID!]
 	clearUsers: Boolean
-	addViewerIDs: [ID!]
-	removeViewerIDs: [ID!]
-	clearViewers: Boolean
-	addEditorIDs: [ID!]
-	removeEditorIDs: [ID!]
-	clearEditors: Boolean
-	addBlockedGroupIDs: [ID!]
-	removeBlockedGroupIDs: [ID!]
-	clearBlockedGroups: Boolean
 	addProgramMembers: [CreateProgramMembershipInput!]
 }
 """
@@ -33493,6 +33620,16 @@ input UpdateRiskInput {
 	"""
 	details: Map
 	clearDetails: Boolean
+	ownerID: ID
+	addBlockedGroupIDs: [ID!]
+	removeBlockedGroupIDs: [ID!]
+	clearBlockedGroups: Boolean
+	addEditorIDs: [ID!]
+	removeEditorIDs: [ID!]
+	clearEditors: Boolean
+	addViewerIDs: [ID!]
+	removeViewerIDs: [ID!]
+	clearViewers: Boolean
 	addControlIDs: [ID!]
 	removeControlIDs: [ID!]
 	clearControl: Boolean
@@ -33502,19 +33639,9 @@ input UpdateRiskInput {
 	addActionplanIDs: [ID!]
 	removeActionplanIDs: [ID!]
 	clearActionplans: Boolean
-	ownerID: ID
 	addProgramIDs: [ID!]
 	removeProgramIDs: [ID!]
-	clearProgram: Boolean
-	addViewerIDs: [ID!]
-	removeViewerIDs: [ID!]
-	clearViewers: Boolean
-	addEditorIDs: [ID!]
-	removeEditorIDs: [ID!]
-	clearEditors: Boolean
-	addBlockedGroupIDs: [ID!]
-	removeBlockedGroupIDs: [ID!]
-	clearBlockedGroups: Boolean
+	clearPrograms: Boolean
 }
 """
 UpdateStandardInput is used for update Standard object.

--- a/schema/ent.graphql
+++ b/schema/ent.graphql
@@ -2183,6 +2183,10 @@ type ControlObjective implements Node {
   """
   tags: [String!]
   """
+  the ID of the organization owner of the object
+  """
+  ownerID: ID!
+  """
   the name of the control objective
   """
   name: String!
@@ -2226,6 +2230,19 @@ type ControlObjective implements Node {
   json data including details of the control objective
   """
   details: Map
+  owner: Organization!
+  """
+  groups that are blocked from viewing or editing the risk
+  """
+  blockedGroups: [Group!]
+  """
+  provides edit access to the risk to members of the group
+  """
+  editors: [Group!]
+  """
+  provides view access to the risk to members of the group
+  """
+  viewers: [Group!]
   policy: [InternalPolicy!]
   controls: [Control!]
   procedures: [Procedure!]
@@ -2281,6 +2298,10 @@ type ControlObjectiveHistory implements Node {
   tags associated with the object
   """
   tags: [String!]
+  """
+  the ID of the organization owner of the object
+  """
+  ownerID: String!
   """
   the name of the control objective
   """
@@ -2514,6 +2535,22 @@ input ControlObjectiveHistoryWhereInput {
   deletedByNotNil: Boolean
   deletedByEqualFold: String
   deletedByContainsFold: String
+  """
+  owner_id field predicates
+  """
+  ownerID: String
+  ownerIDNEQ: String
+  ownerIDIn: [String!]
+  ownerIDNotIn: [String!]
+  ownerIDGT: String
+  ownerIDGTE: String
+  ownerIDLT: String
+  ownerIDLTE: String
+  ownerIDContains: String
+  ownerIDHasPrefix: String
+  ownerIDHasSuffix: String
+  ownerIDEqualFold: String
+  ownerIDContainsFold: String
   """
   name field predicates
   """
@@ -2808,6 +2845,22 @@ input ControlObjectiveWhereInput {
   deletedByEqualFold: String
   deletedByContainsFold: String
   """
+  owner_id field predicates
+  """
+  ownerID: ID
+  ownerIDNEQ: ID
+  ownerIDIn: [ID!]
+  ownerIDNotIn: [ID!]
+  ownerIDGT: ID
+  ownerIDGTE: ID
+  ownerIDLT: ID
+  ownerIDLTE: ID
+  ownerIDContains: ID
+  ownerIDHasPrefix: ID
+  ownerIDHasSuffix: ID
+  ownerIDEqualFold: ID
+  ownerIDContainsFold: ID
+  """
   name field predicates
   """
   name: String
@@ -2985,6 +3038,26 @@ input ControlObjectiveWhereInput {
   mappedFrameworksNotNil: Boolean
   mappedFrameworksEqualFold: String
   mappedFrameworksContainsFold: String
+  """
+  owner edge predicates
+  """
+  hasOwner: Boolean
+  hasOwnerWith: [OrganizationWhereInput!]
+  """
+  blocked_groups edge predicates
+  """
+  hasBlockedGroups: Boolean
+  hasBlockedGroupsWith: [GroupWhereInput!]
+  """
+  editors edge predicates
+  """
+  hasEditors: Boolean
+  hasEditorsWith: [GroupWhereInput!]
+  """
+  viewers edge predicates
+  """
+  hasViewers: Boolean
+  hasViewersWith: [GroupWhereInput!]
   """
   policy edge predicates
   """
@@ -3616,6 +3689,10 @@ input CreateControlObjectiveInput {
   json data including details of the control objective
   """
   details: Map
+  ownerID: ID!
+  blockedGroupIDs: [ID!]
+  editorIDs: [ID!]
+  viewerIDs: [ID!]
   policyIDs: [ID!]
   controlIDs: [ID!]
   procedureIDs: [ID!]
@@ -3987,6 +4064,9 @@ input CreateGroupInput {
   riskViewerIDs: [ID!]
   riskEditorIDs: [ID!]
   riskBlockedGroupIDs: [ID!]
+  controlobjectiveViewerIDs: [ID!]
+  controlobjectiveEditorIDs: [ID!]
+  controlobjectiveBlockedGroupIDs: [ID!]
 }
 """
 CreateGroupMembershipInput is used for create GroupMembership object.
@@ -4120,14 +4200,14 @@ input CreateInternalPolicyInput {
   """
   details: Map
   ownerID: ID
+  blockedGroupIDs: [ID!]
+  editorIDs: [ID!]
   controlobjectiveIDs: [ID!]
   controlIDs: [ID!]
   procedureIDs: [ID!]
   narrativeIDs: [ID!]
   taskIDs: [ID!]
   programIDs: [ID!]
-  editorIDs: [ID!]
-  blockedGroupIDs: [ID!]
 }
 """
 CreateInviteInput is used for create Invite object.
@@ -4350,6 +4430,7 @@ input CreateOrganizationInput {
   procedureIDs: [ID!]
   internalpolicyIDs: [ID!]
   riskIDs: [ID!]
+  controlobjectiveIDs: [ID!]
 }
 """
 CreateOrganizationSettingInput is used for create OrganizationSetting object.
@@ -4468,14 +4549,14 @@ input CreateProcedureInput {
   """
   details: Map
   ownerID: ID
+  blockedGroupIDs: [ID!]
+  editorIDs: [ID!]
   controlIDs: [ID!]
   internalpolicyIDs: [ID!]
   narrativeIDs: [ID!]
   riskIDs: [ID!]
   taskIDs: [ID!]
   programIDs: [ID!]
-  editorIDs: [ID!]
-  blockedGroupIDs: [ID!]
 }
 """
 CreateProgramInput is used for create Program object.
@@ -4519,6 +4600,9 @@ input CreateProgramInput {
   """
   auditorReadComments: Boolean
   ownerID: ID
+  blockedGroupIDs: [ID!]
+  editorIDs: [ID!]
+  viewerIDs: [ID!]
   controlIDs: [ID!]
   subcontrolIDs: [ID!]
   controlobjectiveIDs: [ID!]
@@ -4532,9 +4616,6 @@ input CreateProgramInput {
   actionplanIDs: [ID!]
   standardIDs: [ID!]
   userIDs: [ID!]
-  viewerIDs: [ID!]
-  editorIDs: [ID!]
-  blockedGroupIDs: [ID!]
 }
 """
 CreateProgramMembershipInput is used for create ProgramMembership object.
@@ -4594,14 +4675,14 @@ input CreateRiskInput {
   json data for the risk document
   """
   details: Map
+  ownerID: ID!
+  blockedGroupIDs: [ID!]
+  editorIDs: [ID!]
+  viewerIDs: [ID!]
   controlIDs: [ID!]
   procedureIDs: [ID!]
   actionplanIDs: [ID!]
-  ownerID: ID!
   programIDs: [ID!]
-  viewerIDs: [ID!]
-  editorIDs: [ID!]
-  blockedGroupIDs: [ID!]
 }
 """
 CreateStandardInput is used for create Standard object.
@@ -10785,6 +10866,9 @@ type Group implements Node {
   riskViewers: [Risk!]
   riskEditors: [Risk!]
   riskBlockedGroups: [Risk!]
+  controlobjectiveViewers: [ControlObjective!]
+  controlobjectiveEditors: [ControlObjective!]
+  controlobjectiveBlockedGroups: [ControlObjective!]
   members: [GroupMembership!]
 }
 """
@@ -12343,6 +12427,21 @@ input GroupWhereInput {
   hasRiskBlockedGroups: Boolean
   hasRiskBlockedGroupsWith: [RiskWhereInput!]
   """
+  controlobjective_viewers edge predicates
+  """
+  hasControlobjectiveViewers: Boolean
+  hasControlobjectiveViewersWith: [ControlObjectiveWhereInput!]
+  """
+  controlobjective_editors edge predicates
+  """
+  hasControlobjectiveEditors: Boolean
+  hasControlobjectiveEditorsWith: [ControlObjectiveWhereInput!]
+  """
+  controlobjective_blocked_groups edge predicates
+  """
+  hasControlobjectiveBlockedGroups: Boolean
+  hasControlobjectiveBlockedGroupsWith: [ControlObjectiveWhereInput!]
+  """
   members edge predicates
   """
   hasMembers: Boolean
@@ -13518,20 +13617,20 @@ type InternalPolicy implements Node {
   """
   details: Map
   owner: Organization
+  """
+  groups that are blocked from viewing or editing the risk
+  """
+  blockedGroups: [Group!]
+  """
+  provides edit access to the risk to members of the group
+  """
+  editors: [Group!]
   controlobjectives: [ControlObjective!]
   controls: [Control!]
   procedures: [Procedure!]
   narratives: [Narrative!]
   tasks: [Task!]
   programs: [Program!]
-  """
-  provides edit access to the policy to members of the group
-  """
-  editors: [Group!]
-  """
-  groups that are blocked from viewing or editing the policy
-  """
-  blockedGroups: [Group!]
 }
 """
 A connection to a list of items.
@@ -14208,6 +14307,16 @@ input InternalPolicyWhereInput {
   hasOwner: Boolean
   hasOwnerWith: [OrganizationWhereInput!]
   """
+  blocked_groups edge predicates
+  """
+  hasBlockedGroups: Boolean
+  hasBlockedGroupsWith: [GroupWhereInput!]
+  """
+  editors edge predicates
+  """
+  hasEditors: Boolean
+  hasEditorsWith: [GroupWhereInput!]
+  """
   controlobjectives edge predicates
   """
   hasControlobjectives: Boolean
@@ -14237,16 +14346,6 @@ input InternalPolicyWhereInput {
   """
   hasPrograms: Boolean
   hasProgramsWith: [ProgramWhereInput!]
-  """
-  editors edge predicates
-  """
-  hasEditors: Boolean
-  hasEditorsWith: [GroupWhereInput!]
-  """
-  blocked_groups edge predicates
-  """
-  hasBlockedGroups: Boolean
-  hasBlockedGroupsWith: [GroupWhereInput!]
 }
 type Invite implements Node {
   id: ID!
@@ -17073,6 +17172,7 @@ type Organization implements Node {
   procedures: [Procedure!]
   internalpolicies: [InternalPolicy!]
   risks: [Risk!]
+  controlobjectives: [ControlObjective!]
   members: [OrgMembership!]
 }
 """
@@ -18495,6 +18595,11 @@ input OrganizationWhereInput {
   hasRisks: Boolean
   hasRisksWith: [RiskWhereInput!]
   """
+  controlobjectives edge predicates
+  """
+  hasControlobjectives: Boolean
+  hasControlobjectivesWith: [ControlObjectiveWhereInput!]
+  """
   members edge predicates
   """
   hasMembers: Boolean
@@ -18811,20 +18916,20 @@ type Procedure implements Node {
   """
   details: Map
   owner: Organization
+  """
+  groups that are blocked from viewing or editing the risk
+  """
+  blockedGroups: [Group!]
+  """
+  provides edit access to the risk to members of the group
+  """
+  editors: [Group!]
   control: [Control!]
   internalpolicy: [InternalPolicy!]
   narratives: [Narrative!]
   risks: [Risk!]
   tasks: [Task!]
   programs: [Program!]
-  """
-  provides edit access to the procedure to members of the group
-  """
-  editors: [Group!]
-  """
-  groups that are blocked from viewing or editing the procedure
-  """
-  blockedGroups: [Group!]
 }
 """
 A connection to a list of items.
@@ -19541,6 +19646,16 @@ input ProcedureWhereInput {
   hasOwner: Boolean
   hasOwnerWith: [OrganizationWhereInput!]
   """
+  blocked_groups edge predicates
+  """
+  hasBlockedGroups: Boolean
+  hasBlockedGroupsWith: [GroupWhereInput!]
+  """
+  editors edge predicates
+  """
+  hasEditors: Boolean
+  hasEditorsWith: [GroupWhereInput!]
+  """
   control edge predicates
   """
   hasControl: Boolean
@@ -19570,16 +19685,6 @@ input ProcedureWhereInput {
   """
   hasPrograms: Boolean
   hasProgramsWith: [ProgramWhereInput!]
-  """
-  editors edge predicates
-  """
-  hasEditors: Boolean
-  hasEditorsWith: [GroupWhereInput!]
-  """
-  blocked_groups edge predicates
-  """
-  hasBlockedGroups: Boolean
-  hasBlockedGroupsWith: [GroupWhereInput!]
 }
 type Program implements Node {
   id: ID!
@@ -19630,6 +19735,18 @@ type Program implements Node {
   """
   auditorReadComments: Boolean!
   owner: Organization
+  """
+  groups that are blocked from viewing or editing the risk
+  """
+  blockedGroups: [Group!]
+  """
+  provides edit access to the risk to members of the group
+  """
+  editors: [Group!]
+  """
+  provides view access to the risk to members of the group
+  """
+  viewers: [Group!]
   controls: [Control!]
   subcontrols: [Subcontrol!]
   controlobjectives: [ControlObjective!]
@@ -19646,18 +19763,6 @@ type Program implements Node {
   """
   standards: [Standard!]
   users: [User!]
-  """
-  provides view access to the program to members of the group
-  """
-  viewers: [Group!]
-  """
-  provides edit access to the program to members of the group
-  """
-  editors: [Group!]
-  """
-  groups that are blocked from viewing or editing the program
-  """
-  blockedGroups: [Group!]
   members: [ProgramMembership!]
 }
 """
@@ -20694,6 +20799,21 @@ input ProgramWhereInput {
   hasOwner: Boolean
   hasOwnerWith: [OrganizationWhereInput!]
   """
+  blocked_groups edge predicates
+  """
+  hasBlockedGroups: Boolean
+  hasBlockedGroupsWith: [GroupWhereInput!]
+  """
+  editors edge predicates
+  """
+  hasEditors: Boolean
+  hasEditorsWith: [GroupWhereInput!]
+  """
+  viewers edge predicates
+  """
+  hasViewers: Boolean
+  hasViewersWith: [GroupWhereInput!]
+  """
   controls edge predicates
   """
   hasControls: Boolean
@@ -20758,21 +20878,6 @@ input ProgramWhereInput {
   """
   hasUsers: Boolean
   hasUsersWith: [UserWhereInput!]
-  """
-  viewers edge predicates
-  """
-  hasViewers: Boolean
-  hasViewersWith: [GroupWhereInput!]
-  """
-  editors edge predicates
-  """
-  hasEditors: Boolean
-  hasEditorsWith: [GroupWhereInput!]
-  """
-  blocked_groups edge predicates
-  """
-  hasBlockedGroups: Boolean
-  hasBlockedGroupsWith: [GroupWhereInput!]
   """
   members edge predicates
   """
@@ -22930,6 +23035,10 @@ type Risk implements Node {
   """
   tags: [String!]
   """
+  the ID of the organization owner of the object
+  """
+  ownerID: ID!
+  """
   the name of the risk
   """
   name: String!
@@ -22969,27 +23078,23 @@ type Risk implements Node {
   json data for the risk document
   """
   details: Map
-  """
-  the ID of the organization owner of the risk
-  """
-  ownerID: ID!
-  control: [Control!]
-  procedure: [Procedure!]
-  actionplans: [ActionPlan!]
   owner: Organization!
-  program: [Program!]
   """
-  provides view access to the risk to members of the group
+  groups that are blocked from viewing or editing the risk
   """
-  viewers: [Group!]
+  blockedGroups: [Group!]
   """
   provides edit access to the risk to members of the group
   """
   editors: [Group!]
   """
-  groups that are blocked from viewing or editing the risk
+  provides view access to the risk to members of the group
   """
-  blockedGroups: [Group!]
+  viewers: [Group!]
+  control: [Control!]
+  procedure: [Procedure!]
+  actionplans: [ActionPlan!]
+  programs: [Program!]
 }
 """
 A connection to a list of items.
@@ -23037,6 +23142,10 @@ type RiskHistory implements Node {
   """
   tags: [String!]
   """
+  the ID of the organization owner of the object
+  """
+  ownerID: String!
+  """
   the name of the risk
   """
   name: String!
@@ -23076,10 +23185,6 @@ type RiskHistory implements Node {
   json data for the risk document
   """
   details: Map
-  """
-  the ID of the organization owner of the risk
-  """
-  ownerID: String!
 }
 """
 A connection to a list of items.
@@ -23286,6 +23391,22 @@ input RiskHistoryWhereInput {
   deletedByEqualFold: String
   deletedByContainsFold: String
   """
+  owner_id field predicates
+  """
+  ownerID: String
+  ownerIDNEQ: String
+  ownerIDIn: [String!]
+  ownerIDNotIn: [String!]
+  ownerIDGT: String
+  ownerIDGTE: String
+  ownerIDLT: String
+  ownerIDLTE: String
+  ownerIDContains: String
+  ownerIDHasPrefix: String
+  ownerIDHasSuffix: String
+  ownerIDEqualFold: String
+  ownerIDContainsFold: String
+  """
   name field predicates
   """
   name: String
@@ -23427,22 +23548,6 @@ input RiskHistoryWhereInput {
   satisfiesNotNil: Boolean
   satisfiesEqualFold: String
   satisfiesContainsFold: String
-  """
-  owner_id field predicates
-  """
-  ownerID: String
-  ownerIDNEQ: String
-  ownerIDIn: [String!]
-  ownerIDNotIn: [String!]
-  ownerIDGT: String
-  ownerIDGTE: String
-  ownerIDLT: String
-  ownerIDLTE: String
-  ownerIDContains: String
-  ownerIDHasPrefix: String
-  ownerIDHasSuffix: String
-  ownerIDEqualFold: String
-  ownerIDContainsFold: String
 }
 """
 RiskRiskImpact is enum for the field impact
@@ -23574,6 +23679,22 @@ input RiskWhereInput {
   deletedByNotNil: Boolean
   deletedByEqualFold: String
   deletedByContainsFold: String
+  """
+  owner_id field predicates
+  """
+  ownerID: ID
+  ownerIDNEQ: ID
+  ownerIDIn: [ID!]
+  ownerIDNotIn: [ID!]
+  ownerIDGT: ID
+  ownerIDGTE: ID
+  ownerIDLT: ID
+  ownerIDLTE: ID
+  ownerIDContains: ID
+  ownerIDHasPrefix: ID
+  ownerIDHasSuffix: ID
+  ownerIDEqualFold: ID
+  ownerIDContainsFold: ID
   """
   name field predicates
   """
@@ -23717,21 +23838,25 @@ input RiskWhereInput {
   satisfiesEqualFold: String
   satisfiesContainsFold: String
   """
-  owner_id field predicates
+  owner edge predicates
   """
-  ownerID: ID
-  ownerIDNEQ: ID
-  ownerIDIn: [ID!]
-  ownerIDNotIn: [ID!]
-  ownerIDGT: ID
-  ownerIDGTE: ID
-  ownerIDLT: ID
-  ownerIDLTE: ID
-  ownerIDContains: ID
-  ownerIDHasPrefix: ID
-  ownerIDHasSuffix: ID
-  ownerIDEqualFold: ID
-  ownerIDContainsFold: ID
+  hasOwner: Boolean
+  hasOwnerWith: [OrganizationWhereInput!]
+  """
+  blocked_groups edge predicates
+  """
+  hasBlockedGroups: Boolean
+  hasBlockedGroupsWith: [GroupWhereInput!]
+  """
+  editors edge predicates
+  """
+  hasEditors: Boolean
+  hasEditorsWith: [GroupWhereInput!]
+  """
+  viewers edge predicates
+  """
+  hasViewers: Boolean
+  hasViewersWith: [GroupWhereInput!]
   """
   control edge predicates
   """
@@ -23748,30 +23873,10 @@ input RiskWhereInput {
   hasActionplans: Boolean
   hasActionplansWith: [ActionPlanWhereInput!]
   """
-  owner edge predicates
+  programs edge predicates
   """
-  hasOwner: Boolean
-  hasOwnerWith: [OrganizationWhereInput!]
-  """
-  program edge predicates
-  """
-  hasProgram: Boolean
-  hasProgramWith: [ProgramWhereInput!]
-  """
-  viewers edge predicates
-  """
-  hasViewers: Boolean
-  hasViewersWith: [GroupWhereInput!]
-  """
-  editors edge predicates
-  """
-  hasEditors: Boolean
-  hasEditorsWith: [GroupWhereInput!]
-  """
-  blocked_groups edge predicates
-  """
-  hasBlockedGroups: Boolean
-  hasBlockedGroupsWith: [GroupWhereInput!]
+  hasPrograms: Boolean
+  hasProgramsWith: [ProgramWhereInput!]
 }
 type Standard implements Node {
   id: ID!
@@ -27611,6 +27716,16 @@ input UpdateControlObjectiveInput {
   """
   details: Map
   clearDetails: Boolean
+  ownerID: ID
+  addBlockedGroupIDs: [ID!]
+  removeBlockedGroupIDs: [ID!]
+  clearBlockedGroups: Boolean
+  addEditorIDs: [ID!]
+  removeEditorIDs: [ID!]
+  clearEditors: Boolean
+  addViewerIDs: [ID!]
+  removeViewerIDs: [ID!]
+  clearViewers: Boolean
   addPolicyIDs: [ID!]
   removePolicyIDs: [ID!]
   clearPolicy: Boolean
@@ -28159,6 +28274,15 @@ input UpdateGroupInput {
   addRiskBlockedGroupIDs: [ID!]
   removeRiskBlockedGroupIDs: [ID!]
   clearRiskBlockedGroups: Boolean
+  addControlobjectiveViewerIDs: [ID!]
+  removeControlobjectiveViewerIDs: [ID!]
+  clearControlobjectiveViewers: Boolean
+  addControlobjectiveEditorIDs: [ID!]
+  removeControlobjectiveEditorIDs: [ID!]
+  clearControlobjectiveEditors: Boolean
+  addControlobjectiveBlockedGroupIDs: [ID!]
+  removeControlobjectiveBlockedGroupIDs: [ID!]
+  clearControlobjectiveBlockedGroups: Boolean
 }
 """
 UpdateGroupMembershipInput is used for update GroupMembership object.
@@ -28320,6 +28444,12 @@ input UpdateInternalPolicyInput {
   clearDetails: Boolean
   ownerID: ID
   clearOwner: Boolean
+  addBlockedGroupIDs: [ID!]
+  removeBlockedGroupIDs: [ID!]
+  clearBlockedGroups: Boolean
+  addEditorIDs: [ID!]
+  removeEditorIDs: [ID!]
+  clearEditors: Boolean
   addControlobjectiveIDs: [ID!]
   removeControlobjectiveIDs: [ID!]
   clearControlobjectives: Boolean
@@ -28338,12 +28468,6 @@ input UpdateInternalPolicyInput {
   addProgramIDs: [ID!]
   removeProgramIDs: [ID!]
   clearPrograms: Boolean
-  addEditorIDs: [ID!]
-  removeEditorIDs: [ID!]
-  clearEditors: Boolean
-  addBlockedGroupIDs: [ID!]
-  removeBlockedGroupIDs: [ID!]
-  clearBlockedGroups: Boolean
 }
 """
 UpdateInviteInput is used for update Invite object.
@@ -28650,6 +28774,9 @@ input UpdateOrganizationInput {
   addRiskIDs: [ID!]
   removeRiskIDs: [ID!]
   clearRisks: Boolean
+  addControlobjectiveIDs: [ID!]
+  removeControlobjectiveIDs: [ID!]
+  clearControlobjectives: Boolean
 }
 """
 UpdateOrganizationSettingInput is used for update OrganizationSetting object.
@@ -28798,6 +28925,12 @@ input UpdateProcedureInput {
   clearDetails: Boolean
   ownerID: ID
   clearOwner: Boolean
+  addBlockedGroupIDs: [ID!]
+  removeBlockedGroupIDs: [ID!]
+  clearBlockedGroups: Boolean
+  addEditorIDs: [ID!]
+  removeEditorIDs: [ID!]
+  clearEditors: Boolean
   addControlIDs: [ID!]
   removeControlIDs: [ID!]
   clearControl: Boolean
@@ -28816,12 +28949,6 @@ input UpdateProcedureInput {
   addProgramIDs: [ID!]
   removeProgramIDs: [ID!]
   clearPrograms: Boolean
-  addEditorIDs: [ID!]
-  removeEditorIDs: [ID!]
-  clearEditors: Boolean
-  addBlockedGroupIDs: [ID!]
-  removeBlockedGroupIDs: [ID!]
-  clearBlockedGroups: Boolean
 }
 """
 UpdateProgramInput is used for update Program object.
@@ -28871,6 +28998,15 @@ input UpdateProgramInput {
   auditorReadComments: Boolean
   ownerID: ID
   clearOwner: Boolean
+  addBlockedGroupIDs: [ID!]
+  removeBlockedGroupIDs: [ID!]
+  clearBlockedGroups: Boolean
+  addEditorIDs: [ID!]
+  removeEditorIDs: [ID!]
+  clearEditors: Boolean
+  addViewerIDs: [ID!]
+  removeViewerIDs: [ID!]
+  clearViewers: Boolean
   addControlIDs: [ID!]
   removeControlIDs: [ID!]
   clearControls: Boolean
@@ -28910,15 +29046,6 @@ input UpdateProgramInput {
   addUserIDs: [ID!]
   removeUserIDs: [ID!]
   clearUsers: Boolean
-  addViewerIDs: [ID!]
-  removeViewerIDs: [ID!]
-  clearViewers: Boolean
-  addEditorIDs: [ID!]
-  removeEditorIDs: [ID!]
-  clearEditors: Boolean
-  addBlockedGroupIDs: [ID!]
-  removeBlockedGroupIDs: [ID!]
-  clearBlockedGroups: Boolean
 }
 """
 UpdateProgramMembershipInput is used for update ProgramMembership object.
@@ -28987,6 +29114,16 @@ input UpdateRiskInput {
   """
   details: Map
   clearDetails: Boolean
+  ownerID: ID
+  addBlockedGroupIDs: [ID!]
+  removeBlockedGroupIDs: [ID!]
+  clearBlockedGroups: Boolean
+  addEditorIDs: [ID!]
+  removeEditorIDs: [ID!]
+  clearEditors: Boolean
+  addViewerIDs: [ID!]
+  removeViewerIDs: [ID!]
+  clearViewers: Boolean
   addControlIDs: [ID!]
   removeControlIDs: [ID!]
   clearControl: Boolean
@@ -28996,19 +29133,9 @@ input UpdateRiskInput {
   addActionplanIDs: [ID!]
   removeActionplanIDs: [ID!]
   clearActionplans: Boolean
-  ownerID: ID
   addProgramIDs: [ID!]
   removeProgramIDs: [ID!]
-  clearProgram: Boolean
-  addViewerIDs: [ID!]
-  removeViewerIDs: [ID!]
-  clearViewers: Boolean
-  addEditorIDs: [ID!]
-  removeEditorIDs: [ID!]
-  clearEditors: Boolean
-  addBlockedGroupIDs: [ID!]
-  removeBlockedGroupIDs: [ID!]
-  clearBlockedGroups: Boolean
+  clearPrograms: Boolean
 }
 """
 UpdateStandardInput is used for update Standard object.


### PR DESCRIPTION
- Adds a new `GroupPermissionsMixin` that will add the group edges + hooks when added to a schema for viewer, editor, and blocked groups permissions
- Adds the control objective cli command
- Updates the fga model for control objective, sub controls, and controls to align with the `risk` permissions
- Updates the `controlobjective` schema to include the object owned mixin based on their parent program, and the new group permissions mixin for group based permissions
- Cleans up all existing schemas with group permissions to use the new mixin instead of adding manually to each schema
- Adds a `WithOrganizationOwner` to the object owned mixin to add the org owned field, edges, and hook to object owned schemas - this allows the fields to be added, without the `parent` inherited permissions
- Removes the duplicated FilterQuery interceptor from a few schemas (this is already the default interceptor for object owned schemas)
- Adds CRUD tests for control objectives