### PR TITLE
feat: apollo linter

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -195,7 +195,7 @@ steps:
 
           # ignore exit code for now
           set +e
-          result=$(rover graph check --schema internal/graphapi/clientschema/schema.graphql Openlane-2fwyqq@current --format plain -o $$lint_result_file 2>&1 > /dev/null)          status=$$?
+          result=$(rover graph check --schema $$GRAPHQL_SCHEMA_LOCATION $$GRAPHQL_SCHEMA_NAME --format plain -o $$lint_result_file 2>&1 > /dev/null)
           set -e
 
           output=$$(cat $$lint_result_file)

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -9,163 +9,165 @@ env:
   SMALL_RUNNER_QUEUE: self-hosted-garage-vms
   RUNNER_LARGE: "large"
   RUNNER_SMALL: "small"
+  GRAPHQL_SCHEMA_LOCATION: "internal/graphapi/clientschema/schema.graphql"
+  GRAPHQL_SCHEMA_NAME: "Openlane-2fwyqq@current"
 
 steps:
-  - group: ":knife: Pre-check"
-    key: "precheck"
-    steps:
-      - label: ":golang: go generate"
-        key: "generate"
-        agents:
-          queue: $LARGE_RUNNER_QUEUE
-          size: $RUNNER_LARGE
-        cancel_on_build_failing: true
-        plugins:
-          - docker#v5.12.0:
-              image: "ghcr.io/theopenlane/build-image:latest"
-              always_pull: true
-              command: ["task", "ci"]
-              environment:
-                - "GOTOOLCHAIN=auto"
-      - label: ":yaml: generate config"
-        key: "generate_config"
-        cancel_on_build_failing: true
-        plugins:
-          - docker#v5.12.0:
-              image: "ghcr.io/theopenlane/build-image:latest"
-              always_pull: true
-              command: ["task", "config:ci"]
-              environment:
-                - "GOTOOLCHAIN=auto"
-  - group: ":test_tube: Tests"
-    key: "tests"
-    steps:
-      - label: ":golangci-lint: lint :lint-roller:"
-        if: build.branch !~ /^renovate\//
-        agents:
-          queue: $LARGE_RUNNER_QUEUE
-          size: $RUNNER_LARGE
-          location: "SAT"
-        cancel_on_build_failing: true
-        timeout_in_minutes: 20
-        key: "lint"
-        plugins:
-          - docker#v5.12.0:
-              image: "ghcr.io/theopenlane/build-image:latest"
-              command: ["task", "go:lint:ci"]
-              always_pull: true
-              environment:
-                - "GOTOOLCHAIN=auto"
-        artifact_paths: ["coverage.out"]
-      - label: ":golang: go test - {{matrix.version}}"
-        agents:
-          queue: $LARGE_RUNNER_QUEUE
-          size: $RUNNER_LARGE
-        key: "go_test"
-        cancel_on_build_failing: true
-        env:
-          TEST_DB_URL: "docker://postgres:{{matrix.version}}"
-        matrix:
-          setup:
-            version:
-              - 17-alpine
-        plugins:
-          - docker#v5.12.0:
-              image: ghcr.io/theopenlane/build-image:latest
-              always_pull: true
-              command: ["task", "go:test:cover"]
-              environment:
-                - "TEST_DB_URL"
-                - "TEST_DB_CONTAINER_EXPIRY=8" # container expiry in minutes
-                - "TEST_DB_HOST=172.17.0.1" # docker host ip on linux
-                - "TESTCONTAINERS_RYUK_DISABLED=true"
-              volumes:
-                - "/var/run/docker.sock:/var/run/docker.sock"
-        artifact_paths: ["coverage.out"]
-      - label: ":auth0: fga model test"
-        if: build.branch !~ /^renovate\//
-        agents:
-          queue: $SMALL_RUNNER_QUEUE
-          size: $RUNNER_SMALL
-        key: "fga_test"
-        plugins:
-          - docker#v5.12.0:
-              image: openfga/cli:v0.5.1
-              command: ["model", "test", "--tests", "fga/tests/tests.yaml"]
-  - group: ":closed_lock_with_key: Security Checks"
-    key: "security"
-    if: build.branch !~ /^renovate\//
-    steps:
-      - label: ":github: upload PR reports"
-        key: "scan-upload-pr"
-        cancel_on_build_failing: true
-        if: build.pull_request.id != null
-        depends_on: ["go_test"]
-        plugins:
-          - cluster-secrets#v1.0.0:
-              variables:
-                SONAR_TOKEN: SONAR_TOKEN
-          - artifacts#v1.9.4:
-              download: "coverage.out"
-              step: "go_test"
-          - docker#v5.12.0:
-              image: "sonarsource/sonar-scanner-cli:11.0"
-              environment:
-                - "SONAR_TOKEN"
-                - "SONAR_HOST_URL=$SONAR_HOST"
-                - "SONAR_SCANNER_OPTS=-Dsonar.pullrequest.branch=$BUILDKITE_BRANCH -Dsonar.pullrequest.base=$BUILDKITE_PULL_REQUEST_BASE_BRANCH -Dsonar.pullrequest.key=$BUILDKITE_PULL_REQUEST"
-      - label: ":github: upload reports"
-        key: "scan-upload"
-        cancel_on_build_failing: true
-        if: build.branch == "main" && build.tag == null
-        depends_on: ["go_test"]
-        plugins:
-          - cluster-secrets#v1.0.0:
-              variables:
-                SONAR_TOKEN: SONAR_TOKEN
-          - artifacts#v1.9.4:
-              download: coverage.out
-              step: "go_test"
-          - docker#v5.12.0:
-              image: "sonarsource/sonar-scanner-cli:11.0"
-              environment:
-                - "SONAR_TOKEN"
-                - "SONAR_HOST_URL=$SONAR_HOST"
-  - group: ":golang: Builds"
-    key: "go-builds"
-    if: build.branch !~ /^renovate\//
-    steps:
-      - label: ":golang: build"
-        key: "gobuild-server"
-        cancel_on_build_failing: true
-        artifact_paths: "bin/${APP_NAME}"
-        agents:
-          queue: $LARGE_RUNNER_QUEUE
-          size: $RUNNER_LARGE
-        plugins:
-          - docker#v5.12.0:
-              image: "ghcr.io/theopenlane/build-image:latest"
-              always_pull: true
-              environment:
-                - CGO_ENABLED=0
-                - GOOS=linux
-              command: ["task", "go:build:ci"]
-      - label: ":terminal: build cli"
-        key: "gobuild-cli"
-        agents:
-          queue: $LARGE_RUNNER_QUEUE
-          size: $RUNNER_LARGE
-        cancel_on_build_failing: true
-        artifact_paths: "bin/openlane-cli"
-        plugins:
-          - docker#v5.12.0:
-              image: "ghcr.io/theopenlane/build-image:latest"
-              always_pull: true
-              environment:
-                - GOOS=darwin
-                - GOARCH=arm64
-              command: ["task", "go:build-cli:ci"]
-  - group: ":database: atlas migrate"
+  # - group: ":knife: Pre-check"
+  #   key: "precheck"
+  #   steps:
+  #     - label: ":golang: go generate"
+  #       key: "generate"
+  #       agents:
+  #         queue: $LARGE_RUNNER_QUEUE
+  #         size: $RUNNER_LARGE
+  #       cancel_on_build_failing: true
+  #       plugins:
+  #         - docker#v5.12.0:
+  #             image: "ghcr.io/theopenlane/build-image:latest"
+  #             always_pull: true
+  #             command: ["task", "ci"]
+  #             environment:
+  #               - "GOTOOLCHAIN=auto"
+  #     - label: ":yaml: generate config"
+  #       key: "generate_config"
+  #       cancel_on_build_failing: true
+  #       plugins:
+  #         - docker#v5.12.0:
+  #             image: "ghcr.io/theopenlane/build-image:latest"
+  #             always_pull: true
+  #             command: ["task", "config:ci"]
+  #             environment:
+  #               - "GOTOOLCHAIN=auto"
+  # - group: ":test_tube: Tests"
+  #   key: "tests"
+  #   steps:
+  #     - label: ":golangci-lint: lint :lint-roller:"
+  #       if: build.branch !~ /^renovate\//
+  #       agents:
+  #         queue: $LARGE_RUNNER_QUEUE
+  #         size: $RUNNER_LARGE
+  #         location: "SAT"
+  #       cancel_on_build_failing: true
+  #       timeout_in_minutes: 20
+  #       key: "lint"
+  #       plugins:
+  #         - docker#v5.12.0:
+  #             image: "ghcr.io/theopenlane/build-image:latest"
+  #             command: ["task", "go:lint:ci"]
+  #             always_pull: true
+  #             environment:
+  #               - "GOTOOLCHAIN=auto"
+  #       artifact_paths: ["coverage.out"]
+  #     - label: ":golang: go test - {{matrix.version}}"
+  #       agents:
+  #         queue: $LARGE_RUNNER_QUEUE
+  #         size: $RUNNER_LARGE
+  #       key: "go_test"
+  #       cancel_on_build_failing: true
+  #       env:
+  #         TEST_DB_URL: "docker://postgres:{{matrix.version}}"
+  #       matrix:
+  #         setup:
+  #           version:
+  #             - 17-alpine
+  #       plugins:
+  #         - docker#v5.12.0:
+  #             image: ghcr.io/theopenlane/build-image:latest
+  #             always_pull: true
+  #             command: ["task", "go:test:cover"]
+  #             environment:
+  #               - "TEST_DB_URL"
+  #               - "TEST_DB_CONTAINER_EXPIRY=8" # container expiry in minutes
+  #               - "TEST_DB_HOST=172.17.0.1" # docker host ip on linux
+  #               - "TESTCONTAINERS_RYUK_DISABLED=true"
+  #             volumes:
+  #               - "/var/run/docker.sock:/var/run/docker.sock"
+  #       artifact_paths: ["coverage.out"]
+  #     - label: ":auth0: fga model test"
+  #       if: build.branch !~ /^renovate\//
+  #       agents:
+  #         queue: $SMALL_RUNNER_QUEUE
+  #         size: $RUNNER_SMALL
+  #       key: "fga_test"
+  #       plugins:
+  #         - docker#v5.12.0:
+  #             image: openfga/cli:v0.5.1
+  #             command: ["model", "test", "--tests", "fga/tests/tests.yaml"]
+  # - group: ":closed_lock_with_key: Security Checks"
+  #   key: "security"
+  #   if: build.branch !~ /^renovate\//
+  #   steps:
+  #     - label: ":github: upload PR reports"
+  #       key: "scan-upload-pr"
+  #       cancel_on_build_failing: true
+  #       if: build.pull_request.id != null
+  #       depends_on: ["go_test"]
+  #       plugins:
+  #         - cluster-secrets#v1.0.0:
+  #             variables:
+  #               SONAR_TOKEN: SONAR_TOKEN
+  #         - artifacts#v1.9.4:
+  #             download: "coverage.out"
+  #             step: "go_test"
+  #         - docker#v5.12.0:
+  #             image: "sonarsource/sonar-scanner-cli:11.0"
+  #             environment:
+  #               - "SONAR_TOKEN"
+  #               - "SONAR_HOST_URL=$SONAR_HOST"
+  #               - "SONAR_SCANNER_OPTS=-Dsonar.pullrequest.branch=$BUILDKITE_BRANCH -Dsonar.pullrequest.base=$BUILDKITE_PULL_REQUEST_BASE_BRANCH -Dsonar.pullrequest.key=$BUILDKITE_PULL_REQUEST"
+  #     - label: ":github: upload reports"
+  #       key: "scan-upload"
+  #       cancel_on_build_failing: true
+  #       if: build.branch == "main" && build.tag == null
+  #       depends_on: ["go_test"]
+  #       plugins:
+  #         - cluster-secrets#v1.0.0:
+  #             variables:
+  #               SONAR_TOKEN: SONAR_TOKEN
+  #         - artifacts#v1.9.4:
+  #             download: coverage.out
+  #             step: "go_test"
+  #         - docker#v5.12.0:
+  #             image: "sonarsource/sonar-scanner-cli:11.0"
+  #             environment:
+  #               - "SONAR_TOKEN"
+  #               - "SONAR_HOST_URL=$SONAR_HOST"
+  # - group: ":golang: Builds"
+  #   key: "go-builds"
+  #   if: build.branch !~ /^renovate\//
+  #   steps:
+  #     - label: ":golang: build"
+  #       key: "gobuild-server"
+  #       cancel_on_build_failing: true
+  #       artifact_paths: "bin/${APP_NAME}"
+  #       agents:
+  #         queue: $LARGE_RUNNER_QUEUE
+  #         size: $RUNNER_LARGE
+  #       plugins:
+  #         - docker#v5.12.0:
+  #             image: "ghcr.io/theopenlane/build-image:latest"
+  #             always_pull: true
+  #             environment:
+  #               - CGO_ENABLED=0
+  #               - GOOS=linux
+  #             command: ["task", "go:build:ci"]
+  #     - label: ":terminal: build cli"
+  #       key: "gobuild-cli"
+  #       agents:
+  #         queue: $LARGE_RUNNER_QUEUE
+  #         size: $RUNNER_LARGE
+  #       cancel_on_build_failing: true
+  #       artifact_paths: "bin/openlane-cli"
+  #       plugins:
+  #         - docker#v5.12.0:
+  #             image: "ghcr.io/theopenlane/build-image:latest"
+  #             always_pull: true
+  #             environment:
+  #               - GOOS=darwin
+  #               - GOARCH=arm64
+  #             command: ["task", "go:build-cli:ci"]
+  - group: ":database: schema lint"
     key: "database"
     if: build.branch !~ /^renovate\//
     steps:
@@ -182,195 +184,40 @@ steps:
               dev-url: "docker://postgres/17/dev?search_path=public"
               dir: "file://db/migrations"
               step: lint
-      - label: ":rocket: atlas push"
-        if: build.branch == "main" && build.tag == null
-        key: "atlas_migrate"
-        plugins:
-          - cluster-secrets#v1.0.0:
-              variables:
-                ATLAS_CLOUD_TOKEN: ATLAS_CLOUD_TOKEN
-          - theopenlane/atlas#v1.1.0:
-              project: core
-              dev-url: "docker://postgres/17/dev?search_path=public"
-              dir: "file://db/migrations"
-              step: migrate
-  - group: ":docker: Image Build"
-    depends_on: "go-builds"
-    if: build.branch !~ /^renovate\//
-    key: "image-build"
-    steps:
-      - label: ":docker: docker pr build"
-        key: "docker-pr-build"
-        agents:
-          queue: $LARGE_RUNNER_QUEUE
-          size: $RUNNER_LARGE
+      - label: ":graphql: lint graphql schema"
+        key: "apollo-lint-schema"
+        soft_fail:
+          - exit_status: 1
         cancel_on_build_failing: true
-        if: build.branch != "main" && build.tag == null
-        commands: |
-          #!/bin/bash
-          ls
-        plugins:
-          - artifacts#v1.9.4:
-              download:
-                - from: "bin/${APP_NAME}"
-                  to: "${APP_NAME}"
-              step: "gobuild-server"
-          - cluster-secrets#v1.0.0:
-              variables:
-                SECRET_GHCR_PUBLISH_TOKEN: SECRET_GHCR_PUBLISH_TOKEN
-          - docker-login#v3.0.0: # we need to login for the image to be accessible on the host
-              username: openlane-bender
-              password-env: SECRET_GHCR_PUBLISH_TOKEN
-              server: ghcr.io
-          - theopenlane/docker-metadata#v1.0.0:
-              images:
-                - "${IMAGE_REPO}"
-              extra_tags:
-                - "${IMAGE_TAG}"
-          - theopenlane/container-build#v1.1.0:
-              dockerfile: docker/Dockerfile
-              push: false
-              build-args:
-                - NAME=${APP_NAME}
-          - equinixmetal-buildkite/trivy#v1.19.0:
-              severity: CRITICAL,HIGH
-              ignore-unfixed: true
-              scanners: misconfig,secret,vuln
-              skip-files: "cosign.key,Dockerfile.dev"
-              trivy-version: "0.57.1"
-      - label: ":docker: docker build and publish"
-        cancel_on_build_failing: true
-        if: build.branch == "main" && build.tag == null
-        commands: |
-          #!/bin/bash
-          ls
-        plugins:
-          - artifacts#v1.9.4:
-              download:
-                - from: "bin/${APP_NAME}"
-                  to: "${APP_NAME}"
-              step: "gobuild-server"
-          - cluster-secrets#v1.0.0:
-              variables:
-                SECRET_GHCR_PUBLISH_TOKEN: SECRET_GHCR_PUBLISH_TOKEN
-          - docker-login#v3.0.0:
-              username: openlane-bender
-              password-env: SECRET_GHCR_PUBLISH_TOKEN
-              server: ghcr.io
-          - theopenlane/docker-metadata#v1.0.0:
-              images:
-                - "${IMAGE_REPO}"
-              extra_tags:
-                - "${IMAGE_TAG}"
-          - theopenlane/container-build#v1.1.0:
-              dockerfile: docker/Dockerfile
-              push: true
-              build-args:
-                - NAME=${APP_NAME}
-          - equinixmetal-buildkite/trivy#v1.19.0:
-              severity: CRITICAL,HIGH
-              ignore-unfixed: true
-              scanners: misconfig,secret,vuln
-              skip-files: "cosign.key,Dockerfile.dev"
-              trivy-version: "0.57.1"
-      - label: ":docker: docker build and publish all in one"
-        key: "docker-build-aio"
-        agents:
-          queue: $LARGE_RUNNER_QUEUE
-          size: $RUNNER_LARGE
-        if: build.branch == "main" && build.tag == null
-        cancel_on_build_failing: true
-        commands: |
-          #!/bin/bash
-        plugins:
-          - cluster-secrets#v1.0.0:
-              variables:
-                SECRET_GCR_PUBLISH_TOKEN: SECRET_GCR_PUBLISH_TOKEN
-          - docker-login#v3.0.0:
-              username: _json_key_base64
-              password-env: SECRET_GCR_PUBLISH_TOKEN
-              server: us-west1-docker.pkg.dev
-          - theopenlane/docker-metadata#v1.0.0:
-              tag_prefix: "aio-"
-              debug: true
-              images:
-                - "${GCR_REPO}"
-              extra_tags:
-                - "${IMAGE_TAG}"
-          - theopenlane/container-build#v1.1.0:
-              dockerfile: docker/all-in-one/Dockerfile.all-in-one
-              push: true
-              build-args:
-                - NAME=${APP_NAME}
-      - label: ":docker: docker build and publish"
-        key: "docker-build-and-tag"
-        cancel_on_build_failing: true
-        if: build.tag != null
-        commands: |
-          #!/bin/bash
-        plugins:
-          - artifacts#v1.9.4:
-              download:
-                - from: "bin/${APP_NAME}"
-                  to: "${APP_NAME}"
-              step: "gobuild-server"
-          - cluster-secrets#v1.0.0:
-              variables:
-                SECRET_GHCR_PUBLISH_TOKEN: SECRET_GHCR_PUBLISH_TOKEN
-          - docker-login#v3.0.0:
-              username: openlane-bender
-              password-env: SECRET_GHCR_PUBLISH_TOKEN
-              server: ghcr.io
-          - theopenlane/docker-metadata#v1.0.0:
-              images:
-                - "${IMAGE_REPO}"
-              extra_tags:
-                - "${BUILDKITE_TAG}"
-          - theopenlane/container-build#v1.1.0:
-              dockerfile: docker/Dockerfile
-              push: true
-              build-args:
-                - NAME=${APP_NAME}
-      - label: ":docker: docker build and publish all in one"
-        key: "docker-build-aio-and-tag"
-        agents:
-          queue: $LARGE_RUNNER_QUEUE
-          size: $RUNNER_LARGE
-        cancel_on_build_failing: true
-        if: build.tag != null
-        commands: |
-          #!/bin/bash
-        plugins:
-          - cluster-secrets#v1.0.0:
-              variables:
-                SECRET_GCR_PUBLISH_TOKEN: SECRET_GCR_PUBLISH_TOKEN
-          - docker-login#v3.0.0:
-              username: _json_key_base64
-              password-env: SECRET_GCR_PUBLISH_TOKEN
-              server: us-west1-docker.pkg.dev
-          - theopenlane/docker-metadata#v1.0.0:
-              tag_prefix: "aio-"
-              debug: true
-              images:
-                - "${GCR_REPO}"
-              extra_tags:
-                - "${BUILDKITE_TAG}"
-          - theopenlane/container-build#v1.1.0:
-              dockerfile: docker/all-in-one/Dockerfile.all-in-one
-              push: true
-              build-args:
-                - NAME=${APP_NAME}
-  - group: ":rocket: Publish"
-    key: "publish"
-    if: build.tag != null
-    steps:
-      - label: ":graphql: publish graphql schema"
-        key: "apollo-publish-schema"
-        cancel_on_build_failing: true
-        command: "rover graph publish --schema $$GRAPHQL_SCHEMA_LOCATION $$GRAPHQL_SCHEMA_NAME"
-        env:
-          GRAPHQL_SCHEMA_LOCATION: "internal/graphapi/clientschema/schema.graphql"
-          GRAPHQL_SCHEMA_NAME: "Openlane-2fwyqq@current"
+        command: |
+          #!/bin/sh
+          lint_result_file=$$(mktemp)
+
+          # ignore exit code for now
+          set +e
+          result=$(rover graph check --schema internal/graphapi/clientschema/schema.graphql Openlane-2fwyqq@current --format plain -o $$lint_result_file 2>&1 > /dev/null)          status=$$?
+          set -e
+
+          output=$$(cat $$lint_result_file)
+
+          if [[ "$$output" = "" ]]; then
+              echo ""
+              echo "Linting Failed:"
+              echo "$${result#*error\[E043\]: }"
+
+              echo -e ":graphql: **Graphql Lint Failure**   <br /> $${result#*error\[E043\]: }" |  buildkite-agent annotate --context apollo-lint-schema --style error
+
+              exit 1
+          else
+              echo ""
+              echo "Linting result:"
+              echo $$output
+
+              echo -e ":graphql: **Graphql Lint Results** \n <details><summary> Linter Result </summary><code>$$output</code></details>" |  buildkite-agent annotate --context apollo-lint-schema --style success
+
+              exit 0
+          fi
+        artifact_paths: linter-result.txt
         plugins:
           - cluster-secrets#v1.0.0:
               variables:
@@ -381,3 +228,200 @@ steps:
               propagate-environment: true
               environment:
                 - "APOLLO_KEY"
+                - "BUILDKITE_AGENT_ACCESS_TOKEN"
+# - group: ":docker: Image Build"
+#   depends_on: "go-builds"
+#   if: build.branch !~ /^renovate\//
+#   key: "image-build"
+#   steps:
+#     - label: ":docker: docker pr build"
+#       key: "docker-pr-build"
+#       agents:
+#         queue: $LARGE_RUNNER_QUEUE
+#         size: $RUNNER_LARGE
+#       cancel_on_build_failing: true
+#       if: build.branch != "main" && build.tag == null
+#       commands: |
+#         #!/bin/bash
+#         ls
+#       plugins:
+#         - artifacts#v1.9.4:
+#             download:
+#               - from: "bin/${APP_NAME}"
+#                 to: "${APP_NAME}"
+#             step: "gobuild-server"
+#         - cluster-secrets#v1.0.0:
+#             variables:
+#               SECRET_GHCR_PUBLISH_TOKEN: SECRET_GHCR_PUBLISH_TOKEN
+#         - docker-login#v3.0.0: # we need to login for the image to be accessible on the host
+#             username: openlane-bender
+#             password-env: SECRET_GHCR_PUBLISH_TOKEN
+#             server: ghcr.io
+#         - theopenlane/docker-metadata#v1.0.0:
+#             images:
+#               - "${IMAGE_REPO}"
+#             extra_tags:
+#               - "${IMAGE_TAG}"
+#         - theopenlane/container-build#v1.1.0:
+#             dockerfile: docker/Dockerfile
+#             push: false
+#             build-args:
+#               - NAME=${APP_NAME}
+#         - equinixmetal-buildkite/trivy#v1.19.0:
+#             severity: CRITICAL,HIGH
+#             ignore-unfixed: true
+#             scanners: misconfig,secret,vuln
+#             skip-files: "cosign.key,Dockerfile.dev"
+#             trivy-version: "0.57.1"
+#     - label: ":docker: docker build and publish"
+#       cancel_on_build_failing: true
+#       if: build.branch == "main" && build.tag == null
+#       commands: |
+#         #!/bin/bash
+#         ls
+#       plugins:
+#         - artifacts#v1.9.4:
+#             download:
+#               - from: "bin/${APP_NAME}"
+#                 to: "${APP_NAME}"
+#             step: "gobuild-server"
+#         - cluster-secrets#v1.0.0:
+#             variables:
+#               SECRET_GHCR_PUBLISH_TOKEN: SECRET_GHCR_PUBLISH_TOKEN
+#         - docker-login#v3.0.0:
+#             username: openlane-bender
+#             password-env: SECRET_GHCR_PUBLISH_TOKEN
+#             server: ghcr.io
+#         - theopenlane/docker-metadata#v1.0.0:
+#             images:
+#               - "${IMAGE_REPO}"
+#             extra_tags:
+#               - "${IMAGE_TAG}"
+#         - theopenlane/container-build#v1.1.0:
+#             dockerfile: docker/Dockerfile
+#             push: true
+#             build-args:
+#               - NAME=${APP_NAME}
+#         - equinixmetal-buildkite/trivy#v1.19.0:
+#             severity: CRITICAL,HIGH
+#             ignore-unfixed: true
+#             scanners: misconfig,secret,vuln
+#             skip-files: "cosign.key,Dockerfile.dev"
+#             trivy-version: "0.57.1"
+#     - label: ":docker: docker build and publish all in one"
+#       key: "docker-build-aio"
+#       agents:
+#         queue: $LARGE_RUNNER_QUEUE
+#         size: $RUNNER_LARGE
+#       if: build.branch == "main" && build.tag == null
+#       cancel_on_build_failing: true
+#       commands: |
+#         #!/bin/bash
+#       plugins:
+#         - cluster-secrets#v1.0.0:
+#             variables:
+#               SECRET_GCR_PUBLISH_TOKEN: SECRET_GCR_PUBLISH_TOKEN
+#         - docker-login#v3.0.0:
+#             username: _json_key_base64
+#             password-env: SECRET_GCR_PUBLISH_TOKEN
+#             server: us-west1-docker.pkg.dev
+#         - theopenlane/docker-metadata#v1.0.0:
+#             tag_prefix: "aio-"
+#             debug: true
+#             images:
+#               - "${GCR_REPO}"
+#             extra_tags:
+#               - "${IMAGE_TAG}"
+#         - theopenlane/container-build#v1.1.0:
+#             dockerfile: docker/all-in-one/Dockerfile.all-in-one
+#             push: true
+#             build-args:
+#               - NAME=${APP_NAME}
+#     - label: ":docker: docker build and publish"
+#       key: "docker-build-and-tag"
+#       cancel_on_build_failing: true
+#       if: build.tag != null
+#       commands: |
+#         #!/bin/bash
+#       plugins:
+#         - artifacts#v1.9.4:
+#             download:
+#               - from: "bin/${APP_NAME}"
+#                 to: "${APP_NAME}"
+#             step: "gobuild-server"
+#         - cluster-secrets#v1.0.0:
+#             variables:
+#               SECRET_GHCR_PUBLISH_TOKEN: SECRET_GHCR_PUBLISH_TOKEN
+#         - docker-login#v3.0.0:
+#             username: openlane-bender
+#             password-env: SECRET_GHCR_PUBLISH_TOKEN
+#             server: ghcr.io
+#         - theopenlane/docker-metadata#v1.0.0:
+#             images:
+#               - "${IMAGE_REPO}"
+#             extra_tags:
+#               - "${BUILDKITE_TAG}"
+#         - theopenlane/container-build#v1.1.0:
+#             dockerfile: docker/Dockerfile
+#             push: true
+#             build-args:
+#               - NAME=${APP_NAME}
+#     - label: ":docker: docker build and publish all in one"
+#       key: "docker-build-aio-and-tag"
+#       agents:
+#         queue: $LARGE_RUNNER_QUEUE
+#         size: $RUNNER_LARGE
+#       cancel_on_build_failing: true
+#       if: build.tag != null
+#       commands: |
+#         #!/bin/bash
+#       plugins:
+#         - cluster-secrets#v1.0.0:
+#             variables:
+#               SECRET_GCR_PUBLISH_TOKEN: SECRET_GCR_PUBLISH_TOKEN
+#         - docker-login#v3.0.0:
+#             username: _json_key_base64
+#             password-env: SECRET_GCR_PUBLISH_TOKEN
+#             server: us-west1-docker.pkg.dev
+#         - theopenlane/docker-metadata#v1.0.0:
+#             tag_prefix: "aio-"
+#             debug: true
+#             images:
+#               - "${GCR_REPO}"
+#             extra_tags:
+#               - "${BUILDKITE_TAG}"
+#         - theopenlane/container-build#v1.1.0:
+#             dockerfile: docker/all-in-one/Dockerfile.all-in-one
+#             push: true
+#             build-args:
+#               - NAME=${APP_NAME}
+# - group: ":rocket: Publish"
+#   key: "publish"
+#   steps:
+#     - label: ":graphql: publish graphql schema"
+#       key: "apollo-publish-schema"
+#       if: build.tag != null
+#       cancel_on_build_failing: true
+#       command: "rover graph publish --schema $$GRAPHQL_SCHEMA_LOCATION $$GRAPHQL_SCHEMA_NAME"
+#       plugins:
+#         - cluster-secrets#v1.0.0:
+#             variables:
+#               APOLLO_KEY: APOLLO_KEY
+#         - docker#v5.12.0:
+#             image: "ghcr.io/theopenlane/build-image:latest"
+#             always_pull: true
+#             propagate-environment: true
+#             environment:
+#               - "APOLLO_KEY"
+#     - label: ":rocket: atlas push"
+#       if: build.branch == "main" && build.tag == null
+#       key: "atlas_migrate"
+#       plugins:
+#         - cluster-secrets#v1.0.0:
+#             variables:
+#               ATLAS_CLOUD_TOKEN: ATLAS_CLOUD_TOKEN
+#         - theopenlane/atlas#v1.1.0:
+#             project: core
+#             dev-url: "docker://postgres/17/dev?search_path=public"
+#             dir: "file://db/migrations"
+#             step: migrate

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -13,160 +13,160 @@ env:
   GRAPHQL_SCHEMA_NAME: "Openlane-2fwyqq@current"
 
 steps:
-  # - group: ":knife: Pre-check"
-  #   key: "precheck"
-  #   steps:
-  #     - label: ":golang: go generate"
-  #       key: "generate"
-  #       agents:
-  #         queue: $LARGE_RUNNER_QUEUE
-  #         size: $RUNNER_LARGE
-  #       cancel_on_build_failing: true
-  #       plugins:
-  #         - docker#v5.12.0:
-  #             image: "ghcr.io/theopenlane/build-image:latest"
-  #             always_pull: true
-  #             command: ["task", "ci"]
-  #             environment:
-  #               - "GOTOOLCHAIN=auto"
-  #     - label: ":yaml: generate config"
-  #       key: "generate_config"
-  #       cancel_on_build_failing: true
-  #       plugins:
-  #         - docker#v5.12.0:
-  #             image: "ghcr.io/theopenlane/build-image:latest"
-  #             always_pull: true
-  #             command: ["task", "config:ci"]
-  #             environment:
-  #               - "GOTOOLCHAIN=auto"
-  # - group: ":test_tube: Tests"
-  #   key: "tests"
-  #   steps:
-  #     - label: ":golangci-lint: lint :lint-roller:"
-  #       if: build.branch !~ /^renovate\//
-  #       agents:
-  #         queue: $LARGE_RUNNER_QUEUE
-  #         size: $RUNNER_LARGE
-  #         location: "SAT"
-  #       cancel_on_build_failing: true
-  #       timeout_in_minutes: 20
-  #       key: "lint"
-  #       plugins:
-  #         - docker#v5.12.0:
-  #             image: "ghcr.io/theopenlane/build-image:latest"
-  #             command: ["task", "go:lint:ci"]
-  #             always_pull: true
-  #             environment:
-  #               - "GOTOOLCHAIN=auto"
-  #       artifact_paths: ["coverage.out"]
-  #     - label: ":golang: go test - {{matrix.version}}"
-  #       agents:
-  #         queue: $LARGE_RUNNER_QUEUE
-  #         size: $RUNNER_LARGE
-  #       key: "go_test"
-  #       cancel_on_build_failing: true
-  #       env:
-  #         TEST_DB_URL: "docker://postgres:{{matrix.version}}"
-  #       matrix:
-  #         setup:
-  #           version:
-  #             - 17-alpine
-  #       plugins:
-  #         - docker#v5.12.0:
-  #             image: ghcr.io/theopenlane/build-image:latest
-  #             always_pull: true
-  #             command: ["task", "go:test:cover"]
-  #             environment:
-  #               - "TEST_DB_URL"
-  #               - "TEST_DB_CONTAINER_EXPIRY=8" # container expiry in minutes
-  #               - "TEST_DB_HOST=172.17.0.1" # docker host ip on linux
-  #               - "TESTCONTAINERS_RYUK_DISABLED=true"
-  #             volumes:
-  #               - "/var/run/docker.sock:/var/run/docker.sock"
-  #       artifact_paths: ["coverage.out"]
-  #     - label: ":auth0: fga model test"
-  #       if: build.branch !~ /^renovate\//
-  #       agents:
-  #         queue: $SMALL_RUNNER_QUEUE
-  #         size: $RUNNER_SMALL
-  #       key: "fga_test"
-  #       plugins:
-  #         - docker#v5.12.0:
-  #             image: openfga/cli:v0.5.1
-  #             command: ["model", "test", "--tests", "fga/tests/tests.yaml"]
-  # - group: ":closed_lock_with_key: Security Checks"
-  #   key: "security"
-  #   if: build.branch !~ /^renovate\//
-  #   steps:
-  #     - label: ":github: upload PR reports"
-  #       key: "scan-upload-pr"
-  #       cancel_on_build_failing: true
-  #       if: build.pull_request.id != null
-  #       depends_on: ["go_test"]
-  #       plugins:
-  #         - cluster-secrets#v1.0.0:
-  #             variables:
-  #               SONAR_TOKEN: SONAR_TOKEN
-  #         - artifacts#v1.9.4:
-  #             download: "coverage.out"
-  #             step: "go_test"
-  #         - docker#v5.12.0:
-  #             image: "sonarsource/sonar-scanner-cli:11.0"
-  #             environment:
-  #               - "SONAR_TOKEN"
-  #               - "SONAR_HOST_URL=$SONAR_HOST"
-  #               - "SONAR_SCANNER_OPTS=-Dsonar.pullrequest.branch=$BUILDKITE_BRANCH -Dsonar.pullrequest.base=$BUILDKITE_PULL_REQUEST_BASE_BRANCH -Dsonar.pullrequest.key=$BUILDKITE_PULL_REQUEST"
-  #     - label: ":github: upload reports"
-  #       key: "scan-upload"
-  #       cancel_on_build_failing: true
-  #       if: build.branch == "main" && build.tag == null
-  #       depends_on: ["go_test"]
-  #       plugins:
-  #         - cluster-secrets#v1.0.0:
-  #             variables:
-  #               SONAR_TOKEN: SONAR_TOKEN
-  #         - artifacts#v1.9.4:
-  #             download: coverage.out
-  #             step: "go_test"
-  #         - docker#v5.12.0:
-  #             image: "sonarsource/sonar-scanner-cli:11.0"
-  #             environment:
-  #               - "SONAR_TOKEN"
-  #               - "SONAR_HOST_URL=$SONAR_HOST"
-  # - group: ":golang: Builds"
-  #   key: "go-builds"
-  #   if: build.branch !~ /^renovate\//
-  #   steps:
-  #     - label: ":golang: build"
-  #       key: "gobuild-server"
-  #       cancel_on_build_failing: true
-  #       artifact_paths: "bin/${APP_NAME}"
-  #       agents:
-  #         queue: $LARGE_RUNNER_QUEUE
-  #         size: $RUNNER_LARGE
-  #       plugins:
-  #         - docker#v5.12.0:
-  #             image: "ghcr.io/theopenlane/build-image:latest"
-  #             always_pull: true
-  #             environment:
-  #               - CGO_ENABLED=0
-  #               - GOOS=linux
-  #             command: ["task", "go:build:ci"]
-  #     - label: ":terminal: build cli"
-  #       key: "gobuild-cli"
-  #       agents:
-  #         queue: $LARGE_RUNNER_QUEUE
-  #         size: $RUNNER_LARGE
-  #       cancel_on_build_failing: true
-  #       artifact_paths: "bin/openlane-cli"
-  #       plugins:
-  #         - docker#v5.12.0:
-  #             image: "ghcr.io/theopenlane/build-image:latest"
-  #             always_pull: true
-  #             environment:
-  #               - GOOS=darwin
-  #               - GOARCH=arm64
-  #             command: ["task", "go:build-cli:ci"]
+  - group: ":knife: Pre-check"
+    key: "precheck"
+    steps:
+      - label: ":golang: go generate"
+        key: "generate"
+        agents:
+          queue: $LARGE_RUNNER_QUEUE
+          size: $RUNNER_LARGE
+        cancel_on_build_failing: true
+        plugins:
+          - docker#v5.12.0:
+              image: "ghcr.io/theopenlane/build-image:latest"
+              always_pull: true
+              command: ["task", "ci"]
+              environment:
+                - "GOTOOLCHAIN=auto"
+      - label: ":yaml: generate config"
+        key: "generate_config"
+        cancel_on_build_failing: true
+        plugins:
+          - docker#v5.12.0:
+              image: "ghcr.io/theopenlane/build-image:latest"
+              always_pull: true
+              command: ["task", "config:ci"]
+              environment:
+                - "GOTOOLCHAIN=auto"
+  - group: ":test_tube: Tests"
+    key: "tests"
+    steps:
+      - label: ":golangci-lint: lint :lint-roller:"
+        if: build.branch !~ /^renovate\//
+        agents:
+          queue: $LARGE_RUNNER_QUEUE
+          size: $RUNNER_LARGE
+          location: "SAT"
+        cancel_on_build_failing: true
+        timeout_in_minutes: 20
+        key: "lint"
+        plugins:
+          - docker#v5.12.0:
+              image: "ghcr.io/theopenlane/build-image:latest"
+              command: ["task", "go:lint:ci"]
+              always_pull: true
+              environment:
+                - "GOTOOLCHAIN=auto"
+        artifact_paths: ["coverage.out"]
+      - label: ":golang: go test - {{matrix.version}}"
+        agents:
+          queue: $LARGE_RUNNER_QUEUE
+          size: $RUNNER_LARGE
+        key: "go_test"
+        cancel_on_build_failing: true
+        env:
+          TEST_DB_URL: "docker://postgres:{{matrix.version}}"
+        matrix:
+          setup:
+            version:
+              - 17-alpine
+        plugins:
+          - docker#v5.12.0:
+              image: ghcr.io/theopenlane/build-image:latest
+              always_pull: true
+              command: ["task", "go:test:cover"]
+              environment:
+                - "TEST_DB_URL"
+                - "TEST_DB_CONTAINER_EXPIRY=8" # container expiry in minutes
+                - "TEST_DB_HOST=172.17.0.1" # docker host ip on linux
+                - "TESTCONTAINERS_RYUK_DISABLED=true"
+              volumes:
+                - "/var/run/docker.sock:/var/run/docker.sock"
+        artifact_paths: ["coverage.out"]
+      - label: ":auth0: fga model test"
+        if: build.branch !~ /^renovate\//
+        agents:
+          queue: $SMALL_RUNNER_QUEUE
+          size: $RUNNER_SMALL
+        key: "fga_test"
+        plugins:
+          - docker#v5.12.0:
+              image: openfga/cli:v0.5.1
+              command: ["model", "test", "--tests", "fga/tests/tests.yaml"]
+  - group: ":closed_lock_with_key: Security Checks"
+    key: "security"
+    if: build.branch !~ /^renovate\//
+    steps:
+      - label: ":github: upload PR reports"
+        key: "scan-upload-pr"
+        cancel_on_build_failing: true
+        if: build.pull_request.id != null
+        depends_on: ["go_test"]
+        plugins:
+          - cluster-secrets#v1.0.0:
+              variables:
+                SONAR_TOKEN: SONAR_TOKEN
+          - artifacts#v1.9.4:
+              download: "coverage.out"
+              step: "go_test"
+          - docker#v5.12.0:
+              image: "sonarsource/sonar-scanner-cli:11.0"
+              environment:
+                - "SONAR_TOKEN"
+                - "SONAR_HOST_URL=$SONAR_HOST"
+                - "SONAR_SCANNER_OPTS=-Dsonar.pullrequest.branch=$BUILDKITE_BRANCH -Dsonar.pullrequest.base=$BUILDKITE_PULL_REQUEST_BASE_BRANCH -Dsonar.pullrequest.key=$BUILDKITE_PULL_REQUEST"
+      - label: ":github: upload reports"
+        key: "scan-upload"
+        cancel_on_build_failing: true
+        if: build.branch == "main" && build.tag == null
+        depends_on: ["go_test"]
+        plugins:
+          - cluster-secrets#v1.0.0:
+              variables:
+                SONAR_TOKEN: SONAR_TOKEN
+          - artifacts#v1.9.4:
+              download: coverage.out
+              step: "go_test"
+          - docker#v5.12.0:
+              image: "sonarsource/sonar-scanner-cli:11.0"
+              environment:
+                - "SONAR_TOKEN"
+                - "SONAR_HOST_URL=$SONAR_HOST"
+  - group: ":golang: Builds"
+    key: "go-builds"
+    if: build.branch !~ /^renovate\//
+    steps:
+      - label: ":golang: build"
+        key: "gobuild-server"
+        cancel_on_build_failing: true
+        artifact_paths: "bin/${APP_NAME}"
+        agents:
+          queue: $LARGE_RUNNER_QUEUE
+          size: $RUNNER_LARGE
+        plugins:
+          - docker#v5.12.0:
+              image: "ghcr.io/theopenlane/build-image:latest"
+              always_pull: true
+              environment:
+                - CGO_ENABLED=0
+                - GOOS=linux
+              command: ["task", "go:build:ci"]
+      - label: ":terminal: build cli"
+        key: "gobuild-cli"
+        agents:
+          queue: $LARGE_RUNNER_QUEUE
+          size: $RUNNER_LARGE
+        cancel_on_build_failing: true
+        artifact_paths: "bin/openlane-cli"
+        plugins:
+          - docker#v5.12.0:
+              image: "ghcr.io/theopenlane/build-image:latest"
+              always_pull: true
+              environment:
+                - GOOS=darwin
+                - GOARCH=arm64
+              command: ["task", "go:build-cli:ci"]
   - group: ":database: schema lint"
     key: "database"
     if: build.branch !~ /^renovate\//
@@ -210,8 +210,7 @@ steps:
               exit 1
           else
               echo ""
-              echo "Linting result:"
-              echo $$output
+              echo "Linting Passed. See annotation for details."
 
               echo -e ":graphql: **Graphql Lint Results** \n <details><summary> Linter Result </summary><code>$$output</code></details>" |  buildkite-agent annotate --context apollo-lint-schema --style success
 
@@ -229,199 +228,199 @@ steps:
               environment:
                 - "APOLLO_KEY"
                 - "BUILDKITE_AGENT_ACCESS_TOKEN"
-# - group: ":docker: Image Build"
-#   depends_on: "go-builds"
-#   if: build.branch !~ /^renovate\//
-#   key: "image-build"
-#   steps:
-#     - label: ":docker: docker pr build"
-#       key: "docker-pr-build"
-#       agents:
-#         queue: $LARGE_RUNNER_QUEUE
-#         size: $RUNNER_LARGE
-#       cancel_on_build_failing: true
-#       if: build.branch != "main" && build.tag == null
-#       commands: |
-#         #!/bin/bash
-#         ls
-#       plugins:
-#         - artifacts#v1.9.4:
-#             download:
-#               - from: "bin/${APP_NAME}"
-#                 to: "${APP_NAME}"
-#             step: "gobuild-server"
-#         - cluster-secrets#v1.0.0:
-#             variables:
-#               SECRET_GHCR_PUBLISH_TOKEN: SECRET_GHCR_PUBLISH_TOKEN
-#         - docker-login#v3.0.0: # we need to login for the image to be accessible on the host
-#             username: openlane-bender
-#             password-env: SECRET_GHCR_PUBLISH_TOKEN
-#             server: ghcr.io
-#         - theopenlane/docker-metadata#v1.0.0:
-#             images:
-#               - "${IMAGE_REPO}"
-#             extra_tags:
-#               - "${IMAGE_TAG}"
-#         - theopenlane/container-build#v1.1.0:
-#             dockerfile: docker/Dockerfile
-#             push: false
-#             build-args:
-#               - NAME=${APP_NAME}
-#         - equinixmetal-buildkite/trivy#v1.19.0:
-#             severity: CRITICAL,HIGH
-#             ignore-unfixed: true
-#             scanners: misconfig,secret,vuln
-#             skip-files: "cosign.key,Dockerfile.dev"
-#             trivy-version: "0.57.1"
-#     - label: ":docker: docker build and publish"
-#       cancel_on_build_failing: true
-#       if: build.branch == "main" && build.tag == null
-#       commands: |
-#         #!/bin/bash
-#         ls
-#       plugins:
-#         - artifacts#v1.9.4:
-#             download:
-#               - from: "bin/${APP_NAME}"
-#                 to: "${APP_NAME}"
-#             step: "gobuild-server"
-#         - cluster-secrets#v1.0.0:
-#             variables:
-#               SECRET_GHCR_PUBLISH_TOKEN: SECRET_GHCR_PUBLISH_TOKEN
-#         - docker-login#v3.0.0:
-#             username: openlane-bender
-#             password-env: SECRET_GHCR_PUBLISH_TOKEN
-#             server: ghcr.io
-#         - theopenlane/docker-metadata#v1.0.0:
-#             images:
-#               - "${IMAGE_REPO}"
-#             extra_tags:
-#               - "${IMAGE_TAG}"
-#         - theopenlane/container-build#v1.1.0:
-#             dockerfile: docker/Dockerfile
-#             push: true
-#             build-args:
-#               - NAME=${APP_NAME}
-#         - equinixmetal-buildkite/trivy#v1.19.0:
-#             severity: CRITICAL,HIGH
-#             ignore-unfixed: true
-#             scanners: misconfig,secret,vuln
-#             skip-files: "cosign.key,Dockerfile.dev"
-#             trivy-version: "0.57.1"
-#     - label: ":docker: docker build and publish all in one"
-#       key: "docker-build-aio"
-#       agents:
-#         queue: $LARGE_RUNNER_QUEUE
-#         size: $RUNNER_LARGE
-#       if: build.branch == "main" && build.tag == null
-#       cancel_on_build_failing: true
-#       commands: |
-#         #!/bin/bash
-#       plugins:
-#         - cluster-secrets#v1.0.0:
-#             variables:
-#               SECRET_GCR_PUBLISH_TOKEN: SECRET_GCR_PUBLISH_TOKEN
-#         - docker-login#v3.0.0:
-#             username: _json_key_base64
-#             password-env: SECRET_GCR_PUBLISH_TOKEN
-#             server: us-west1-docker.pkg.dev
-#         - theopenlane/docker-metadata#v1.0.0:
-#             tag_prefix: "aio-"
-#             debug: true
-#             images:
-#               - "${GCR_REPO}"
-#             extra_tags:
-#               - "${IMAGE_TAG}"
-#         - theopenlane/container-build#v1.1.0:
-#             dockerfile: docker/all-in-one/Dockerfile.all-in-one
-#             push: true
-#             build-args:
-#               - NAME=${APP_NAME}
-#     - label: ":docker: docker build and publish"
-#       key: "docker-build-and-tag"
-#       cancel_on_build_failing: true
-#       if: build.tag != null
-#       commands: |
-#         #!/bin/bash
-#       plugins:
-#         - artifacts#v1.9.4:
-#             download:
-#               - from: "bin/${APP_NAME}"
-#                 to: "${APP_NAME}"
-#             step: "gobuild-server"
-#         - cluster-secrets#v1.0.0:
-#             variables:
-#               SECRET_GHCR_PUBLISH_TOKEN: SECRET_GHCR_PUBLISH_TOKEN
-#         - docker-login#v3.0.0:
-#             username: openlane-bender
-#             password-env: SECRET_GHCR_PUBLISH_TOKEN
-#             server: ghcr.io
-#         - theopenlane/docker-metadata#v1.0.0:
-#             images:
-#               - "${IMAGE_REPO}"
-#             extra_tags:
-#               - "${BUILDKITE_TAG}"
-#         - theopenlane/container-build#v1.1.0:
-#             dockerfile: docker/Dockerfile
-#             push: true
-#             build-args:
-#               - NAME=${APP_NAME}
-#     - label: ":docker: docker build and publish all in one"
-#       key: "docker-build-aio-and-tag"
-#       agents:
-#         queue: $LARGE_RUNNER_QUEUE
-#         size: $RUNNER_LARGE
-#       cancel_on_build_failing: true
-#       if: build.tag != null
-#       commands: |
-#         #!/bin/bash
-#       plugins:
-#         - cluster-secrets#v1.0.0:
-#             variables:
-#               SECRET_GCR_PUBLISH_TOKEN: SECRET_GCR_PUBLISH_TOKEN
-#         - docker-login#v3.0.0:
-#             username: _json_key_base64
-#             password-env: SECRET_GCR_PUBLISH_TOKEN
-#             server: us-west1-docker.pkg.dev
-#         - theopenlane/docker-metadata#v1.0.0:
-#             tag_prefix: "aio-"
-#             debug: true
-#             images:
-#               - "${GCR_REPO}"
-#             extra_tags:
-#               - "${BUILDKITE_TAG}"
-#         - theopenlane/container-build#v1.1.0:
-#             dockerfile: docker/all-in-one/Dockerfile.all-in-one
-#             push: true
-#             build-args:
-#               - NAME=${APP_NAME}
-# - group: ":rocket: Publish"
-#   key: "publish"
-#   steps:
-#     - label: ":graphql: publish graphql schema"
-#       key: "apollo-publish-schema"
-#       if: build.tag != null
-#       cancel_on_build_failing: true
-#       command: "rover graph publish --schema $$GRAPHQL_SCHEMA_LOCATION $$GRAPHQL_SCHEMA_NAME"
-#       plugins:
-#         - cluster-secrets#v1.0.0:
-#             variables:
-#               APOLLO_KEY: APOLLO_KEY
-#         - docker#v5.12.0:
-#             image: "ghcr.io/theopenlane/build-image:latest"
-#             always_pull: true
-#             propagate-environment: true
-#             environment:
-#               - "APOLLO_KEY"
-#     - label: ":rocket: atlas push"
-#       if: build.branch == "main" && build.tag == null
-#       key: "atlas_migrate"
-#       plugins:
-#         - cluster-secrets#v1.0.0:
-#             variables:
-#               ATLAS_CLOUD_TOKEN: ATLAS_CLOUD_TOKEN
-#         - theopenlane/atlas#v1.1.0:
-#             project: core
-#             dev-url: "docker://postgres/17/dev?search_path=public"
-#             dir: "file://db/migrations"
-#             step: migrate
+  - group: ":docker: Image Build"
+    depends_on: "go-builds"
+    if: build.branch !~ /^renovate\//
+    key: "image-build"
+    steps:
+      - label: ":docker: docker pr build"
+        key: "docker-pr-build"
+        agents:
+          queue: $LARGE_RUNNER_QUEUE
+          size: $RUNNER_LARGE
+        cancel_on_build_failing: true
+        if: build.branch != "main" && build.tag == null
+        commands: |
+          #!/bin/bash
+          ls
+        plugins:
+          - artifacts#v1.9.4:
+              download:
+                - from: "bin/${APP_NAME}"
+                  to: "${APP_NAME}"
+              step: "gobuild-server"
+          - cluster-secrets#v1.0.0:
+              variables:
+                SECRET_GHCR_PUBLISH_TOKEN: SECRET_GHCR_PUBLISH_TOKEN
+          - docker-login#v3.0.0: # we need to login for the image to be accessible on the host
+              username: openlane-bender
+              password-env: SECRET_GHCR_PUBLISH_TOKEN
+              server: ghcr.io
+          - theopenlane/docker-metadata#v1.0.0:
+              images:
+                - "${IMAGE_REPO}"
+              extra_tags:
+                - "${IMAGE_TAG}"
+          - theopenlane/container-build#v1.1.0:
+              dockerfile: docker/Dockerfile
+              push: false
+              build-args:
+                - NAME=${APP_NAME}
+          - equinixmetal-buildkite/trivy#v1.19.0:
+              severity: CRITICAL,HIGH
+              ignore-unfixed: true
+              scanners: misconfig,secret,vuln
+              skip-files: "cosign.key,Dockerfile.dev"
+              trivy-version: "0.57.1"
+      - label: ":docker: docker build and publish"
+        cancel_on_build_failing: true
+        if: build.branch == "main" && build.tag == null
+        commands: |
+          #!/bin/bash
+          ls
+        plugins:
+          - artifacts#v1.9.4:
+              download:
+                - from: "bin/${APP_NAME}"
+                  to: "${APP_NAME}"
+              step: "gobuild-server"
+          - cluster-secrets#v1.0.0:
+              variables:
+                SECRET_GHCR_PUBLISH_TOKEN: SECRET_GHCR_PUBLISH_TOKEN
+          - docker-login#v3.0.0:
+              username: openlane-bender
+              password-env: SECRET_GHCR_PUBLISH_TOKEN
+              server: ghcr.io
+          - theopenlane/docker-metadata#v1.0.0:
+              images:
+                - "${IMAGE_REPO}"
+              extra_tags:
+                - "${IMAGE_TAG}"
+          - theopenlane/container-build#v1.1.0:
+              dockerfile: docker/Dockerfile
+              push: true
+              build-args:
+                - NAME=${APP_NAME}
+          - equinixmetal-buildkite/trivy#v1.19.0:
+              severity: CRITICAL,HIGH
+              ignore-unfixed: true
+              scanners: misconfig,secret,vuln
+              skip-files: "cosign.key,Dockerfile.dev"
+              trivy-version: "0.57.1"
+      - label: ":docker: docker build and publish all in one"
+        key: "docker-build-aio"
+        agents:
+          queue: $LARGE_RUNNER_QUEUE
+          size: $RUNNER_LARGE
+        if: build.branch == "main" && build.tag == null
+        cancel_on_build_failing: true
+        commands: |
+          #!/bin/bash
+        plugins:
+          - cluster-secrets#v1.0.0:
+              variables:
+                SECRET_GCR_PUBLISH_TOKEN: SECRET_GCR_PUBLISH_TOKEN
+          - docker-login#v3.0.0:
+              username: _json_key_base64
+              password-env: SECRET_GCR_PUBLISH_TOKEN
+              server: us-west1-docker.pkg.dev
+          - theopenlane/docker-metadata#v1.0.0:
+              tag_prefix: "aio-"
+              debug: true
+              images:
+                - "${GCR_REPO}"
+              extra_tags:
+                - "${IMAGE_TAG}"
+          - theopenlane/container-build#v1.1.0:
+              dockerfile: docker/all-in-one/Dockerfile.all-in-one
+              push: true
+              build-args:
+                - NAME=${APP_NAME}
+      - label: ":docker: docker build and publish"
+        key: "docker-build-and-tag"
+        cancel_on_build_failing: true
+        if: build.tag != null
+        commands: |
+          #!/bin/bash
+        plugins:
+          - artifacts#v1.9.4:
+              download:
+                - from: "bin/${APP_NAME}"
+                  to: "${APP_NAME}"
+              step: "gobuild-server"
+          - cluster-secrets#v1.0.0:
+              variables:
+                SECRET_GHCR_PUBLISH_TOKEN: SECRET_GHCR_PUBLISH_TOKEN
+          - docker-login#v3.0.0:
+              username: openlane-bender
+              password-env: SECRET_GHCR_PUBLISH_TOKEN
+              server: ghcr.io
+          - theopenlane/docker-metadata#v1.0.0:
+              images:
+                - "${IMAGE_REPO}"
+              extra_tags:
+                - "${BUILDKITE_TAG}"
+          - theopenlane/container-build#v1.1.0:
+              dockerfile: docker/Dockerfile
+              push: true
+              build-args:
+                - NAME=${APP_NAME}
+      - label: ":docker: docker build and publish all in one"
+        key: "docker-build-aio-and-tag"
+        agents:
+          queue: $LARGE_RUNNER_QUEUE
+          size: $RUNNER_LARGE
+        cancel_on_build_failing: true
+        if: build.tag != null
+        commands: |
+          #!/bin/bash
+        plugins:
+          - cluster-secrets#v1.0.0:
+              variables:
+                SECRET_GCR_PUBLISH_TOKEN: SECRET_GCR_PUBLISH_TOKEN
+          - docker-login#v3.0.0:
+              username: _json_key_base64
+              password-env: SECRET_GCR_PUBLISH_TOKEN
+              server: us-west1-docker.pkg.dev
+          - theopenlane/docker-metadata#v1.0.0:
+              tag_prefix: "aio-"
+              debug: true
+              images:
+                - "${GCR_REPO}"
+              extra_tags:
+                - "${BUILDKITE_TAG}"
+          - theopenlane/container-build#v1.1.0:
+              dockerfile: docker/all-in-one/Dockerfile.all-in-one
+              push: true
+              build-args:
+                - NAME=${APP_NAME}
+  - group: ":rocket: Publish"
+    key: "publish"
+    steps:
+      - label: ":graphql: publish graphql schema"
+        key: "apollo-publish-schema"
+        if: build.tag != null
+        cancel_on_build_failing: true
+        command: "rover graph publish --schema $$GRAPHQL_SCHEMA_LOCATION $$GRAPHQL_SCHEMA_NAME"
+        plugins:
+          - cluster-secrets#v1.0.0:
+              variables:
+                APOLLO_KEY: APOLLO_KEY
+          - docker#v5.12.0:
+              image: "ghcr.io/theopenlane/build-image:latest"
+              always_pull: true
+              propagate-environment: true
+              environment:
+                - "APOLLO_KEY"
+      - label: ":rocket: atlas push"
+        if: build.branch == "main" && build.tag == null
+        key: "atlas_migrate"
+        plugins:
+          - cluster-secrets#v1.0.0:
+              variables:
+                ATLAS_CLOUD_TOKEN: ATLAS_CLOUD_TOKEN
+          - theopenlane/atlas#v1.1.0:
+              project: core
+              dev-url: "docker://postgres/17/dev?search_path=public"
+              dir: "file://db/migrations"
+              step: migrate


### PR DESCRIPTION
Adds a graphql linter for schema changes, set to soft fail.

Example on error: https://buildkite.com/theopenlane/core/builds/1931
Example on success: https://buildkite.com/theopenlane/core/builds/1932

Moves atlas schema publish to the publish step