### PR TITLE
bug: fix renable totpAllowed = true after disable

### DIFF
--- a/internal/ent/hooks/tfasettings.go
+++ b/internal/ent/hooks/tfasettings.go
@@ -94,8 +94,8 @@ func HookVerifyTFA() ent.Hook {
 			if ok && !totpAllowed {
 				// if TOTP is not allowed, clear the TFA settings
 				m.SetVerified(false)
-				m.SetRecoveryCodes(nil)
-				m.SetTfaSecret("")
+				m.ClearRecoveryCodes()
+				m.ClearTfaSecret()
 
 				// disable TFA on the user settings
 				if err := setUserTFASetting(ctx, m, false); err != nil {

--- a/internal/graphapi/tfasetting_test.go
+++ b/internal/graphapi/tfasetting_test.go
@@ -227,7 +227,7 @@ func (suite *GraphTestSuite) TestMutationUpdateTFASetting() {
 				TotpAllowed: lo.ToPtr(true),
 			},
 			client: suite.client.api,
-			ctx:    testUser2.UserCtx,
+			ctx:    testUser1.UserCtx,
 		},
 	}
 
@@ -272,6 +272,9 @@ func (suite *GraphTestSuite) TestMutationUpdateTFASetting() {
 			} else if !*tc.input.TotpAllowed { // settings were cleared
 				assert.Empty(t, resp.UpdateTFASetting.QRCode)
 				assert.Empty(t, resp.UpdateTFASetting.TfaSecret)
+				assert.Empty(t, resp.UpdateTFASetting.RecoveryCodes)
+				assert.False(t, resp.UpdateTFASetting.TfaSetting.Verified)
+				assert.False(t, *resp.UpdateTFASetting.TfaSetting.TotpAllowed)
 			}
 
 			// make sure user setting is updated correctly


### PR DESCRIPTION
- fixes test to accurately check for this use case
- fixes the empty string to be nil when cleared so a new TFA secret gets generated