### PR TITLE
bug: retry feature pull with backoff + add missing fields from org subscriptions

### DIFF
--- a/cmd/cli/cmd/orgsubscription/root.go
+++ b/cmd/cli/cmd/orgsubscription/root.go
@@ -81,8 +81,7 @@ func jsonOutput(out any) error {
 // tableOutput prints the output in a table format
 func tableOutput(out []openlaneclient.OrgSubscription) {
 	// create a table writer
-	// TODO: add additional columns to the table writer
-	writer := tables.NewTableWriter(command.OutOrStdout(), "ID", "StripeCustomerID", "StripeSubscriptionStatus", "ProductTier", "Features", "ExpiresAt")
+	writer := tables.NewTableWriter(command.OutOrStdout(), "ID", "Active", "StripeCustomerID", "StripeSubscriptionStatus", "ProductTier", "Features", "Price", "ExpiresAt")
 	for _, i := range out {
 		features := []string{}
 		if i.Features != nil {
@@ -94,11 +93,18 @@ func tableOutput(out []openlaneclient.OrgSubscription) {
 			exp = i.ExpiresAt.String()
 		}
 
+		price := ""
+		if i.ProductPrice != nil {
+			price = i.ProductPrice.String()
+		}
+
 		writer.AddRow(i.ID,
+			i.Active,
 			*i.StripeCustomerID,
 			*i.StripeSubscriptionStatus,
 			*i.ProductTier,
 			strings.Join(features, ", "),
+			price,
 			exp,
 		)
 	}

--- a/db/migrations-goose-postgres/20250110162830_subscription_price.sql
+++ b/db/migrations-goose-postgres/20250110162830_subscription_price.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- modify "org_subscription_history" table
+ALTER TABLE "org_subscription_history" ADD COLUMN "product_price" jsonb NULL;
+-- modify "org_subscriptions" table
+ALTER TABLE "org_subscriptions" ADD COLUMN "product_price" jsonb NULL;
+
+-- +goose Down
+-- reverse: modify "org_subscriptions" table
+ALTER TABLE "org_subscriptions" DROP COLUMN "product_price";
+-- reverse: modify "org_subscription_history" table
+ALTER TABLE "org_subscription_history" DROP COLUMN "product_price";

--- a/db/migrations-goose-postgres/atlas.sum
+++ b/db/migrations-goose-postgres/atlas.sum
@@ -1,5 +1,6 @@
-h1:QXCrkYR4vxggy2Kk14xhgOkCom8B/+rl+I7Rgzroh0k=
+h1:TRyOA0hBgJWu/ryMtc4bGT7xQ4ZM7obgNDeGGFkC+No=
 20241211231032_init.sql h1:Cj6GduEDECy6Y+8DfI6767WosqG2AKWybIyJJ6AgKqA=
 20241212223714_consistent_naming.sql h1:RvnNmsStlHkmAdSCnX1fFh/KYgfj1RMYYEc4iCN9JcQ=
 20250109002850_billing_address.sql h1:m0ek3WXqRgS3+ZbSa/DcIMB16vb8Tjm2MgNqyRll3rU=
 20250109054654_remove_stripe_id.sql h1:OfeshKT2+ydfx+36e4uBrdQ31tuurcJsKXyYDp1ZiZg=
+20250110162830_subscription_price.sql h1:ju8ocKPbqtOalaBZ1aGk8qCDLbgxFCDoA0Dmkr9bLzA=

--- a/db/migrations/20250110162828_subscription_price.sql
+++ b/db/migrations/20250110162828_subscription_price.sql
@@ -1,0 +1,4 @@
+-- Modify "org_subscription_history" table
+ALTER TABLE "org_subscription_history" ADD COLUMN "product_price" jsonb NULL;
+-- Modify "org_subscriptions" table
+ALTER TABLE "org_subscriptions" ADD COLUMN "product_price" jsonb NULL;

--- a/db/migrations/atlas.sum
+++ b/db/migrations/atlas.sum
@@ -1,5 +1,6 @@
-h1:8AGIgzcKy+aGOwhLSJk/xgL6kfmXBArWQGmrkTdVur4=
+h1:erRnNniAqlfYXxANR5MxeFGdCDzegYYF35eOGuZi0Fg=
 20241211231032_init.sql h1:TxjpHzKPB/5L2i7V2JfO1y+Cep/AyQN5wGjhY7saCeE=
 20241212223712_consistent_naming.sql h1:tbdYOtixhW66Jmvy3aCm+X6neI/SRVvItKM0Bdn26TA=
 20250109002849_billing_address.sql h1:mspCGbJ6HVmx3r4j+d/WvruzirJdJ8u5x18WF9R9ESE=
 20250109054653_remove_stripe_id.sql h1:dB086/w/Ws7ZK8OvbRWX7ejN4HfizCKxcE3q/+Jv4U8=
+20250110162828_subscription_price.sql h1:RlvrTtH6+PIFuJ+Fp5S06w0ho3B2O/Nn6QcWqSHLWEA=

--- a/internal/ent/generated/auditing.go
+++ b/internal/ent/generated/auditing.go
@@ -1342,6 +1342,9 @@ func (osh *OrgSubscriptionHistory) changes(new *OrgSubscriptionHistory) []Change
 	if !reflect.DeepEqual(osh.ProductTier, new.ProductTier) {
 		changes = append(changes, NewChange(orgsubscriptionhistory.FieldProductTier, osh.ProductTier, new.ProductTier))
 	}
+	if !reflect.DeepEqual(osh.ProductPrice, new.ProductPrice) {
+		changes = append(changes, NewChange(orgsubscriptionhistory.FieldProductPrice, osh.ProductPrice, new.ProductPrice))
+	}
 	if !reflect.DeepEqual(osh.StripeProductTierID, new.StripeProductTierID) {
 		changes = append(changes, NewChange(orgsubscriptionhistory.FieldStripeProductTierID, osh.StripeProductTierID, new.StripeProductTierID))
 	}

--- a/internal/ent/generated/entql.go
+++ b/internal/ent/generated/entql.go
@@ -1212,6 +1212,7 @@ var schemaGraph = func() *sqlgraph.Schema {
 			orgsubscription.FieldOwnerID:                  {Type: field.TypeString, Column: orgsubscription.FieldOwnerID},
 			orgsubscription.FieldStripeSubscriptionID:     {Type: field.TypeString, Column: orgsubscription.FieldStripeSubscriptionID},
 			orgsubscription.FieldProductTier:              {Type: field.TypeString, Column: orgsubscription.FieldProductTier},
+			orgsubscription.FieldProductPrice:             {Type: field.TypeJSON, Column: orgsubscription.FieldProductPrice},
 			orgsubscription.FieldStripeProductTierID:      {Type: field.TypeString, Column: orgsubscription.FieldStripeProductTierID},
 			orgsubscription.FieldStripeSubscriptionStatus: {Type: field.TypeString, Column: orgsubscription.FieldStripeSubscriptionStatus},
 			orgsubscription.FieldActive:                   {Type: field.TypeBool, Column: orgsubscription.FieldActive},
@@ -1245,6 +1246,7 @@ var schemaGraph = func() *sqlgraph.Schema {
 			orgsubscriptionhistory.FieldOwnerID:                  {Type: field.TypeString, Column: orgsubscriptionhistory.FieldOwnerID},
 			orgsubscriptionhistory.FieldStripeSubscriptionID:     {Type: field.TypeString, Column: orgsubscriptionhistory.FieldStripeSubscriptionID},
 			orgsubscriptionhistory.FieldProductTier:              {Type: field.TypeString, Column: orgsubscriptionhistory.FieldProductTier},
+			orgsubscriptionhistory.FieldProductPrice:             {Type: field.TypeJSON, Column: orgsubscriptionhistory.FieldProductPrice},
 			orgsubscriptionhistory.FieldStripeProductTierID:      {Type: field.TypeString, Column: orgsubscriptionhistory.FieldStripeProductTierID},
 			orgsubscriptionhistory.FieldStripeSubscriptionStatus: {Type: field.TypeString, Column: orgsubscriptionhistory.FieldStripeSubscriptionStatus},
 			orgsubscriptionhistory.FieldActive:                   {Type: field.TypeBool, Column: orgsubscriptionhistory.FieldActive},
@@ -12123,6 +12125,11 @@ func (f *OrgSubscriptionFilter) WhereProductTier(p entql.StringP) {
 	f.Where(p.Field(orgsubscription.FieldProductTier))
 }
 
+// WhereProductPrice applies the entql json.RawMessage predicate on the product_price field.
+func (f *OrgSubscriptionFilter) WhereProductPrice(p entql.BytesP) {
+	f.Where(p.Field(orgsubscription.FieldProductPrice))
+}
+
 // WhereStripeProductTierID applies the entql string predicate on the stripe_product_tier_id field.
 func (f *OrgSubscriptionFilter) WhereStripeProductTierID(p entql.StringP) {
 	f.Where(p.Field(orgsubscription.FieldStripeProductTierID))
@@ -12275,6 +12282,11 @@ func (f *OrgSubscriptionHistoryFilter) WhereStripeSubscriptionID(p entql.StringP
 // WhereProductTier applies the entql string predicate on the product_tier field.
 func (f *OrgSubscriptionHistoryFilter) WhereProductTier(p entql.StringP) {
 	f.Where(p.Field(orgsubscriptionhistory.FieldProductTier))
+}
+
+// WhereProductPrice applies the entql json.RawMessage predicate on the product_price field.
+func (f *OrgSubscriptionHistoryFilter) WhereProductPrice(p entql.BytesP) {
+	f.Where(p.Field(orgsubscriptionhistory.FieldProductPrice))
 }
 
 // WhereStripeProductTierID applies the entql string predicate on the stripe_product_tier_id field.

--- a/internal/ent/generated/gql_collection.go
+++ b/internal/ent/generated/gql_collection.go
@@ -7338,6 +7338,11 @@ func (os *OrgSubscriptionQuery) collectField(ctx context.Context, oneNode bool, 
 				selectedFields = append(selectedFields, orgsubscription.FieldProductTier)
 				fieldSeen[orgsubscription.FieldProductTier] = struct{}{}
 			}
+		case "productPrice":
+			if _, ok := fieldSeen[orgsubscription.FieldProductPrice]; !ok {
+				selectedFields = append(selectedFields, orgsubscription.FieldProductPrice)
+				fieldSeen[orgsubscription.FieldProductPrice] = struct{}{}
+			}
 		case "stripeProductTierID":
 			if _, ok := fieldSeen[orgsubscription.FieldStripeProductTierID]; !ok {
 				selectedFields = append(selectedFields, orgsubscription.FieldStripeProductTierID)
@@ -7494,6 +7499,11 @@ func (osh *OrgSubscriptionHistoryQuery) collectField(ctx context.Context, oneNod
 			if _, ok := fieldSeen[orgsubscriptionhistory.FieldProductTier]; !ok {
 				selectedFields = append(selectedFields, orgsubscriptionhistory.FieldProductTier)
 				fieldSeen[orgsubscriptionhistory.FieldProductTier] = struct{}{}
+			}
+		case "productPrice":
+			if _, ok := fieldSeen[orgsubscriptionhistory.FieldProductPrice]; !ok {
+				selectedFields = append(selectedFields, orgsubscriptionhistory.FieldProductPrice)
+				fieldSeen[orgsubscriptionhistory.FieldProductPrice] = struct{}{}
 			}
 		case "stripeProductTierID":
 			if _, ok := fieldSeen[orgsubscriptionhistory.FieldStripeProductTierID]; !ok {

--- a/internal/ent/generated/history_from_mutation.go
+++ b/internal/ent/generated/history_from_mutation.go
@@ -4398,6 +4398,10 @@ func (m *OrgSubscriptionMutation) CreateHistoryFromCreate(ctx context.Context) e
 		create = create.SetProductTier(productTier)
 	}
 
+	if productPrice, exists := m.ProductPrice(); exists {
+		create = create.SetProductPrice(productPrice)
+	}
+
 	if stripeProductTierID, exists := m.StripeProductTierID(); exists {
 		create = create.SetStripeProductTierID(stripeProductTierID)
 	}
@@ -4518,6 +4522,12 @@ func (m *OrgSubscriptionMutation) CreateHistoryFromUpdate(ctx context.Context) e
 			create = create.SetProductTier(orgsubscription.ProductTier)
 		}
 
+		if productPrice, exists := m.ProductPrice(); exists {
+			create = create.SetProductPrice(productPrice)
+		} else {
+			create = create.SetProductPrice(orgsubscription.ProductPrice)
+		}
+
 		if stripeProductTierID, exists := m.StripeProductTierID(); exists {
 			create = create.SetStripeProductTierID(stripeProductTierID)
 		} else {
@@ -4597,6 +4607,7 @@ func (m *OrgSubscriptionMutation) CreateHistoryFromDelete(ctx context.Context) e
 			SetOwnerID(orgsubscription.OwnerID).
 			SetStripeSubscriptionID(orgsubscription.StripeSubscriptionID).
 			SetProductTier(orgsubscription.ProductTier).
+			SetProductPrice(orgsubscription.ProductPrice).
 			SetStripeProductTierID(orgsubscription.StripeProductTierID).
 			SetStripeSubscriptionStatus(orgsubscription.StripeSubscriptionStatus).
 			SetActive(orgsubscription.Active).

--- a/internal/ent/generated/migrate/schema.go
+++ b/internal/ent/generated/migrate/schema.go
@@ -1416,6 +1416,7 @@ var (
 		{Name: "deleted_by", Type: field.TypeString, Nullable: true},
 		{Name: "stripe_subscription_id", Type: field.TypeString, Nullable: true},
 		{Name: "product_tier", Type: field.TypeString, Nullable: true},
+		{Name: "product_price", Type: field.TypeJSON, Nullable: true},
 		{Name: "stripe_product_tier_id", Type: field.TypeString, Nullable: true},
 		{Name: "stripe_subscription_status", Type: field.TypeString, Nullable: true},
 		{Name: "active", Type: field.TypeBool, Default: true},
@@ -1432,7 +1433,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "org_subscriptions_organizations_org_subscriptions",
-				Columns:    []*schema.Column{OrgSubscriptionsColumns[17]},
+				Columns:    []*schema.Column{OrgSubscriptionsColumns[18]},
 				RefColumns: []*schema.Column{OrganizationsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -1455,6 +1456,7 @@ var (
 		{Name: "owner_id", Type: field.TypeString, Nullable: true},
 		{Name: "stripe_subscription_id", Type: field.TypeString, Nullable: true},
 		{Name: "product_tier", Type: field.TypeString, Nullable: true},
+		{Name: "product_price", Type: field.TypeJSON, Nullable: true},
 		{Name: "stripe_product_tier_id", Type: field.TypeString, Nullable: true},
 		{Name: "stripe_subscription_status", Type: field.TypeString, Nullable: true},
 		{Name: "active", Type: field.TypeBool, Default: true},

--- a/internal/ent/generated/mutation.go
+++ b/internal/ent/generated/mutation.go
@@ -64064,6 +64064,7 @@ type OrgSubscriptionMutation struct {
 	deleted_by                 *string
 	stripe_subscription_id     *string
 	product_tier               *string
+	product_price              *models.Price
 	stripe_product_tier_id     *string
 	stripe_subscription_status *string
 	active                     *bool
@@ -64725,6 +64726,55 @@ func (m *OrgSubscriptionMutation) ResetProductTier() {
 	delete(m.clearedFields, orgsubscription.FieldProductTier)
 }
 
+// SetProductPrice sets the "product_price" field.
+func (m *OrgSubscriptionMutation) SetProductPrice(value models.Price) {
+	m.product_price = &value
+}
+
+// ProductPrice returns the value of the "product_price" field in the mutation.
+func (m *OrgSubscriptionMutation) ProductPrice() (r models.Price, exists bool) {
+	v := m.product_price
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldProductPrice returns the old "product_price" field's value of the OrgSubscription entity.
+// If the OrgSubscription object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *OrgSubscriptionMutation) OldProductPrice(ctx context.Context) (v models.Price, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldProductPrice is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldProductPrice requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldProductPrice: %w", err)
+	}
+	return oldValue.ProductPrice, nil
+}
+
+// ClearProductPrice clears the value of the "product_price" field.
+func (m *OrgSubscriptionMutation) ClearProductPrice() {
+	m.product_price = nil
+	m.clearedFields[orgsubscription.FieldProductPrice] = struct{}{}
+}
+
+// ProductPriceCleared returns if the "product_price" field was cleared in this mutation.
+func (m *OrgSubscriptionMutation) ProductPriceCleared() bool {
+	_, ok := m.clearedFields[orgsubscription.FieldProductPrice]
+	return ok
+}
+
+// ResetProductPrice resets all changes to the "product_price" field.
+func (m *OrgSubscriptionMutation) ResetProductPrice() {
+	m.product_price = nil
+	delete(m.clearedFields, orgsubscription.FieldProductPrice)
+}
+
 // SetStripeProductTierID sets the "stripe_product_tier_id" field.
 func (m *OrgSubscriptionMutation) SetStripeProductTierID(s string) {
 	m.stripe_product_tier_id = &s
@@ -65083,7 +65133,7 @@ func (m *OrgSubscriptionMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *OrgSubscriptionMutation) Fields() []string {
-	fields := make([]string, 0, 17)
+	fields := make([]string, 0, 18)
 	if m.created_at != nil {
 		fields = append(fields, orgsubscription.FieldCreatedAt)
 	}
@@ -65116,6 +65166,9 @@ func (m *OrgSubscriptionMutation) Fields() []string {
 	}
 	if m.product_tier != nil {
 		fields = append(fields, orgsubscription.FieldProductTier)
+	}
+	if m.product_price != nil {
+		fields = append(fields, orgsubscription.FieldProductPrice)
 	}
 	if m.stripe_product_tier_id != nil {
 		fields = append(fields, orgsubscription.FieldStripeProductTierID)
@@ -65165,6 +65218,8 @@ func (m *OrgSubscriptionMutation) Field(name string) (ent.Value, bool) {
 		return m.StripeSubscriptionID()
 	case orgsubscription.FieldProductTier:
 		return m.ProductTier()
+	case orgsubscription.FieldProductPrice:
+		return m.ProductPrice()
 	case orgsubscription.FieldStripeProductTierID:
 		return m.StripeProductTierID()
 	case orgsubscription.FieldStripeSubscriptionStatus:
@@ -65208,6 +65263,8 @@ func (m *OrgSubscriptionMutation) OldField(ctx context.Context, name string) (en
 		return m.OldStripeSubscriptionID(ctx)
 	case orgsubscription.FieldProductTier:
 		return m.OldProductTier(ctx)
+	case orgsubscription.FieldProductPrice:
+		return m.OldProductPrice(ctx)
 	case orgsubscription.FieldStripeProductTierID:
 		return m.OldStripeProductTierID(ctx)
 	case orgsubscription.FieldStripeSubscriptionStatus:
@@ -65305,6 +65362,13 @@ func (m *OrgSubscriptionMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetProductTier(v)
+		return nil
+	case orgsubscription.FieldProductPrice:
+		v, ok := value.(models.Price)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetProductPrice(v)
 		return nil
 	case orgsubscription.FieldStripeProductTierID:
 		v, ok := value.(string)
@@ -65408,6 +65472,9 @@ func (m *OrgSubscriptionMutation) ClearedFields() []string {
 	if m.FieldCleared(orgsubscription.FieldProductTier) {
 		fields = append(fields, orgsubscription.FieldProductTier)
 	}
+	if m.FieldCleared(orgsubscription.FieldProductPrice) {
+		fields = append(fields, orgsubscription.FieldProductPrice)
+	}
 	if m.FieldCleared(orgsubscription.FieldStripeProductTierID) {
 		fields = append(fields, orgsubscription.FieldStripeProductTierID)
 	}
@@ -65467,6 +65534,9 @@ func (m *OrgSubscriptionMutation) ClearField(name string) error {
 	case orgsubscription.FieldProductTier:
 		m.ClearProductTier()
 		return nil
+	case orgsubscription.FieldProductPrice:
+		m.ClearProductPrice()
+		return nil
 	case orgsubscription.FieldStripeProductTierID:
 		m.ClearStripeProductTierID()
 		return nil
@@ -65522,6 +65592,9 @@ func (m *OrgSubscriptionMutation) ResetField(name string) error {
 		return nil
 	case orgsubscription.FieldProductTier:
 		m.ResetProductTier()
+		return nil
+	case orgsubscription.FieldProductPrice:
+		m.ResetProductPrice()
 		return nil
 	case orgsubscription.FieldStripeProductTierID:
 		m.ResetStripeProductTierID()
@@ -65640,6 +65713,7 @@ type OrgSubscriptionHistoryMutation struct {
 	owner_id                   *string
 	stripe_subscription_id     *string
 	product_tier               *string
+	product_price              *models.Price
 	stripe_product_tier_id     *string
 	stripe_subscription_status *string
 	active                     *bool
@@ -66420,6 +66494,55 @@ func (m *OrgSubscriptionHistoryMutation) ResetProductTier() {
 	delete(m.clearedFields, orgsubscriptionhistory.FieldProductTier)
 }
 
+// SetProductPrice sets the "product_price" field.
+func (m *OrgSubscriptionHistoryMutation) SetProductPrice(value models.Price) {
+	m.product_price = &value
+}
+
+// ProductPrice returns the value of the "product_price" field in the mutation.
+func (m *OrgSubscriptionHistoryMutation) ProductPrice() (r models.Price, exists bool) {
+	v := m.product_price
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldProductPrice returns the old "product_price" field's value of the OrgSubscriptionHistory entity.
+// If the OrgSubscriptionHistory object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *OrgSubscriptionHistoryMutation) OldProductPrice(ctx context.Context) (v models.Price, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldProductPrice is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldProductPrice requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldProductPrice: %w", err)
+	}
+	return oldValue.ProductPrice, nil
+}
+
+// ClearProductPrice clears the value of the "product_price" field.
+func (m *OrgSubscriptionHistoryMutation) ClearProductPrice() {
+	m.product_price = nil
+	m.clearedFields[orgsubscriptionhistory.FieldProductPrice] = struct{}{}
+}
+
+// ProductPriceCleared returns if the "product_price" field was cleared in this mutation.
+func (m *OrgSubscriptionHistoryMutation) ProductPriceCleared() bool {
+	_, ok := m.clearedFields[orgsubscriptionhistory.FieldProductPrice]
+	return ok
+}
+
+// ResetProductPrice resets all changes to the "product_price" field.
+func (m *OrgSubscriptionHistoryMutation) ResetProductPrice() {
+	m.product_price = nil
+	delete(m.clearedFields, orgsubscriptionhistory.FieldProductPrice)
+}
+
 // SetStripeProductTierID sets the "stripe_product_tier_id" field.
 func (m *OrgSubscriptionHistoryMutation) SetStripeProductTierID(s string) {
 	m.stripe_product_tier_id = &s
@@ -66751,7 +66874,7 @@ func (m *OrgSubscriptionHistoryMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *OrgSubscriptionHistoryMutation) Fields() []string {
-	fields := make([]string, 0, 20)
+	fields := make([]string, 0, 21)
 	if m.history_time != nil {
 		fields = append(fields, orgsubscriptionhistory.FieldHistoryTime)
 	}
@@ -66793,6 +66916,9 @@ func (m *OrgSubscriptionHistoryMutation) Fields() []string {
 	}
 	if m.product_tier != nil {
 		fields = append(fields, orgsubscriptionhistory.FieldProductTier)
+	}
+	if m.product_price != nil {
+		fields = append(fields, orgsubscriptionhistory.FieldProductPrice)
 	}
 	if m.stripe_product_tier_id != nil {
 		fields = append(fields, orgsubscriptionhistory.FieldStripeProductTierID)
@@ -66848,6 +66974,8 @@ func (m *OrgSubscriptionHistoryMutation) Field(name string) (ent.Value, bool) {
 		return m.StripeSubscriptionID()
 	case orgsubscriptionhistory.FieldProductTier:
 		return m.ProductTier()
+	case orgsubscriptionhistory.FieldProductPrice:
+		return m.ProductPrice()
 	case orgsubscriptionhistory.FieldStripeProductTierID:
 		return m.StripeProductTierID()
 	case orgsubscriptionhistory.FieldStripeSubscriptionStatus:
@@ -66897,6 +67025,8 @@ func (m *OrgSubscriptionHistoryMutation) OldField(ctx context.Context, name stri
 		return m.OldStripeSubscriptionID(ctx)
 	case orgsubscriptionhistory.FieldProductTier:
 		return m.OldProductTier(ctx)
+	case orgsubscriptionhistory.FieldProductPrice:
+		return m.OldProductPrice(ctx)
 	case orgsubscriptionhistory.FieldStripeProductTierID:
 		return m.OldStripeProductTierID(ctx)
 	case orgsubscriptionhistory.FieldStripeSubscriptionStatus:
@@ -67016,6 +67146,13 @@ func (m *OrgSubscriptionHistoryMutation) SetField(name string, value ent.Value) 
 		}
 		m.SetProductTier(v)
 		return nil
+	case orgsubscriptionhistory.FieldProductPrice:
+		v, ok := value.(models.Price)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetProductPrice(v)
+		return nil
 	case orgsubscriptionhistory.FieldStripeProductTierID:
 		v, ok := value.(string)
 		if !ok {
@@ -67121,6 +67258,9 @@ func (m *OrgSubscriptionHistoryMutation) ClearedFields() []string {
 	if m.FieldCleared(orgsubscriptionhistory.FieldProductTier) {
 		fields = append(fields, orgsubscriptionhistory.FieldProductTier)
 	}
+	if m.FieldCleared(orgsubscriptionhistory.FieldProductPrice) {
+		fields = append(fields, orgsubscriptionhistory.FieldProductPrice)
+	}
 	if m.FieldCleared(orgsubscriptionhistory.FieldStripeProductTierID) {
 		fields = append(fields, orgsubscriptionhistory.FieldStripeProductTierID)
 	}
@@ -67182,6 +67322,9 @@ func (m *OrgSubscriptionHistoryMutation) ClearField(name string) error {
 		return nil
 	case orgsubscriptionhistory.FieldProductTier:
 		m.ClearProductTier()
+		return nil
+	case orgsubscriptionhistory.FieldProductPrice:
+		m.ClearProductPrice()
 		return nil
 	case orgsubscriptionhistory.FieldStripeProductTierID:
 		m.ClearStripeProductTierID()
@@ -67247,6 +67390,9 @@ func (m *OrgSubscriptionHistoryMutation) ResetField(name string) error {
 		return nil
 	case orgsubscriptionhistory.FieldProductTier:
 		m.ResetProductTier()
+		return nil
+	case orgsubscriptionhistory.FieldProductPrice:
+		m.ResetProductPrice()
 		return nil
 	case orgsubscriptionhistory.FieldStripeProductTierID:
 		m.ResetStripeProductTierID()

--- a/internal/ent/generated/orgsubscription/orgsubscription.go
+++ b/internal/ent/generated/orgsubscription/orgsubscription.go
@@ -37,6 +37,8 @@ const (
 	FieldStripeSubscriptionID = "stripe_subscription_id"
 	// FieldProductTier holds the string denoting the product_tier field in the database.
 	FieldProductTier = "product_tier"
+	// FieldProductPrice holds the string denoting the product_price field in the database.
+	FieldProductPrice = "product_price"
 	// FieldStripeProductTierID holds the string denoting the stripe_product_tier_id field in the database.
 	FieldStripeProductTierID = "stripe_product_tier_id"
 	// FieldStripeSubscriptionStatus holds the string denoting the stripe_subscription_status field in the database.
@@ -76,6 +78,7 @@ var Columns = []string{
 	FieldOwnerID,
 	FieldStripeSubscriptionID,
 	FieldProductTier,
+	FieldProductPrice,
 	FieldStripeProductTierID,
 	FieldStripeSubscriptionStatus,
 	FieldActive,

--- a/internal/ent/generated/orgsubscription/where.go
+++ b/internal/ent/generated/orgsubscription/where.go
@@ -817,6 +817,16 @@ func ProductTierContainsFold(v string) predicate.OrgSubscription {
 	return predicate.OrgSubscription(sql.FieldContainsFold(FieldProductTier, v))
 }
 
+// ProductPriceIsNil applies the IsNil predicate on the "product_price" field.
+func ProductPriceIsNil() predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldIsNull(FieldProductPrice))
+}
+
+// ProductPriceNotNil applies the NotNil predicate on the "product_price" field.
+func ProductPriceNotNil() predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldNotNull(FieldProductPrice))
+}
+
 // StripeProductTierIDEQ applies the EQ predicate on the "stripe_product_tier_id" field.
 func StripeProductTierIDEQ(v string) predicate.OrgSubscription {
 	return predicate.OrgSubscription(sql.FieldEQ(FieldStripeProductTierID, v))

--- a/internal/ent/generated/orgsubscription_create.go
+++ b/internal/ent/generated/orgsubscription_create.go
@@ -12,6 +12,7 @@ import (
 	"entgo.io/ent/schema/field"
 	"github.com/theopenlane/core/internal/ent/generated/organization"
 	"github.com/theopenlane/core/internal/ent/generated/orgsubscription"
+	"github.com/theopenlane/core/pkg/models"
 )
 
 // OrgSubscriptionCreate is the builder for creating a OrgSubscription entity.
@@ -163,6 +164,20 @@ func (osc *OrgSubscriptionCreate) SetProductTier(s string) *OrgSubscriptionCreat
 func (osc *OrgSubscriptionCreate) SetNillableProductTier(s *string) *OrgSubscriptionCreate {
 	if s != nil {
 		osc.SetProductTier(*s)
+	}
+	return osc
+}
+
+// SetProductPrice sets the "product_price" field.
+func (osc *OrgSubscriptionCreate) SetProductPrice(m models.Price) *OrgSubscriptionCreate {
+	osc.mutation.SetProductPrice(m)
+	return osc
+}
+
+// SetNillableProductPrice sets the "product_price" field if the given value is not nil.
+func (osc *OrgSubscriptionCreate) SetNillableProductPrice(m *models.Price) *OrgSubscriptionCreate {
+	if m != nil {
+		osc.SetProductPrice(*m)
 	}
 	return osc
 }
@@ -426,6 +441,10 @@ func (osc *OrgSubscriptionCreate) createSpec() (*OrgSubscription, *sqlgraph.Crea
 	if value, ok := osc.mutation.ProductTier(); ok {
 		_spec.SetField(orgsubscription.FieldProductTier, field.TypeString, value)
 		_node.ProductTier = value
+	}
+	if value, ok := osc.mutation.ProductPrice(); ok {
+		_spec.SetField(orgsubscription.FieldProductPrice, field.TypeJSON, value)
+		_node.ProductPrice = value
 	}
 	if value, ok := osc.mutation.StripeProductTierID(); ok {
 		_spec.SetField(orgsubscription.FieldStripeProductTierID, field.TypeString, value)

--- a/internal/ent/generated/orgsubscription_update.go
+++ b/internal/ent/generated/orgsubscription_update.go
@@ -15,6 +15,7 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated/organization"
 	"github.com/theopenlane/core/internal/ent/generated/orgsubscription"
 	"github.com/theopenlane/core/internal/ent/generated/predicate"
+	"github.com/theopenlane/core/pkg/models"
 
 	"github.com/theopenlane/core/internal/ent/generated/internal"
 )
@@ -180,6 +181,26 @@ func (osu *OrgSubscriptionUpdate) SetNillableProductTier(s *string) *OrgSubscrip
 // ClearProductTier clears the value of the "product_tier" field.
 func (osu *OrgSubscriptionUpdate) ClearProductTier() *OrgSubscriptionUpdate {
 	osu.mutation.ClearProductTier()
+	return osu
+}
+
+// SetProductPrice sets the "product_price" field.
+func (osu *OrgSubscriptionUpdate) SetProductPrice(m models.Price) *OrgSubscriptionUpdate {
+	osu.mutation.SetProductPrice(m)
+	return osu
+}
+
+// SetNillableProductPrice sets the "product_price" field if the given value is not nil.
+func (osu *OrgSubscriptionUpdate) SetNillableProductPrice(m *models.Price) *OrgSubscriptionUpdate {
+	if m != nil {
+		osu.SetProductPrice(*m)
+	}
+	return osu
+}
+
+// ClearProductPrice clears the value of the "product_price" field.
+func (osu *OrgSubscriptionUpdate) ClearProductPrice() *OrgSubscriptionUpdate {
+	osu.mutation.ClearProductPrice()
 	return osu
 }
 
@@ -434,6 +455,12 @@ func (osu *OrgSubscriptionUpdate) sqlSave(ctx context.Context) (n int, err error
 	if osu.mutation.ProductTierCleared() {
 		_spec.ClearField(orgsubscription.FieldProductTier, field.TypeString)
 	}
+	if value, ok := osu.mutation.ProductPrice(); ok {
+		_spec.SetField(orgsubscription.FieldProductPrice, field.TypeJSON, value)
+	}
+	if osu.mutation.ProductPriceCleared() {
+		_spec.ClearField(orgsubscription.FieldProductPrice, field.TypeJSON)
+	}
 	if value, ok := osu.mutation.StripeProductTierID(); ok {
 		_spec.SetField(orgsubscription.FieldStripeProductTierID, field.TypeString, value)
 	}
@@ -674,6 +701,26 @@ func (osuo *OrgSubscriptionUpdateOne) SetNillableProductTier(s *string) *OrgSubs
 // ClearProductTier clears the value of the "product_tier" field.
 func (osuo *OrgSubscriptionUpdateOne) ClearProductTier() *OrgSubscriptionUpdateOne {
 	osuo.mutation.ClearProductTier()
+	return osuo
+}
+
+// SetProductPrice sets the "product_price" field.
+func (osuo *OrgSubscriptionUpdateOne) SetProductPrice(m models.Price) *OrgSubscriptionUpdateOne {
+	osuo.mutation.SetProductPrice(m)
+	return osuo
+}
+
+// SetNillableProductPrice sets the "product_price" field if the given value is not nil.
+func (osuo *OrgSubscriptionUpdateOne) SetNillableProductPrice(m *models.Price) *OrgSubscriptionUpdateOne {
+	if m != nil {
+		osuo.SetProductPrice(*m)
+	}
+	return osuo
+}
+
+// ClearProductPrice clears the value of the "product_price" field.
+func (osuo *OrgSubscriptionUpdateOne) ClearProductPrice() *OrgSubscriptionUpdateOne {
+	osuo.mutation.ClearProductPrice()
 	return osuo
 }
 
@@ -957,6 +1004,12 @@ func (osuo *OrgSubscriptionUpdateOne) sqlSave(ctx context.Context) (_node *OrgSu
 	}
 	if osuo.mutation.ProductTierCleared() {
 		_spec.ClearField(orgsubscription.FieldProductTier, field.TypeString)
+	}
+	if value, ok := osuo.mutation.ProductPrice(); ok {
+		_spec.SetField(orgsubscription.FieldProductPrice, field.TypeJSON, value)
+	}
+	if osuo.mutation.ProductPriceCleared() {
+		_spec.ClearField(orgsubscription.FieldProductPrice, field.TypeJSON)
 	}
 	if value, ok := osuo.mutation.StripeProductTierID(); ok {
 		_spec.SetField(orgsubscription.FieldStripeProductTierID, field.TypeString, value)

--- a/internal/ent/generated/orgsubscriptionhistory/orgsubscriptionhistory.go
+++ b/internal/ent/generated/orgsubscriptionhistory/orgsubscriptionhistory.go
@@ -44,6 +44,8 @@ const (
 	FieldStripeSubscriptionID = "stripe_subscription_id"
 	// FieldProductTier holds the string denoting the product_tier field in the database.
 	FieldProductTier = "product_tier"
+	// FieldProductPrice holds the string denoting the product_price field in the database.
+	FieldProductPrice = "product_price"
 	// FieldStripeProductTierID holds the string denoting the stripe_product_tier_id field in the database.
 	FieldStripeProductTierID = "stripe_product_tier_id"
 	// FieldStripeSubscriptionStatus holds the string denoting the stripe_subscription_status field in the database.
@@ -77,6 +79,7 @@ var Columns = []string{
 	FieldOwnerID,
 	FieldStripeSubscriptionID,
 	FieldProductTier,
+	FieldProductPrice,
 	FieldStripeProductTierID,
 	FieldStripeSubscriptionStatus,
 	FieldActive,

--- a/internal/ent/generated/orgsubscriptionhistory/where.go
+++ b/internal/ent/generated/orgsubscriptionhistory/where.go
@@ -960,6 +960,16 @@ func ProductTierContainsFold(v string) predicate.OrgSubscriptionHistory {
 	return predicate.OrgSubscriptionHistory(sql.FieldContainsFold(FieldProductTier, v))
 }
 
+// ProductPriceIsNil applies the IsNil predicate on the "product_price" field.
+func ProductPriceIsNil() predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldIsNull(FieldProductPrice))
+}
+
+// ProductPriceNotNil applies the NotNil predicate on the "product_price" field.
+func ProductPriceNotNil() predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldNotNull(FieldProductPrice))
+}
+
 // StripeProductTierIDEQ applies the EQ predicate on the "stripe_product_tier_id" field.
 func StripeProductTierIDEQ(v string) predicate.OrgSubscriptionHistory {
 	return predicate.OrgSubscriptionHistory(sql.FieldEQ(FieldStripeProductTierID, v))

--- a/internal/ent/generated/orgsubscriptionhistory_create.go
+++ b/internal/ent/generated/orgsubscriptionhistory_create.go
@@ -11,6 +11,7 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/theopenlane/core/internal/ent/generated/orgsubscriptionhistory"
+	"github.com/theopenlane/core/pkg/models"
 	"github.com/theopenlane/entx/history"
 )
 
@@ -197,6 +198,20 @@ func (oshc *OrgSubscriptionHistoryCreate) SetProductTier(s string) *OrgSubscript
 func (oshc *OrgSubscriptionHistoryCreate) SetNillableProductTier(s *string) *OrgSubscriptionHistoryCreate {
 	if s != nil {
 		oshc.SetProductTier(*s)
+	}
+	return oshc
+}
+
+// SetProductPrice sets the "product_price" field.
+func (oshc *OrgSubscriptionHistoryCreate) SetProductPrice(m models.Price) *OrgSubscriptionHistoryCreate {
+	oshc.mutation.SetProductPrice(m)
+	return oshc
+}
+
+// SetNillableProductPrice sets the "product_price" field if the given value is not nil.
+func (oshc *OrgSubscriptionHistoryCreate) SetNillableProductPrice(m *models.Price) *OrgSubscriptionHistoryCreate {
+	if m != nil {
+		oshc.SetProductPrice(*m)
 	}
 	return oshc
 }
@@ -466,6 +481,10 @@ func (oshc *OrgSubscriptionHistoryCreate) createSpec() (*OrgSubscriptionHistory,
 	if value, ok := oshc.mutation.ProductTier(); ok {
 		_spec.SetField(orgsubscriptionhistory.FieldProductTier, field.TypeString, value)
 		_node.ProductTier = value
+	}
+	if value, ok := oshc.mutation.ProductPrice(); ok {
+		_spec.SetField(orgsubscriptionhistory.FieldProductPrice, field.TypeJSON, value)
+		_node.ProductPrice = value
 	}
 	if value, ok := oshc.mutation.StripeProductTierID(); ok {
 		_spec.SetField(orgsubscriptionhistory.FieldStripeProductTierID, field.TypeString, value)

--- a/internal/ent/generated/orgsubscriptionhistory_update.go
+++ b/internal/ent/generated/orgsubscriptionhistory_update.go
@@ -14,6 +14,7 @@ import (
 	"entgo.io/ent/schema/field"
 	"github.com/theopenlane/core/internal/ent/generated/orgsubscriptionhistory"
 	"github.com/theopenlane/core/internal/ent/generated/predicate"
+	"github.com/theopenlane/core/pkg/models"
 
 	"github.com/theopenlane/core/internal/ent/generated/internal"
 )
@@ -179,6 +180,26 @@ func (oshu *OrgSubscriptionHistoryUpdate) SetNillableProductTier(s *string) *Org
 // ClearProductTier clears the value of the "product_tier" field.
 func (oshu *OrgSubscriptionHistoryUpdate) ClearProductTier() *OrgSubscriptionHistoryUpdate {
 	oshu.mutation.ClearProductTier()
+	return oshu
+}
+
+// SetProductPrice sets the "product_price" field.
+func (oshu *OrgSubscriptionHistoryUpdate) SetProductPrice(m models.Price) *OrgSubscriptionHistoryUpdate {
+	oshu.mutation.SetProductPrice(m)
+	return oshu
+}
+
+// SetNillableProductPrice sets the "product_price" field if the given value is not nil.
+func (oshu *OrgSubscriptionHistoryUpdate) SetNillableProductPrice(m *models.Price) *OrgSubscriptionHistoryUpdate {
+	if m != nil {
+		oshu.SetProductPrice(*m)
+	}
+	return oshu
+}
+
+// ClearProductPrice clears the value of the "product_price" field.
+func (oshu *OrgSubscriptionHistoryUpdate) ClearProductPrice() *OrgSubscriptionHistoryUpdate {
+	oshu.mutation.ClearProductPrice()
 	return oshu
 }
 
@@ -412,6 +433,12 @@ func (oshu *OrgSubscriptionHistoryUpdate) sqlSave(ctx context.Context) (n int, e
 	if oshu.mutation.ProductTierCleared() {
 		_spec.ClearField(orgsubscriptionhistory.FieldProductTier, field.TypeString)
 	}
+	if value, ok := oshu.mutation.ProductPrice(); ok {
+		_spec.SetField(orgsubscriptionhistory.FieldProductPrice, field.TypeJSON, value)
+	}
+	if oshu.mutation.ProductPriceCleared() {
+		_spec.ClearField(orgsubscriptionhistory.FieldProductPrice, field.TypeJSON)
+	}
 	if value, ok := oshu.mutation.StripeProductTierID(); ok {
 		_spec.SetField(orgsubscriptionhistory.FieldStripeProductTierID, field.TypeString, value)
 	}
@@ -621,6 +648,26 @@ func (oshuo *OrgSubscriptionHistoryUpdateOne) SetNillableProductTier(s *string) 
 // ClearProductTier clears the value of the "product_tier" field.
 func (oshuo *OrgSubscriptionHistoryUpdateOne) ClearProductTier() *OrgSubscriptionHistoryUpdateOne {
 	oshuo.mutation.ClearProductTier()
+	return oshuo
+}
+
+// SetProductPrice sets the "product_price" field.
+func (oshuo *OrgSubscriptionHistoryUpdateOne) SetProductPrice(m models.Price) *OrgSubscriptionHistoryUpdateOne {
+	oshuo.mutation.SetProductPrice(m)
+	return oshuo
+}
+
+// SetNillableProductPrice sets the "product_price" field if the given value is not nil.
+func (oshuo *OrgSubscriptionHistoryUpdateOne) SetNillableProductPrice(m *models.Price) *OrgSubscriptionHistoryUpdateOne {
+	if m != nil {
+		oshuo.SetProductPrice(*m)
+	}
+	return oshuo
+}
+
+// ClearProductPrice clears the value of the "product_price" field.
+func (oshuo *OrgSubscriptionHistoryUpdateOne) ClearProductPrice() *OrgSubscriptionHistoryUpdateOne {
+	oshuo.mutation.ClearProductPrice()
 	return oshuo
 }
 
@@ -883,6 +930,12 @@ func (oshuo *OrgSubscriptionHistoryUpdateOne) sqlSave(ctx context.Context) (_nod
 	}
 	if oshuo.mutation.ProductTierCleared() {
 		_spec.ClearField(orgsubscriptionhistory.FieldProductTier, field.TypeString)
+	}
+	if value, ok := oshuo.mutation.ProductPrice(); ok {
+		_spec.SetField(orgsubscriptionhistory.FieldProductPrice, field.TypeJSON, value)
+	}
+	if oshuo.mutation.ProductPriceCleared() {
+		_spec.ClearField(orgsubscriptionhistory.FieldProductPrice, field.TypeJSON)
 	}
 	if value, ok := oshuo.mutation.StripeProductTierID(); ok {
 		_spec.SetField(orgsubscriptionhistory.FieldStripeProductTierID, field.TypeString, value)

--- a/internal/ent/generated/runtime/runtime.go
+++ b/internal/ent/generated/runtime/runtime.go
@@ -2191,7 +2191,7 @@ func init() {
 	// orgsubscription.OwnerIDValidator is a validator for the "owner_id" field. It is called by the builders before save.
 	orgsubscription.OwnerIDValidator = orgsubscriptionDescOwnerID.Validators[0].(func(string) error)
 	// orgsubscriptionDescActive is the schema descriptor for active field.
-	orgsubscriptionDescActive := orgsubscriptionFields[4].Descriptor()
+	orgsubscriptionDescActive := orgsubscriptionFields[5].Descriptor()
 	// orgsubscription.DefaultActive holds the default value on creation for the active field.
 	orgsubscription.DefaultActive = orgsubscriptionDescActive.Default.(bool)
 	// orgsubscriptionDescID is the schema descriptor for id field.
@@ -2223,7 +2223,7 @@ func init() {
 	// orgsubscriptionhistory.DefaultTags holds the default value on creation for the tags field.
 	orgsubscriptionhistory.DefaultTags = orgsubscriptionhistoryDescTags.Default.([]string)
 	// orgsubscriptionhistoryDescActive is the schema descriptor for active field.
-	orgsubscriptionhistoryDescActive := orgsubscriptionhistoryFields[17].Descriptor()
+	orgsubscriptionhistoryDescActive := orgsubscriptionhistoryFields[18].Descriptor()
 	// orgsubscriptionhistory.DefaultActive holds the default value on creation for the active field.
 	orgsubscriptionhistory.DefaultActive = orgsubscriptionhistoryDescActive.Default.(bool)
 	// orgsubscriptionhistoryDescID is the schema descriptor for id field.

--- a/internal/ent/interceptors/orgsubscription.go
+++ b/internal/ent/interceptors/orgsubscription.go
@@ -20,6 +20,11 @@ func InterceptorSubscriptionURL() ent.Interceptor {
 			}
 
 			// get the fields that were queried and check for the SubscriptionURL field
+			// skip if there isn't a graphql context
+			if ok := graphql.HasOperationContext(ctx); !ok {
+				return v, nil
+			}
+
 			fields := graphql.CollectFieldsCtx(ctx, []string{"SubscriptionURL"})
 
 			// if the SubscriptionURL field wasn't queried, return the result as is

--- a/internal/ent/interceptors/orgsubscription.go
+++ b/internal/ent/interceptors/orgsubscription.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"entgo.io/ent"
-	"github.com/99designs/gqlgen/graphql"
 	"github.com/rs/zerolog/log"
 
 	"github.com/theopenlane/core/internal/ent/generated"
@@ -20,12 +19,7 @@ func InterceptorSubscriptionURL() ent.Interceptor {
 				return nil, err
 			}
 
-			// get the fields that were queried and check for the SubscriptionURL field
-			// skip if there isn't a graphql context
-			if ok := graphql.HasOperationContext(ctx); !ok {
-				return v, nil
-			}
-
+			// get the fields that were queried and check for the subscriptionURL field
 			fields := utils.CheckForRequestedField(ctx, "subscriptionURL")
 
 			// if the SubscriptionURL field wasn't queried, return the result as is

--- a/internal/ent/interceptors/orgsubscription.go
+++ b/internal/ent/interceptors/orgsubscription.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/intercept"
+	"github.com/theopenlane/core/internal/ent/utils"
 )
 
 func InterceptorSubscriptionURL() ent.Interceptor {
@@ -25,10 +26,10 @@ func InterceptorSubscriptionURL() ent.Interceptor {
 				return v, nil
 			}
 
-			fields := graphql.CollectFieldsCtx(ctx, []string{"SubscriptionURL"})
+			fields := utils.CheckForRequestedField(ctx, "subscriptionURL")
 
 			// if the SubscriptionURL field wasn't queried, return the result as is
-			if len(fields) == 0 {
+			if fields == false {
 				return v, nil
 			}
 

--- a/internal/ent/interceptors/orgsubscription.go
+++ b/internal/ent/interceptors/orgsubscription.go
@@ -29,7 +29,7 @@ func InterceptorSubscriptionURL() ent.Interceptor {
 			fields := utils.CheckForRequestedField(ctx, "subscriptionURL")
 
 			// if the SubscriptionURL field wasn't queried, return the result as is
-			if fields == false {
+			if !fields {
 				return v, nil
 			}
 

--- a/internal/ent/schema/orgsubscription.go
+++ b/internal/ent/schema/orgsubscription.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/theopenlane/core/internal/ent/interceptors"
 	"github.com/theopenlane/core/internal/ent/mixin"
+	"github.com/theopenlane/core/pkg/models"
 )
 
 // OrgSubscription holds the schema definition for the OrgSubscription entity
@@ -25,6 +26,9 @@ func (OrgSubscription) Fields() []ent.Field {
 			Optional(),
 		field.String("product_tier").
 			Comment("the common name of the product tier the subscription is associated with, e.g. starter tier").
+			Optional(),
+		field.JSON("product_price", models.Price{}).
+			Comment("the price of the product tier").
 			Optional(),
 		field.String("stripe_product_tier_id").
 			Comment("the product id that represents the tier in stripe").

--- a/internal/ent/utils/graphql.go
+++ b/internal/ent/utils/graphql.go
@@ -46,6 +46,7 @@ func getNestedPreloads(ctx *graphql.OperationContext, fields []graphql.Collected
 		preloads = append(preloads, prefixColumn)
 		preloads = append(preloads, getNestedPreloads(ctx, graphql.CollectFields(ctx, column.Selections, nil), prefixColumn)...)
 	}
+
 	return
 }
 
@@ -54,5 +55,6 @@ func getPreloadString(prefix, name string) string {
 	if len(prefix) > 0 {
 		return prefix + "." + name
 	}
+
 	return name
 }

--- a/internal/ent/utils/graphql.go
+++ b/internal/ent/utils/graphql.go
@@ -27,6 +27,11 @@ func CheckForRequestedField(ctx context.Context, fieldName string) bool {
 
 // GetPreloads returns the preloads for the current graphql operation
 func GetPreloads(ctx context.Context) []string {
+	// skip if the context is not a graphql operation context
+	if ok := graphql.HasOperationContext(ctx); !ok {
+		return nil
+	}
+
 	gCtx := graphql.GetOperationContext(ctx)
 	if gCtx == nil {
 		return nil

--- a/internal/ent/utils/graphql.go
+++ b/internal/ent/utils/graphql.go
@@ -1,0 +1,58 @@
+package utils
+
+import (
+	"context"
+	"strings"
+
+	"github.com/99designs/gqlgen/graphql"
+)
+
+// CheckForRequestedField checks if the requested field is in the list of fields
+func CheckForRequestedField(ctx context.Context, fieldName string) bool {
+	fields := GetPreloads(ctx)
+	if fields == nil {
+		return false
+	}
+
+	for _, f := range fields {
+		// fields are in the format of "parent.parent.fieldName", e.g. "organization.orgSubscription.subscriptionURL"
+		// so we check if the fieldName is in the string and not just equal to it
+		if strings.Contains(f, fieldName) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// GetPreloads returns the preloads for the current graphql operation
+func GetPreloads(ctx context.Context) []string {
+	gCtx := graphql.GetOperationContext(ctx)
+	if gCtx == nil {
+		return nil
+	}
+
+	return getNestedPreloads(
+		gCtx,
+		graphql.CollectFieldsCtx(ctx, nil),
+		"",
+	)
+}
+
+// getNestedPreloads returns the nested preloads for the current graphql operation
+func getNestedPreloads(ctx *graphql.OperationContext, fields []graphql.CollectedField, prefix string) (preloads []string) {
+	for _, column := range fields {
+		prefixColumn := getPreloadString(prefix, column.Name)
+		preloads = append(preloads, prefixColumn)
+		preloads = append(preloads, getNestedPreloads(ctx, graphql.CollectFields(ctx, column.Selections, nil), prefixColumn)...)
+	}
+	return
+}
+
+// getPreloadString returns the preload string for the given prefix and name
+func getPreloadString(prefix, name string) string {
+	if len(prefix) > 0 {
+		return prefix + "." + name
+	}
+	return name
+}

--- a/internal/graphapi/clientschema/schema.graphql
+++ b/internal/graphapi/clientschema/schema.graphql
@@ -15877,6 +15877,10 @@ type OrgSubscription implements Node {
 	"""
 	productTier: String
 	"""
+	the price of the product tier
+	"""
+	productPrice: Price
+	"""
 	the product id that represents the tier in stripe
 	"""
 	stripeProductTierID: String
@@ -15960,6 +15964,10 @@ type OrgSubscriptionHistory implements Node {
 	the common name of the product tier the subscription is associated with, e.g. starter tier
 	"""
 	productTier: String
+	"""
+	the price of the product tier
+	"""
+	productPrice: Price
 	"""
 	the product id that represents the tier in stripe
 	"""
@@ -18437,6 +18445,7 @@ input PersonalAccessTokenWhereInput {
 	hasEvents: Boolean
 	hasEventsWith: [EventWhereInput!]
 }
+scalar Price
 type Procedure implements Node {
 	id: ID!
 	createdAt: Time

--- a/internal/graphapi/generate/.gqlgen.yml
+++ b/internal/graphapi/generate/.gqlgen.yml
@@ -87,3 +87,7 @@ models:
   Address:
     model:
       - github.com/theopenlane/core/pkg/models.Address
+  Price:
+    model:
+      - github.com/theopenlane/core/pkg/models.Price
+

--- a/internal/graphapi/generate/.gqlgenc.yml
+++ b/internal/graphapi/generate/.gqlgenc.yml
@@ -17,6 +17,9 @@ models:
   Address:
     model:
       - github.com/theopenlane/core/pkg/models.Address
+  Price:
+    model:
+      - github.com/theopenlane/core/pkg/models.Price
 schema: ["internal/graphapi/clientschema/schema.graphql"]
 query: ["internal/graphapi/query/*.graphql"]
 generate:

--- a/internal/graphapi/generated/root_.generated.go
+++ b/internal/graphapi/generated/root_.generated.go
@@ -1855,6 +1855,7 @@ type ComplexityRoot struct {
 		ID                       func(childComplexity int) int
 		Owner                    func(childComplexity int) int
 		OwnerID                  func(childComplexity int) int
+		ProductPrice             func(childComplexity int) int
 		ProductTier              func(childComplexity int) int
 		StripeCustomerID         func(childComplexity int) int
 		StripeProductTierID      func(childComplexity int) int
@@ -1889,6 +1890,7 @@ type ComplexityRoot struct {
 		ID                       func(childComplexity int) int
 		Operation                func(childComplexity int) int
 		OwnerID                  func(childComplexity int) int
+		ProductPrice             func(childComplexity int) int
 		ProductTier              func(childComplexity int) int
 		Ref                      func(childComplexity int) int
 		StripeCustomerID         func(childComplexity int) int
@@ -12495,6 +12497,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.OrgSubscription.OwnerID(childComplexity), true
 
+	case "OrgSubscription.productPrice":
+		if e.complexity.OrgSubscription.ProductPrice == nil {
+			break
+		}
+
+		return e.complexity.OrgSubscription.ProductPrice(childComplexity), true
+
 	case "OrgSubscription.productTier":
 		if e.complexity.OrgSubscription.ProductTier == nil {
 			break
@@ -12669,6 +12678,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.OrgSubscriptionHistory.OwnerID(childComplexity), true
+
+	case "OrgSubscriptionHistory.productPrice":
+		if e.complexity.OrgSubscriptionHistory.ProductPrice == nil {
+			break
+		}
+
+		return e.complexity.OrgSubscriptionHistory.ProductPrice(childComplexity), true
 
 	case "OrgSubscriptionHistory.productTier":
 		if e.complexity.OrgSubscriptionHistory.ProductTier == nil {
@@ -35209,6 +35225,10 @@ type OrgSubscription implements Node {
   """
   productTier: String
   """
+  the price of the product tier
+  """
+  productPrice: Price
+  """
   the product id that represents the tier in stripe
   """
   stripeProductTierID: String
@@ -35291,6 +35311,10 @@ type OrgSubscriptionHistory implements Node {
   the common name of the product tier the subscription is associated with, e.g. starter tier
   """
   productTier: String
+  """
+  the price of the product tier
+  """
+  productPrice: Price
   """
   the product id that represents the tier in stripe
   """
@@ -51657,7 +51681,8 @@ type RiskBulkCreatePayload {
     risks: [Risk!]
 }`, BuiltIn: false},
 	{Name: "../schema/scalars.graphql", Input: `scalar Upload
-scalar Address`, BuiltIn: false},
+scalar Address
+scalar Price`, BuiltIn: false},
 	{Name: "../schema/search.graphql", Input: `extend type Query{
     """
     Search across APIToken objects

--- a/internal/graphapi/generated/scalars.generated.go
+++ b/internal/graphapi/generated/scalars.generated.go
@@ -81,6 +81,16 @@ func (ec *executionContext) marshalOAddress2ᚖgithubᚗcomᚋtheopenlaneᚋcore
 	return v
 }
 
+func (ec *executionContext) unmarshalOPrice2githubᚗcomᚋtheopenlaneᚋcoreᚋpkgᚋmodelsᚐPrice(ctx context.Context, v any) (models.Price, error) {
+	var res models.Price
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOPrice2githubᚗcomᚋtheopenlaneᚋcoreᚋpkgᚋmodelsᚐPrice(ctx context.Context, sel ast.SelectionSet, v models.Price) graphql.Marshaler {
+	return v
+}
+
 func (ec *executionContext) unmarshalOUpload2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚐUpload(ctx context.Context, v any) (*graphql.Upload, error) {
 	if v == nil {
 		return nil, nil

--- a/internal/graphapi/generated/search.generated.go
+++ b/internal/graphapi/generated/search.generated.go
@@ -1434,6 +1434,8 @@ func (ec *executionContext) fieldContext_OrgSubscriptionSearchResult_orgSubscrip
 				return ec.fieldContext_OrgSubscription_stripeSubscriptionID(ctx, field)
 			case "productTier":
 				return ec.fieldContext_OrgSubscription_productTier(ctx, field)
+			case "productPrice":
+				return ec.fieldContext_OrgSubscription_productPrice(ctx, field)
 			case "stripeProductTierID":
 				return ec.fieldContext_OrgSubscription_stripeProductTierID(ctx, field)
 			case "stripeSubscriptionStatus":

--- a/internal/graphapi/query/adminsearch.graphql
+++ b/internal/graphapi/query/adminsearch.graphql
@@ -202,6 +202,7 @@ query AdminSearch($query: String!) {
           ownerID
           stripeSubscriptionID
           productTier
+          productPrice
           stripeProductTierID
           stripeSubscriptionStatus
           stripeCustomerID

--- a/internal/graphapi/query/orgsubscription.graphql
+++ b/internal/graphapi/query/orgsubscription.graphql
@@ -14,6 +14,7 @@ query GetAllOrgSubscriptions {
         stripeProductTierID
         stripeSubscriptionID
         stripeSubscriptionStatus
+        productPrice
         tags
         updatedAt
         updatedBy
@@ -36,6 +37,7 @@ query GetOrgSubscriptionByID($orgSubscriptionId: ID!) {
     stripeProductTierID
     stripeSubscriptionID
     stripeSubscriptionStatus
+    productPrice
     tags
     updatedAt
     updatedBy
@@ -58,6 +60,7 @@ query GetOrgSubscriptions($where: OrgSubscriptionWhereInput) {
         stripeProductTierID
         stripeSubscriptionID
         stripeSubscriptionStatus
+        productPrice
         tags
         updatedAt
         updatedBy

--- a/internal/graphapi/schema/ent.graphql
+++ b/internal/graphapi/schema/ent.graphql
@@ -13466,6 +13466,10 @@ type OrgSubscription implements Node {
   """
   productTier: String
   """
+  the price of the product tier
+  """
+  productPrice: Price
+  """
   the product id that represents the tier in stripe
   """
   stripeProductTierID: String
@@ -13548,6 +13552,10 @@ type OrgSubscriptionHistory implements Node {
   the common name of the product tier the subscription is associated with, e.g. starter tier
   """
   productTier: String
+  """
+  the price of the product tier
+  """
+  productPrice: Price
   """
   the product id that represents the tier in stripe
   """

--- a/internal/graphapi/schema/scalars.graphql
+++ b/internal/graphapi/schema/scalars.graphql
@@ -1,2 +1,3 @@
 scalar Upload
 scalar Address
+scalar Price

--- a/internal/graphapi/search.go
+++ b/internal/graphapi/search.go
@@ -609,16 +609,20 @@ func adminSearchOrgSubscriptions(ctx context.Context, query string) ([]*generate
 				likeQuery := "%" + query + "%"
 				s.Where(sql.ExprP("(tags)::text LIKE $2", likeQuery)) // search by Tags
 			},
-			orgsubscription.DeletedByContainsFold(query),                // search by DeletedBy
-			orgsubscription.OwnerIDContainsFold(query),                  // search by OwnerID
-			orgsubscription.StripeSubscriptionIDContainsFold(query),     // search by StripeSubscriptionID
-			orgsubscription.ProductTierContainsFold(query),              // search by ProductTier
+			orgsubscription.DeletedByContainsFold(query),            // search by DeletedBy
+			orgsubscription.OwnerIDContainsFold(query),              // search by OwnerID
+			orgsubscription.StripeSubscriptionIDContainsFold(query), // search by StripeSubscriptionID
+			orgsubscription.ProductTierContainsFold(query),          // search by ProductTier
+			func(s *sql.Selector) {
+				likeQuery := "%" + query + "%"
+				s.Where(sql.ExprP("(productprice)::text LIKE $7", likeQuery)) // search by ProductPrice
+			},
 			orgsubscription.StripeProductTierIDContainsFold(query),      // search by StripeProductTierID
 			orgsubscription.StripeSubscriptionStatusContainsFold(query), // search by StripeSubscriptionStatus
 			orgsubscription.StripeCustomerIDContainsFold(query),         // search by StripeCustomerID
 			func(s *sql.Selector) {
 				likeQuery := "%" + query + "%"
-				s.Where(sql.ExprP("(features)::text LIKE $10", likeQuery)) // search by Features
+				s.Where(sql.ExprP("(features)::text LIKE $11", likeQuery)) // search by Features
 			},
 		),
 	).All(ctx)

--- a/pkg/entitlements/customers.go
+++ b/pkg/entitlements/customers.go
@@ -93,6 +93,7 @@ func (sc *StripeClient) FindorCreateCustomer(ctx context.Context, o *Organizatio
 		// get features and retry up to 5 times	if we don't have any
 		// there is a delay between creating the customer and the features being available
 		var feats []string
+
 		const maxRetries = 5
 
 		for i := range maxRetries {

--- a/pkg/entitlements/customers.go
+++ b/pkg/entitlements/customers.go
@@ -67,9 +67,9 @@ func (sc *StripeClient) SearchCustomers(ctx context.Context, query string) (cust
 	return customers, nil
 }
 
-// FindorCreateCustomer attempts to lookup a customer by the organization ID which is set in both the
+// FindOrCreateCustomer attempts to lookup a customer by the organization ID which is set in both the
 // name field attribute as well as in the object metadata field
-func (sc *StripeClient) FindorCreateCustomer(ctx context.Context, o *OrganizationCustomer) (*OrganizationCustomer, error) {
+func (sc *StripeClient) FindOrCreateCustomer(ctx context.Context, o *OrganizationCustomer) (*OrganizationCustomer, error) {
 	customers, err := sc.SearchCustomers(ctx, fmt.Sprintf("name: '%s'", o.OrganizationID))
 	if err != nil {
 		return nil, err

--- a/pkg/entitlements/models.go
+++ b/pkg/entitlements/models.go
@@ -92,7 +92,7 @@ type Plan struct {
 	Status             string
 }
 
-// Plan is the recurring context that holds the payment information
+// Subscription is the recurring context that holds the payment information
 type Subscription struct {
 	ID                 string `json:"plan_id" yaml:"plan_id"`
 	Product            string `json:"product_id" yaml:"product_id"`

--- a/pkg/entitlements/models.go
+++ b/pkg/entitlements/models.go
@@ -95,8 +95,8 @@ type Plan struct {
 // Subscription is the recurring context that holds the payment information
 type Subscription struct {
 	ID                 string `json:"plan_id" yaml:"plan_id"`
-	Product            string `json:"product_id" yaml:"product_id"`
-	Price              string `json:"price_id" yaml:"price_id"`
+	ProductID          string `json:"product_id" yaml:"product_id"`
+	PriceID            string `json:"price_id" yaml:"price_id"`
 	StartDate          int64  `json:"start_date" yaml:"start_date"`
 	EndDate            int64  `json:"end_date" yaml:"end_date"`
 	StripeParams       *stripe.SubscriptionParams
@@ -128,7 +128,9 @@ type Product struct {
 type Price struct {
 	ID           string              `json:"price_id" yaml:"price_id"`
 	Price        float64             `json:"price" yaml:"price"`
+	Currency     string              `json:"currency" yaml:"currency"`
 	ProductID    string              `json:"product_id" yaml:"-"`
+	ProductName  string              `json:"product_name" yaml:"product_name"`
 	Interval     string              `json:"interval" yaml:"interval"`
 	StripeParams *stripe.PriceParams `json:"stripe_params,omitempty" yaml:"stripe_params,omitempty"`
 	StripePrice  []stripe.Price      `json:"stripe_price,omitempty" yaml:"stripe_price,omitempty"`

--- a/pkg/events/soiree/options.go
+++ b/pkg/events/soiree/options.go
@@ -19,7 +19,7 @@ var DefaultIDGenerator = func() string {
 
 // DefaultPanicHandler handles panics by printing the panic value
 var DefaultPanicHandler = func(p interface{}) {
-	log.Error().Msgf("Panic occurred: %v", p)
+	log.Error().Msgf("Panic occurred processing event: %v", p)
 }
 
 // WithErrorHandler sets a custom error handler for an Soiree

--- a/pkg/models/price.go
+++ b/pkg/models/price.go
@@ -1,0 +1,52 @@
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/rs/zerolog/log"
+)
+
+// Price is a custom type for pricing data
+type Price struct {
+	// Amount is the dollar amount of the price (e.g 100)
+	Amount float64 `json:"amount"`
+	// Interval is the interval of the price (e.g monthly, yearly)
+	Interval string `json:"interval"`
+	// Currency is the currency of the price that is being charged (e.g USD)
+	Currency string `json:"currency"`
+}
+
+// String returns a string representation of the price
+func (p Price) String() string {
+	return fmt.Sprintf("%v(%s)/%s", p.Amount, p.Currency, p.Interval)
+}
+
+// MarshalGQL implement the Marshaler interface for gqlgen
+func (p Price) MarshalGQL(w io.Writer) {
+	byteData, err := json.Marshal(p)
+	if err != nil {
+		log.Fatal().Err(err).Msg("error marshalling json object")
+	}
+
+	_, err = w.Write(byteData)
+	if err != nil {
+		log.Fatal().Err(err).Msg("error writing json object")
+	}
+}
+
+// UnmarshalGQL implement the Unmarshaler interface for gqlgen
+func (p *Price) UnmarshalGQL(v interface{}) error {
+	byteData, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(byteData, &p)
+	if err != nil {
+		return err
+	}
+
+	return err
+}

--- a/pkg/openlaneclient/graphclient.go
+++ b/pkg/openlaneclient/graphclient.go
@@ -2532,16 +2532,17 @@ func (t *AdminSearch_AdminSearch_Nodes_NarrativeSearchResult) GetNarratives() []
 }
 
 type AdminSearch_AdminSearch_Nodes_OrgSubscriptionSearchResult_OrgSubscriptions struct {
-	DeletedBy                *string  "json:\"deletedBy,omitempty\" graphql:\"deletedBy\""
-	Features                 []string "json:\"features,omitempty\" graphql:\"features\""
-	ID                       string   "json:\"id\" graphql:\"id\""
-	OwnerID                  *string  "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	ProductTier              *string  "json:\"productTier,omitempty\" graphql:\"productTier\""
-	StripeCustomerID         *string  "json:\"stripeCustomerID,omitempty\" graphql:\"stripeCustomerID\""
-	StripeProductTierID      *string  "json:\"stripeProductTierID,omitempty\" graphql:\"stripeProductTierID\""
-	StripeSubscriptionID     *string  "json:\"stripeSubscriptionID,omitempty\" graphql:\"stripeSubscriptionID\""
-	StripeSubscriptionStatus *string  "json:\"stripeSubscriptionStatus,omitempty\" graphql:\"stripeSubscriptionStatus\""
-	Tags                     []string "json:\"tags,omitempty\" graphql:\"tags\""
+	DeletedBy                *string       "json:\"deletedBy,omitempty\" graphql:\"deletedBy\""
+	Features                 []string      "json:\"features,omitempty\" graphql:\"features\""
+	ID                       string        "json:\"id\" graphql:\"id\""
+	OwnerID                  *string       "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	ProductPrice             *models.Price "json:\"productPrice,omitempty\" graphql:\"productPrice\""
+	ProductTier              *string       "json:\"productTier,omitempty\" graphql:\"productTier\""
+	StripeCustomerID         *string       "json:\"stripeCustomerID,omitempty\" graphql:\"stripeCustomerID\""
+	StripeProductTierID      *string       "json:\"stripeProductTierID,omitempty\" graphql:\"stripeProductTierID\""
+	StripeSubscriptionID     *string       "json:\"stripeSubscriptionID,omitempty\" graphql:\"stripeSubscriptionID\""
+	StripeSubscriptionStatus *string       "json:\"stripeSubscriptionStatus,omitempty\" graphql:\"stripeSubscriptionStatus\""
+	Tags                     []string      "json:\"tags,omitempty\" graphql:\"tags\""
 }
 
 func (t *AdminSearch_AdminSearch_Nodes_OrgSubscriptionSearchResult_OrgSubscriptions) GetDeletedBy() *string {
@@ -2567,6 +2568,12 @@ func (t *AdminSearch_AdminSearch_Nodes_OrgSubscriptionSearchResult_OrgSubscripti
 		t = &AdminSearch_AdminSearch_Nodes_OrgSubscriptionSearchResult_OrgSubscriptions{}
 	}
 	return t.OwnerID
+}
+func (t *AdminSearch_AdminSearch_Nodes_OrgSubscriptionSearchResult_OrgSubscriptions) GetProductPrice() *models.Price {
+	if t == nil {
+		t = &AdminSearch_AdminSearch_Nodes_OrgSubscriptionSearchResult_OrgSubscriptions{}
+	}
+	return t.ProductPrice
 }
 func (t *AdminSearch_AdminSearch_Nodes_OrgSubscriptionSearchResult_OrgSubscriptions) GetProductTier() *string {
 	if t == nil {
@@ -26209,21 +26216,22 @@ func (t *GetOrgMembershipHistories_OrgMembershipHistories) GetEdges() []*GetOrgM
 }
 
 type GetAllOrgSubscriptions_OrgSubscriptions_Edges_Node struct {
-	Active                   bool       "json:\"active\" graphql:\"active\""
-	CreatedAt                *time.Time "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy                *string    "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	ExpiresAt                *time.Time "json:\"expiresAt,omitempty\" graphql:\"expiresAt\""
-	Features                 []string   "json:\"features,omitempty\" graphql:\"features\""
-	ID                       string     "json:\"id\" graphql:\"id\""
-	OwnerID                  *string    "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	ProductTier              *string    "json:\"productTier,omitempty\" graphql:\"productTier\""
-	StripeCustomerID         *string    "json:\"stripeCustomerID,omitempty\" graphql:\"stripeCustomerID\""
-	StripeProductTierID      *string    "json:\"stripeProductTierID,omitempty\" graphql:\"stripeProductTierID\""
-	StripeSubscriptionID     *string    "json:\"stripeSubscriptionID,omitempty\" graphql:\"stripeSubscriptionID\""
-	StripeSubscriptionStatus *string    "json:\"stripeSubscriptionStatus,omitempty\" graphql:\"stripeSubscriptionStatus\""
-	Tags                     []string   "json:\"tags,omitempty\" graphql:\"tags\""
-	UpdatedAt                *time.Time "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy                *string    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Active                   bool          "json:\"active\" graphql:\"active\""
+	CreatedAt                *time.Time    "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy                *string       "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	ExpiresAt                *time.Time    "json:\"expiresAt,omitempty\" graphql:\"expiresAt\""
+	Features                 []string      "json:\"features,omitempty\" graphql:\"features\""
+	ID                       string        "json:\"id\" graphql:\"id\""
+	OwnerID                  *string       "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	ProductPrice             *models.Price "json:\"productPrice,omitempty\" graphql:\"productPrice\""
+	ProductTier              *string       "json:\"productTier,omitempty\" graphql:\"productTier\""
+	StripeCustomerID         *string       "json:\"stripeCustomerID,omitempty\" graphql:\"stripeCustomerID\""
+	StripeProductTierID      *string       "json:\"stripeProductTierID,omitempty\" graphql:\"stripeProductTierID\""
+	StripeSubscriptionID     *string       "json:\"stripeSubscriptionID,omitempty\" graphql:\"stripeSubscriptionID\""
+	StripeSubscriptionStatus *string       "json:\"stripeSubscriptionStatus,omitempty\" graphql:\"stripeSubscriptionStatus\""
+	Tags                     []string      "json:\"tags,omitempty\" graphql:\"tags\""
+	UpdatedAt                *time.Time    "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy                *string       "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *GetAllOrgSubscriptions_OrgSubscriptions_Edges_Node) GetActive() bool {
@@ -26267,6 +26275,12 @@ func (t *GetAllOrgSubscriptions_OrgSubscriptions_Edges_Node) GetOwnerID() *strin
 		t = &GetAllOrgSubscriptions_OrgSubscriptions_Edges_Node{}
 	}
 	return t.OwnerID
+}
+func (t *GetAllOrgSubscriptions_OrgSubscriptions_Edges_Node) GetProductPrice() *models.Price {
+	if t == nil {
+		t = &GetAllOrgSubscriptions_OrgSubscriptions_Edges_Node{}
+	}
+	return t.ProductPrice
 }
 func (t *GetAllOrgSubscriptions_OrgSubscriptions_Edges_Node) GetProductTier() *string {
 	if t == nil {
@@ -26340,21 +26354,22 @@ func (t *GetAllOrgSubscriptions_OrgSubscriptions) GetEdges() []*GetAllOrgSubscri
 }
 
 type GetOrgSubscriptionByID_OrgSubscription struct {
-	Active                   bool       "json:\"active\" graphql:\"active\""
-	CreatedAt                *time.Time "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy                *string    "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	ExpiresAt                *time.Time "json:\"expiresAt,omitempty\" graphql:\"expiresAt\""
-	Features                 []string   "json:\"features,omitempty\" graphql:\"features\""
-	ID                       string     "json:\"id\" graphql:\"id\""
-	OwnerID                  *string    "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	ProductTier              *string    "json:\"productTier,omitempty\" graphql:\"productTier\""
-	StripeCustomerID         *string    "json:\"stripeCustomerID,omitempty\" graphql:\"stripeCustomerID\""
-	StripeProductTierID      *string    "json:\"stripeProductTierID,omitempty\" graphql:\"stripeProductTierID\""
-	StripeSubscriptionID     *string    "json:\"stripeSubscriptionID,omitempty\" graphql:\"stripeSubscriptionID\""
-	StripeSubscriptionStatus *string    "json:\"stripeSubscriptionStatus,omitempty\" graphql:\"stripeSubscriptionStatus\""
-	Tags                     []string   "json:\"tags,omitempty\" graphql:\"tags\""
-	UpdatedAt                *time.Time "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy                *string    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Active                   bool          "json:\"active\" graphql:\"active\""
+	CreatedAt                *time.Time    "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy                *string       "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	ExpiresAt                *time.Time    "json:\"expiresAt,omitempty\" graphql:\"expiresAt\""
+	Features                 []string      "json:\"features,omitempty\" graphql:\"features\""
+	ID                       string        "json:\"id\" graphql:\"id\""
+	OwnerID                  *string       "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	ProductPrice             *models.Price "json:\"productPrice,omitempty\" graphql:\"productPrice\""
+	ProductTier              *string       "json:\"productTier,omitempty\" graphql:\"productTier\""
+	StripeCustomerID         *string       "json:\"stripeCustomerID,omitempty\" graphql:\"stripeCustomerID\""
+	StripeProductTierID      *string       "json:\"stripeProductTierID,omitempty\" graphql:\"stripeProductTierID\""
+	StripeSubscriptionID     *string       "json:\"stripeSubscriptionID,omitempty\" graphql:\"stripeSubscriptionID\""
+	StripeSubscriptionStatus *string       "json:\"stripeSubscriptionStatus,omitempty\" graphql:\"stripeSubscriptionStatus\""
+	Tags                     []string      "json:\"tags,omitempty\" graphql:\"tags\""
+	UpdatedAt                *time.Time    "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy                *string       "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *GetOrgSubscriptionByID_OrgSubscription) GetActive() bool {
@@ -26398,6 +26413,12 @@ func (t *GetOrgSubscriptionByID_OrgSubscription) GetOwnerID() *string {
 		t = &GetOrgSubscriptionByID_OrgSubscription{}
 	}
 	return t.OwnerID
+}
+func (t *GetOrgSubscriptionByID_OrgSubscription) GetProductPrice() *models.Price {
+	if t == nil {
+		t = &GetOrgSubscriptionByID_OrgSubscription{}
+	}
+	return t.ProductPrice
 }
 func (t *GetOrgSubscriptionByID_OrgSubscription) GetProductTier() *string {
 	if t == nil {
@@ -26449,21 +26470,22 @@ func (t *GetOrgSubscriptionByID_OrgSubscription) GetUpdatedBy() *string {
 }
 
 type GetOrgSubscriptions_OrgSubscriptions_Edges_Node struct {
-	Active                   bool       "json:\"active\" graphql:\"active\""
-	CreatedAt                *time.Time "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy                *string    "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	ExpiresAt                *time.Time "json:\"expiresAt,omitempty\" graphql:\"expiresAt\""
-	Features                 []string   "json:\"features,omitempty\" graphql:\"features\""
-	ID                       string     "json:\"id\" graphql:\"id\""
-	OwnerID                  *string    "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	ProductTier              *string    "json:\"productTier,omitempty\" graphql:\"productTier\""
-	StripeCustomerID         *string    "json:\"stripeCustomerID,omitempty\" graphql:\"stripeCustomerID\""
-	StripeProductTierID      *string    "json:\"stripeProductTierID,omitempty\" graphql:\"stripeProductTierID\""
-	StripeSubscriptionID     *string    "json:\"stripeSubscriptionID,omitempty\" graphql:\"stripeSubscriptionID\""
-	StripeSubscriptionStatus *string    "json:\"stripeSubscriptionStatus,omitempty\" graphql:\"stripeSubscriptionStatus\""
-	Tags                     []string   "json:\"tags,omitempty\" graphql:\"tags\""
-	UpdatedAt                *time.Time "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy                *string    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Active                   bool          "json:\"active\" graphql:\"active\""
+	CreatedAt                *time.Time    "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy                *string       "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	ExpiresAt                *time.Time    "json:\"expiresAt,omitempty\" graphql:\"expiresAt\""
+	Features                 []string      "json:\"features,omitempty\" graphql:\"features\""
+	ID                       string        "json:\"id\" graphql:\"id\""
+	OwnerID                  *string       "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	ProductPrice             *models.Price "json:\"productPrice,omitempty\" graphql:\"productPrice\""
+	ProductTier              *string       "json:\"productTier,omitempty\" graphql:\"productTier\""
+	StripeCustomerID         *string       "json:\"stripeCustomerID,omitempty\" graphql:\"stripeCustomerID\""
+	StripeProductTierID      *string       "json:\"stripeProductTierID,omitempty\" graphql:\"stripeProductTierID\""
+	StripeSubscriptionID     *string       "json:\"stripeSubscriptionID,omitempty\" graphql:\"stripeSubscriptionID\""
+	StripeSubscriptionStatus *string       "json:\"stripeSubscriptionStatus,omitempty\" graphql:\"stripeSubscriptionStatus\""
+	Tags                     []string      "json:\"tags,omitempty\" graphql:\"tags\""
+	UpdatedAt                *time.Time    "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy                *string       "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *GetOrgSubscriptions_OrgSubscriptions_Edges_Node) GetActive() bool {
@@ -26507,6 +26529,12 @@ func (t *GetOrgSubscriptions_OrgSubscriptions_Edges_Node) GetOwnerID() *string {
 		t = &GetOrgSubscriptions_OrgSubscriptions_Edges_Node{}
 	}
 	return t.OwnerID
+}
+func (t *GetOrgSubscriptions_OrgSubscriptions_Edges_Node) GetProductPrice() *models.Price {
+	if t == nil {
+		t = &GetOrgSubscriptions_OrgSubscriptions_Edges_Node{}
+	}
+	return t.ProductPrice
 }
 func (t *GetOrgSubscriptions_OrgSubscriptions_Edges_Node) GetProductTier() *string {
 	if t == nil {
@@ -48638,6 +48666,7 @@ const AdminSearchDocument = `query AdminSearch ($query: String!) {
 					ownerID
 					stripeSubscriptionID
 					productTier
+					productPrice
 					stripeProductTierID
 					stripeSubscriptionStatus
 					stripeCustomerID
@@ -56078,6 +56107,7 @@ const GetAllOrgSubscriptionsDocument = `query GetAllOrgSubscriptions {
 				stripeProductTierID
 				stripeSubscriptionID
 				stripeSubscriptionStatus
+				productPrice
 				tags
 				updatedAt
 				updatedBy
@@ -56116,6 +56146,7 @@ const GetOrgSubscriptionByIDDocument = `query GetOrgSubscriptionByID ($orgSubscr
 		stripeProductTierID
 		stripeSubscriptionID
 		stripeSubscriptionStatus
+		productPrice
 		tags
 		updatedAt
 		updatedBy
@@ -56156,6 +56187,7 @@ const GetOrgSubscriptionsDocument = `query GetOrgSubscriptions ($where: OrgSubsc
 				stripeProductTierID
 				stripeSubscriptionID
 				stripeSubscriptionStatus
+				productPrice
 				tags
 				updatedAt
 				updatedBy

--- a/pkg/openlaneclient/models.go
+++ b/pkg/openlaneclient/models.go
@@ -11019,6 +11019,8 @@ type OrgSubscription struct {
 	StripeSubscriptionID *string `json:"stripeSubscriptionID,omitempty"`
 	// the common name of the product tier the subscription is associated with, e.g. starter tier
 	ProductTier *string `json:"productTier,omitempty"`
+	// the price of the product tier
+	ProductPrice *models.Price `json:"productPrice,omitempty"`
 	// the product id that represents the tier in stripe
 	StripeProductTierID *string `json:"stripeProductTierID,omitempty"`
 	// the status of the subscription in stripe -- see https://docs.stripe.com/api/subscriptions/object#subscription_object-status
@@ -11074,6 +11076,8 @@ type OrgSubscriptionHistory struct {
 	StripeSubscriptionID *string `json:"stripeSubscriptionID,omitempty"`
 	// the common name of the product tier the subscription is associated with, e.g. starter tier
 	ProductTier *string `json:"productTier,omitempty"`
+	// the price of the product tier
+	ProductPrice *models.Price `json:"productPrice,omitempty"`
 	// the product id that represents the tier in stripe
 	StripeProductTierID *string `json:"stripeProductTierID,omitempty"`
 	// the status of the subscription in stripe -- see https://docs.stripe.com/api/subscriptions/object#subscription_object-status


### PR DESCRIPTION
There is a slight delay from creation of a subscription and the features being returned from the entitlements endpoint. This PR adds a retry loop on creation so we can get the features. During dev testing, there was between 0 and 1 retries

```
5:17PM DBG subscriptions.go:103 Created trial subscription with ID: sub_1QfVuTBvxky1R7SvW4xkGR5O
5:17PM DBG customers.go:107 no features found for customer, retrying customer_id=cus_RYdAGgsYrS3Dfu
5:17PM DBG customers.go:116 found features for customer customer_id=cus_RYdAGgsYrS3Dfu features=[compliance-module centralized-audit-documentation policy-and-procedure-module]
```

Also a fixes this panic: 
```
3:53PM ERR options.go:22 Panic occurred: missing operation context
```

When org subscription was called outside the graphql context

Adds the missing org subscription fields we need for the UI:

```bash
(⎈ |default:default)➜  core git:(bug-retry-features-pull) ✗ go run cmd/cli/main.go org-subscription get               
  ID                          ACTIVE  STRIPECUSTOMERID    STRIPESUBSCRIPTIONSTATUS  PRODUCTTIER   FEATURES                                            PRICE           EXPIRESAT                      
  01JH8KJREZVKNSY3K6YJYCST4R  true    cus_RYtefBmlseCen5  trialing                  Starter Tier  compliance-module, policy-and-procedure-module,     100(usd)/month  2025-02-09 10:18:21 -0700 MST  
                                                                                                  centralized-audit-documentation                                                                    
```

```bash
(⎈ |default:default)➜  core git:(bug-retry-features-pull) ✗ go run cmd/cli/main.go org-subscription get -z json
{
  "orgSubscriptions": {
    "edges": [
      {
        "node": {
          "active": true,
          "createdAt": "2025-01-10T10:18:22.687749-07:00",
          "createdBy": "01JH8BDT40TQZRQY99KB7YKDA0",
          "expiresAt": "2025-02-09T10:18:21-07:00",
          "features": [
            "compliance-module",
            "policy-and-procedure-module",
            "centralized-audit-documentation"
          ],
          "id": "01JH8KJREZVKNSY3K6YJYCST4R",
          "ownerID": "01JH8KJPBRK1GRFKEN2NX30KRN",
          "productPrice": {
            "amount": 100,
            "currency": "usd",
            "interval": "month"
          },
          "productTier": "Starter Tier",
          "stripeCustomerID": "cus_RYtefBmlseCen5",
          "stripeProductTierID": "prod_RYbPWASHqqLjlI",
          "stripeSubscriptionID": "sub_1QflqjBvxky1R7SvEMllAbW5",
          "stripeSubscriptionStatus": "trialing",
          "updatedAt": "2025-01-10T10:18:22.687697-07:00",
          "updatedBy": "01JH8BDT40TQZRQY99KB7YKDA0"
        }
      }
    ]
  }
}
```

Fixes a bug where the check for subscriptionURL field was not correct and we were always getting the portal session even if the field was not requested