### PR TITLE
bug: don't check if tfa is enabled on validate, this prevents validation on setup

### DIFF
--- a/internal/httpserve/handlers/ent.go
+++ b/internal/httpserve/handlers/ent.go
@@ -263,7 +263,7 @@ func (h *Handler) getUserDetailsByID(ctx context.Context, userID string) (*ent.U
 func (h *Handler) getUserTFASettings(ctx context.Context, userID string) (*ent.User, error) {
 	user, err := transaction.FromContext(ctx).User.Query().Where(
 		user.ID(userID),
-	).WithTfaSettings().WithSetting().Only(ctx)
+	).WithTfaSettings().Only(ctx)
 	if err != nil {
 		log.Error().Err(err).Msg("error retrieving tfa settings for user")
 

--- a/internal/httpserve/handlers/tfavalidate.go
+++ b/internal/httpserve/handlers/tfavalidate.go
@@ -44,12 +44,6 @@ func (h *Handler) ValidateTOTP(ctx echo.Context) error {
 		return h.BadRequest(ctx, err)
 	}
 
-	if user.Edges.Setting == nil || !user.Edges.Setting.IsTfaEnabled {
-		log.Warn().Msg("tfa validation request but user does not have TFA enabled")
-
-		return h.InvalidInput(ctx, err)
-	}
-
 	if user.Edges.TfaSettings == nil || len(user.Edges.TfaSettings) != 1 || user.Edges.TfaSettings[0].TfaSecret == nil {
 		log.Warn().Msg("tfa validation request but user has no TFA settings")
 


### PR DESCRIPTION
When a user is setting up a device, we use this endpoint to verify it is setup correctly before setting `verified=true`. This check prevents this from being possible. 