### PR TITLE
use hosted large for core tests

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -49,6 +49,8 @@ steps:
                 - "GOTOOLCHAIN=auto"
         artifact_paths: ["coverage.out"]
       - label: ":golang: go test - {{matrix.version}}"
+        agents:
+          queue: "hosted-large"
         key: "go_test"
         cancel_on_build_failing: true
         env:


### PR DESCRIPTION
I thought I had put these on large, but I guess I was defaulting to medium. Let's see if this helps the failures/timeouts