### PR TITLE
remove default queue from top, this will be set in the UI instead

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -160,8 +160,6 @@ steps:
         key: "atlas_lint"
         soft_fail:
           - exit_status: 1
-        agents:
-          queue: "hosted-small"
         plugins:
           - cluster-secrets#v1.0.0:
               variables:
@@ -173,8 +171,6 @@ steps:
               step: lint
       - label: ":rocket: atlas push"
         if: build.branch == "main"
-        agents:
-          queue: "hosted-small"
         key: "atlas_migrate"
         plugins:
           - cluster-secrets#v1.0.0:
@@ -192,8 +188,6 @@ steps:
     steps:
       - label: ":docker: docker pr build"
         key: "docker-pr-build"
-        agents:
-          queue: "hosted-large"
         cancel_on_build_failing: true
         if: build.branch != "main" && build.tag == null
         commands: |
@@ -229,9 +223,6 @@ steps:
               skip-files: "cosign.key,Dockerfile.dev"
               trivy-version: "0.57.1"
       - label: ":docker: docker build and publish"
-        key: "docker-build"
-        agents:
-          queue: "hosted-large"
         cancel_on_build_failing: true
         if: build.branch == "main"
         commands: |
@@ -296,8 +287,6 @@ steps:
                 - NAME=${APP_NAME}
       - label: ":docker: docker build and publish"
         key: "docker-build-and-tag"
-        agents:
-          queue: "hosted-large"
         cancel_on_build_failing: true
         if: build.tag != null
         commands: |

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,6 +1,3 @@
-agents:
-  queue: "hosted-medium"
-
 env:
   APP_NAME: ${BUILDKITE_PIPELINE_SLUG}
   IMAGE_REPO: ghcr.io/theopenlane/${APP_NAME}

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -188,6 +188,8 @@ steps:
     steps:
       - label: ":docker: docker pr build"
         key: "docker-pr-build"
+        agents:
+          queue: "hosted-medium"
         cancel_on_build_failing: true
         if: build.branch != "main" && build.tag == null
         commands: |

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -130,6 +130,8 @@ steps:
         key: "gobuild-server"
         cancel_on_build_failing: true
         artifact_paths: "bin/${APP_NAME}"
+        agents:
+          queue: "hosted-medium"
         plugins:
           - docker#v5.12.0:
               image: "ghcr.io/theopenlane/build-image:latest"
@@ -189,7 +191,7 @@ steps:
       - label: ":docker: docker pr build"
         key: "docker-pr-build"
         agents:
-          queue: "hosted-medium"
+          queue: "hosted-large"
         cancel_on_build_failing: true
         if: build.branch != "main" && build.tag == null
         commands: |

--- a/internal/graphapi/internalpolicy.resolvers.go
+++ b/internal/graphapi/internalpolicy.resolvers.go
@@ -33,6 +33,16 @@ func (r *mutationResolver) CreateInternalPolicy(ctx context.Context, input gener
 
 // CreateBulkInternalPolicy is the resolver for the createBulkInternalPolicy field.
 func (r *mutationResolver) CreateBulkInternalPolicy(ctx context.Context, input []*generated.CreateInternalPolicyInput) (*InternalPolicyBulkCreatePayload, error) {
+	if len(input) == 0 {
+		return nil, rout.NewMissingRequiredFieldError("input")
+	}
+
+	// set the organization in the auth context if its not done for us
+	if err := setOrganizationInAuthContext(ctx, input[0].OwnerID); err != nil {
+		log.Error().Err(err).Msg("failed to set organization in auth context")
+		return nil, rout.NewMissingRequiredFieldError("owner_id")
+	}
+
 	return r.bulkCreateInternalPolicy(ctx, input)
 }
 
@@ -43,6 +53,16 @@ func (r *mutationResolver) CreateBulkCSVInternalPolicy(ctx context.Context, inpu
 		log.Error().Err(err).Msg("failed to unmarshal bulk data")
 
 		return nil, err
+	}
+
+	if len(data) == 0 {
+		return nil, rout.NewMissingRequiredFieldError("input")
+	}
+
+	// set the organization in the auth context if its not done for us
+	if err := setOrganizationInAuthContext(ctx, data[0].OwnerID); err != nil {
+		log.Error().Err(err).Msg("failed to set organization in auth context")
+		return nil, rout.NewMissingRequiredFieldError("owner_id")
 	}
 
 	return r.bulkCreateInternalPolicy(ctx, data)


### PR DESCRIPTION
This will allow us to use the UI steps to change queues if we need instead of having to PR for the default. Once we have more capacity I'll remove the `hosted-large` overrides as well:

Steps in UI are now: 
```
agents:
  size: "large"
  queue: "self-hosted-garage-vms"
  
steps:
  - label: ":pipeline:"
    command: "buildkite-agent pipeline upload"
    agents:
      queue: "self-hosted-garage-vms"
      size: "small"
```