### PR TITLE
feat: allow authentication to the cli with the API token or PAT

### DIFF
--- a/cmd/cli/cmd/apitokens/create.go
+++ b/cmd/cli/cmd/apitokens/create.go
@@ -56,10 +56,14 @@ func createValidation() (input openlaneclient.CreateAPITokenInput, err error) {
 
 // create a new api token
 func create(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	input, err := createValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/apitokens/delete.go
+++ b/cmd/cli/cmd/apitokens/delete.go
@@ -35,10 +35,14 @@ func deleteValidation() (string, error) {
 
 // delete an existing api token in the platform
 func delete(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, err := deleteValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/apitokens/get.go
+++ b/cmd/cli/cmd/apitokens/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get retrieves api tokens from the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	tokenID := cmd.Config.String("id")

--- a/cmd/cli/cmd/apitokens/update.go
+++ b/cmd/cli/cmd/apitokens/update.go
@@ -55,10 +55,14 @@ func updateValidation() (id string, input openlaneclient.UpdateAPITokenInput, er
 
 // update an existing api token
 func update(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, input, err := updateValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/client.go
+++ b/cmd/cli/cmd/client.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/99designs/keyring"
 	"github.com/knadh/koanf/v2"
-	"github.com/rs/zerolog/log"
 	"golang.org/x/oauth2"
 
 	"github.com/theopenlane/iam/tokens"
@@ -25,6 +24,8 @@ const (
 	sessionKey      = "open_lane_session"
 )
 
+// TokenAuth uses the token or personal access token to authenticate the client
+// if the token is not provided, it will fall back to JWT and session auth
 func TokenAuth(ctx context.Context, k *koanf.Koanf) (*openlaneclient.OpenlaneClient, error) {
 	token := k.String("token")
 	if token == "" {
@@ -35,7 +36,6 @@ func TokenAuth(ctx context.Context, k *koanf.Koanf) (*openlaneclient.OpenlaneCli
 		return nil, fmt.Errorf("no token provided, will fall back to JWT and session auth")
 	}
 
-	log.Debug().Msg("setting up client with token")
 	config, opts, err := configureDefaultOpts()
 	if err != nil {
 		return nil, err

--- a/cmd/cli/cmd/contact/create.go
+++ b/cmd/cli/cmd/contact/create.go
@@ -68,10 +68,14 @@ func createValidation() (input openlaneclient.CreateContactInput, err error) {
 
 // create a new contact
 func create(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	input, err := createValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/contact/delete.go
+++ b/cmd/cli/cmd/contact/delete.go
@@ -35,10 +35,14 @@ func deleteValidation() (string, error) {
 
 // delete an existing contact in the platform
 func delete(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, err := deleteValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/contact/get.go
+++ b/cmd/cli/cmd/contact/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing contact in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 	// filter options
 	id := cmd.Config.String("id")
 

--- a/cmd/cli/cmd/contact/update.go
+++ b/cmd/cli/cmd/contact/update.go
@@ -69,10 +69,14 @@ func updateValidation() (id string, input openlaneclient.UpdateContactInput, err
 
 // update an existing contact in the platform
 func update(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, input, err := updateValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/contacthistory/get.go
+++ b/cmd/cli/cmd/contacthistory/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing contactHistory in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/control/create.go
+++ b/cmd/cli/cmd/control/create.go
@@ -103,10 +103,14 @@ func createValidation() (input openlaneclient.CreateControlInput, err error) {
 
 // create a new control
 func create(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	input, err := createValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/control/delete.go
+++ b/cmd/cli/cmd/control/delete.go
@@ -35,10 +35,14 @@ func deleteValidation() (string, error) {
 
 // delete an existing control in the platform
 func delete(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, err := deleteValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/control/get.go
+++ b/cmd/cli/cmd/control/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing control in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 	// filter options
 	id := cmd.Config.String("id")
 

--- a/cmd/cli/cmd/control/update.go
+++ b/cmd/cli/cmd/control/update.go
@@ -119,10 +119,14 @@ func updateValidation() (id string, input openlaneclient.UpdateControlInput, err
 
 // update an existing control in the platform
 func update(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, input, err := updateValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/controlhistory/get.go
+++ b/cmd/cli/cmd/controlhistory/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing controlHistory in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/controlobjective/create.go
+++ b/cmd/cli/cmd/controlobjective/create.go
@@ -96,10 +96,14 @@ func createValidation() (input openlaneclient.CreateControlObjectiveInput, err e
 
 // create a new controlObjective
 func create(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	input, err := createValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/controlobjective/delete.go
+++ b/cmd/cli/cmd/controlobjective/delete.go
@@ -35,10 +35,14 @@ func deleteValidation() (string, error) {
 
 // delete an existing controlObjective in the platform
 func delete(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, err := deleteValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/controlobjective/get.go
+++ b/cmd/cli/cmd/controlobjective/get.go
@@ -24,10 +24,14 @@ func init() {
 
 // get an existing controlObjective in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/controlobjective/update.go
+++ b/cmd/cli/cmd/controlobjective/update.go
@@ -112,10 +112,14 @@ func updateValidation() (id string, input openlaneclient.UpdateControlObjectiveI
 
 // update an existing controlObjective in the platform
 func update(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, input, err := updateValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/controlobjectivehistory/get.go
+++ b/cmd/cli/cmd/controlobjectivehistory/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing controlObjectiveHistory in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/documentdatahistory/get.go
+++ b/cmd/cli/cmd/documentdatahistory/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing documentDataHistory in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/entity/create.go
+++ b/cmd/cli/cmd/entity/create.go
@@ -94,10 +94,14 @@ func createValidation(ctx context.Context) (input openlaneclient.CreateEntityInp
 
 // create a new entity
 func create(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	input, err := createValidation(ctx)
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/entity/delete.go
+++ b/cmd/cli/cmd/entity/delete.go
@@ -35,10 +35,14 @@ func deleteValidation() (string, error) {
 
 // delete an existing entity in the platform
 func delete(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, err := deleteValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/entity/get.go
+++ b/cmd/cli/cmd/entity/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing entity in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 	// filter options
 	id := cmd.Config.String("id")
 

--- a/cmd/cli/cmd/entity/update.go
+++ b/cmd/cli/cmd/entity/update.go
@@ -92,10 +92,14 @@ func updateValidation(ctx context.Context) (id string, input openlaneclient.Upda
 
 // update an existing entity in the platform
 func update(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, input, err := updateValidation(ctx)
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/entityhistory/get.go
+++ b/cmd/cli/cmd/entityhistory/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing entityHistory in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/entitytype/create.go
+++ b/cmd/cli/cmd/entitytype/create.go
@@ -38,10 +38,14 @@ func createValidation() (input openlaneclient.CreateEntityTypeInput, err error) 
 
 // create a new entityType
 func create(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	input, err := createValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/entitytype/delete.go
+++ b/cmd/cli/cmd/entitytype/delete.go
@@ -35,10 +35,14 @@ func deleteValidation() (string, error) {
 
 // delete an existing entityType in the platform
 func delete(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, err := deleteValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/entitytype/get.go
+++ b/cmd/cli/cmd/entitytype/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing entity type in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 	// filter options
 	id := cmd.Config.String("id")
 

--- a/cmd/cli/cmd/entitytype/update.go
+++ b/cmd/cli/cmd/entitytype/update.go
@@ -45,10 +45,14 @@ func updateValidation() (id string, input openlaneclient.UpdateEntityTypeInput, 
 
 // update an existing entity type in the platform
 func update(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, input, err := updateValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/entitytypehistory/get.go
+++ b/cmd/cli/cmd/entitytypehistory/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing entityTypeHistory in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/eventhistory/get.go
+++ b/cmd/cli/cmd/eventhistory/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing eventHistory in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/events/create.go
+++ b/cmd/cli/cmd/events/create.go
@@ -66,10 +66,14 @@ func createValidation() (input openlaneclient.CreateEventInput, err error) {
 
 // create a new event
 func create(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	input, err := createValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/events/get.go
+++ b/cmd/cli/cmd/events/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get retrieves all events or a specific event by ID
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id := cmd.Config.String("id")
 

--- a/cmd/cli/cmd/file/delete.go
+++ b/cmd/cli/cmd/file/delete.go
@@ -35,10 +35,14 @@ func deleteValidation() (string, error) {
 
 // delete an existing group in the platform
 func delete(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, err := deleteValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/file/get.go
+++ b/cmd/cli/cmd/file/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing file in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/filehistory/get.go
+++ b/cmd/cli/cmd/filehistory/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing fileHistory in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/group/create.go
+++ b/cmd/cli/cmd/group/create.go
@@ -54,10 +54,14 @@ func createValidation() (input openlaneclient.CreateGroupInput, err error) {
 
 // create a new group
 func create(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	input, err := createValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/group/delete.go
+++ b/cmd/cli/cmd/group/delete.go
@@ -35,10 +35,14 @@ func deleteValidation() (string, error) {
 
 // delete an existing group in the platform
 func delete(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, err := deleteValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/group/get.go
+++ b/cmd/cli/cmd/group/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing group in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/group/update.go
+++ b/cmd/cli/cmd/group/update.go
@@ -54,10 +54,14 @@ func updateValidation() (id string, input openlaneclient.UpdateGroupInput, err e
 
 // update an existing group in the platform
 func update(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, input, err := updateValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/grouphistory/get.go
+++ b/cmd/cli/cmd/grouphistory/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing groupHistory in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/groupmembers/create.go
+++ b/cmd/cli/cmd/groupmembers/create.go
@@ -52,10 +52,14 @@ func createValidation() (input openlaneclient.CreateGroupMembershipInput, err er
 
 // create adds a user to a group in the platform
 func create(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	input, err := createValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/groupmembers/delete.go
+++ b/cmd/cli/cmd/groupmembers/delete.go
@@ -46,10 +46,14 @@ func deleteValidation() (where openlaneclient.GroupMembershipWhereInput, err err
 
 // delete removes a user from a group in the platform
 func delete(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	where, err := deleteValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/groupmembers/get.go
+++ b/cmd/cli/cmd/groupmembers/get.go
@@ -26,10 +26,14 @@ func init() {
 
 // get existing members of a group
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("group-id")

--- a/cmd/cli/cmd/groupmembers/update.go
+++ b/cmd/cli/cmd/groupmembers/update.go
@@ -61,10 +61,14 @@ func updateValidation() (where openlaneclient.GroupMembershipWhereInput, input o
 
 // update a user's role in a group in the platform
 func update(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	where, input, err := updateValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/groupmembershiphistory/get.go
+++ b/cmd/cli/cmd/groupmembershiphistory/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing groupMembershipHistory in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/groupsetting/get.go
+++ b/cmd/cli/cmd/groupsetting/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get group settings from the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/groupsetting/update.go
+++ b/cmd/cli/cmd/groupsetting/update.go
@@ -67,10 +67,14 @@ func updateValidation() (id string, input openlaneclient.UpdateGroupSettingInput
 
 // update an existing group setting in the platform
 func update(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, input, err := updateValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/groupsettinghistory/get.go
+++ b/cmd/cli/cmd/groupsettinghistory/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing groupSettingHistory in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/hushhistory/get.go
+++ b/cmd/cli/cmd/hushhistory/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing hushHistory in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/integration/create.go
+++ b/cmd/cli/cmd/integration/create.go
@@ -50,10 +50,14 @@ func createValidation() (input openlaneclient.CreateIntegrationInput, err error)
 
 // create an integration in the platform
 func create(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	input, err := createValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/integration/get.go
+++ b/cmd/cli/cmd/integration/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get retrieves all integrations or a specific integration by ID
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id := cmd.Config.String("id")
 

--- a/cmd/cli/cmd/integrationhistory/get.go
+++ b/cmd/cli/cmd/integrationhistory/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing integrationHistory in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/internalpolicy/create.go
+++ b/cmd/cli/cmd/internalpolicy/create.go
@@ -75,10 +75,14 @@ func createValidation() (input openlaneclient.CreateInternalPolicyInput, err err
 
 // create a new internal policy
 func create(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	input, err := createValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/internalpolicy/delete.go
+++ b/cmd/cli/cmd/internalpolicy/delete.go
@@ -35,10 +35,14 @@ func deleteValidation() (string, error) {
 
 // delete an existing internal policy in the platform
 func delete(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, err := deleteValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/internalpolicy/get.go
+++ b/cmd/cli/cmd/internalpolicy/get.go
@@ -24,10 +24,14 @@ func init() {
 
 // get an existing internal policy in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/internalpolicy/update.go
+++ b/cmd/cli/cmd/internalpolicy/update.go
@@ -82,10 +82,14 @@ func updateValidation() (id string, input openlaneclient.UpdateInternalPolicyInp
 
 // update an existing internal policy in the platform
 func update(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, input, err := updateValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/internalpolicyhistory/get.go
+++ b/cmd/cli/cmd/internalpolicyhistory/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing internalPolicyHistory in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/invite/create.go
+++ b/cmd/cli/cmd/invite/create.go
@@ -40,10 +40,14 @@ func createValidation() (input openlaneclient.CreateInviteInput, err error) {
 
 // create an invitation in the platform
 func create(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	input, err := createValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/invite/delete.go
+++ b/cmd/cli/cmd/invite/delete.go
@@ -35,10 +35,14 @@ func deleteValidation() (string, error) {
 
 // delete an invitation to join an organization
 func delete(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, err := deleteValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/invite/get.go
+++ b/cmd/cli/cmd/invite/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an organization invitation(s)
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/narrative/create.go
+++ b/cmd/cli/cmd/narrative/create.go
@@ -54,10 +54,14 @@ func createValidation() (input openlaneclient.CreateNarrativeInput, err error) {
 
 // create a new narrative
 func create(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	input, err := createValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/narrative/delete.go
+++ b/cmd/cli/cmd/narrative/delete.go
@@ -35,10 +35,14 @@ func deleteValidation() (string, error) {
 
 // delete an existing narrative in the platform
 func delete(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, err := deleteValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/narrative/get.go
+++ b/cmd/cli/cmd/narrative/get.go
@@ -24,10 +24,14 @@ func init() {
 
 // get an existing narrative in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/narrative/update.go
+++ b/cmd/cli/cmd/narrative/update.go
@@ -70,10 +70,14 @@ func updateValidation() (id string, input openlaneclient.UpdateNarrativeInput, e
 
 // update an existing narrative in the platform
 func update(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, input, err := updateValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/narrativehistory/get.go
+++ b/cmd/cli/cmd/narrativehistory/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing narrativeHistory in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/organization/create.go
+++ b/cmd/cli/cmd/organization/create.go
@@ -69,10 +69,14 @@ func createValidation() (input openlaneclient.CreateOrganizationInput, err error
 
 // create an organization in the platform
 func create(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	input, err := createValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/organization/delete.go
+++ b/cmd/cli/cmd/organization/delete.go
@@ -35,10 +35,14 @@ func deleteValidation() (string, error) {
 
 // delete an organization in the platform
 func delete(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, err := deleteValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/organization/get.go
+++ b/cmd/cli/cmd/organization/get.go
@@ -27,10 +27,14 @@ func init() {
 
 // get an organization in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/organization/update.go
+++ b/cmd/cli/cmd/organization/update.go
@@ -54,10 +54,14 @@ func updateValidation() (id string, input openlaneclient.UpdateOrganizationInput
 
 // update an existing organization in the platform
 func update(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, input, err := updateValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/organizationhistory/get.go
+++ b/cmd/cli/cmd/organizationhistory/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing organizationHistory in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/organizationsetting/get.go
+++ b/cmd/cli/cmd/organizationsetting/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing organization setting in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/organizationsetting/update.go
+++ b/cmd/cli/cmd/organizationsetting/update.go
@@ -78,10 +78,14 @@ func updateValidation() (id string, input openlaneclient.UpdateOrganizationSetti
 
 // update an organization setting in the platform
 func update(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, input, err := updateValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/organizationsettinghistory/get.go
+++ b/cmd/cli/cmd/organizationsettinghistory/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing organizationSettingHistory in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/orgmembers/create.go
+++ b/cmd/cli/cmd/orgmembers/create.go
@@ -50,10 +50,14 @@ func createValidation() (input openlaneclient.CreateOrgMembershipInput, err erro
 }
 
 func create(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	input, err := createValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/orgmembers/delete.go
+++ b/cmd/cli/cmd/orgmembers/delete.go
@@ -38,10 +38,14 @@ func deleteValidation() (where openlaneclient.OrgMembershipWhereInput, err error
 }
 
 func delete(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	where, err := deleteValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/orgmembers/get.go
+++ b/cmd/cli/cmd/orgmembers/get.go
@@ -25,10 +25,14 @@ func init() {
 }
 
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	where := openlaneclient.OrgMembershipWhereInput{}
 

--- a/cmd/cli/cmd/orgmembers/update.go
+++ b/cmd/cli/cmd/orgmembers/update.go
@@ -55,10 +55,14 @@ func updateValidation() (where openlaneclient.OrgMembershipWhereInput, input ope
 }
 
 func update(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	where, input, err := updateValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/orgmembershiphistory/get.go
+++ b/cmd/cli/cmd/orgmembershiphistory/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing orgMembershipHistory in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/personalaccesstokens/create.go
+++ b/cmd/cli/cmd/personalaccesstokens/create.go
@@ -56,10 +56,14 @@ func createValidation() (input openlaneclient.CreatePersonalAccessTokenInput, er
 
 // create a new personal access token
 func create(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	input, err := createValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/personalaccesstokens/delete.go
+++ b/cmd/cli/cmd/personalaccesstokens/delete.go
@@ -35,10 +35,14 @@ func deleteValidation() (string, error) {
 
 // delete a personal access token in the platform
 func delete(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, err := deleteValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/personalaccesstokens/get.go
+++ b/cmd/cli/cmd/personalaccesstokens/get.go
@@ -24,10 +24,14 @@ func init() {
 }
 
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/personalaccesstokens/update.go
+++ b/cmd/cli/cmd/personalaccesstokens/update.go
@@ -60,10 +60,14 @@ func updateValidation() (id string, input openlaneclient.UpdatePersonalAccessTok
 
 // update an existing personal access token
 func update(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, input, err := updateValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/procedure/create.go
+++ b/cmd/cli/cmd/procedure/create.go
@@ -81,10 +81,14 @@ func createValidation() (input openlaneclient.CreateProcedureInput, err error) {
 
 // create a new procedure
 func create(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	input, err := createValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/procedure/delete.go
+++ b/cmd/cli/cmd/procedure/delete.go
@@ -35,10 +35,14 @@ func deleteValidation() (string, error) {
 
 // delete an existing procedure in the platform
 func delete(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, err := deleteValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/procedure/get.go
+++ b/cmd/cli/cmd/procedure/get.go
@@ -24,10 +24,14 @@ func init() {
 
 // get an existing procedure in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/procedure/update.go
+++ b/cmd/cli/cmd/procedure/update.go
@@ -94,10 +94,14 @@ func updateValidation() (id string, input openlaneclient.UpdateProcedureInput, e
 
 // update an existing procedure in the platform
 func update(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, input, err := updateValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/procedurehistory/get.go
+++ b/cmd/cli/cmd/procedurehistory/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing procedureHistory in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/program/create.go
+++ b/cmd/cli/cmd/program/create.go
@@ -83,10 +83,14 @@ func createValidation() (input openlaneclient.CreateProgramInput, err error) {
 
 // create a new program
 func create(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	input, err := createValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/program/delete.go
+++ b/cmd/cli/cmd/program/delete.go
@@ -35,10 +35,14 @@ func deleteValidation() (string, error) {
 
 // delete an existing program in the platform
 func delete(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, err := deleteValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/program/get.go
+++ b/cmd/cli/cmd/program/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing program in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 	// filter options
 	id := cmd.Config.String("id")
 

--- a/cmd/cli/cmd/program/update.go
+++ b/cmd/cli/cmd/program/update.go
@@ -92,10 +92,14 @@ func updateValidation() (id string, input openlaneclient.UpdateProgramInput, err
 
 // update an existing program in the platform
 func update(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, input, err := updateValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/programhistory/get.go
+++ b/cmd/cli/cmd/programhistory/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing programHistory in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/programmembers/create.go
+++ b/cmd/cli/cmd/programmembers/create.go
@@ -52,10 +52,14 @@ func createValidation() (input openlaneclient.CreateProgramMembershipInput, err 
 
 // create adds a user to a program in the platform
 func create(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	input, err := createValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/programmembers/delete.go
+++ b/cmd/cli/cmd/programmembers/delete.go
@@ -46,10 +46,14 @@ func deleteValidation() (where openlaneclient.ProgramMembershipWhereInput, err e
 
 // delete removes a user from a program in the platform
 func delete(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	where, err := deleteValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/programmembers/get.go
+++ b/cmd/cli/cmd/programmembers/get.go
@@ -26,10 +26,14 @@ func init() {
 
 // get existing members of a program
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("program-id")

--- a/cmd/cli/cmd/programmembers/update.go
+++ b/cmd/cli/cmd/programmembers/update.go
@@ -61,10 +61,14 @@ func updateValidation() (where openlaneclient.ProgramMembershipWhereInput, input
 
 // update a user's role in a program in the platform
 func update(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	where, input, err := updateValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/risk/create.go
+++ b/cmd/cli/cmd/risk/create.go
@@ -81,10 +81,14 @@ func createValidation() (input openlaneclient.CreateRiskInput, err error) {
 
 // create a new risk
 func create(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	input, err := createValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/risk/delete.go
+++ b/cmd/cli/cmd/risk/delete.go
@@ -35,10 +35,14 @@ func deleteValidation() (string, error) {
 
 // delete an existing risk in the platform
 func delete(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, err := deleteValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/risk/get.go
+++ b/cmd/cli/cmd/risk/get.go
@@ -24,10 +24,14 @@ func init() {
 
 // get an existing risk in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/risk/update.go
+++ b/cmd/cli/cmd/risk/update.go
@@ -107,10 +107,14 @@ func updateValidation() (id string, input openlaneclient.UpdateRiskInput, err er
 
 // update an existing risk in the platform
 func update(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, input, err := updateValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/riskhistory/get.go
+++ b/cmd/cli/cmd/riskhistory/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing riskHistory in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -69,8 +69,8 @@ func init() {
 	RootCmd.PersistentFlags().String("host", defaultRootHost, "api host url")
 
 	// Token flags
-	RootCmd.PersistentFlags().String("token", "", "api token")
-	RootCmd.PersistentFlags().String("path", "", "personal access token")
+	RootCmd.PersistentFlags().String("token", "", "api token used for authentication, takes precedence over other auth methods")
+	RootCmd.PersistentFlags().String("pat", "", "personal access token used for authentication")
 
 	// Logging flags
 	RootCmd.PersistentFlags().Bool("debug", false, "enable debug logging")

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -68,6 +68,10 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/."+appName+".yaml)")
 	RootCmd.PersistentFlags().String("host", defaultRootHost, "api host url")
 
+	// Token flags
+	RootCmd.PersistentFlags().String("token", "", "api token")
+	RootCmd.PersistentFlags().String("path", "", "personal access token")
+
 	// Logging flags
 	RootCmd.PersistentFlags().Bool("debug", false, "enable debug logging")
 	RootCmd.PersistentFlags().Bool("pretty", false, "enable pretty (human readable) logging output")

--- a/cmd/cli/cmd/search/search.go
+++ b/cmd/cli/cmd/search/search.go
@@ -43,10 +43,14 @@ func validate() (string, error) {
 
 // search searches for organizations, groups, users, subscribers, etc in the system
 func search(ctx context.Context) error { // setup http client
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	query, err := validate()

--- a/cmd/cli/cmd/subcontrol/create.go
+++ b/cmd/cli/cmd/subcontrol/create.go
@@ -119,10 +119,14 @@ func createValidation() (input openlaneclient.CreateSubcontrolInput, err error) 
 
 // create a new subcontrol
 func create(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	input, err := createValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/subcontrol/delete.go
+++ b/cmd/cli/cmd/subcontrol/delete.go
@@ -35,10 +35,14 @@ func deleteValidation() (string, error) {
 
 // delete an existing subcontrol in the platform
 func delete(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, err := deleteValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/subcontrol/get.go
+++ b/cmd/cli/cmd/subcontrol/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing subcontrol in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 	// filter options
 	id := cmd.Config.String("id")
 

--- a/cmd/cli/cmd/subcontrol/update.go
+++ b/cmd/cli/cmd/subcontrol/update.go
@@ -132,10 +132,14 @@ func updateValidation() (id string, input openlaneclient.UpdateSubcontrolInput, 
 
 // update an existing subcontrol in the platform
 func update(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, input, err := updateValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/subcontrolhistory/get.go
+++ b/cmd/cli/cmd/subcontrolhistory/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing subcontrolHistory in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/subscriber/create.go
+++ b/cmd/cli/cmd/subscriber/create.go
@@ -51,10 +51,14 @@ func createValidation() (input []*openlaneclient.CreateSubscriberInput, err erro
 }
 
 func create(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	if cmd.InputFile != "" {
 		input, err := os.OpenFile(cmd.InputFile, os.O_RDWR|os.O_CREATE, os.ModePerm)

--- a/cmd/cli/cmd/subscriber/delete.go
+++ b/cmd/cli/cmd/subscriber/delete.go
@@ -41,10 +41,14 @@ func deleteValidation() (string, *string, error) {
 
 // delete an existing organization subscriber
 func delete(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	email, orgID, err := deleteValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/subscriber/get.go
+++ b/cmd/cli/cmd/subscriber/get.go
@@ -27,10 +27,14 @@ func init() {
 
 // get an existing subscriber(s) of an organization
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	email := cmd.Config.String("email")
 

--- a/cmd/cli/cmd/subscriber/update.go
+++ b/cmd/cli/cmd/subscriber/update.go
@@ -41,10 +41,14 @@ func updateValidation() (email string, input openlaneclient.UpdateSubscriberInpu
 
 // update a subscriber details
 func update(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	email, input, err := updateValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/task/create.go
+++ b/cmd/cli/cmd/task/create.go
@@ -78,10 +78,14 @@ func createValidation() (input openlaneclient.CreateTaskInput, err error) {
 
 // create a new task
 func create(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	input, err := createValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/task/delete.go
+++ b/cmd/cli/cmd/task/delete.go
@@ -35,10 +35,14 @@ func deleteValidation() (string, error) {
 
 // delete an existing task in the platform
 func delete(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, err := deleteValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/task/get.go
+++ b/cmd/cli/cmd/task/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing task in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 	// filter options
 	id := cmd.Config.String("id")
 

--- a/cmd/cli/cmd/task/update.go
+++ b/cmd/cli/cmd/task/update.go
@@ -97,10 +97,14 @@ func updateValidation() (id string, input openlaneclient.UpdateTaskInput, err er
 
 // update an existing task in the platform
 func update(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, input, err := updateValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/taskhistory/get.go
+++ b/cmd/cli/cmd/taskhistory/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing taskHistory in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/template/create.go
+++ b/cmd/cli/cmd/template/create.go
@@ -67,10 +67,14 @@ func createValidation() (input openlaneclient.CreateTemplateInput, err error) {
 
 // create a new template
 func create(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	input, err := createValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/template/get.go
+++ b/cmd/cli/cmd/template/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get retrieves templates from the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id := cmd.Config.String("id")
 

--- a/cmd/cli/cmd/templatehistory/get.go
+++ b/cmd/cli/cmd/templatehistory/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing templateHistory in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/user/create.go
+++ b/cmd/cli/cmd/user/create.go
@@ -82,10 +82,13 @@ func createValidation() (input openlaneclient.CreateUserInput, avatarFile *graph
 
 // create a new user
 func create(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err := cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	input, avatarFile, err := createValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/user/delete.go
+++ b/cmd/cli/cmd/user/delete.go
@@ -35,10 +35,14 @@ func deleteValidation() (string, error) {
 
 // delete a user in the platform
 func delete(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, err := deleteValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/user/get.go
+++ b/cmd/cli/cmd/user/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get retrieves all users or a specific user by ID
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/user/update.go
+++ b/cmd/cli/cmd/user/update.go
@@ -79,10 +79,14 @@ func updateValidation() (id string, input openlaneclient.UpdateUserInput, avatar
 
 // update an existing user
 func update(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, input, avatarFile, err := updateValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/userhistory/get.go
+++ b/cmd/cli/cmd/userhistory/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing userHistory in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/usersetting/get.go
+++ b/cmd/cli/cmd/usersetting/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get retrieves user settings from the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/cmd/cli/cmd/usersetting/update.go
+++ b/cmd/cli/cmd/usersetting/update.go
@@ -75,10 +75,14 @@ func updateValidation() (id string, input openlaneclient.UpdateUserSettingInput,
 
 // update an existing user setting
 func update(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, input, err := updateValidation()
 	cobra.CheckErr(err)

--- a/cmd/cli/cmd/usersettinghistory/get.go
+++ b/cmd/cli/cmd/usersettinghistory/get.go
@@ -25,10 +25,14 @@ func init() {
 
 // get an existing userSettingHistory in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	// filter options
 	id := cmd.Config.String("id")

--- a/pkg/gencmd/templates/create.tmpl
+++ b/pkg/gencmd/templates/create.tmpl
@@ -37,10 +37,14 @@ func createValidation() (input openlaneclient.Create{{ .Name | ToUpperCamel }}In
 
 // create a new {{ .Name | ToLowerCamel }}
 func create(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err := cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	input, err := createValidation()
 	cobra.CheckErr(err)

--- a/pkg/gencmd/templates/delete.tmpl
+++ b/pkg/gencmd/templates/delete.tmpl
@@ -35,10 +35,14 @@ func deleteValidation() (string, error) {
 
 // delete an existing {{ .Name | ToLowerCamel }} in the platform
 func delete(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, err := deleteValidation()
 	cobra.CheckErr(err)

--- a/pkg/gencmd/templates/get.tmpl
+++ b/pkg/gencmd/templates/get.tmpl
@@ -29,10 +29,14 @@ func init() {
 
 // get an existing {{ .Name | ToLowerCamel }} in the platform
 func get(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	{{- if not .ListOnly }}
 	// filter options

--- a/pkg/gencmd/templates/update.tmpl
+++ b/pkg/gencmd/templates/update.tmpl
@@ -44,10 +44,14 @@ func updateValidation() (id string, input openlaneclient.Update{{ .Name | ToUppe
 
 // update an existing {{ .Name | ToLowerCamel }} in the platform
 func update(ctx context.Context) error {
-	// setup http client
-	client, err := cmd.SetupClientWithAuth(ctx)
-	cobra.CheckErr(err)
-	defer cmd.StoreSessionCookies(client)
+	// attempt to setup with token, otherwise fall back to JWT with session
+	client, err := cmd.TokenAuth(ctx, cmd.Config)
+	if err != nil || client == nil {
+		// setup http client
+		client, err = cmd.SetupClientWithAuth(ctx)
+		cobra.CheckErr(err)
+		defer cmd.StoreSessionCookies(client)
+	}
 
 	id, input, err := updateValidation()
 	cobra.CheckErr(err)


### PR DESCRIPTION
Adds flags for `token` and `pat` to the root and attempts to authenticate first with the token before falling back to the JWT + session. 

```
      --pat string      personal access token used for authentication
      --token string    api token used for authentication, takes precedence over other auth methods
```

This allows setting either `CORE_TOKEN` or `CORE_PAT` in your environment variables and using the CLI. 

```
(⎈ |default:default)➜  core git:(feat-token-auth-cli) export CORE_PAT=tolp_REDACTED
(⎈ |default:default)➜  core git:(feat-token-auth-cli) go run cmd/cli/main.go group get                                     
  ID                          NAME                            DESCRIPTION  VISIBILITY  ORGANIZATION  MEMBERS  
  01JFH6E6SQ1S8GF33PF20FXT8F  internal-auditors                            PUBLIC      meowmeow      0        
  01JFH6EQ40RZYFJXM75S0K6TPJ  internal-auditors2                           PUBLIC      meowmeow      0        
  01JFH6HVGG3VR6REM429CBA7AH  internal-auditorsasdfs                       PUBLIC      meowmeow      0        
  01JFH6QJQ5Q9AG0ZJMD3C3WDZM  internal-auditorsasdfssadfasdf               PUBLIC      meowmeow      1        

(⎈ |default:default)➜  core git:(feat-token-auth-cli) export CORE_TOKEN=tola_REDACTED
(⎈ |default:default)➜  core git:(feat-token-auth-cli) go run cmd/cli/main.go group get                                                       
  ID                          NAME                            DESCRIPTION  VISIBILITY  ORGANIZATION  MEMBERS  
  01JFH6E6SQ1S8GF33PF20FXT8F  internal-auditors                            PUBLIC      meowmeow      0        
  01JFH6EQ40RZYFJXM75S0K6TPJ  internal-auditors2                           PUBLIC      meowmeow      0        
  01JFH6HVGG3VR6REM429CBA7AH  internal-auditorsasdfs                       PUBLIC      meowmeow      0        
  01JFH6QJQ5Q9AG0ZJMD3C3WDZM  internal-auditorsasdfssadfasdf               PUBLIC      meowmeow      1        
```