### PR TITLE
feat: qr code on create, recovery codes on verification of device

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -32,7 +32,7 @@ env:
   ## generate env vars for caching
   GO_GENERATE_FAST_DEBUG: "false" # set to true to debug go-generate-fast
   GO_GENERATE_FAST_CACHE_DIR: "/tmp/.cache"
-  GO_GENERATE_FAST_DISABLE: "true" # set to true to disable cached entries
+  GO_GENERATE_FAST_DISABLE: "false" # set to true to disable cached entries
   GO_GENERATE_FAST_RECACHE: "false" # set to true to recache all entries
 
 tasks:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -32,7 +32,7 @@ env:
   ## generate env vars for caching
   GO_GENERATE_FAST_DEBUG: "false" # set to true to debug go-generate-fast
   GO_GENERATE_FAST_CACHE_DIR: "/tmp/.cache"
-  GO_GENERATE_FAST_DISABLE: "false" # set to true to disable cached entries
+  GO_GENERATE_FAST_DISABLE: "true" # set to true to disable cached entries
   GO_GENERATE_FAST_RECACHE: "false" # set to true to recache all entries
 
 tasks:

--- a/internal/ent/generated/runtime/runtime.go
+++ b/internal/ent/generated/runtime/runtime.go
@@ -3040,6 +3040,8 @@ func init() {
 	tfasetting.Hooks[3] = tfasettingMixinHooks3[0]
 
 	tfasetting.Hooks[4] = tfasettingHooks[0]
+
+	tfasetting.Hooks[5] = tfasettingHooks[1]
 	tfasettingMixinInters2 := tfasettingMixin[2].Interceptors()
 	tfasetting.Interceptors[0] = tfasettingMixinInters2[0]
 	tfasettingMixinFields0 := tfasettingMixin[0].Fields()

--- a/internal/ent/generated/tfasetting/tfasetting.go
+++ b/internal/ent/generated/tfasetting/tfasetting.go
@@ -88,7 +88,7 @@ func ValidColumn(column string) bool {
 //
 //	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
-	Hooks        [5]ent.Hook
+	Hooks        [6]ent.Hook
 	Interceptors [1]ent.Interceptor
 	Policy       ent.Policy
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.

--- a/internal/ent/hooks/tfasettings.go
+++ b/internal/ent/hooks/tfasettings.go
@@ -17,7 +17,40 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated/usersetting"
 )
 
+// HookEnableTFA is a hook that generates the tfa secrets if the totp setting is set to allowed
 func HookEnableTFA() ent.Hook {
+	return hook.On(func(next ent.Mutator) ent.Mutator {
+		return hook.TFASettingFunc(func(ctx context.Context, m *generated.TFASettingMutation) (generated.Value, error) {
+			// if the user has TOTP enabled, generate a secret
+			totpAllowed, ok := m.TotpAllowed()
+
+			if !ok || !totpAllowed {
+				return next.Mutate(ctx, m)
+			}
+
+			u, err := constructTOTPUser(ctx, m)
+			if err != nil {
+				return nil, err
+			}
+
+			u.TFASecret, err = m.TOTP.TOTPManager.TOTPSecret(u)
+			if err != nil {
+				log.Error().Err(err).Msg("unable to generate TOTP secret")
+
+				return nil, err
+			}
+
+			// set the TFA secret
+			m.SetTfaSecret(u.TFASecret)
+
+			return next.Mutate(ctx, m)
+		})
+	}, ent.OpCreate)
+}
+
+// HookVerifyTFA is a hook that will generate recovery codes and enable TFA for a user
+// if the TFA has been verified
+func HookVerifyTFA() ent.Hook {
 	return hook.On(func(next ent.Mutator) ent.Mutator {
 		return hook.TFASettingFunc(func(ctx context.Context, m *generated.TFASettingMutation) (generated.Value, error) {
 			// once verified, create recovery codes
@@ -32,38 +65,59 @@ func HookEnableTFA() ent.Hook {
 			}
 
 			if (ok && verified) || regenBackupCodes {
-				u, err := constructTOTPUser(ctx, m)
-				if err != nil {
-					return nil, err
-				}
-
-				u.TFASecret, err = m.TOTP.TOTPManager.TOTPSecret(u)
-				if err != nil {
-					log.Error().Err(err).Msg("unable to generate TOTP secret")
-
-					return nil, err
-				}
-
-				m.SetTfaSecret(u.TFASecret)
-
+				log.Error().Bool("regenBackupCodes", regenBackupCodes).Msg("generating recovery codes and enabling TFA")
 				codes := m.TOTP.TOTPManager.GenerateRecoveryCodes()
 				m.SetRecoveryCodes(codes)
 
 				if verified {
-					// update user settings
-					_, err := m.Client().UserSetting.Update().
-						Where(usersetting.UserID(u.ID)).
-						SetIsTfaEnabled(true). // set tfa enabled to true
-						Save(ctx)
-					if err != nil {
+					if err := setUserTFASetting(ctx, m, true); err != nil {
 						return nil, err
 					}
 				}
 			}
 
+			totpAllowed, ok := m.TotpAllowed()
+			if ok && !totpAllowed {
+				// if TOTP is not allowed, clear the TFA settings
+				m.SetVerified(false)
+				m.SetRecoveryCodes(nil)
+				m.SetTfaSecret("")
+
+				// disable TFA on the user settings
+				if err := setUserTFASetting(ctx, m, false); err != nil {
+					return nil, err
+				}
+
+			}
+
 			return next.Mutate(ctx, m)
 		})
 	}, ent.OpUpdate|ent.OpUpdateOne)
+}
+
+// enableTFA is a function that enables TFA for a user on their user settings
+// once the TFA has been verified
+func setUserTFASetting(ctx context.Context, m *generated.TFASettingMutation, enabled bool) error {
+	userID, ok := m.OwnerID()
+	if !ok {
+		var err error
+
+		userID, err = auth.GetUserIDFromContext(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	// update user settings
+	if err := m.Client().UserSetting.Update().
+		Where(usersetting.UserID(userID)).
+		SetIsTfaEnabled(enabled). // set tfa enabled
+		Exec(ctx); err != nil {
+
+		return err
+	}
+
+	return nil
 }
 
 // constructTOTPUser constructs a TOTP user object from the mutation

--- a/internal/ent/hooks/tfasettings.go
+++ b/internal/ent/hooks/tfasettings.go
@@ -31,6 +31,7 @@ func HookEnableTFA() ent.Hook {
 			// check if the user has a TFA secret
 			if m.Op() != ent.OpCreate {
 				id, _ := m.ID() // get the ID of the TFA setting which will always be present on update
+
 				existingSetting, err := m.Client().TFASetting.Get(ctx, id)
 				if err != nil {
 					return nil, err

--- a/internal/ent/schema/tfasetting.go
+++ b/internal/ent/schema/tfasetting.go
@@ -83,7 +83,9 @@ func (TFASetting) Mixin() []ent.Mixin {
 // Hooks of the TFASetting
 func (TFASetting) Hooks() []ent.Hook {
 	return []ent.Hook{
-		hooks.HookEnableTFA(), // sets 2fa on user settings and stores recovery codes
+		hooks.HookEnableTFA(), // sets 2fa secret if totp is allowed
+		hooks.HookVerifyTFA(), // generates recovery codes and enables TFA on a user settings
+
 	}
 }
 

--- a/internal/graphapi/clientschema/schema.graphql
+++ b/internal/graphapi/clientschema/schema.graphql
@@ -27015,6 +27015,7 @@ type TFASettingCreatePayload {
 	Created tfaSetting
 	"""
 	tfaSetting: TFASetting!
+	qrCode: String
 }
 """
 An edge in a connection.

--- a/internal/graphapi/generated/actionplan.generated.go
+++ b/internal/graphapi/generated/actionplan.generated.go
@@ -15036,6 +15036,8 @@ func (ec *executionContext) fieldContext_Mutation_createTFASetting(ctx context.C
 			switch field.Name {
 			case "tfaSetting":
 				return ec.fieldContext_TFASettingCreatePayload_tfaSetting(ctx, field)
+			case "qrCode":
+				return ec.fieldContext_TFASettingCreatePayload_qrCode(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TFASettingCreatePayload", field.Name)
 		},

--- a/internal/graphapi/generated/root_.generated.go
+++ b/internal/graphapi/generated/root_.generated.go
@@ -3017,6 +3017,7 @@ type ComplexityRoot struct {
 	}
 
 	TFASettingCreatePayload struct {
+		QRCode     func(childComplexity int) int
 		TfaSetting func(childComplexity int) int
 	}
 
@@ -19079,6 +19080,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.TFASettingConnection.TotalCount(childComplexity), true
+
+	case "TFASettingCreatePayload.qrCode":
+		if e.complexity.TFASettingCreatePayload.QRCode == nil {
+			break
+		}
+
+		return e.complexity.TFASettingCreatePayload.QRCode(childComplexity), true
 
 	case "TFASettingCreatePayload.tfaSetting":
 		if e.complexity.TFASettingCreatePayload.TfaSetting == nil {
@@ -53601,7 +53609,12 @@ type TemplateBulkCreatePayload {
 	{Name: "../schema/tfaextended.graphql", Input: `extend type TFASettingUpdatePayload {
     qrCode: String
     recoveryCodes: [String!]
-}`, BuiltIn: false},
+}
+
+extend type TFASettingCreatePayload {
+    qrCode: String
+}
+`, BuiltIn: false},
 	{Name: "../schema/tfasetting.graphql", Input: `extend type Query {
     """
     Look up tfaSetting for the current user

--- a/internal/graphapi/generated/tfasetting.generated.go
+++ b/internal/graphapi/generated/tfasetting.generated.go
@@ -95,6 +95,47 @@ func (ec *executionContext) fieldContext_TFASettingCreatePayload_tfaSetting(_ co
 	return fc, nil
 }
 
+func (ec *executionContext) _TFASettingCreatePayload_qrCode(ctx context.Context, field graphql.CollectedField, obj *model.TFASettingCreatePayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TFASettingCreatePayload_qrCode(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.QRCode, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TFASettingCreatePayload_qrCode(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TFASettingCreatePayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _TFASettingUpdatePayload_tfaSetting(ctx context.Context, field graphql.CollectedField, obj *model.TFASettingUpdatePayload) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_TFASettingUpdatePayload_tfaSetting(ctx, field)
 	if err != nil {
@@ -271,6 +312,8 @@ func (ec *executionContext) _TFASettingCreatePayload(ctx context.Context, sel as
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "qrCode":
+			out.Values[i] = ec._TFASettingCreatePayload_qrCode(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/internal/graphapi/model/gen_models.go
+++ b/internal/graphapi/model/gen_models.go
@@ -918,6 +918,7 @@ type SubscriberUpdatePayload struct {
 type TFASettingCreatePayload struct {
 	// Created tfaSetting
 	TfaSetting *generated.TFASetting `json:"tfaSetting"`
+	QRCode     *string               `json:"qrCode,omitempty"`
 }
 
 // Return response for updateTFASetting mutation

--- a/internal/graphapi/models_test.go
+++ b/internal/graphapi/models_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/brianvoe/gofakeit/v7"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	ent "github.com/theopenlane/core/internal/ent/generated"
@@ -67,6 +68,8 @@ type UserCleanup struct {
 
 type TFASettingBuilder struct {
 	client *client
+
+	totpAllowed *bool
 }
 
 type OrgMemberBuilder struct {
@@ -383,8 +386,12 @@ func (u *UserCleanup) MustDelete(ctx context.Context, t *testing.T) {
 
 // MustNew tfa settings builder is used to create, without authz checks, tfa settings in the database
 func (tf *TFASettingBuilder) MustNew(ctx context.Context, t *testing.T, userID string) *ent.TFASetting {
+	if tf.totpAllowed == nil {
+		tf.totpAllowed = lo.ToPtr(true)
+	}
+
 	return tf.client.db.TFASetting.Create().
-		SetTotpAllowed(true).
+		SetTotpAllowed(*tf.totpAllowed).
 		SetOwnerID(userID).
 		SaveX(ctx)
 }

--- a/internal/graphapi/query/tfasetting.graphql
+++ b/internal/graphapi/query/tfasetting.graphql
@@ -7,6 +7,7 @@ mutation CreateTFASetting($input: CreateTFASettingInput!) {
         id
       }
     }
+    qrCode
   }
 }
 

--- a/internal/graphapi/schema/tfaextended.graphql
+++ b/internal/graphapi/schema/tfaextended.graphql
@@ -2,3 +2,7 @@ extend type TFASettingUpdatePayload {
     qrCode: String
     recoveryCodes: [String!]
 }
+
+extend type TFASettingCreatePayload {
+    qrCode: String
+}

--- a/internal/graphapi/tfahelpers.go
+++ b/internal/graphapi/tfahelpers.go
@@ -1,0 +1,35 @@
+package graphapi
+
+import (
+	"context"
+
+	"entgo.io/ent/dialect/sql"
+	"github.com/theopenlane/iam/totp"
+
+	"github.com/theopenlane/core/internal/ent/generated"
+	"github.com/theopenlane/core/internal/ent/utils"
+)
+
+// generateTFAQRCode generates a QR code for the user's TFA secret
+func (r *mutationResolver) generateTFAQRCode(ctx context.Context, settings *generated.TFASetting, email, userID string) (string, error) {
+	if !utils.CheckForRequestedField(ctx, "qrCode") {
+		return "", nil
+	}
+
+	if !settings.TotpAllowed || settings.TfaSecret == nil {
+		return "", nil
+	}
+
+	// generate a new QR code if it was requested
+	qrCode, err := r.db.TOTP.TOTPManager.TOTPQRString(&totp.User{
+		ID:            userID,
+		TFASecret:     *settings.TfaSecret,
+		Email:         sql.NullString{String: email, Valid: true},
+		IsTOTPAllowed: settings.TotpAllowed,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return qrCode, nil
+}

--- a/internal/graphapi/tfasetting_test.go
+++ b/internal/graphapi/tfasetting_test.go
@@ -162,7 +162,11 @@ func (suite *GraphTestSuite) TestMutationCreateTFASetting() {
 func (suite *GraphTestSuite) TestMutationUpdateTFASetting() {
 	t := suite.T()
 
+	// create tfa settings for users
 	(&TFASettingBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t, testUser1.ID)
+
+	// create one with not enabled by default
+	(&TFASettingBuilder{client: suite.client, totpAllowed: lo.ToPtr(false)}).MustNew(testUser2.UserCtx, t, testUser2.ID)
 
 	recoveryCodes := []string{}
 
@@ -176,7 +180,8 @@ func (suite *GraphTestSuite) TestMutationUpdateTFASetting() {
 		{
 			name: "update verify",
 			input: openlaneclient.UpdateTFASettingInput{
-				Verified: lo.ToPtr(true),
+				TotpAllowed: lo.ToPtr(true),
+				Verified:    lo.ToPtr(true),
 			},
 			client: suite.client.api,
 			ctx:    testUser1.UserCtx,
@@ -213,6 +218,14 @@ func (suite *GraphTestSuite) TestMutationUpdateTFASetting() {
 			},
 			client: suite.client.api,
 			ctx:    testUser1.UserCtx,
+		},
+		{
+			name: "update TotpAllowed to true should enable TFA",
+			input: openlaneclient.UpdateTFASettingInput{
+				TotpAllowed: lo.ToPtr(true),
+			},
+			client: suite.client.api,
+			ctx:    testUser2.UserCtx,
 		},
 	}
 

--- a/internal/graphapi/tfasetting_test.go
+++ b/internal/graphapi/tfasetting_test.go
@@ -110,6 +110,15 @@ func (suite *GraphTestSuite) TestMutationCreateTFASetting() {
 			ctx:    testUser1.UserCtx,
 			errMsg: "tfasetting already exists",
 		},
+		{
+			name:   "create with not enabling totp should not return qr code",
+			userID: viewOnlyUser.ID,
+			input: openlaneclient.CreateTFASettingInput{
+				TotpAllowed: lo.ToPtr(false),
+			},
+			client: suite.client.api,
+			ctx:    viewOnlyUser.UserCtx,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -131,6 +140,13 @@ func (suite *GraphTestSuite) TestMutationCreateTFASetting() {
 
 			// Make sure provided values match
 			assert.Equal(t, tc.input.TotpAllowed, resp.CreateTFASetting.TfaSetting.TotpAllowed)
+
+			if *tc.input.TotpAllowed {
+				assert.NotEmpty(t, resp.CreateTFASetting.QRCode)
+			} else {
+				assert.Empty(t, resp.CreateTFASetting.QRCode)
+			}
+
 			require.NotEmpty(t, resp.CreateTFASetting.TfaSetting.Owner)
 			assert.Equal(t, tc.userID, resp.CreateTFASetting.TfaSetting.Owner.ID)
 
@@ -190,6 +206,14 @@ func (suite *GraphTestSuite) TestMutationUpdateTFASetting() {
 			client: suite.client.api,
 			ctx:    testUser1.UserCtx,
 		},
+		{
+			name: "update totp to false should clear settings",
+			input: openlaneclient.UpdateTFASettingInput{
+				TotpAllowed: lo.ToPtr(false),
+			},
+			client: suite.client.api,
+			ctx:    testUser1.UserCtx,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -209,25 +233,36 @@ func (suite *GraphTestSuite) TestMutationUpdateTFASetting() {
 			require.NotNil(t, resp)
 			require.NotNil(t, resp.UpdateTFASetting.TfaSetting)
 
-			// Make sure provided values match
-			assert.NotEmpty(t, resp.UpdateTFASetting.RecoveryCodes)
-
 			// backup codes should only be regenerated on explicit request
-			if tc.input.RegenBackupCodes != nil {
-				if *tc.input.RegenBackupCodes {
-					assert.NotEqual(t, recoveryCodes, resp.UpdateTFASetting.RecoveryCodes)
-				} else {
-					assert.Equal(t, recoveryCodes, resp.UpdateTFASetting.RecoveryCodes)
+			// and should only be returned on initial verification or regen request
+			if (tc.input.RegenBackupCodes != nil && *tc.input.RegenBackupCodes) ||
+				(tc.input.Verified != nil && *tc.input.Verified) {
+				// recovery codes should be returned
+				assert.NotEmpty(t, resp.UpdateTFASetting.RecoveryCodes)
+
+				if tc.input.RegenBackupCodes != nil {
+					if *tc.input.RegenBackupCodes {
+						assert.NotEqual(t, recoveryCodes, resp.UpdateTFASetting.RecoveryCodes)
+					} else {
+						assert.Equal(t, recoveryCodes, resp.UpdateTFASetting.RecoveryCodes)
+					}
 				}
+			} else {
+				assert.Empty(t, resp.UpdateTFASetting.RecoveryCodes)
 			}
 
-			// make sure user setting was not updated
+			// make sure user setting is updated correctly
 			userSettings, err := tc.client.GetAllUserSettings(tc.ctx)
 			require.NoError(t, err)
 			require.Len(t, userSettings.UserSettings.Edges, 1)
 
 			if resp.UpdateTFASetting.TfaSetting.Verified {
 				assert.True(t, *userSettings.UserSettings.Edges[0].Node.IsTfaEnabled)
+			}
+
+			// ensure TFA is disabled if totp is not allowed
+			if !*resp.UpdateTFASetting.TfaSetting.TotpAllowed {
+				assert.False(t, *userSettings.UserSettings.Edges[0].Node.IsTfaEnabled)
 			}
 
 			// set at the end so we can compare later

--- a/pkg/openlaneclient/graphclient.go
+++ b/pkg/openlaneclient/graphclient.go
@@ -42764,9 +42764,16 @@ func (t *CreateTFASetting_CreateTFASetting_TfaSetting) GetVerified() bool {
 }
 
 type CreateTFASetting_CreateTFASetting struct {
+	QRCode     *string                                      "json:\"qrCode,omitempty\" graphql:\"qrCode\""
 	TfaSetting CreateTFASetting_CreateTFASetting_TfaSetting "json:\"tfaSetting\" graphql:\"tfaSetting\""
 }
 
+func (t *CreateTFASetting_CreateTFASetting) GetQRCode() *string {
+	if t == nil {
+		t = &CreateTFASetting_CreateTFASetting{}
+	}
+	return t.QRCode
+}
 func (t *CreateTFASetting_CreateTFASetting) GetTfaSetting() *CreateTFASetting_CreateTFASetting_TfaSetting {
 	if t == nil {
 		t = &CreateTFASetting_CreateTFASetting{}
@@ -61983,6 +61990,7 @@ const CreateTFASettingDocument = `mutation CreateTFASetting ($input: CreateTFASe
 				id
 			}
 		}
+		qrCode
 	}
 }
 `

--- a/pkg/openlaneclient/models.go
+++ b/pkg/openlaneclient/models.go
@@ -17558,6 +17558,7 @@ type TFASettingConnection struct {
 type TFASettingCreatePayload struct {
 	// Created tfaSetting
 	TfaSetting *TFASetting `json:"tfaSetting"`
+	QRCode     *string     `json:"qrCode,omitempty"`
 }
 
 // An edge in a connection.


### PR DESCRIPTION
- TFA secret + QRCode should be be generated when tfa settings are created and `totpAllowed` is set to true
- Recovery codes should only be returned when verifying or regenerating recovery codes

Flow: 

- Create TFA setting with `totpAllowed=true`, tfa secret generated, qr code returned (if requested)
- Update TFA setting with `verified`, recovery codes returned
- Update TFA setting with `regenBackupCodes`, new recovery codes returned

- If a TFA setting is created with `totpAllowed=false`, an update will also trigger the creation of the tfa secret
- If totpAllowed is set to false, the secret and recovery codes will be removed and the users 2fa enabled setting will be set to false
