### PR TITLE
Feat stripe webhook receiver

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: yamlfmt
   - repo: https://github.com/crate-ci/typos
     # ensure this stays in this format, the auto-updater might update to something like typos-dict-v0.11.35 which is not correct
-    rev: v1.28.2
+    rev: v1.29.0
     hooks:
       - id: typos
   - repo: local

--- a/internal/httpserve/handlers/ent.go
+++ b/internal/httpserve/handlers/ent.go
@@ -9,6 +9,7 @@ import (
 
 	ent "github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/emailverificationtoken"
+	"github.com/theopenlane/core/internal/ent/generated/event"
 	"github.com/theopenlane/core/internal/ent/generated/invite"
 	"github.com/theopenlane/core/internal/ent/generated/passwordresettoken"
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
@@ -498,4 +499,27 @@ func (h *Handler) getOrgByID(ctx context.Context, id string) (*ent.Organization,
 	}
 
 	return org, nil
+}
+
+// createEvent creates a new event in the database but requires mapped input
+func (h *Handler) createEvent(ctx context.Context, input ent.CreateEventInput) (*ent.Event, error) {
+	event, err := transaction.FromContext(ctx).Event.Create().SetInput(input).Save(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("error creating event")
+
+		return nil, err
+	}
+
+	return event, nil
+}
+
+// checkForEventID checks if the event ID exists in the database
+func (h *Handler) checkForEventID(ctx context.Context, id string) (bool, error) {
+	exists, err := transaction.FromContext(ctx).Event.Query().Where(event.EventID(id)).Exist(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("error checking for event ID")
+		return false, err
+	}
+
+	return exists, nil
 }

--- a/internal/httpserve/handlers/errors.go
+++ b/internal/httpserve/handlers/errors.go
@@ -65,8 +65,6 @@ var (
 	ErrNoBillingEmail = errors.New("no billing email found")
 	// ErrPersonalOrgsNoBilling is returned when the org ID looked up is a personal org
 	ErrPersonalOrgsNoBilling = errors.New("personal orgs do not have billing")
-	// ErrEventNotFound is returned when the event is not found
-	ErrEventNotFound = errors.New("generated: event not found")
 )
 
 var (

--- a/internal/httpserve/handlers/errors.go
+++ b/internal/httpserve/handlers/errors.go
@@ -17,77 +17,56 @@ import (
 var (
 	// ErrBadRequest is returned when the request cannot be processed
 	ErrBadRequest = errors.New("invalid request")
-
 	// ErrProcessingRequest is returned when the request cannot be processed
 	ErrProcessingRequest = errors.New("error processing request, please try again")
-
 	// ErrMissingRequiredFields is returned when the login request has an empty username or password
 	ErrMissingRequiredFields = errors.New("invalid request, missing username and/or password")
-
 	// ErrInvalidInput is returned when the input is invalid
 	ErrInvalidInput = errors.New("invalid input")
-
 	// ErrNotFound is returned when the requested object is not found
 	ErrNotFound = errors.New("object not found in the database")
-
 	// ErrMissingField is returned when a field is missing duh
 	ErrMissingField = errors.New("missing required field")
-
 	// ErrInvalidCredentials is returned when the password is invalid or missing
 	ErrInvalidCredentials = errors.New("credentials are missing or invalid")
-
 	// ErrUnverifiedUser is returned when email_verified on the user is false
 	ErrUnverifiedUser = errors.New("user is not verified")
-
 	// ErrUnableToVerifyEmail is returned when user's email is not able to be verified
 	ErrUnableToVerifyEmail = errors.New("could not verify email")
-
 	// ErrMaxAttempts is returned when user has requested the max retry attempts to verify their email
 	ErrMaxAttempts = errors.New("max attempts verifying email address")
-
 	// ErrNoEmailFound is returned when using an oauth provider and the email address cannot be determined
 	ErrNoEmailFound = errors.New("no email found from oauth provider")
-
 	// ErrInvalidProvider is returned when registering a user with an unsupported oauth provider
 	ErrInvalidProvider = errors.New("oauth2 provider not supported")
-
 	// ErrNoAuthUser is returned when the user couldn't be identified by the request
 	ErrNoAuthUser = errors.New("could not identify authenticated user in request")
-
 	// ErrPassWordResetTokenInvalid is returned when the provided token and secret do not match the stored
 	ErrPassWordResetTokenInvalid = errors.New("password reset token invalid")
-
 	// ErrNonUniquePassword is returned when the password was already used
 	ErrNonUniquePassword = errors.New("password was already used, please try again")
-
 	// ErrPasswordTooWeak is returned when the password is too weak
 	ErrPasswordTooWeak = errors.New("password is too weak: use a combination of upper and lower case letters, numbers, and special characters")
-
 	// ErrMaxDeviceLimit is returned when the user has reached the max device limit
 	ErrMaxDeviceLimit = errors.New("max device limit reached")
-
 	// ErrDeviceAlreadyRegistered is returned when the device is already registered
 	ErrDeviceAlreadyRegistered = errors.New("device already registered")
-
 	// ErrSubscriberNotFound is returned when the subscriber is not found
 	ErrSubscriberNotFound = errors.New("subscriber not found")
-
 	// ErrExpiredToken is returned when the token has expired
 	ErrExpiredToken = errors.New("token has expired")
-
 	// ErrUnauthorized is returned when the user is not authorized to make the request
 	ErrUnauthorized = errors.New("not authorized")
-
 	// ErrConflict is returned when the request cannot be processed due to a conflict
 	ErrConflict = errors.New("conflict")
-
 	// ErrAlreadySwitchedIntoOrg is returned when a user attempts to switch into an org they are currently authenticated in
 	ErrAlreadySwitchedIntoOrg = errors.New("user already switched into organization")
-
 	// ErrNoBillingEmail is returned when the user has no billing email
 	ErrNoBillingEmail = errors.New("no billing email found")
 	// ErrPersonalOrgsNoBilling is returned when the org ID looked up is a personal org
 	ErrPersonalOrgsNoBilling = errors.New("personal orgs do not have billing")
+	// ErrEventNotFound is returned when the event is not found
+	ErrEventNotFound = errors.New("generated: event not found")
 )
 
 var (

--- a/internal/httpserve/handlers/webhook.go
+++ b/internal/httpserve/handlers/webhook.go
@@ -1,0 +1,89 @@
+package handlers
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/rs/zerolog/log"
+	"github.com/stripe/stripe-go/v81/webhook"
+	echo "github.com/theopenlane/echox"
+
+	ent "github.com/theopenlane/core/internal/ent/generated"
+)
+
+// WebhookReceiverHandler handles incoming stripe webhook events
+func (h *Handler) WebhookReceiverHandler(ctx echo.Context) error {
+	req := ctx.Request()
+	res := ctx.Response()
+
+	const MaxBodyBytes = int64(65536)
+	req.Body = http.MaxBytesReader(res.Writer, req.Body, MaxBodyBytes)
+
+	payload, err := io.ReadAll(req.Body)
+	if err != nil {
+		return ctx.String(http.StatusServiceUnavailable, fmt.Errorf("problem with request. Error: %w", err).Error())
+	}
+
+	event, err := webhook.ConstructEvent(payload, req.Header.Get("Stripe-Signature"), h.Entitlements.Config.StripeWebhookSecret)
+	if err != nil {
+		return ctx.String(http.StatusBadRequest, fmt.Errorf("error verifying webhook signature. Error: %w", err).Error())
+	}
+
+	exists, err := h.checkForEventID(ctx.Request().Context(), event.ID)
+	if err != nil {
+		return h.InternalServerError(ctx, err)
+	}
+
+	if exists {
+		log.Warn().Msgf("Event already received: %v", event.ID)
+
+		out := WebhookResponse{
+			Message: "Event already received",
+		}
+
+		return h.Success(ctx, out)
+	}
+
+	if !exists {
+		log.Warn().Msgf("Event not exists loop: %v", event.ID)
+
+		if err := h.Entitlements.HandleEvent(ctx.Request().Context(), &event); err != nil {
+			return h.InternalServerError(ctx, err)
+		}
+
+		input := ent.CreateEventInput{
+			EventID:   &event.ID,
+			EventType: "stripe",
+			// TODO unmarshall event data into internal event
+		}
+
+		meowevent, err := h.createEvent(ctx.Request().Context(), input)
+		if err != nil {
+			return h.InternalServerError(ctx, err)
+		}
+
+		log.Warn().Msgf("Internal event: %v", meowevent)
+	}
+
+	out := WebhookResponse{
+		Message: "Received!",
+	}
+
+	return h.Success(ctx, out)
+}
+
+// WebhookRequest is the request object for the webhook handler
+type WebhookRequest struct {
+	// TODO determine if there's any request data actually need or needs to be validated given the signature verification that's already occurring
+}
+
+// WebhookResponse is the response object for the webhook handler
+type WebhookResponse struct {
+	Message string
+}
+
+// Validate validates the webhook request
+func (r *WebhookRequest) Validate() error {
+	return nil
+}

--- a/internal/httpserve/route/router.go
+++ b/internal/httpserve/route/router.go
@@ -201,6 +201,7 @@ func RegisterRoutes(router *Router) error {
 		registerAccountRolesHandler,
 		registerAccountRolesOrganizationHandler,
 		registerAppleMerchantHandler,
+		registerWebhookHandler,
 	}
 
 	for _, route := range routeHandlers {

--- a/internal/httpserve/route/webhook.go
+++ b/internal/httpserve/route/webhook.go
@@ -1,0 +1,30 @@
+package route
+
+import (
+	"net/http"
+
+	echo "github.com/theopenlane/echox"
+)
+
+// registerWebhookHandler registers a webhook endpoint handler behind the /stripe/ path for handling inbound event receivers from stripe
+func registerWebhookHandler(router *Router) (err error) {
+	path := "/stripe/webhook"
+	method := http.MethodPost
+	name := "StripeWebhook"
+
+	route := echo.Route{
+		Name:        name,
+		Method:      method,
+		Path:        path,
+		Middlewares: mw,
+		Handler: func(c echo.Context) error {
+			return router.Handler.WebhookReceiverHandler(c)
+		},
+	}
+
+	if err := router.AddEchoOnlyRoute(path, method, route); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/httpserve/serveropts/option.go
+++ b/internal/httpserve/serveropts/option.go
@@ -327,7 +327,7 @@ func WithOTP() ServerOption {
 				}),
 			}
 
-			// append redis client if enabed
+			// append redis client if enabled
 			if s.Config.Settings.TOTP.WithRedis {
 				opts = append(opts, totp.WithRedis(s.Config.Handler.RedisClient))
 			}

--- a/internal/httpserve/serveropts/option.go
+++ b/internal/httpserve/serveropts/option.go
@@ -460,7 +460,7 @@ func WithObjectStorage() ServerOption {
 func WithEntitlements() ServerOption {
 	return newApplyFunc(func(s *ServerOptions) {
 		if s.Config.Settings.Entitlements.Enabled {
-			config := entitlements.NewConfig(entitlements.WithTrialSubscriptionPriceID(s.Config.Settings.Entitlements.TrialSubscriptionPriceID))
+			config := entitlements.NewConfig(entitlements.WithTrialSubscriptionPriceID(s.Config.Settings.Entitlements.TrialSubscriptionPriceID), entitlements.WithStripeWebhookSecret(s.Config.Settings.Entitlements.StripeWebhookSecret))
 
 			client := entitlements.NewStripeClient(
 				entitlements.WithAPIKey(s.Config.Settings.Entitlements.PrivateStripeKey),

--- a/pkg/entitlements/README.md
+++ b/pkg/entitlements/README.md
@@ -1,0 +1,16 @@
+# Stripe integration
+
+`brew install stripe/stripe-cli/stripe`
+
+`stripe login` and then use your associated credentials
+
+`stripe listen --forward-to localhost:17608/v1/stripe/webhook`
+
+`stripe trigger payment_intent.succeeded`
+
+## Unprocessed
+
+If your webhook endpoint temporarily can’t process events, Stripe automatically resends the undelivered events to your endpoint for up to three days, increasing the time for your webhook endpoint to eventually receive and process all events.
+
+This guide explains how to speed up that process by manually processing the undelivered events.
+

--- a/pkg/entitlements/README.md
+++ b/pkg/entitlements/README.md
@@ -13,5 +13,3 @@ To test webhooks locally:
 ## Unprocessed
 
 If your webhook endpoint temporarily can’t process events, Stripe automatically resends the undelivered events to your endpoint for up to three days, increasing the time for your webhook endpoint to eventually receive and process all events.
-
-

--- a/pkg/entitlements/README.md
+++ b/pkg/entitlements/README.md
@@ -1,5 +1,7 @@
 # Stripe integration
 
+To test webhooks locally:
+
 `brew install stripe/stripe-cli/stripe`
 
 `stripe login` and then use your associated credentials
@@ -12,5 +14,4 @@
 
 If your webhook endpoint temporarily can’t process events, Stripe automatically resends the undelivered events to your endpoint for up to three days, increasing the time for your webhook endpoint to eventually receive and process all events.
 
-This guide explains how to speed up that process by manually processing the undelivered events.
 

--- a/pkg/entitlements/client.go
+++ b/pkg/entitlements/client.go
@@ -11,7 +11,7 @@ type StripeClient struct {
 	// apikey is the Stripe API key
 	apikey string
 	// config is the configuration for the Stripe client
-	config Config
+	Config Config
 }
 
 // NewStripeClient creates a new Stripe client
@@ -32,7 +32,7 @@ type StripeOptions func(*StripeClient)
 // WithConfig sets the config for the Stripe client
 func WithConfig(config Config) StripeOptions {
 	return func(sc *StripeClient) {
-		sc.config = config
+		sc.Config = config
 	}
 }
 

--- a/pkg/entitlements/customers.go
+++ b/pkg/entitlements/customers.go
@@ -20,6 +20,13 @@ func (sc *StripeClient) CreateCustomer(c *OrganizationCustomer) (*stripe.Custome
 		Email: &c.BillingEmail,
 		Name:  &c.OrganizationID,
 		Phone: &c.BillingPhone,
+		Address: &stripe.AddressParams{
+			Line1:      c.ContactInfo.Line1,
+			City:       c.ContactInfo.City,
+			State:      c.ContactInfo.State,
+			PostalCode: c.ContactInfo.PostalCode,
+			Country:    c.ContactInfo.Country,
+		},
 		Metadata: map[string]string{
 			"organization_id":          c.OrganizationID,
 			"organization_settings_id": c.OrganizationSettingsID,

--- a/pkg/entitlements/events.go
+++ b/pkg/entitlements/events.go
@@ -1,0 +1,63 @@
+package entitlements
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/rs/zerolog/log"
+	"github.com/stripe/stripe-go/v81"
+)
+
+// unmarshalEventData is used to unmarshal event data from a stripe.Event object into a specific type T
+func unmarshalEventData[T interface{}](e *stripe.Event) (*T, error) {
+	var data T
+
+	err := json.Unmarshal(e.Data.Raw, &data)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to unmarshal event data")
+	}
+
+	return &data, err
+}
+
+// HandleEvent umarshals event data and triggers a corresponding function to be executed based on case match
+func (sc *StripeClient) HandleEvent(c context.Context, e *stripe.Event) error {
+	switch e.Type {
+	case "customer.subscription.updated", "customer.subscription.deleted", "customer.subscription.paused":
+		subscription, err := unmarshalEventData[stripe.Subscription](e)
+		if err == nil {
+			return sc.handleSubscriptionUpdated(subscription)
+		}
+	case "payment_intent.succeeded":
+		cust, err := unmarshalEventData[stripe.PaymentIntent](e)
+		if err == nil {
+			return sc.handlePaymentIntent(c, cust)
+		}
+	}
+
+	return nil
+}
+
+// handleSubscriptionUpdated handles subscription updated events
+func (sc *StripeClient) handleSubscriptionUpdated(s *stripe.Subscription) error {
+	_, err := sc.GetSubscriptionByID(s.ID)
+	if err != nil {
+		return err
+	}
+
+	// TODO implement update logic; for now just confirm the lookup flow is successful and print the event
+
+	return nil
+}
+
+// handlePaymentIntent handles payment intent events
+func (sc *StripeClient) handlePaymentIntent(c context.Context, stripeCust *stripe.PaymentIntent) error {
+	_, err := sc.GetCustomerByStripeID(c, stripeCust.ID)
+	if err != nil {
+		return err
+	}
+
+	// TODO implement payment intent logic; for now just confirm the lookup flow is successful and print the event
+
+	return nil
+}

--- a/pkg/entitlements/models.go
+++ b/pkg/entitlements/models.go
@@ -17,14 +17,34 @@ type OrganizationCustomer struct {
 	OrganizationName       string `json:"organization_name"`
 	Features               []string
 	Subscription
+	ContactInfo
 }
 
-// MapToStripeCustomer maps the OrganizationCustomer to a stripe customer for more easy querying
+// ContactInfo holds the contact information for the organization
+type ContactInfo struct {
+	Email      string  `json:"email"`
+	Phone      string  `json:"phone"`
+	City       *string `form:"city"`
+	Country    *string `form:"country"`
+	Line1      *string `form:"line1"`
+	Line2      *string `form:"line2"`
+	PostalCode *string `form:"postal_code"`
+	State      *string `form:"state"`
+}
+
 func (o *OrganizationCustomer) MapToStripeCustomer() *stripe.CustomerParams {
 	return &stripe.CustomerParams{
 		Email: &o.BillingEmail,
 		Name:  &o.OrganizationID,
 		Phone: &o.BillingPhone,
+		Address: &stripe.AddressParams{
+			Line1:      o.Line1,
+			Line2:      o.Line2,
+			City:       o.City,
+			State:      o.State,
+			PostalCode: o.PostalCode,
+			Country:    o.Country,
+		},
 		Metadata: map[string]string{
 			"organization_id":          o.OrganizationID,
 			"organization_settings_id": o.OrganizationSettingsID,

--- a/pkg/entitlements/subscriptions.go
+++ b/pkg/entitlements/subscriptions.go
@@ -79,7 +79,7 @@ func (sc *StripeClient) CreateTrialSubscription(customerID string) (*Subscriptio
 		Customer: stripe.String(customerID),
 		Items: []*stripe.SubscriptionItemsParams{
 			{
-				Price: &sc.config.TrialSubscriptionPriceID,
+				Price: &sc.Config.TrialSubscriptionPriceID,
 			},
 		},
 		TrialPeriodDays: stripe.Int64(trialdays),
@@ -111,7 +111,7 @@ func (sc *StripeClient) CreateTrialSubscription(customerID string) (*Subscriptio
 func (sc *StripeClient) CreateBillingPortalUpdateSession(subsID, custID string) (Checkout, error) {
 	params := &stripe.BillingPortalSessionParams{
 		Customer:  &custID,
-		ReturnURL: &sc.config.StripeBillingPortalSuccessURL,
+		ReturnURL: &sc.Config.StripeBillingPortalSuccessURL,
 		FlowData: &stripe.BillingPortalSessionFlowDataParams{
 			Type: stripe.String("subscription_update"),
 			SubscriptionUpdate: &stripe.BillingPortalSessionFlowDataSubscriptionUpdateParams{


### PR DESCRIPTION
- initial implementation of a route + handler which receives stripe webhooks, performs signature verification, and matches event by type to perform event unmarshaling
- current implementation creates internal event ID references and performs look ups to prevent double processing
- no actual update logic is being performed by the handler - future pull requests will add additional logic as necessary but this will allow is to begin receiving and logging webhooks
- other misc changes: pre-commit update, removal of unnecessary white space / line breaks, initialize stripe client with webhook secret in serverOpts