### PR TITLE
bug:org owner access to compliance objects 

### DIFF
--- a/fga/model/model.fga
+++ b/fga/model/model.fga
@@ -292,3 +292,4 @@ type task
     define assignee: [user]
     define audit_log_viewer: ([user, service] or audit_log_viewer from parent) and can_view
     define parent: [user, service, program, organization, control, procedure, group, internal_policy, subcontrol, control_objective]
+    define editor: [organization#owner]

--- a/fga/model/model.fga
+++ b/fga/model/model.fga
@@ -150,17 +150,18 @@ type control
     define audit_log_viewer: ([user, service] or audit_log_viewer from parent) and can_view
     define parent: [user, service, program]
     define viewer: [group#member]
-    define editor: [group#member]
+    define editor: [group#member, organization#owner]
     define blocked: [user, group#member]
 # subcontrols are associated with an organization but do not inherit access from the organization
 # subcontrols inherit access from the their parent control(s)
 type subcontrol
   relations
     define can_view: [user, service] or can_edit or can_view from parent
-    define can_edit: [user, service] or can_edit from parent
-    define can_delete: [user, service] or can_delete from parent
+    define can_edit: [user, service] or editor or can_edit from parent
+    define can_delete: [user, service] or editor or can_delete from parent
     define audit_log_viewer: ([user, service] or audit_log_viewer from parent) and can_view
     define parent: [user, service, control]
+    define editor: [organization#owner]
 # control objectives inherit access from the associated program or from associated groups
 # the control objective author will be assigned as an admin of the control objective
 type control_objective
@@ -171,7 +172,7 @@ type control_objective
     define audit_log_viewer: ([user, service] or audit_log_viewer from parent) and can_view
     define parent: [user, service, program]
     define viewer: [group#member]
-    define editor: [group#member]
+    define editor: [group#member, organization#owner]
     define blocked: [user, group#member]
 # risks are associated with an organization but do not inherit access from the organization
 # the risk creator will be made the admin of the risk and all other access will be assigned via
@@ -184,7 +185,7 @@ type risk
     define audit_log_viewer: ([user, service] or audit_log_viewer from parent) and can_view
     define parent: [user, service, program]
     define viewer: [group#member] or editor
-    define editor: [group#member]
+    define editor: [group#member, organization#owner]
     define blocked: [user, group#member]
 # narratives are associated with an organization but do not inherit access from the organization
 # the narrative creator will be made the admin of the narrative and all other access will be assigned via
@@ -197,7 +198,7 @@ type narrative
     define audit_log_viewer: ([user, service] or audit_log_viewer from parent) and can_view
     define parent: [user, service, program]
     define viewer: [group#member] or editor
-    define editor: [group#member]
+    define editor: [group#member, organization#owner]
     define blocked: [user, group#member]
 # policies are always assigned to an organization and by default all org members can view
 # groups can be used to exclude users from being able to view a internal policy

--- a/internal/ent/hooks/authzmutationhelpers.go
+++ b/internal/ent/hooks/authzmutationhelpers.go
@@ -228,6 +228,26 @@ func GetObjectIDFromEntValue(m ent.Value) (string, error) {
 	return o.ID, nil
 }
 
+// GetObjectIDFromEntDeleteValue extracts the object deleted id from a generic ent value return type
+// this function should be called after the mutation has been successful
+func GetObjectIDFromEntDeleteValue(m ent.Value) (string, error) {
+	type objectIDer struct {
+		DeletedID string `json:"id"`
+	}
+
+	tmp, err := json.Marshal(m)
+	if err != nil {
+		return "", err
+	}
+
+	var o objectIDer
+	if err := json.Unmarshal(tmp, &o); err != nil {
+		return "", err
+	}
+
+	return o.DeletedID, nil
+}
+
 // getParentIDFromEntValue extracts the parent id from a generic ent value return type
 // if it is not set, it will return an empty string
 // this function does not ensure that the mutation was successful, it only extracts the id

--- a/internal/ent/hooks/authzmutationhelpers.go
+++ b/internal/ent/hooks/authzmutationhelpers.go
@@ -16,7 +16,8 @@ import (
 	"github.com/theopenlane/core/internal/ent/privacy/utils"
 )
 
-func getObjectTypeFromEntMutation(m ent.Mutation) string {
+// GetObjectTypeFromEntMutation gets the object type from the ent mutation
+func GetObjectTypeFromEntMutation(m ent.Mutation) string {
 	return strcase.SnakeCase(m.Type())
 }
 
@@ -60,7 +61,7 @@ func createParentTuples(ctx context.Context, m ent.Mutation, objectID string, pa
 		tr := fgax.TupleRequest{
 			SubjectType: subjectType,
 			ObjectID:    objectID,                        // this is the object id being created
-			ObjectType:  getObjectTypeFromEntMutation(m), // this is the object type being created
+			ObjectType:  GetObjectTypeFromEntMutation(m), // this is the object type being created
 			Relation:    fgax.ParentRelation,
 		}
 
@@ -84,7 +85,7 @@ func createOrgOwnerParentTuple(ctx context.Context, m ent.Mutation, objectID str
 	tr := fgax.TupleRequest{
 		SubjectType: "organization",
 		ObjectID:    objectID,                        // this is the object id being created
-		ObjectType:  getObjectTypeFromEntMutation(m), // this is the object type being created
+		ObjectType:  GetObjectTypeFromEntMutation(m), // this is the object type being created
 		Relation:    fgax.ParentRelation,
 	}
 
@@ -110,7 +111,7 @@ func createTuplesByRelation(ctx context.Context, m ent.Mutation, objectID string
 			SubjectType:     subjectType,
 			SubjectRelation: fgax.MemberRelation,
 			ObjectID:        objectID,                        // this is the object id being created
-			ObjectType:      getObjectTypeFromEntMutation(m), // this is the object type being created
+			ObjectType:      GetObjectTypeFromEntMutation(m), // this is the object type being created
 			Relation:        relation.String(),
 		}
 
@@ -166,7 +167,7 @@ func removeParentTuples(ctx context.Context, m ent.Mutation, objectID string, pa
 		tr := fgax.TupleRequest{
 			SubjectType: subjectType,
 			ObjectID:    objectID,                        // this is the object id being created
-			ObjectType:  getObjectTypeFromEntMutation(m), // this is the object type being created
+			ObjectType:  GetObjectTypeFromEntMutation(m), // this is the object type being created
 			Relation:    fgax.ParentRelation,
 		}
 
@@ -192,7 +193,7 @@ func removeTuplesByRelation(ctx context.Context, m ent.Mutation, objectID string
 			SubjectType:     subjectType,
 			SubjectRelation: fgax.MemberRelation,
 			ObjectID:        objectID,                        // this is the object id being created
-			ObjectType:      getObjectTypeFromEntMutation(m), // this is the object type being created
+			ObjectType:      GetObjectTypeFromEntMutation(m), // this is the object type being created
 			Relation:        relation.String(),
 		}
 
@@ -207,9 +208,9 @@ func removeTuplesByRelation(ctx context.Context, m ent.Mutation, objectID string
 	return removeTuples, nil
 }
 
-// getObjectIDFromEntValue extracts the object id from a generic ent value return type
+// GetObjectIDFromEntValue extracts the object id from a generic ent value return type
 // this function should be called after the mutation has been successful
-func getObjectIDFromEntValue(m ent.Value) (string, error) {
+func GetObjectIDFromEntValue(m ent.Value) (string, error) {
 	type objectIDer struct {
 		ID string `json:"id"`
 	}

--- a/internal/ent/hooks/authzmutationhelpers.go
+++ b/internal/ent/hooks/authzmutationhelpers.go
@@ -228,26 +228,6 @@ func GetObjectIDFromEntValue(m ent.Value) (string, error) {
 	return o.ID, nil
 }
 
-// GetObjectIDFromEntDeleteValue extracts the object deleted id from a generic ent value return type
-// this function should be called after the mutation has been successful
-func GetObjectIDFromEntDeleteValue(m ent.Value) (string, error) {
-	type objectIDer struct {
-		DeletedID string `json:"id"`
-	}
-
-	tmp, err := json.Marshal(m)
-	if err != nil {
-		return "", err
-	}
-
-	var o objectIDer
-	if err := json.Unmarshal(tmp, &o); err != nil {
-		return "", err
-	}
-
-	return o.DeletedID, nil
-}
-
 // getParentIDFromEntValue extracts the parent id from a generic ent value return type
 // if it is not set, it will return an empty string
 // this function does not ensure that the mutation was successful, it only extracts the id

--- a/internal/ent/hooks/authzmutationhelpers_test.go
+++ b/internal/ent/hooks/authzmutationhelpers_test.go
@@ -42,7 +42,7 @@ func TestGetObjectIDFromEntValue(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := getObjectIDFromEntValue(tt.input)
+			got, err := GetObjectIDFromEntValue(tt.input)
 			if tt.wantErr {
 				assert.Error(t, err)
 

--- a/internal/ent/hooks/group.go
+++ b/internal/ent/hooks/group.go
@@ -122,7 +122,7 @@ func groupCreateHook(ctx context.Context, m *generated.GroupMutation) error {
 				return err
 			}
 		} else {
-			if err := addTokenEditPermissions(ctx, objID, getObjectTypeFromEntMutation(m)); err != nil {
+			if err := addTokenEditPermissions(ctx, objID, GetObjectTypeFromEntMutation(m)); err != nil {
 				return err
 			}
 		}
@@ -135,7 +135,7 @@ func groupCreateHook(ctx context.Context, m *generated.GroupMutation) error {
 			SubjectID:   org,
 			SubjectType: "organization",
 			ObjectID:    objID,
-			ObjectType:  getObjectTypeFromEntMutation(m),
+			ObjectType:  GetObjectTypeFromEntMutation(m),
 		}
 
 		log.Debug().Interface("tuple", req).Msg("creating relationship tuple")
@@ -204,7 +204,7 @@ func groupDeleteHook(ctx context.Context, m *generated.GroupMutation) error {
 		return nil
 	}
 
-	objType := getObjectTypeFromEntMutation(m)
+	objType := GetObjectTypeFromEntMutation(m)
 	object := fmt.Sprintf("%s:%s", objType, objID)
 
 	log.Debug().Str("object", object).Msg("deleting relationship tuples")

--- a/internal/ent/hooks/objectownedtuples.go
+++ b/internal/ent/hooks/objectownedtuples.go
@@ -23,7 +23,7 @@ func HookObjectOwnedTuples(parents []string, skipUser bool) ent.Hook {
 				return nil, err
 			}
 
-			objectID, err := getObjectIDFromEntValue(retVal)
+			objectID, err := GetObjectIDFromEntValue(retVal)
 			if err != nil {
 				return nil, err
 			}
@@ -47,7 +47,7 @@ func HookObjectOwnedTuples(parents []string, skipUser bool) ent.Hook {
 					SubjectID:   a.SubjectID,
 					SubjectType: subject,
 					ObjectID:    objectID,                        // this is the object id being created
-					ObjectType:  getObjectTypeFromEntMutation(m), // this is the object type being created
+					ObjectType:  GetObjectTypeFromEntMutation(m), // this is the object type being created
 					Relation:    fgax.ParentRelation,
 				})
 
@@ -98,7 +98,7 @@ func HookRelationTuples(objects map[string]string, relation fgax.Relation) ent.H
 				return nil, err
 			}
 
-			objectID, err := getObjectIDFromEntValue(retVal)
+			objectID, err := GetObjectIDFromEntValue(retVal)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/ent/hooks/organization.go
+++ b/internal/ent/hooks/organization.go
@@ -430,7 +430,7 @@ func createOrgMemberOwner(ctx context.Context, oID string, m *generated.Organiza
 
 	// if this was created with an API token, do not create an owner but add the service tuple to fga
 	if auth.IsAPITokenAuthentication(ctx) {
-		return addTokenEditPermissions(ctx, oID, getObjectTypeFromEntMutation(m))
+		return addTokenEditPermissions(ctx, oID, GetObjectTypeFromEntMutation(m))
 	}
 
 	// get userID from context

--- a/internal/ent/hooks/orgownedtuples.go
+++ b/internal/ent/hooks/orgownedtuples.go
@@ -23,7 +23,7 @@ func HookOrgOwnedTuples(skipUser bool) ent.Hook {
 				return nil, err
 			}
 
-			objectID, err := getObjectIDFromEntValue(retVal)
+			objectID, err := GetObjectIDFromEntValue(retVal)
 			if err != nil {
 				return nil, err
 			}
@@ -47,7 +47,7 @@ func HookOrgOwnedTuples(skipUser bool) ent.Hook {
 					SubjectID:   a.SubjectID,
 					SubjectType: subject,
 					ObjectID:    objectID,                        // this is the object id being created
-					ObjectType:  getObjectTypeFromEntMutation(m), // this is the object type being created
+					ObjectType:  GetObjectTypeFromEntMutation(m), // this is the object type being created
 					Relation:    fgax.AdminRelation,
 				})
 

--- a/internal/ent/hooks/program.go
+++ b/internal/ent/hooks/program.go
@@ -48,7 +48,7 @@ func programCreateHook(ctx context.Context, m *generated.ProgramMutation) error 
 				return err
 			}
 		} else {
-			if err := addTokenEditPermissions(ctx, objID, getObjectTypeFromEntMutation(m)); err != nil {
+			if err := addTokenEditPermissions(ctx, objID, GetObjectTypeFromEntMutation(m)); err != nil {
 				return err
 			}
 		}
@@ -60,7 +60,7 @@ func programCreateHook(ctx context.Context, m *generated.ProgramMutation) error 
 			SubjectID:   org,
 			SubjectType: "organization",
 			ObjectID:    objID,
-			ObjectType:  getObjectTypeFromEntMutation(m),
+			ObjectType:  GetObjectTypeFromEntMutation(m),
 		}
 
 		log.Debug().Interface("request", req).
@@ -114,7 +114,7 @@ func programDeleteHook(ctx context.Context, m *generated.ProgramMutation) error 
 		return nil
 	}
 
-	objType := getObjectTypeFromEntMutation(m)
+	objType := GetObjectTypeFromEntMutation(m)
 	object := fmt.Sprintf("%s:%s", objType, objID)
 
 	log.Debug().Str("object", object).Msg("deleting relationship tuples")

--- a/internal/ent/hooks/task.go
+++ b/internal/ent/hooks/task.go
@@ -54,14 +54,14 @@ func HookTaskAssignee() ent.Hook {
 							SubjectID:   assignee,
 							SubjectType: "user",
 							ObjectID:    taskID,
-							ObjectType:  getObjectTypeFromEntMutation(m),
+							ObjectType:  GetObjectTypeFromEntMutation(m),
 							Relation:    "assignee",
 						})
 
 						// get the current assignee and remove them
 						resp, err := utils.AuthzClientFromContext(ctx).ListUserRequest(ctx, fgax.ListRequest{
 							ObjectID:   taskID,
-							ObjectType: getObjectTypeFromEntMutation(m),
+							ObjectType: GetObjectTypeFromEntMutation(m),
 							Relation:   "assignee",
 						})
 						if err != nil {
@@ -79,7 +79,7 @@ func HookTaskAssignee() ent.Hook {
 								SubjectID:   user.Object.Id,
 								SubjectType: user.Object.Type,
 								ObjectID:    taskID,
-								ObjectType:  getObjectTypeFromEntMutation(m),
+								ObjectType:  GetObjectTypeFromEntMutation(m),
 								Relation:    "assignee",
 							})
 

--- a/internal/ent/schema/mixin_orgowned.go
+++ b/internal/ent/schema/mixin_orgowned.go
@@ -6,8 +6,10 @@ import (
 
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
+	"github.com/rs/zerolog/log"
 
 	"github.com/theopenlane/iam/auth"
+	"github.com/theopenlane/iam/fgax"
 	"github.com/theopenlane/utils/contextx"
 
 	"github.com/theopenlane/core/internal/ent/generated"
@@ -15,6 +17,7 @@ import (
 	"github.com/theopenlane/core/internal/ent/hooks"
 	"github.com/theopenlane/core/internal/ent/interceptors"
 	"github.com/theopenlane/core/internal/ent/privacy/rule"
+	"github.com/theopenlane/core/internal/ent/privacy/utils"
 )
 
 const (
@@ -95,11 +98,32 @@ var orgHookCreateFunc HookFunc = func(o ObjectOwnedMixin) ent.Hook {
 			// set owner on create mutation
 			if m.Op() == ent.OpCreate {
 				if err := setOwnerIDField(ctx, m); err != nil {
+					log.Error().Err(err).Msg("failed to set owner id field")
+
 					return nil, err
 				}
 			}
 
-			return next.Mutate(ctx, m)
+			retVal, err := next.Mutate(ctx, m)
+			if err != nil {
+				return nil, err
+			}
+
+			// add organization owner editor relation to the object
+			id, err := hooks.GetObjectIDFromEntValue(retVal)
+			if err != nil {
+				log.Error().Err(err).Msg("failed to get object id from ent value")
+
+				return nil, err
+			}
+
+			if err := addOrganizationOwnerEditorRelation(ctx, m, id); err != nil {
+				log.Error().Err(err).Msg("failed to add organization owner editor relation")
+
+				return nil, err
+			}
+
+			return retVal, err
 		})
 	}
 }
@@ -119,6 +143,33 @@ func setOwnerIDField(ctx context.Context, m ent.Mutation) error {
 
 	// set owner on mutation
 	if err := m.SetField(ownerFieldName, orgID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func addOrganizationOwnerEditorRelation(ctx context.Context, m ent.Mutation, id string) error {
+	// always add the organization owner relationship as an editor
+	orgID, err := auth.GetOrganizationIDFromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get organization id from context: %w", err)
+	}
+
+	log.Info().Str("org_id", orgID).Msg("adding organization owner editor relation")
+
+	tr := fgax.TupleRequest{
+		SubjectType:     "organization",
+		SubjectID:       orgID,
+		SubjectRelation: fgax.OwnerRelation,
+		ObjectID:        id,                                    // this is the object id being created
+		ObjectType:      hooks.GetObjectTypeFromEntMutation(m), // this is the object type being created
+		Relation:        fgax.EditorRelation,
+	}
+
+	t := fgax.GetTupleKey(tr)
+
+	if _, err := utils.AuthzClientFromContext(ctx).WriteTupleKeys(ctx, []fgax.TupleKey{t}, nil); err != nil {
 		return err
 	}
 

--- a/internal/graphapi/control_test.go
+++ b/internal/graphapi/control_test.go
@@ -418,7 +418,7 @@ func (suite *GraphTestSuite) TestMutationCreateControl() {
 				}
 			}
 
-			// ensure the org owner has access to the control objective that was created by an api token
+			// ensure the org owner has access to the control that was created by an api token
 			if tc.client == suite.client.apiWithToken {
 				res, err := suite.client.api.GetControlByID(testUser1.UserCtx, resp.CreateControl.Control.ID)
 				require.NoError(t, err)

--- a/internal/graphapi/control_test.go
+++ b/internal/graphapi/control_test.go
@@ -417,6 +417,14 @@ func (suite *GraphTestSuite) TestMutationCreateControl() {
 					assert.Equal(t, viewerGroup.ID, edge.ID)
 				}
 			}
+
+			// ensure the org owner has access to the control objective that was created by an api token
+			if tc.client == suite.client.apiWithToken {
+				res, err := suite.client.api.GetControlByID(testUser1.UserCtx, resp.CreateControl.Control.ID)
+				require.NoError(t, err)
+				require.NotEmpty(t, res)
+				assert.Equal(t, resp.CreateControl.Control.ID, res.Control.ID)
+			}
 		})
 	}
 }

--- a/internal/graphapi/controlobjective_test.go
+++ b/internal/graphapi/controlobjective_test.go
@@ -419,6 +419,14 @@ func (suite *GraphTestSuite) TestMutationCreateControlObjective() {
 					assert.Equal(t, viewerGroup.ID, edge.ID)
 				}
 			}
+
+			// ensure the org owner has access to the control objective that was created by an api token
+			if tc.client == suite.client.apiWithToken {
+				res, err := suite.client.api.GetControlObjectiveByID(testUser1.UserCtx, resp.CreateControlObjective.ControlObjective.ID)
+				require.NoError(t, err)
+				require.NotEmpty(t, res)
+				assert.Equal(t, resp.CreateControlObjective.ControlObjective.ID, res.ControlObjective.ID)
+			}
 		})
 	}
 }

--- a/internal/graphapi/narrative_test.go
+++ b/internal/graphapi/narrative_test.go
@@ -368,7 +368,7 @@ func (suite *GraphTestSuite) TestMutationCreateNarrative() {
 				}
 			}
 
-			// ensure the org owner has access to the control objective that was created by an api token
+			// ensure the org owner has access to the narrative that was created by an api token
 			if tc.client == suite.client.apiWithToken {
 				res, err := suite.client.api.GetNarrativeByID(testUser1.UserCtx, resp.CreateNarrative.Narrative.ID)
 				require.NoError(t, err)

--- a/internal/graphapi/narrative_test.go
+++ b/internal/graphapi/narrative_test.go
@@ -367,6 +367,14 @@ func (suite *GraphTestSuite) TestMutationCreateNarrative() {
 					assert.Equal(t, viewerGroup.ID, edge.ID)
 				}
 			}
+
+			// ensure the org owner has access to the control objective that was created by an api token
+			if tc.client == suite.client.apiWithToken {
+				res, err := suite.client.api.GetNarrativeByID(testUser1.UserCtx, resp.CreateNarrative.Narrative.ID)
+				require.NoError(t, err)
+				require.NotEmpty(t, res)
+				assert.Equal(t, resp.CreateNarrative.Narrative.ID, res.Narrative.ID)
+			}
 		})
 	}
 }

--- a/internal/graphapi/risk_test.go
+++ b/internal/graphapi/risk_test.go
@@ -413,7 +413,7 @@ func (suite *GraphTestSuite) TestMutationCreateRisk() {
 				}
 			}
 
-			// ensure the org owner has access to the control objective that was created by an api token
+			// ensure the org owner has access to the risk that was created by an api token
 			if tc.client == suite.client.apiWithToken {
 				res, err := suite.client.api.GetRiskByID(testUser1.UserCtx, resp.CreateRisk.Risk.ID)
 				require.NoError(t, err)

--- a/internal/graphapi/risk_test.go
+++ b/internal/graphapi/risk_test.go
@@ -412,6 +412,14 @@ func (suite *GraphTestSuite) TestMutationCreateRisk() {
 					assert.Equal(t, viewerGroup.ID, edge.ID)
 				}
 			}
+
+			// ensure the org owner has access to the control objective that was created by an api token
+			if tc.client == suite.client.apiWithToken {
+				res, err := suite.client.api.GetRiskByID(testUser1.UserCtx, resp.CreateRisk.Risk.ID)
+				require.NoError(t, err)
+				require.NotEmpty(t, res)
+				assert.Equal(t, resp.CreateRisk.Risk.ID, res.Risk.ID)
+			}
 		})
 	}
 }

--- a/internal/graphapi/subcontrol_test.go
+++ b/internal/graphapi/subcontrol_test.go
@@ -435,7 +435,7 @@ func (suite *GraphTestSuite) TestMutationCreateSubcontrol() {
 				assert.Empty(t, resp.CreateSubcontrol.Subcontrol.Details)
 			}
 
-			// ensure the org owner has access to the control objective that was created by an api token
+			// ensure the org owner has access to the subcontrol that was created by an api token
 			if tc.client == suite.client.apiWithToken {
 				res, err := suite.client.api.GetSubcontrolByID(testUser1.UserCtx, resp.CreateSubcontrol.Subcontrol.ID)
 				require.NoError(t, err)

--- a/internal/graphapi/subcontrol_test.go
+++ b/internal/graphapi/subcontrol_test.go
@@ -434,6 +434,14 @@ func (suite *GraphTestSuite) TestMutationCreateSubcontrol() {
 			} else {
 				assert.Empty(t, resp.CreateSubcontrol.Subcontrol.Details)
 			}
+
+			// ensure the org owner has access to the control objective that was created by an api token
+			if tc.client == suite.client.apiWithToken {
+				res, err := suite.client.api.GetSubcontrolByID(testUser1.UserCtx, resp.CreateSubcontrol.Subcontrol.ID)
+				require.NoError(t, err)
+				require.NotEmpty(t, res)
+				assert.Equal(t, resp.CreateSubcontrol.Subcontrol.ID, res.Subcontrol.ID)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Objects that were being created with an API token we not accessible to any human user in the org. Organization owners should always have edit access to all objects created within the system. 

This adds an additional `orgnazation#owner` relation to the compliance objects that were being "orphaned" (not accessible outside the API token unless edges to a program/group were added) to be visible by the organization owner. 