### PR TITLE
bug: fix missing feature in subscriptions

### DIFF
--- a/pkg/entitlements/subscriptions.go
+++ b/pkg/entitlements/subscriptions.go
@@ -149,16 +149,18 @@ func (sc *StripeClient) retrieveActiveEntitlements(customerID string) ([]string,
 
 	iter := sc.Client.EntitlementsActiveEntitlements.List(params)
 
-	if !iter.Next() {
-		return nil, nil, iter.Err()
-	}
-
 	feat := []string{}
 	featNames := []string{}
 
 	for iter.Next() {
 		feat = append(feat, iter.EntitlementsActiveEntitlement().LookupKey)
 		featNames = append(featNames, iter.EntitlementsActiveEntitlement().Feature.Name)
+	}
+
+	if iter.Err() != nil {
+		log.Err(iter.Err()).Msg("failed to find active entitlements")
+
+		return nil, nil, iter.Err()
 	}
 
 	return feat, featNames, nil


### PR DESCRIPTION
Calling `iter.Next() ` early caused the iter to advance by 1 without getting the result; we should instead check the error after it is called. 