### PR TITLE
fix: csv upload should not save file

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -61,8 +61,8 @@ codegenerators:
       - any-glob-to-any-file: internal/ent/templates/**
 coreclient:
   - changed-files:
-      - any-glob-to-any-file: pkg/openalneclient/**
-      - any-glob-to-any-file: nternal/graphapi/query/**
+      - any-glob-to-any-file: pkg/openlaneclient/**
+      - any-glob-to-any-file: internal/graphapi/query/**
 config:
   - changed-files:
       - any-glob-to-any-file: config/**

--- a/internal/graphapi/organization_test.go
+++ b/internal/graphapi/organization_test.go
@@ -2,8 +2,10 @@ package graphapi_test
 
 import (
 	"context"
+	"os"
 	"testing"
 
+	"github.com/99designs/gqlgen/graphql"
 	"github.com/brianvoe/gofakeit/v7"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -342,6 +344,29 @@ func (suite *GraphTestSuite) TestMutationCreateOrganization() {
 			(&OrganizationCleanup{client: suite.client, ID: resp.CreateOrganization.Organization.ID}).MustDelete(testUser1.UserCtx, t)
 		})
 	}
+}
+
+func (suite *GraphTestSuite) TestMutationBulkCSVUploadOrganization() {
+	t := suite.T()
+
+	fileName := "testdata/uploads/orgs.csv"
+
+	input, err := os.OpenFile(fileName, os.O_RDWR|os.O_CREATE, os.ModePerm)
+	require.NoError(t, err)
+
+	file := graphql.Upload{
+		File:        input,
+		Filename:    fileName,
+		ContentType: "text/csv",
+	}
+
+	resp, err := suite.client.api.CreateBulkCSVOrganization(testUser1.UserCtx, file)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// make sure the orgs were created
+	assert.Len(t, resp.CreateBulkCSVOrganization.Organizations, 2)
 }
 
 func (suite *GraphTestSuite) TestMutationUpdateOrganization() {

--- a/internal/graphapi/testdata/uploads/orgs.csv
+++ b/internal/graphapi/testdata/uploads/orgs.csv
@@ -1,0 +1,3 @@
+Name
+Kroll Dogs Ratings Agency
+Thomson Cats


### PR DESCRIPTION
- fixes csv upload, the files were being saved to the `files` schema and then unable to be read for input. These files should instead be skipped by the middleware
- fixes labeler that apparently did not save on my last PR

Confirmed `opencloud-cloud` works correctly again to seed data:

```
task cli:init                                          
task: [cli:init] go run cmd/cli/main.go seed init
> registering users...  10% [>              ]  [0s:0s]{"level":"info","app":"openlane-cloud","file":{},"time":"2024-12-14T20:29:02-07:00","message":"loaded CSV file"}
> creating organizations...  20% [==>            ]  [1s:4s]{"level":"info","app":"openlane-cloud","file":"demodata/orgs.csv","time":"2024-12-14T20:29:03-07:00","message":"loading organizations"}
{"level":"info","app":"openlane-cloud","file":{},"time":"2024-12-14T20:29:03-07:00","message":"loaded CSV file"}
> creating groups...  60% [========>      ]  [3s:2s]{"level":"info","app":"openlane-cloud","file":{},"time":"2024-12-14T20:29:05-07:00","message":"loaded CSV file"}
> creating invites...  70% [=========>     ]  [3s:2s]{"level":"info","app":"openlane-cloud","file":{},"time":"2024-12-14T20:29:06-07:00","message":"loaded CSV file"}
> creating subscribers...  80% [===========>   ]  [3s:1s]{"level":"info","app":"openlane-cloud","file":{},"time":"2024-12-14T20:29:06-07:00","message":"loaded CSV file"}
```