### PR TITLE
feat: option to also return tfa secret on update/create in addition to qr code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/riverqueue/river v0.15.0
 	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.15.0
 	github.com/rs/zerolog v1.33.0
-	github.com/samber/lo v1.48.0
+	github.com/samber/lo v1.49.0
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1
 	github.com/sebdah/goldie/v2 v2.5.5
 	github.com/spf13/cobra v1.8.1
@@ -67,7 +67,7 @@ require (
 	github.com/theopenlane/entx v0.4.3
 	github.com/theopenlane/gqlgen-plugins v0.4.4
 	github.com/theopenlane/httpsling v0.2.2
-	github.com/theopenlane/iam v0.7.1
+	github.com/theopenlane/iam v0.7.3
 	github.com/theopenlane/newman v0.1.2
 	github.com/theopenlane/riverboat v0.0.7
 	github.com/theopenlane/utils v0.4.3

--- a/go.sum
+++ b/go.sum
@@ -857,8 +857,8 @@ github.com/sagikazarmark/locafero v0.6.0 h1:ON7AQg37yzcRPU69mt7gwhFEBwxI6P9T4Qu3
 github.com/sagikazarmark/locafero v0.6.0/go.mod h1:77OmuIc6VTraTXKXIs/uvUxKGUXjE1GbemJYHqdNjX0=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
-github.com/samber/lo v1.48.0 h1:ELOfcaM7vdYPe0egBS2Nxa8LxkY4lR+9LBzj0l6cHJ0=
-github.com/samber/lo v1.48.0/go.mod h1:dO6KHFzUKXgP8LDhU0oI8d2hekjXnGOu0DB8Jecxd6o=
+github.com/samber/lo v1.49.0 h1:AGnTnQrg1jpFuwECPUSoxZCfVH5W22b605kWSry3YxM=
+github.com/samber/lo v1.49.0/go.mod h1:dO6KHFzUKXgP8LDhU0oI8d2hekjXnGOu0DB8Jecxd6o=
 github.com/sanposhiho/wastedassign/v2 v2.1.0 h1:crurBF7fJKIORrV85u9UUpePDYGWnwvv3+A96WvwXT0=
 github.com/sanposhiho/wastedassign/v2 v2.1.0/go.mod h1:+oSmSC+9bQ+VUAxA66nBb0Z7N8CK7mscKTDYC6aIek4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
@@ -969,8 +969,8 @@ github.com/theopenlane/gqlgen-plugins v0.4.4 h1:3TpVQMkmm2cdLOu0Basppp7Rv9KihTN0
 github.com/theopenlane/gqlgen-plugins v0.4.4/go.mod h1:8ilst9sRzH+cq01Z/bNiFBYdoB5AoaGi5W8tsNsRqnM=
 github.com/theopenlane/httpsling v0.2.2 h1:QqJo/VsjeiM6/RnWZpRQX3I7T62j5u9WdXo52zUWyi0=
 github.com/theopenlane/httpsling v0.2.2/go.mod h1:mrSaIZs4lhcBsOJCv/n67N7eDZ/skD6vA8l8y9MDrKk=
-github.com/theopenlane/iam v0.7.1 h1:bg/WxBwbIfaNwB41Zzlmk+Z0vJiGP+DpX8Nfo+IMPk4=
-github.com/theopenlane/iam v0.7.1/go.mod h1:RC5WbZnqi5bR2GaDURFmi6xLAxSSW0HFR+OvmFMp2nk=
+github.com/theopenlane/iam v0.7.3 h1:SIZiZl8raA0+Ybb9zZvcnhdJxW++XrgjMaEdiuJhbjw=
+github.com/theopenlane/iam v0.7.3/go.mod h1:pudtCEtl1LkYltQLQn775K9Zqrp1VSnj3qOrjx6QQsQ=
 github.com/theopenlane/newman v0.1.2 h1:BKn1fjT4tU7AxonFjx+4QNAIq0B9ZlT2wM9cWgBA6Hs=
 github.com/theopenlane/newman v0.1.2/go.mod h1:Z6lRBzDVJeGl+Rh8hZ1fIvybBpm0AxuoP1Lj6wY8ylw=
 github.com/theopenlane/riverboat v0.0.7 h1:zT/H6ipMRLVYQEGLGgwUI6B1wXEBS0ARhkfzv+Pekwg=

--- a/internal/graphapi/clientschema/schema.graphql
+++ b/internal/graphapi/clientschema/schema.graphql
@@ -27015,6 +27015,7 @@ type TFASettingCreatePayload {
 	Created tfaSetting
 	"""
 	tfaSetting: TFASetting!
+	tfaSecret: String
 	qrCode: String
 }
 """
@@ -27038,6 +27039,7 @@ type TFASettingUpdatePayload {
 	Updated tfaSetting
 	"""
 	tfaSetting: TFASetting!
+	tfaSecret: String
 	qrCode: String
 	recoveryCodes: [String!]
 }

--- a/internal/graphapi/generated/actionplan.generated.go
+++ b/internal/graphapi/generated/actionplan.generated.go
@@ -15036,6 +15036,8 @@ func (ec *executionContext) fieldContext_Mutation_createTFASetting(ctx context.C
 			switch field.Name {
 			case "tfaSetting":
 				return ec.fieldContext_TFASettingCreatePayload_tfaSetting(ctx, field)
+			case "tfaSecret":
+				return ec.fieldContext_TFASettingCreatePayload_tfaSecret(ctx, field)
 			case "qrCode":
 				return ec.fieldContext_TFASettingCreatePayload_qrCode(ctx, field)
 			}
@@ -15097,6 +15099,8 @@ func (ec *executionContext) fieldContext_Mutation_updateTFASetting(ctx context.C
 			switch field.Name {
 			case "tfaSetting":
 				return ec.fieldContext_TFASettingUpdatePayload_tfaSetting(ctx, field)
+			case "tfaSecret":
+				return ec.fieldContext_TFASettingUpdatePayload_tfaSecret(ctx, field)
 			case "qrCode":
 				return ec.fieldContext_TFASettingUpdatePayload_qrCode(ctx, field)
 			case "recoveryCodes":

--- a/internal/graphapi/generated/root_.generated.go
+++ b/internal/graphapi/generated/root_.generated.go
@@ -3018,6 +3018,7 @@ type ComplexityRoot struct {
 
 	TFASettingCreatePayload struct {
 		QRCode     func(childComplexity int) int
+		TfaSecret  func(childComplexity int) int
 		TfaSetting func(childComplexity int) int
 	}
 
@@ -3029,6 +3030,7 @@ type ComplexityRoot struct {
 	TFASettingUpdatePayload struct {
 		QRCode        func(childComplexity int) int
 		RecoveryCodes func(childComplexity int) int
+		TfaSecret     func(childComplexity int) int
 		TfaSetting    func(childComplexity int) int
 	}
 
@@ -19088,6 +19090,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.TFASettingCreatePayload.QRCode(childComplexity), true
 
+	case "TFASettingCreatePayload.tfaSecret":
+		if e.complexity.TFASettingCreatePayload.TfaSecret == nil {
+			break
+		}
+
+		return e.complexity.TFASettingCreatePayload.TfaSecret(childComplexity), true
+
 	case "TFASettingCreatePayload.tfaSetting":
 		if e.complexity.TFASettingCreatePayload.TfaSetting == nil {
 			break
@@ -19122,6 +19131,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.TFASettingUpdatePayload.RecoveryCodes(childComplexity), true
+
+	case "TFASettingUpdatePayload.tfaSecret":
+		if e.complexity.TFASettingUpdatePayload.TfaSecret == nil {
+			break
+		}
+
+		return e.complexity.TFASettingUpdatePayload.TfaSecret(childComplexity), true
 
 	case "TFASettingUpdatePayload.tfaSetting":
 		if e.complexity.TFASettingUpdatePayload.TfaSetting == nil {
@@ -53607,11 +53623,13 @@ type TemplateBulkCreatePayload {
     templates: [Template!]
 }`, BuiltIn: false},
 	{Name: "../schema/tfaextended.graphql", Input: `extend type TFASettingUpdatePayload {
+    tfaSecret: String
     qrCode: String
     recoveryCodes: [String!]
 }
 
 extend type TFASettingCreatePayload {
+    tfaSecret: String
     qrCode: String
 }
 `, BuiltIn: false},

--- a/internal/graphapi/generated/tfasetting.generated.go
+++ b/internal/graphapi/generated/tfasetting.generated.go
@@ -95,6 +95,47 @@ func (ec *executionContext) fieldContext_TFASettingCreatePayload_tfaSetting(_ co
 	return fc, nil
 }
 
+func (ec *executionContext) _TFASettingCreatePayload_tfaSecret(ctx context.Context, field graphql.CollectedField, obj *model.TFASettingCreatePayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TFASettingCreatePayload_tfaSecret(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TfaSecret, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TFASettingCreatePayload_tfaSecret(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TFASettingCreatePayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _TFASettingCreatePayload_qrCode(ctx context.Context, field graphql.CollectedField, obj *model.TFASettingCreatePayload) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_TFASettingCreatePayload_qrCode(ctx, field)
 	if err != nil {
@@ -197,6 +238,47 @@ func (ec *executionContext) fieldContext_TFASettingUpdatePayload_tfaSetting(_ co
 				return ec.fieldContext_TFASetting_owner(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TFASetting", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TFASettingUpdatePayload_tfaSecret(ctx context.Context, field graphql.CollectedField, obj *model.TFASettingUpdatePayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TFASettingUpdatePayload_tfaSecret(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TfaSecret, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TFASettingUpdatePayload_tfaSecret(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TFASettingUpdatePayload",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -312,6 +394,8 @@ func (ec *executionContext) _TFASettingCreatePayload(ctx context.Context, sel as
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "tfaSecret":
+			out.Values[i] = ec._TFASettingCreatePayload_tfaSecret(ctx, field, obj)
 		case "qrCode":
 			out.Values[i] = ec._TFASettingCreatePayload_qrCode(ctx, field, obj)
 		default:
@@ -353,6 +437,8 @@ func (ec *executionContext) _TFASettingUpdatePayload(ctx context.Context, sel as
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "tfaSecret":
+			out.Values[i] = ec._TFASettingUpdatePayload_tfaSecret(ctx, field, obj)
 		case "qrCode":
 			out.Values[i] = ec._TFASettingUpdatePayload_qrCode(ctx, field, obj)
 		case "recoveryCodes":

--- a/internal/graphapi/model/gen_models.go
+++ b/internal/graphapi/model/gen_models.go
@@ -918,6 +918,7 @@ type SubscriberUpdatePayload struct {
 type TFASettingCreatePayload struct {
 	// Created tfaSetting
 	TfaSetting *generated.TFASetting `json:"tfaSetting"`
+	TfaSecret  *string               `json:"tfaSecret,omitempty"`
 	QRCode     *string               `json:"qrCode,omitempty"`
 }
 
@@ -925,6 +926,7 @@ type TFASettingCreatePayload struct {
 type TFASettingUpdatePayload struct {
 	// Updated tfaSetting
 	TfaSetting    *generated.TFASetting `json:"tfaSetting"`
+	TfaSecret     *string               `json:"tfaSecret,omitempty"`
 	QRCode        *string               `json:"qrCode,omitempty"`
 	RecoveryCodes []string              `json:"recoveryCodes,omitempty"`
 }

--- a/internal/graphapi/query/tfasetting.graphql
+++ b/internal/graphapi/query/tfasetting.graphql
@@ -8,6 +8,7 @@ mutation CreateTFASetting($input: CreateTFASettingInput!) {
       }
     }
     qrCode
+    tfaSecret
   }
 }
 
@@ -42,6 +43,7 @@ mutation UpdateTFASetting($input: UpdateTFASettingInput!) {
       verified
     }
     qrCode
+    tfaSecret
     recoveryCodes
   }
 }

--- a/internal/graphapi/schema/tfaextended.graphql
+++ b/internal/graphapi/schema/tfaextended.graphql
@@ -1,8 +1,10 @@
 extend type TFASettingUpdatePayload {
+    tfaSecret: String
     qrCode: String
     recoveryCodes: [String!]
 }
 
 extend type TFASettingCreatePayload {
+    tfaSecret: String
     qrCode: String
 }

--- a/internal/graphapi/tfahelpers.go
+++ b/internal/graphapi/tfahelpers.go
@@ -33,3 +33,22 @@ func (r *mutationResolver) generateTFAQRCode(ctx context.Context, settings *gene
 
 	return qrCode, nil
 }
+
+// getDecryptedTFASecret returns the TFA secret for the user, decrypted
+func (r *mutationResolver) getDecryptedTFASecret(ctx context.Context, settings *generated.TFASetting) (string, error) {
+	if !utils.CheckForRequestedField(ctx, "tfaSecret") {
+		return "", nil
+	}
+
+	if !settings.TotpAllowed || settings.TfaSecret == nil {
+		return "", nil
+	}
+
+	// generate a new QR code if it was requested
+	secret, err := r.db.TOTP.TOTPManager.TOTPDecryptedSecret(*settings.TfaSecret)
+	if err != nil {
+		return "", err
+	}
+
+	return secret, nil
+}

--- a/internal/graphapi/tfasetting.resolvers.go
+++ b/internal/graphapi/tfasetting.resolvers.go
@@ -45,7 +45,12 @@ func (r *mutationResolver) CreateTFASetting(ctx context.Context, input generated
 		return nil, parseRequestError(err, action{action: ActionUpdate, object: "tfasetting"})
 	}
 
-	return &model.TFASettingCreatePayload{TfaSetting: settings, QRCode: &qrCode}, nil
+	secret, err := r.getDecryptedTFASecret(ctx, settings)
+	if err != nil {
+		return nil, parseRequestError(err, action{action: ActionUpdate, object: "tfasetting"})
+	}
+
+	return &model.TFASettingCreatePayload{TfaSetting: settings, QRCode: &qrCode, TfaSecret: &secret}, nil
 }
 
 // UpdateTFASetting is the resolver for the updateTFASetting field.
@@ -78,9 +83,15 @@ func (r *mutationResolver) UpdateTFASetting(ctx context.Context, input generated
 		return nil, parseRequestError(err, action{action: ActionUpdate, object: "tfasetting"})
 	}
 
+	secret, err := r.getDecryptedTFASecret(ctx, updatedSettings)
+	if err != nil {
+		return nil, parseRequestError(err, action{action: ActionUpdate, object: "tfasetting"})
+	}
+
 	out := &model.TFASettingUpdatePayload{
 		TfaSetting: updatedSettings,
 		QRCode:     &qrCode,
+		TfaSecret:  &secret,
 	}
 
 	gtx := graphql.GetOperationContext(ctx)

--- a/internal/graphapi/tfasetting_test.go
+++ b/internal/graphapi/tfasetting_test.go
@@ -143,8 +143,10 @@ func (suite *GraphTestSuite) TestMutationCreateTFASetting() {
 
 			if *tc.input.TotpAllowed {
 				assert.NotEmpty(t, resp.CreateTFASetting.QRCode)
+				assert.NotEmpty(t, resp.CreateTFASetting.TfaSecret)
 			} else {
 				assert.Empty(t, resp.CreateTFASetting.QRCode)
+				assert.Empty(t, resp.CreateTFASetting.TfaSecret)
 			}
 
 			require.NotEmpty(t, resp.CreateTFASetting.TfaSetting.Owner)
@@ -262,6 +264,14 @@ func (suite *GraphTestSuite) TestMutationUpdateTFASetting() {
 				}
 			} else {
 				assert.Empty(t, resp.UpdateTFASetting.RecoveryCodes)
+			}
+
+			if tc.input.TotpAllowed == nil || *tc.input.TotpAllowed {
+				assert.NotEmpty(t, resp.UpdateTFASetting.QRCode)
+				assert.NotEmpty(t, resp.UpdateTFASetting.TfaSecret)
+			} else if !*tc.input.TotpAllowed { // settings were cleared
+				assert.Empty(t, resp.UpdateTFASetting.QRCode)
+				assert.Empty(t, resp.UpdateTFASetting.TfaSecret)
 			}
 
 			// make sure user setting is updated correctly

--- a/internal/httpserve/serveropts/option.go
+++ b/internal/httpserve/serveropts/option.go
@@ -328,6 +328,8 @@ func WithOTP() ServerOption {
 					Version: 0,
 					Key:     s.Config.Settings.TOTP.Secret,
 				}),
+				totp.WithRecoveryCodeLength(s.Config.Settings.TOTP.RecoveryCodeLength),
+				totp.WithRecoveryCodeCount(s.Config.Settings.TOTP.RecoveryCodeCount),
 			}
 
 			// append redis client if enabled

--- a/pkg/openlaneclient/graphclient.go
+++ b/pkg/openlaneclient/graphclient.go
@@ -42765,6 +42765,7 @@ func (t *CreateTFASetting_CreateTFASetting_TfaSetting) GetVerified() bool {
 
 type CreateTFASetting_CreateTFASetting struct {
 	QRCode     *string                                      "json:\"qrCode,omitempty\" graphql:\"qrCode\""
+	TfaSecret  *string                                      "json:\"tfaSecret,omitempty\" graphql:\"tfaSecret\""
 	TfaSetting CreateTFASetting_CreateTFASetting_TfaSetting "json:\"tfaSetting\" graphql:\"tfaSetting\""
 }
 
@@ -42773,6 +42774,12 @@ func (t *CreateTFASetting_CreateTFASetting) GetQRCode() *string {
 		t = &CreateTFASetting_CreateTFASetting{}
 	}
 	return t.QRCode
+}
+func (t *CreateTFASetting_CreateTFASetting) GetTfaSecret() *string {
+	if t == nil {
+		t = &CreateTFASetting_CreateTFASetting{}
+	}
+	return t.TfaSecret
 }
 func (t *CreateTFASetting_CreateTFASetting) GetTfaSetting() *CreateTFASetting_CreateTFASetting_TfaSetting {
 	if t == nil {
@@ -42896,6 +42903,7 @@ func (t *UpdateTFASetting_UpdateTFASetting_TfaSetting) GetVerified() bool {
 type UpdateTFASetting_UpdateTFASetting struct {
 	QRCode        *string                                      "json:\"qrCode,omitempty\" graphql:\"qrCode\""
 	RecoveryCodes []string                                     "json:\"recoveryCodes,omitempty\" graphql:\"recoveryCodes\""
+	TfaSecret     *string                                      "json:\"tfaSecret,omitempty\" graphql:\"tfaSecret\""
 	TfaSetting    UpdateTFASetting_UpdateTFASetting_TfaSetting "json:\"tfaSetting\" graphql:\"tfaSetting\""
 }
 
@@ -42910,6 +42918,12 @@ func (t *UpdateTFASetting_UpdateTFASetting) GetRecoveryCodes() []string {
 		t = &UpdateTFASetting_UpdateTFASetting{}
 	}
 	return t.RecoveryCodes
+}
+func (t *UpdateTFASetting_UpdateTFASetting) GetTfaSecret() *string {
+	if t == nil {
+		t = &UpdateTFASetting_UpdateTFASetting{}
+	}
+	return t.TfaSecret
 }
 func (t *UpdateTFASetting_UpdateTFASetting) GetTfaSetting() *UpdateTFASetting_UpdateTFASetting_TfaSetting {
 	if t == nil {
@@ -61991,6 +62005,7 @@ const CreateTFASettingDocument = `mutation CreateTFASetting ($input: CreateTFASe
 			}
 		}
 		qrCode
+		tfaSecret
 	}
 }
 `
@@ -62075,6 +62090,7 @@ const UpdateTFASettingDocument = `mutation UpdateTFASetting ($input: UpdateTFASe
 			verified
 		}
 		qrCode
+		tfaSecret
 		recoveryCodes
 	}
 }

--- a/pkg/openlaneclient/models.go
+++ b/pkg/openlaneclient/models.go
@@ -17558,6 +17558,7 @@ type TFASettingConnection struct {
 type TFASettingCreatePayload struct {
 	// Created tfaSetting
 	TfaSetting *TFASetting `json:"tfaSetting"`
+	TfaSecret  *string     `json:"tfaSecret,omitempty"`
 	QRCode     *string     `json:"qrCode,omitempty"`
 }
 
@@ -17573,6 +17574,7 @@ type TFASettingEdge struct {
 type TFASettingUpdatePayload struct {
 	// Updated tfaSetting
 	TfaSetting    *TFASetting `json:"tfaSetting"`
+	TfaSecret     *string     `json:"tfaSecret,omitempty"`
 	QRCode        *string     `json:"qrCode,omitempty"`
 	RecoveryCodes []string    `json:"recoveryCodes,omitempty"`
 }


### PR DESCRIPTION
- updates iam for default config settings
- actually uses the config values for recovery code details
- adds `tfaSecret` (decrypted) to response in the same conditions as `qrCode`
example response on update:

```
{
  "data": {
    "updateTFASetting": {
      "qrCode": "otpauth://totp/theopenlane.io:mitb@theopenlane.io?algorithm=SHA1&digits=6&issuer=theopenlane.io&period=30&secret=OCO6JNXT6QS65GPQ653ISMUDVVPHUYQ4",
      "recoveryCodes": [
        "3MIA7648",
        "T7DGWPR5",
        "W3GJC2Q9",
        "S72UGSYR",
        "RBCGLAT3",
        "Y7W4PCRU",
        "U3OBLCCK",
        "PF0MMGI5",
        "9ELXS2OG",
        "WAJ7G5Z9",
        "HE4L5GXT",
        "SQ1MS2OC",
        "WS0TTKLN",
        "5CO4KHDC",
        "MRPON148",
        "6F0SHE0T"
      ],
      "tfaSecret": "OCO6JNXT6QS65GPQ653ISMUDVVPHUYQ4",
      "tfaSetting": {
        "id": "01JJJNYD20HRQWH7JBTDSGHM6Z",
        "verified": true,
        "totpAllowed": true
      }
    }
  },
  "extensions": {
    "auth": {
      "authentication_type": "pat"
    },
    "server_latency": "50.615041ms",
    "trace_id": "mydfMxnziHQolmntnhOYhGvqtuzbgtmg"
  }
}
```