### PR TITLE
bug: switch back to 20250106.725 version of runner

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -33,7 +33,7 @@ jobs:
     permissions:
       contents: write # To add assets to a release.
       id-token: write # To do keyless signing with cosign
-    runs-on: macos-latest
+    runs-on: macos-20250106.725
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The latest macos broke our cli build; where it will now try to save to the `keyring` (backup file) instead of the `keychain`. Hopeing this will fix it until I can figure out the things to get it working. 

```
Enter passphrase to unlock "/Users/sarahfunkhouser/Library/Application Support/openlane/keyring": 
```

The last working verison of the cli was `0.6.10`