### PR TITLE
Use env vars to set large/small jobs

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -5,6 +5,8 @@ env:
   IMAGE_TAG: ${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:8}
   SONAR_HOST: https://sonarcloud.io
   GOFLAGS: -buildvcs=false
+  LARGE_RUNNER: self-hosted-garage-vms
+  RUNNER_SIZE: "large"
 
 steps:
   - group: ":knife: Pre-check"
@@ -13,7 +15,8 @@ steps:
       - label: ":golang: go generate"
         key: "generate"
         agents:
-          queue: "hosted-large"
+          queue: $LARGE_RUNNER
+          size: $RUNNER_SIZE
         cancel_on_build_failing: true
         plugins:
           - docker#v5.12.0:
@@ -38,7 +41,8 @@ steps:
       - label: ":golangci-lint: lint :lint-roller:"
         if: build.branch !~ /^renovate\//
         agents:
-          queue: "hosted-large"
+          queue: $LARGE_RUNNER
+          size: $RUNNER_SIZE
         cancel_on_build_failing: true
         timeout_in_minutes: 20
         key: "lint"
@@ -52,7 +56,8 @@ steps:
         artifact_paths: ["coverage.out"]
       - label: ":golang: go test - {{matrix.version}}"
         agents:
-          queue: "hosted-large"
+          queue: $LARGE_RUNNER
+          size: $RUNNER_SIZE
         key: "go_test"
         cancel_on_build_failing: true
         env:
@@ -191,7 +196,8 @@ steps:
       - label: ":docker: docker pr build"
         key: "docker-pr-build"
         agents:
-          queue: "hosted-large"
+          queue: $LARGE_RUNNER
+          size: $RUNNER_SIZE
         cancel_on_build_failing: true
         if: build.branch != "main" && build.tag == null
         commands: |
@@ -264,7 +270,8 @@ steps:
       - label: ":docker: docker build and publish all in one"
         key: "docker-build-aio"
         agents:
-          queue: "hosted-large"
+          queue: $LARGE_RUNNER
+          size: $RUNNER_SIZE
         if: build.branch == "main"
         cancel_on_build_failing: true
         commands: |
@@ -321,7 +328,8 @@ steps:
       - label: ":docker: docker build and publish all in one"
         key: "docker-build-aio-and-tag"
         agents:
-          queue: "hosted-large"
+          queue: $LARGE_RUNNER
+          size: $RUNNER_SIZE
         cancel_on_build_failing: true
         if: build.tag != null
         commands: |

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -5,8 +5,10 @@ env:
   IMAGE_TAG: ${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:8}
   SONAR_HOST: https://sonarcloud.io
   GOFLAGS: -buildvcs=false
-  LARGE_RUNNER: self-hosted-garage-vms
-  RUNNER_SIZE: "large"
+  LARGE_RUNNER_QUEUE: self-hosted-garage-vms
+  SMALL_RUNNER_QUEUE: self-hosted-garage-vms
+  RUNNER_LARGE: "large"
+  RUNNER_SMALL: "small"
 
 steps:
   - group: ":knife: Pre-check"
@@ -15,8 +17,8 @@ steps:
       - label: ":golang: go generate"
         key: "generate"
         agents:
-          queue: $LARGE_RUNNER
-          size: $RUNNER_SIZE
+          queue: $LARGE_RUNNER_QUEUE
+          size: $RUNNER_LARGE
         cancel_on_build_failing: true
         plugins:
           - docker#v5.12.0:
@@ -41,8 +43,8 @@ steps:
       - label: ":golangci-lint: lint :lint-roller:"
         if: build.branch !~ /^renovate\//
         agents:
-          queue: $LARGE_RUNNER
-          size: $RUNNER_SIZE
+          queue: $LARGE_RUNNER_QUEUE
+          size: $RUNNER_LARGE
         cancel_on_build_failing: true
         timeout_in_minutes: 20
         key: "lint"
@@ -56,8 +58,8 @@ steps:
         artifact_paths: ["coverage.out"]
       - label: ":golang: go test - {{matrix.version}}"
         agents:
-          queue: $LARGE_RUNNER
-          size: $RUNNER_SIZE
+          queue: $LARGE_RUNNER_QUEUE
+          size: $RUNNER_LARGE
         key: "go_test"
         cancel_on_build_failing: true
         env:
@@ -82,7 +84,8 @@ steps:
       - label: ":auth0: fga model test"
         if: build.branch !~ /^renovate\//
         agents:
-          queue: "hosted-small"
+          queue: $SMALL_RUNNER_QUEUE
+          size: $RUNNER_SMALL
         key: "fga_test"
         plugins:
           - docker#v5.12.0:
@@ -136,7 +139,8 @@ steps:
         cancel_on_build_failing: true
         artifact_paths: "bin/${APP_NAME}"
         agents:
-          queue: "hosted-medium"
+          queue: $LARGE_RUNNER_QUEUE
+          size: $RUNNER_LARGE
         plugins:
           - docker#v5.12.0:
               image: "ghcr.io/theopenlane/build-image:latest"
@@ -148,7 +152,8 @@ steps:
       - label: ":terminal: build cli"
         key: "gobuild-cli"
         agents:
-          queue: "hosted-small"
+          queue: $LARGE_RUNNER_QUEUE
+          size: $RUNNER_LARGE
         cancel_on_build_failing: true
         artifact_paths: "bin/openlane-cli"
         plugins:
@@ -196,8 +201,8 @@ steps:
       - label: ":docker: docker pr build"
         key: "docker-pr-build"
         agents:
-          queue: $LARGE_RUNNER
-          size: $RUNNER_SIZE
+          queue: $LARGE_RUNNER_QUEUE
+          size: $RUNNER_LARGE
         cancel_on_build_failing: true
         if: build.branch != "main" && build.tag == null
         commands: |
@@ -270,8 +275,8 @@ steps:
       - label: ":docker: docker build and publish all in one"
         key: "docker-build-aio"
         agents:
-          queue: $LARGE_RUNNER
-          size: $RUNNER_SIZE
+          queue: $LARGE_RUNNER_QUEUE
+          size: $RUNNER_LARGE
         if: build.branch == "main"
         cancel_on_build_failing: true
         commands: |
@@ -328,8 +333,8 @@ steps:
       - label: ":docker: docker build and publish all in one"
         key: "docker-build-aio-and-tag"
         agents:
-          queue: $LARGE_RUNNER
-          size: $RUNNER_SIZE
+          queue: $LARGE_RUNNER_QUEUE
+          size: $RUNNER_LARGE
         cancel_on_build_failing: true
         if: build.tag != null
         commands: |


### PR DESCRIPTION
This will allow us to easily switch to a hosted queue if needed for some reason by setting the env vars in the UI vs. having to a PR a change to the pipeline itself.

If you override the env vars to a hosted queue, the tags should be ignored. 