### PR TITLE
feat: permissions field on group query

### DIFF
--- a/internal/ent/generated/group/group.go
+++ b/internal/ent/generated/group/group.go
@@ -373,7 +373,7 @@ func ValidColumn(column string) bool {
 //
 //	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
-	Hooks        [8]ent.Hook
+	Hooks        [9]ent.Hook
 	Interceptors [3]ent.Interceptor
 	Policy       ent.Policy
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.

--- a/internal/ent/generated/runtime/runtime.go
+++ b/internal/ent/generated/runtime/runtime.go
@@ -1188,6 +1188,7 @@ func init() {
 	groupMixinHooks1 := groupMixin[1].Hooks()
 	groupMixinHooks2 := groupMixin[2].Hooks()
 	groupMixinHooks4 := groupMixin[4].Hooks()
+	groupMixinHooks5 := groupMixin[5].Hooks()
 	groupHooks := schema.Group{}.Hooks()
 
 	group.Hooks[1] = groupMixinHooks0[0]
@@ -1198,11 +1199,13 @@ func init() {
 
 	group.Hooks[4] = groupMixinHooks4[0]
 
-	group.Hooks[5] = groupHooks[0]
+	group.Hooks[5] = groupMixinHooks5[0]
 
-	group.Hooks[6] = groupHooks[1]
+	group.Hooks[6] = groupHooks[0]
 
-	group.Hooks[7] = groupHooks[2]
+	group.Hooks[7] = groupHooks[1]
+
+	group.Hooks[8] = groupHooks[2]
 	groupMixinInters1 := groupMixin[1].Interceptors()
 	groupMixinInters4 := groupMixin[4].Interceptors()
 	groupInters := schema.Group{}.Interceptors()

--- a/internal/ent/hooks/objectownedtuples.go
+++ b/internal/ent/hooks/objectownedtuples.go
@@ -332,8 +332,10 @@ func HookRelationTuples(objects map[string]string, relation fgax.Relation) ent.H
 // using the tuple structs that are about to be written
 func checkAccessToObjectsFromTuples(ctx context.Context, m ent.Mutation, tuples []fgax.TupleKey) error {
 	for _, tuple := range tuples {
-		objectID := tuple.Object.Identifier
-		objectType := string(tuple.Object.Kind)
+		// subject is the group that the permissions are being added to
+		// this is the reverse edge
+		objectID := tuple.Subject.Identifier
+		objectType := string(tuple.Subject.Kind)
 
 		if _, allow := privacy.DecisionFromContext(ctx); allow {
 			return nil

--- a/internal/ent/schema/mixin_grouppermissions.go
+++ b/internal/ent/schema/mixin_grouppermissions.go
@@ -135,3 +135,13 @@ func (g GroupPermissionsEdgesMixin) Edges() []ent.Edge {
 
 	return edges
 }
+
+// Hooks of the GroupPermissionsEdgesMixin
+func (g GroupPermissionsEdgesMixin) Hooks() []ent.Hook {
+	return []ent.Hook{
+		hook.On(
+			hooks.HookGroupPermissionsTuples(),
+			ent.OpCreate|ent.OpUpdateOne|ent.OpUpdateOne,
+		),
+	}
+}

--- a/internal/graphapi/clientschema/schema.graphql
+++ b/internal/graphapi/clientschema/schema.graphql
@@ -9584,6 +9584,10 @@ type Group implements Node {
 	files: [File!]
 	tasks: [Task!]
 	members: [GroupMembership!]
+	"""
+	permissions the group provides
+	"""
+	permissions: [GroupPermissions!]
 }
 """
 Return response for createBulkGroup mutation
@@ -10461,6 +10465,18 @@ Properties by which Group connections can be ordered.
 enum GroupOrderField {
 	name
 	display_name
+}
+"""
+GroupPermissions contains details for the related object and the permissions
+the group provides (or removes in the case of blocked) to the object within the
+organization
+"""
+type GroupPermissions {
+	objectType: String!
+	permissions: Permission!
+	id: ID
+	displayID: String
+	name: String
 }
 type GroupSearchResult {
 	groups: [Group!]
@@ -19583,6 +19599,15 @@ type PageInfo {
 	When paginating forwards, the cursor to continue.
 	"""
 	endCursor: Cursor
+}
+"""
+Permission is enum for the permissions types
+"""
+enum Permission @goModel(model: "github.com/theopenlane/core/pkg/enums.Permission") {
+	EDITOR
+	VIEWER
+	CREATOR
+	BLOCKED
 }
 type PersonalAccessToken implements Node {
 	id: ID!

--- a/internal/graphapi/clientschema/schema.graphql
+++ b/internal/graphapi/clientschema/schema.graphql
@@ -14335,9 +14335,9 @@ type Mutation {
 	"""
 	createGroupWithMembers(
 		"""
-		values of the group
+		values of the group to be created
 		"""
-		group: CreateGroupInput!
+		groupInput: CreateGroupInput!
 
 		"""
 		group members to be added to the group
@@ -14799,9 +14799,9 @@ type Mutation {
 	"""
 	createOrganizationWithMembers(
 		"""
-		values of the new organization
+		values of the new organization to be created
 		"""
-		organization: CreateOrganizationInput!
+		organizationInput: CreateOrganizationInput!
 
 		"""
 		avatar file to Upload

--- a/internal/graphapi/control_test.go
+++ b/internal/graphapi/control_test.go
@@ -217,7 +217,7 @@ func (suite *GraphTestSuite) TestMutationCreateControl() {
 		{
 			name: "add groups",
 			request: openlaneclient.CreateControlInput{
-				Name:            "Test Procedure",
+				Name:            "Test Control CC1.2",
 				EditorIDs:       []string{testUser1.GroupID},
 				BlockedGroupIDs: []string{blockedGroup.ID},
 				ViewerIDs:       []string{viewerGroup.ID},

--- a/internal/graphapi/controlobjective_test.go
+++ b/internal/graphapi/controlobjective_test.go
@@ -170,6 +170,9 @@ func (suite *GraphTestSuite) TestMutationCreateControlObjective() {
 	program2 := (&ProgramBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	programAnotherUser := (&ProgramBuilder{client: suite.client}).MustNew(testUser2.UserCtx, t)
 
+	// group for the view only user
+	groupMember := (&GroupMemberBuilder{client: suite.client, UserID: viewOnlyUser.ID}).MustNew(testUser1.UserCtx, t)
+
 	// add adminUser to the program so that they can create a control objective associated with the program1
 	(&ProgramMemberBuilder{client: suite.client, ProgramID: program1.ID,
 		UserID: adminUser.ID, Role: enums.RoleAdmin.String()}).
@@ -303,7 +306,7 @@ func (suite *GraphTestSuite) TestMutationCreateControlObjective() {
 			if tc.addGroupToOrg {
 				_, err := suite.client.api.UpdateOrganization(testUser1.UserCtx, testUser1.OrganizationID,
 					openlaneclient.UpdateOrganizationInput{
-						AddControlObjectiveCreatorIDs: []string{viewOnlyUser.GroupID},
+						AddControlObjectiveCreatorIDs: []string{groupMember.GroupID},
 					}, nil)
 				require.NoError(t, err)
 			}

--- a/internal/graphapi/ent.resolvers.go
+++ b/internal/graphapi/ent.resolvers.go
@@ -1152,6 +1152,9 @@ func (r *queryResolver) UserSettingHistories(ctx context.Context, after *entgql.
 	return res, err
 }
 
+// Group returns gqlgenerated.GroupResolver implementation.
+func (r *Resolver) Group() gqlgenerated.GroupResolver { return &groupResolver{r} }
+
 // Query returns gqlgenerated.QueryResolver implementation.
 func (r *Resolver) Query() gqlgenerated.QueryResolver { return &queryResolver{r} }
 
@@ -1195,6 +1198,7 @@ func (r *Resolver) UpdateTFASettingInput() gqlgenerated.UpdateTFASettingInputRes
 	return &updateTFASettingInputResolver{r}
 }
 
+type groupResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
 type createEntityInputResolver struct{ *Resolver }
 type createGroupInputResolver struct{ *Resolver }

--- a/internal/graphapi/generated/actionplan.generated.go
+++ b/internal/graphapi/generated/actionplan.generated.go
@@ -72,7 +72,7 @@ type MutationResolver interface {
 	CreateBulkCSVGroup(ctx context.Context, input graphql.Upload) (*model.GroupBulkCreatePayload, error)
 	UpdateGroup(ctx context.Context, id string, input generated.UpdateGroupInput) (*model.GroupUpdatePayload, error)
 	DeleteGroup(ctx context.Context, id string) (*model.GroupDeletePayload, error)
-	CreateGroupWithMembers(ctx context.Context, group generated.CreateGroupInput, members []*model.GroupMembersInput) (*model.GroupCreatePayload, error)
+	CreateGroupWithMembers(ctx context.Context, groupInput generated.CreateGroupInput, members []*model.GroupMembersInput) (*model.GroupCreatePayload, error)
 	CreateGroupMembership(ctx context.Context, input generated.CreateGroupMembershipInput) (*model.GroupMembershipCreatePayload, error)
 	CreateBulkGroupMembership(ctx context.Context, input []*generated.CreateGroupMembershipInput) (*model.GroupMembershipBulkCreatePayload, error)
 	CreateBulkCSVGroupMembership(ctx context.Context, input graphql.Upload) (*model.GroupMembershipBulkCreatePayload, error)
@@ -118,7 +118,7 @@ type MutationResolver interface {
 	CreateBulkCSVOrganizationSetting(ctx context.Context, input graphql.Upload) (*model.OrganizationSettingBulkCreatePayload, error)
 	UpdateOrganizationSetting(ctx context.Context, id string, input generated.UpdateOrganizationSettingInput) (*model.OrganizationSettingUpdatePayload, error)
 	DeleteOrganizationSetting(ctx context.Context, id string) (*model.OrganizationSettingDeletePayload, error)
-	CreateOrganizationWithMembers(ctx context.Context, organization generated.CreateOrganizationInput, avatarFile *graphql.Upload, members []*model.OrgMembersInput) (*model.OrganizationCreatePayload, error)
+	CreateOrganizationWithMembers(ctx context.Context, organizationInput generated.CreateOrganizationInput, avatarFile *graphql.Upload, members []*model.OrgMembersInput) (*model.OrganizationCreatePayload, error)
 	CreateOrgMembership(ctx context.Context, input generated.CreateOrgMembershipInput) (*model.OrgMembershipCreatePayload, error)
 	CreateBulkOrgMembership(ctx context.Context, input []*generated.CreateOrgMembershipInput) (*model.OrgMembershipBulkCreatePayload, error)
 	CreateBulkCSVOrgMembership(ctx context.Context, input graphql.Upload) (*model.OrgMembershipBulkCreatePayload, error)
@@ -2346,11 +2346,11 @@ func (ec *executionContext) field_Mutation_createGroupSetting_argsInput(
 func (ec *executionContext) field_Mutation_createGroupWithMembers_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
-	arg0, err := ec.field_Mutation_createGroupWithMembers_argsGroup(ctx, rawArgs)
+	arg0, err := ec.field_Mutation_createGroupWithMembers_argsGroupInput(ctx, rawArgs)
 	if err != nil {
 		return nil, err
 	}
-	args["group"] = arg0
+	args["groupInput"] = arg0
 	arg1, err := ec.field_Mutation_createGroupWithMembers_argsMembers(ctx, rawArgs)
 	if err != nil {
 		return nil, err
@@ -2358,17 +2358,17 @@ func (ec *executionContext) field_Mutation_createGroupWithMembers_args(ctx conte
 	args["members"] = arg1
 	return args, nil
 }
-func (ec *executionContext) field_Mutation_createGroupWithMembers_argsGroup(
+func (ec *executionContext) field_Mutation_createGroupWithMembers_argsGroupInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (generated.CreateGroupInput, error) {
-	if _, ok := rawArgs["group"]; !ok {
+	if _, ok := rawArgs["groupInput"]; !ok {
 		var zeroVal generated.CreateGroupInput
 		return zeroVal, nil
 	}
 
-	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("group"))
-	if tmp, ok := rawArgs["group"]; ok {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("groupInput"))
+	if tmp, ok := rawArgs["groupInput"]; ok {
 		return ec.unmarshalNCreateGroupInput2githubᚗcomᚋtheopenlaneᚋcoreᚋinternalᚋentᚋgeneratedᚐCreateGroupInput(ctx, tmp)
 	}
 
@@ -2621,11 +2621,11 @@ func (ec *executionContext) field_Mutation_createOrganizationSetting_argsInput(
 func (ec *executionContext) field_Mutation_createOrganizationWithMembers_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
-	arg0, err := ec.field_Mutation_createOrganizationWithMembers_argsOrganization(ctx, rawArgs)
+	arg0, err := ec.field_Mutation_createOrganizationWithMembers_argsOrganizationInput(ctx, rawArgs)
 	if err != nil {
 		return nil, err
 	}
-	args["organization"] = arg0
+	args["organizationInput"] = arg0
 	arg1, err := ec.field_Mutation_createOrganizationWithMembers_argsAvatarFile(ctx, rawArgs)
 	if err != nil {
 		return nil, err
@@ -2638,17 +2638,17 @@ func (ec *executionContext) field_Mutation_createOrganizationWithMembers_args(ct
 	args["members"] = arg2
 	return args, nil
 }
-func (ec *executionContext) field_Mutation_createOrganizationWithMembers_argsOrganization(
+func (ec *executionContext) field_Mutation_createOrganizationWithMembers_argsOrganizationInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (generated.CreateOrganizationInput, error) {
-	if _, ok := rawArgs["organization"]; !ok {
+	if _, ok := rawArgs["organizationInput"]; !ok {
 		var zeroVal generated.CreateOrganizationInput
 		return zeroVal, nil
 	}
 
-	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("organization"))
-	if tmp, ok := rawArgs["organization"]; ok {
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("organizationInput"))
+	if tmp, ok := rawArgs["organizationInput"]; ok {
 		return ec.unmarshalNCreateOrganizationInput2githubᚗcomᚋtheopenlaneᚋcoreᚋinternalᚋentᚋgeneratedᚐCreateOrganizationInput(ctx, tmp)
 	}
 
@@ -9392,7 +9392,7 @@ func (ec *executionContext) _Mutation_createGroupWithMembers(ctx context.Context
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().CreateGroupWithMembers(rctx, fc.Args["group"].(generated.CreateGroupInput), fc.Args["members"].([]*model.GroupMembersInput))
+		return ec.resolvers.Mutation().CreateGroupWithMembers(rctx, fc.Args["groupInput"].(generated.CreateGroupInput), fc.Args["members"].([]*model.GroupMembersInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -12106,7 +12106,7 @@ func (ec *executionContext) _Mutation_createOrganizationWithMembers(ctx context.
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().CreateOrganizationWithMembers(rctx, fc.Args["organization"].(generated.CreateOrganizationInput), fc.Args["avatarFile"].(*graphql.Upload), fc.Args["members"].([]*model.OrgMembersInput))
+		return ec.resolvers.Mutation().CreateOrganizationWithMembers(rctx, fc.Args["organizationInput"].(generated.CreateOrganizationInput), fc.Args["avatarFile"].(*graphql.Upload), fc.Args["members"].([]*model.OrgMembersInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/internal/graphapi/generated/group.generated.go
+++ b/internal/graphapi/generated/group.generated.go
@@ -151,6 +151,8 @@ func (ec *executionContext) fieldContext_GroupBulkCreatePayload_groups(_ context
 				return ec.fieldContext_Group_tasks(ctx, field)
 			case "members":
 				return ec.fieldContext_Group_members(ctx, field)
+			case "permissions":
+				return ec.fieldContext_Group_permissions(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Group", field.Name)
 		},
@@ -283,6 +285,8 @@ func (ec *executionContext) fieldContext_GroupCreatePayload_group(_ context.Cont
 				return ec.fieldContext_Group_tasks(ctx, field)
 			case "members":
 				return ec.fieldContext_Group_members(ctx, field)
+			case "permissions":
+				return ec.fieldContext_Group_permissions(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Group", field.Name)
 		},
@@ -459,6 +463,8 @@ func (ec *executionContext) fieldContext_GroupUpdatePayload_group(_ context.Cont
 				return ec.fieldContext_Group_tasks(ctx, field)
 			case "members":
 				return ec.fieldContext_Group_members(ctx, field)
+			case "permissions":
+				return ec.fieldContext_Group_permissions(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Group", field.Name)
 		},

--- a/internal/graphapi/generated/groupextended.generated.go
+++ b/internal/graphapi/generated/groupextended.generated.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/theopenlane/core/internal/graphapi/model"
+	"errors"
 )
 
 // region    ************************** generated!.gotpl **************************
@@ -22,6 +23,188 @@ import (
 // endregion ************************** directives.gotpl **************************
 
 // region    **************************** field.gotpl *****************************
+
+func (ec *executionContext) _GroupPermissions_objectType(ctx context.Context, field graphql.CollectedField, obj *model.GroupPermissions) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GroupPermissions_objectType(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ObjectType, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GroupPermissions_objectType(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GroupPermissions",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+
+
+func (ec *executionContext) fieldContext_GroupPermissions_permissions(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GroupPermissions",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Permission does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GroupPermissions_id(ctx context.Context, field graphql.CollectedField, obj *model.GroupPermissions) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GroupPermissions_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOID2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GroupPermissions_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GroupPermissions",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GroupPermissions_displayID(ctx context.Context, field graphql.CollectedField, obj *model.GroupPermissions) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GroupPermissions_displayID(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DisplayID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GroupPermissions_displayID(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GroupPermissions",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GroupPermissions_name(ctx context.Context, field graphql.CollectedField, obj *model.GroupPermissions) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GroupPermissions_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GroupPermissions_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GroupPermissions",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
 
 // endregion **************************** field.gotpl *****************************
 
@@ -71,7 +254,6 @@ func (ec *executionContext) unmarshalInputGroupMembersInput(ctx context.Context,
 
 // endregion **************************** object.gotpl ****************************
 
-// region    ***************************** type.gotpl *****************************
 
 func (ec *executionContext) unmarshalNGroupMembersInput2ᚖgithubᚗcomᚋtheopenlaneᚋcoreᚋinternalᚋgraphapiᚋmodelᚐGroupMembersInput(ctx context.Context, v any) (*model.GroupMembersInput, error) {
 	res, err := ec.unmarshalInputGroupMembersInput(ctx, v)

--- a/internal/graphapi/generated/groupextended.generated.go
+++ b/internal/graphapi/generated/groupextended.generated.go
@@ -4,10 +4,15 @@ package gqlgenerated
 
 import (
 	"context"
+	"errors"
+	"strconv"
+	"sync"
+	"sync/atomic"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/theopenlane/core/internal/graphapi/model"
-	"errors"
+	"github.com/theopenlane/core/pkg/enums"
+	"github.com/vektah/gqlparser/v2/ast"
 )
 
 // region    ************************** generated!.gotpl **************************
@@ -68,7 +73,36 @@ func (ec *executionContext) fieldContext_GroupPermissions_objectType(_ context.C
 	return fc, nil
 }
 
-
+func (ec *executionContext) _GroupPermissions_permissions(ctx context.Context, field graphql.CollectedField, obj *model.GroupPermissions) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GroupPermissions_permissions(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Permissions, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(enums.Permission)
+	fc.Result = res
+	return ec.marshalNPermission2githubᚗcomᚋtheopenlaneᚋcoreᚋpkgᚋenumsᚐPermission(ctx, field.Selections, res)
+}
 
 func (ec *executionContext) fieldContext_GroupPermissions_permissions(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
@@ -252,12 +286,83 @@ func (ec *executionContext) unmarshalInputGroupMembersInput(ctx context.Context,
 
 // region    **************************** object.gotpl ****************************
 
+var groupPermissionsImplementors = []string{"GroupPermissions"}
+
+func (ec *executionContext) _GroupPermissions(ctx context.Context, sel ast.SelectionSet, obj *model.GroupPermissions) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, groupPermissionsImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("GroupPermissions")
+		case "objectType":
+			out.Values[i] = ec._GroupPermissions_objectType(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "permissions":
+			out.Values[i] = ec._GroupPermissions_permissions(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "id":
+			out.Values[i] = ec._GroupPermissions_id(ctx, field, obj)
+		case "displayID":
+			out.Values[i] = ec._GroupPermissions_displayID(ctx, field, obj)
+		case "name":
+			out.Values[i] = ec._GroupPermissions_name(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 // endregion **************************** object.gotpl ****************************
 
+// region    ***************************** type.gotpl *****************************
 
 func (ec *executionContext) unmarshalNGroupMembersInput2ᚖgithubᚗcomᚋtheopenlaneᚋcoreᚋinternalᚋgraphapiᚋmodelᚐGroupMembersInput(ctx context.Context, v any) (*model.GroupMembersInput, error) {
 	res, err := ec.unmarshalInputGroupMembersInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNGroupPermissions2ᚖgithubᚗcomᚋtheopenlaneᚋcoreᚋinternalᚋgraphapiᚋmodelᚐGroupPermissions(ctx context.Context, sel ast.SelectionSet, v *model.GroupPermissions) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._GroupPermissions(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNPermission2githubᚗcomᚋtheopenlaneᚋcoreᚋpkgᚋenumsᚐPermission(ctx context.Context, v any) (enums.Permission, error) {
+	var res enums.Permission
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNPermission2githubᚗcomᚋtheopenlaneᚋcoreᚋpkgᚋenumsᚐPermission(ctx context.Context, sel ast.SelectionSet, v enums.Permission) graphql.Marshaler {
+	return v
 }
 
 func (ec *executionContext) unmarshalOGroupMembersInput2ᚕᚖgithubᚗcomᚋtheopenlaneᚋcoreᚋinternalᚋgraphapiᚋmodelᚐGroupMembersInputᚄ(ctx context.Context, v any) ([]*model.GroupMembersInput, error) {
@@ -278,6 +383,53 @@ func (ec *executionContext) unmarshalOGroupMembersInput2ᚕᚖgithubᚗcomᚋthe
 		}
 	}
 	return res, nil
+}
+
+func (ec *executionContext) marshalOGroupPermissions2ᚕᚖgithubᚗcomᚋtheopenlaneᚋcoreᚋinternalᚋgraphapiᚋmodelᚐGroupPermissionsᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.GroupPermissions) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNGroupPermissions2ᚖgithubᚗcomᚋtheopenlaneᚋcoreᚋinternalᚋgraphapiᚋmodelᚐGroupPermissions(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 // endregion ***************************** type.gotpl *****************************

--- a/internal/graphapi/generated/root_.generated.go
+++ b/internal/graphapi/generated/root_.generated.go
@@ -35,6 +35,7 @@ type Config struct {
 }
 
 type ResolverRoot interface {
+	Group() GroupResolver
 	Mutation() MutationResolver
 	Query() QueryResolver
 	CreateEntityInput() CreateEntityInputResolver
@@ -1050,6 +1051,7 @@ type ComplexityRoot struct {
 		NarrativeViewers              func(childComplexity int) int
 		Owner                         func(childComplexity int) int
 		OwnerID                       func(childComplexity int) int
+		Permissions                   func(childComplexity int) int
 		ProcedureBlockedGroups        func(childComplexity int) int
 		ProcedureEditors              func(childComplexity int) int
 		ProgramBlockedGroups          func(childComplexity int) int
@@ -1190,6 +1192,14 @@ type ComplexityRoot struct {
 
 	GroupMembershipUpdatePayload struct {
 		GroupMembership func(childComplexity int) int
+	}
+
+	GroupPermissions struct {
+		DisplayID   func(childComplexity int) int
+		ID          func(childComplexity int) int
+		Name        func(childComplexity int) int
+		ObjectType  func(childComplexity int) int
+		Permissions func(childComplexity int) int
 	}
 
 	GroupSearchResult struct {
@@ -8036,6 +8046,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Group.OwnerID(childComplexity), true
 
+	case "Group.permissions":
+		if e.complexity.Group.Permissions == nil {
+			break
+		}
+
+		return e.complexity.Group.Permissions(childComplexity), true
+
 	case "Group.procedureBlockedGroups":
 		if e.complexity.Group.ProcedureBlockedGroups == nil {
 			break
@@ -8637,6 +8654,41 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.GroupMembershipUpdatePayload.GroupMembership(childComplexity), true
+
+	case "GroupPermissions.displayID":
+		if e.complexity.GroupPermissions.DisplayID == nil {
+			break
+		}
+
+		return e.complexity.GroupPermissions.DisplayID(childComplexity), true
+
+	case "GroupPermissions.id":
+		if e.complexity.GroupPermissions.ID == nil {
+			break
+		}
+
+		return e.complexity.GroupPermissions.ID(childComplexity), true
+
+	case "GroupPermissions.name":
+		if e.complexity.GroupPermissions.Name == nil {
+			break
+		}
+
+		return e.complexity.GroupPermissions.Name(childComplexity), true
+
+	case "GroupPermissions.objectType":
+		if e.complexity.GroupPermissions.ObjectType == nil {
+			break
+		}
+
+		return e.complexity.GroupPermissions.ObjectType(childComplexity), true
+
+	case "GroupPermissions.permissions":
+		if e.complexity.GroupPermissions.Permissions == nil {
+			break
+		}
+
+		return e.complexity.GroupPermissions.Permissions(childComplexity), true
 
 	case "GroupSearchResult.groups":
 		if e.complexity.GroupSearchResult.Groups == nil {
@@ -52969,6 +53021,35 @@ extend type Mutation{
         """
         members: [GroupMembersInput!]
     ): GroupCreatePayload!
+}
+"""
+Permission is enum for the permissions types
+"""
+enum Permission @goModel(model: "github.com/theopenlane/core/pkg/enums.Permission") {
+  EDITOR
+  VIEWER
+  CREATOR
+  BLOCKED
+}
+
+"""
+GroupPermissions contains details for the related object and the permissions
+the group provides (or removes in the case of blocked) to the object within the
+organization
+"""
+type GroupPermissions {
+  objectType: String!
+  permissions: Permission!
+  id: ID
+  displayID: String
+  name: String
+}
+
+extend type Group {
+  """
+  permissions the group provides
+  """
+  permissions: [GroupPermissions!]
 }`, BuiltIn: false},
 	{Name: "../schema/groupmembership.graphql", Input: `extend type Query {
     """

--- a/internal/graphapi/generated/root_.generated.go
+++ b/internal/graphapi/generated/root_.generated.go
@@ -1654,7 +1654,7 @@ type ComplexityRoot struct {
 		CreateGroup                      func(childComplexity int, input generated.CreateGroupInput) int
 		CreateGroupMembership            func(childComplexity int, input generated.CreateGroupMembershipInput) int
 		CreateGroupSetting               func(childComplexity int, input generated.CreateGroupSettingInput) int
-		CreateGroupWithMembers           func(childComplexity int, group generated.CreateGroupInput, members []*model.GroupMembersInput) int
+		CreateGroupWithMembers           func(childComplexity int, groupInput generated.CreateGroupInput, members []*model.GroupMembersInput) int
 		CreateHush                       func(childComplexity int, input generated.CreateHushInput) int
 		CreateIntegration                func(childComplexity int, input generated.CreateIntegrationInput) int
 		CreateInternalPolicy             func(childComplexity int, input generated.CreateInternalPolicyInput) int
@@ -1663,7 +1663,7 @@ type ComplexityRoot struct {
 		CreateOrgMembership              func(childComplexity int, input generated.CreateOrgMembershipInput) int
 		CreateOrganization               func(childComplexity int, input generated.CreateOrganizationInput, avatarFile *graphql.Upload) int
 		CreateOrganizationSetting        func(childComplexity int, input generated.CreateOrganizationSettingInput) int
-		CreateOrganizationWithMembers    func(childComplexity int, organization generated.CreateOrganizationInput, avatarFile *graphql.Upload, members []*model.OrgMembersInput) int
+		CreateOrganizationWithMembers    func(childComplexity int, organizationInput generated.CreateOrganizationInput, avatarFile *graphql.Upload, members []*model.OrgMembersInput) int
 		CreatePersonalAccessToken        func(childComplexity int, input generated.CreatePersonalAccessTokenInput) int
 		CreateProcedure                  func(childComplexity int, input generated.CreateProcedureInput) int
 		CreateProgram                    func(childComplexity int, input generated.CreateProgramInput) int
@@ -11171,7 +11171,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.CreateGroupWithMembers(childComplexity, args["group"].(generated.CreateGroupInput), args["members"].([]*model.GroupMembersInput)), true
+		return e.complexity.Mutation.CreateGroupWithMembers(childComplexity, args["groupInput"].(generated.CreateGroupInput), args["members"].([]*model.GroupMembersInput)), true
 
 	case "Mutation.createHush":
 		if e.complexity.Mutation.CreateHush == nil {
@@ -11279,7 +11279,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.CreateOrganizationWithMembers(childComplexity, args["organization"].(generated.CreateOrganizationInput), args["avatarFile"].(*graphql.Upload), args["members"].([]*model.OrgMembersInput)), true
+		return e.complexity.Mutation.CreateOrganizationWithMembers(childComplexity, args["organizationInput"].(generated.CreateOrganizationInput), args["avatarFile"].(*graphql.Upload), args["members"].([]*model.OrgMembersInput)), true
 
 	case "Mutation.createPersonalAccessToken":
 		if e.complexity.Mutation.CreatePersonalAccessToken == nil {
@@ -53013,15 +53013,16 @@ extend type Mutation{
     """
     createGroupWithMembers(
         """
-        values of the group
+        values of the group to be created
         """
-        group: CreateGroupInput!
+        groupInput: CreateGroupInput!
         """
         group members to be added to the group
         """
         members: [GroupMembersInput!]
     ): GroupCreatePayload!
 }
+
 """
 Permission is enum for the permissions types
 """
@@ -54010,9 +54011,9 @@ extend type Mutation{
     """
     createOrganizationWithMembers(
         """
-        values of the new organization
+        values of the new organization to be created
         """
-        organization: CreateOrganizationInput!
+        organizationInput: CreateOrganizationInput!
         """
         avatar file to Upload
         """

--- a/internal/graphapi/generated/search.generated.go
+++ b/internal/graphapi/generated/search.generated.go
@@ -1138,6 +1138,8 @@ func (ec *executionContext) fieldContext_GroupSearchResult_groups(_ context.Cont
 				return ec.fieldContext_Group_tasks(ctx, field)
 			case "members":
 				return ec.fieldContext_Group_members(ctx, field)
+			case "permissions":
+				return ec.fieldContext_Group_permissions(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Group", field.Name)
 		},

--- a/internal/graphapi/group_test.go
+++ b/internal/graphapi/group_test.go
@@ -192,6 +192,9 @@ func (suite *GraphTestSuite) TestMutationCreateGroup() {
 
 	name := gofakeit.Name()
 
+	// group for the view only user
+	groupMember := (&GroupMemberBuilder{client: suite.client, UserID: viewOnlyUser.ID}).MustNew(testUser1.UserCtx, t)
+
 	testCases := []struct {
 		name          string
 		groupName     string
@@ -291,7 +294,7 @@ func (suite *GraphTestSuite) TestMutationCreateGroup() {
 			if tc.addGroupToOrg {
 				_, err := suite.client.api.UpdateOrganization(testUser1.UserCtx, testUser1.OrganizationID,
 					openlaneclient.UpdateOrganizationInput{
-						AddGroupCreatorIDs: []string{viewOnlyUser.GroupID},
+						AddGroupCreatorIDs: []string{groupMember.GroupID},
 					}, nil)
 				require.NoError(t, err)
 			}

--- a/internal/graphapi/group_test.go
+++ b/internal/graphapi/group_test.go
@@ -575,7 +575,7 @@ func (suite *GraphTestSuite) TestMutationUpdateGroup() {
 			},
 			client:   suite.client.api,
 			ctx:      adminUser.UserCtx,
-			errorMsg: "you are not authorized to perform this action",
+			errorMsg: notAuthorizedErrorMsg,
 		},
 		{
 			name: "update name, happy path",
@@ -713,14 +713,14 @@ func (suite *GraphTestSuite) TestMutationUpdateGroup() {
 				require.NoError(t, err)
 				require.NotNil(t, programResp)
 
-				// // ensure user can now access the control (they have editor access)
-				// description := gofakeit.HipsterSentence(10)
-				// controlResp, err := suite.client.api.UpdateControl(gmCtx, control.ID, openlaneclient.UpdateControlInput{
-				// 	Description: &description,
-				// })
-				// require.NoError(t, err)
-				// require.NotNil(t, controlResp)
-				// assert.Equal(t, description, *controlResp.UpdateControl.Control.Description)
+				// ensure user can now access the control (they have editor access and should be able to make changes)
+				description := gofakeit.HipsterSentence(10)
+				controlResp, err := suite.client.api.UpdateControl(gmCtx, control.ID, openlaneclient.UpdateControlInput{
+					Description: &description,
+				})
+				require.NoError(t, err)
+				require.NotNil(t, controlResp)
+				assert.Equal(t, description, *controlResp.UpdateControl.Control.Description)
 
 				// access to procedures is granted by default in the org
 				procedureResp, err := suite.client.api.GetProcedureByID(gmCtx, procedure.ID)

--- a/internal/graphapi/group_test.go
+++ b/internal/graphapi/group_test.go
@@ -488,9 +488,32 @@ func (suite *GraphTestSuite) TestMutationUpdateGroup() {
 	descriptionUpdate := gofakeit.HipsterSentence(10)
 	gravatarURLUpdate := gofakeit.URL()
 
-	group := (&GroupBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	group := (&GroupBuilder{client: suite.client, Owner: testUser1.OrganizationID}).MustNew(testUser1.UserCtx, t)
+	gm := (&GroupMemberBuilder{client: suite.client, GroupID: group.ID}).MustNew(testUser1.UserCtx, t)
 
 	om := (&OrgMemberBuilder{client: suite.client, OrgID: testUser1.OrganizationID}).MustNew(testUser1.UserCtx, t)
+
+	program := (&ProgramBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	procedure := (&ProcedureBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	control := (&ControlBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+
+	gmCtx, err := auth.NewTestContextWithOrgID(gm.UserID, testUser1.OrganizationID)
+	require.NoError(t, err)
+
+	// ensure user cannot get access to the program
+	programResp, err := suite.client.api.GetProgramByID(gmCtx, program.ID)
+	require.Error(t, err)
+	require.Nil(t, programResp)
+
+	// ensure user cannot get access to the control
+	controlResp, err := suite.client.api.GetControlByID(gmCtx, control.ID)
+	require.Error(t, err)
+	require.Nil(t, controlResp)
+
+	// access to procedures is granted by default in the org
+	procedureResp, err := suite.client.api.GetProcedureByID(gmCtx, procedure.ID)
+	require.NoError(t, err)
+	require.NotNil(t, procedureResp)
 
 	testCases := []struct {
 		name        string
@@ -500,6 +523,57 @@ func (suite *GraphTestSuite) TestMutationUpdateGroup() {
 		ctx         context.Context
 		errorMsg    string
 	}{
+		{
+			name: "add permissions to object, happy path",
+			updateInput: openlaneclient.UpdateGroupInput{
+				AddProgramViewerIDs:         []string{program.ID},
+				AddProcedureBlockedGroupIDs: []string{procedure.ID},
+				AddControlEditorIDs:         []string{control.ID},
+			},
+			client: suite.client.api,
+			ctx:    testUser1.UserCtx,
+			expectedRes: openlaneclient.UpdateGroup_UpdateGroup_Group{
+				ID:          group.ID,
+				Name:        group.Name,
+				DisplayName: group.DisplayName,
+				Description: &group.Description,
+				Setting: &openlaneclient.UpdateGroup_UpdateGroup_Group_Setting{
+					JoinPolicy: enums.JoinPolicyOpen,
+				},
+				Permissions: []*openlaneclient.UpdateGroup_UpdateGroup_Group_Permissions{
+					{
+						ObjectType:  "Program",
+						ID:          &program.ID,
+						Permissions: enums.Viewer,
+						DisplayID:   &program.DisplayID,
+						Name:        &program.Name,
+					},
+					{
+						ObjectType:  "Procedure",
+						ID:          &procedure.ID,
+						Permissions: enums.Blocked,
+						DisplayID:   &procedure.DisplayID,
+						Name:        &procedure.Name,
+					},
+					{
+						ObjectType:  "Control",
+						ID:          &control.ID,
+						Permissions: enums.Editor,
+						DisplayID:   &control.DisplayID,
+						Name:        &control.Name,
+					},
+				},
+			},
+		},
+		{
+			name: "add permissions to object, no access to program",
+			updateInput: openlaneclient.UpdateGroupInput{
+				AddProgramEditorIDs: []string{program.ID},
+			},
+			client:   suite.client.api,
+			ctx:      adminUser.UserCtx,
+			errorMsg: "you are not authorized to perform this action",
+		},
 		{
 			name: "update name, happy path",
 			updateInput: openlaneclient.UpdateGroupInput{
@@ -618,14 +692,38 @@ func (suite *GraphTestSuite) TestMutationUpdateGroup() {
 
 			if tc.updateInput.AddGroupMembers != nil {
 				// Adding a member to an group will make it 2 users, there is an admin
-				// assigned to the group automatically
-				assert.Len(t, updatedGroup.Members, 2)
-				assert.Equal(t, tc.expectedRes.Members[0].Role, updatedGroup.Members[1].Role)
-				assert.Equal(t, tc.expectedRes.Members[0].User.ID, updatedGroup.Members[1].User.ID)
+				// assigned to the group automatically and a member added in the test case
+				assert.Len(t, updatedGroup.Members, 3)
+				assert.Equal(t, tc.expectedRes.Members[0].Role, updatedGroup.Members[2].Role)
+				assert.Equal(t, tc.expectedRes.Members[0].User.ID, updatedGroup.Members[2].User.ID)
 			}
 
 			if tc.updateInput.UpdateGroupSettings != nil {
 				assert.Equal(t, updatedGroup.GetSetting().JoinPolicy, enums.JoinPolicyOpen)
+			}
+
+			if tc.updateInput.AddProgramViewerIDs != nil || tc.updateInput.AddProcedureEditorIDs != nil || tc.updateInput.AddControlBlockedGroupIDs != nil {
+				assert.Equal(t, len(tc.expectedRes.Permissions), len(updatedGroup.Permissions))
+
+				// ensure user can now get access to the program
+				programResp, err := suite.client.api.GetProgramByID(gmCtx, program.ID)
+				require.NoError(t, err)
+				require.NotNil(t, programResp)
+
+				// // ensure user can now access the control (they have editor access)
+				// description := gofakeit.HipsterSentence(10)
+				// controlResp, err := suite.client.api.UpdateControl(gmCtx, control.ID, openlaneclient.UpdateControlInput{
+				// 	Description: &description,
+				// })
+				// require.NoError(t, err)
+				// require.NotNil(t, controlResp)
+				// assert.Equal(t, description, *controlResp.UpdateControl.Control.Description)
+
+				// access to procedures is granted by default in the org
+				procedureResp, err := suite.client.api.GetProcedureByID(gmCtx, procedure.ID)
+				require.Error(t, err)
+				require.Nil(t, procedureResp)
+
 			}
 		})
 	}

--- a/internal/graphapi/groupextended.resolvers.go
+++ b/internal/graphapi/groupextended.resolvers.go
@@ -10,9 +10,11 @@ import (
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/rs/zerolog/log"
 	"github.com/theopenlane/core/internal/ent/generated"
+	"github.com/theopenlane/core/internal/ent/generated/group"
 	entgroup "github.com/theopenlane/core/internal/ent/generated/group"
 	"github.com/theopenlane/core/internal/ent/generated/groupmembership"
 	"github.com/theopenlane/core/internal/graphapi/model"
+	"github.com/theopenlane/core/pkg/enums"
 )
 
 // CreateGroupWithMembers is the resolver for the createGroupWithMembers field.
@@ -47,6 +49,98 @@ func (r *mutationResolver) CreateGroupWithMembers(ctx context.Context, group gen
 	return &model.GroupCreatePayload{
 		Group: finalResult,
 	}, nil
+}
+
+// Permissions is the resolver for the permissions field.
+func (r *groupResolver) Permissions(ctx context.Context, obj *generated.Group) ([]*model.GroupPermissions, error) {
+	perms := make([]*model.GroupPermissions, 0)
+
+	// TODO (sfunk): we should generate this code in the future
+	// based off the group permissions mixin
+	res, err := withTransactionalMutation(ctx).Group.Query().Where(group.ID(obj.ID)).
+		// Control permissions
+		WithControlEditors().
+		WithControlViewers().
+		WithControlBlockedGroups().
+		WithControlCreators().
+
+		// Control Objective permissions
+		WithControlObjectiveEditors().
+		WithControlObjectiveViewers().
+		WithControlObjectiveBlockedGroups().
+		WithControlObjectiveCreators().
+
+		// Program permissions
+		WithProgramViewers().
+		WithProgramEditors().
+		WithProgramBlockedGroups().
+		WithProgramCreators().
+
+		// Risk permissions
+		WithRiskViewers().
+		WithRiskEditors().
+		WithRiskBlockedGroups().
+		WithRiskCreators().
+
+		// Internal Policy permissions
+		WithInternalPolicyEditors().
+		WithInternalPolicyBlockedGroups().
+		WithInternalPolicyCreators().
+
+		// Procedure permissions
+		WithProcedureEditors().
+		WithProcedureBlockedGroups().
+		WithProcedureCreators().
+
+		// Narrative permissions
+		WithNarrativeViewers().
+		WithNarrativeEditors().
+		WithNarrativeBlockedGroups().
+		WithNarrativeCreators().
+
+		// Group permissions
+		WithGroupCreators().
+		Only(ctx)
+	if err != nil {
+		return nil, parseRequestError(err, action{action: ActionGet, object: "group"})
+	}
+
+	perms = append(perms, getGroupPermissions(res.Edges.ControlViewers, generated.TypeControl, enums.Viewer)...)
+	perms = append(perms, getGroupPermissions(res.Edges.ControlEditors, generated.TypeControl, enums.Editor)...)
+	perms = append(perms, getGroupPermissions(res.Edges.ControlBlockedGroups, generated.TypeControl, enums.Blocked)...)
+	perms = append(perms, getGroupPermissions(res.Edges.ControlCreators, generated.TypeControl, enums.Creator)...)
+
+	perms = append(perms, getGroupPermissions(res.Edges.ControlObjectiveViewers, generated.TypeControlObjective, enums.Viewer)...)
+	perms = append(perms, getGroupPermissions(res.Edges.ControlObjectiveEditors, generated.TypeControlObjective, enums.Editor)...)
+	perms = append(perms, getGroupPermissions(res.Edges.ControlObjectiveBlockedGroups, generated.TypeControlObjective, enums.Blocked)...)
+	perms = append(perms, getGroupPermissions(res.Edges.ControlObjectiveCreators, generated.TypeControlObjective, enums.Creator)...)
+
+	perms = append(perms, getGroupPermissions(res.Edges.ProgramViewers, generated.TypeProgram, enums.Viewer)...)
+	perms = append(perms, getGroupPermissions(res.Edges.ProgramEditors, generated.TypeProgram, enums.Editor)...)
+	perms = append(perms, getGroupPermissions(res.Edges.ProgramBlockedGroups, generated.TypeProgram, enums.Blocked)...)
+	perms = append(perms, getGroupPermissions(res.Edges.ProgramCreators, generated.TypeProgram, enums.Creator)...)
+
+	perms = append(perms, getGroupPermissions(res.Edges.RiskViewers, generated.TypeRisk, enums.Viewer)...)
+	perms = append(perms, getGroupPermissions(res.Edges.RiskEditors, generated.TypeRisk, enums.Editor)...)
+	perms = append(perms, getGroupPermissions(res.Edges.RiskBlockedGroups, generated.TypeRisk, enums.Blocked)...)
+	perms = append(perms, getGroupPermissions(res.Edges.RiskCreators, generated.TypeRisk, enums.Creator)...)
+
+	perms = append(perms, getGroupPermissions(res.Edges.InternalPolicyEditors, generated.TypeInternalPolicy, enums.Editor)...)
+	perms = append(perms, getGroupPermissions(res.Edges.InternalPolicyBlockedGroups, generated.TypeInternalPolicy, enums.Blocked)...)
+	perms = append(perms, getGroupPermissions(res.Edges.InternalPolicyCreators, generated.TypeInternalPolicy, enums.Creator)...)
+
+	perms = append(perms, getGroupPermissions(res.Edges.ProcedureEditors, generated.TypeProcedure, enums.Editor)...)
+	perms = append(perms, getGroupPermissions(res.Edges.ProcedureBlockedGroups, generated.TypeProcedure, enums.Blocked)...)
+	perms = append(perms, getGroupPermissions(res.Edges.ProcedureCreators, generated.TypeProcedure, enums.Creator)...)
+
+	perms = append(perms, getGroupPermissions(res.Edges.NarrativeViewers, generated.TypeNarrative, enums.Viewer)...)
+	perms = append(perms, getGroupPermissions(res.Edges.NarrativeEditors, generated.TypeProcedure, enums.Editor)...)
+	perms = append(perms, getGroupPermissions(res.Edges.NarrativeBlockedGroups, generated.TypeProcedure, enums.Blocked)...)
+	perms = append(perms, getGroupPermissions(res.Edges.NarrativeCreators, generated.TypeProcedure, enums.Creator)...)
+
+	perms = append(perms, getGroupPermissions(res.Edges.GroupCreators, generated.TypeGroup, enums.Creator)...)
+
+	return perms, nil
 }
 
 // CreateGroupSettings is the resolver for the createGroupSettings field.

--- a/internal/graphapi/groupextended.resolvers.go
+++ b/internal/graphapi/groupextended.resolvers.go
@@ -27,44 +27,34 @@ func (r *groupResolver) Permissions(ctx context.Context, obj *generated.Group) (
 		WithControlEditors().
 		WithControlViewers().
 		WithControlBlockedGroups().
-		WithControlCreators().
 
 		// Control Objective permissions
 		WithControlObjectiveEditors().
 		WithControlObjectiveViewers().
 		WithControlObjectiveBlockedGroups().
-		WithControlObjectiveCreators().
 
 		// Program permissions
 		WithProgramViewers().
 		WithProgramEditors().
 		WithProgramBlockedGroups().
-		WithProgramCreators().
 
 		// Risk permissions
 		WithRiskViewers().
 		WithRiskEditors().
 		WithRiskBlockedGroups().
-		WithRiskCreators().
 
 		// Internal Policy permissions
 		WithInternalPolicyEditors().
 		WithInternalPolicyBlockedGroups().
-		WithInternalPolicyCreators().
 
 		// Procedure permissions
 		WithProcedureEditors().
 		WithProcedureBlockedGroups().
-		WithProcedureCreators().
 
 		// Narrative permissions
 		WithNarrativeViewers().
 		WithNarrativeEditors().
 		WithNarrativeBlockedGroups().
-		WithNarrativeCreators().
-
-		// Group permissions
-		WithGroupCreators().
 		Only(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "group"})
@@ -73,37 +63,28 @@ func (r *groupResolver) Permissions(ctx context.Context, obj *generated.Group) (
 	perms = append(perms, getGroupPermissions(res.Edges.ControlViewers, generated.TypeControl, enums.Viewer)...)
 	perms = append(perms, getGroupPermissions(res.Edges.ControlEditors, generated.TypeControl, enums.Editor)...)
 	perms = append(perms, getGroupPermissions(res.Edges.ControlBlockedGroups, generated.TypeControl, enums.Blocked)...)
-	perms = append(perms, getGroupPermissions(res.Edges.ControlCreators, generated.TypeControl, enums.Creator)...)
 
 	perms = append(perms, getGroupPermissions(res.Edges.ControlObjectiveViewers, generated.TypeControlObjective, enums.Viewer)...)
 	perms = append(perms, getGroupPermissions(res.Edges.ControlObjectiveEditors, generated.TypeControlObjective, enums.Editor)...)
 	perms = append(perms, getGroupPermissions(res.Edges.ControlObjectiveBlockedGroups, generated.TypeControlObjective, enums.Blocked)...)
-	perms = append(perms, getGroupPermissions(res.Edges.ControlObjectiveCreators, generated.TypeControlObjective, enums.Creator)...)
 
 	perms = append(perms, getGroupPermissions(res.Edges.ProgramViewers, generated.TypeProgram, enums.Viewer)...)
 	perms = append(perms, getGroupPermissions(res.Edges.ProgramEditors, generated.TypeProgram, enums.Editor)...)
 	perms = append(perms, getGroupPermissions(res.Edges.ProgramBlockedGroups, generated.TypeProgram, enums.Blocked)...)
-	perms = append(perms, getGroupPermissions(res.Edges.ProgramCreators, generated.TypeProgram, enums.Creator)...)
 
 	perms = append(perms, getGroupPermissions(res.Edges.RiskViewers, generated.TypeRisk, enums.Viewer)...)
 	perms = append(perms, getGroupPermissions(res.Edges.RiskEditors, generated.TypeRisk, enums.Editor)...)
 	perms = append(perms, getGroupPermissions(res.Edges.RiskBlockedGroups, generated.TypeRisk, enums.Blocked)...)
-	perms = append(perms, getGroupPermissions(res.Edges.RiskCreators, generated.TypeRisk, enums.Creator)...)
 
 	perms = append(perms, getGroupPermissions(res.Edges.InternalPolicyEditors, generated.TypeInternalPolicy, enums.Editor)...)
 	perms = append(perms, getGroupPermissions(res.Edges.InternalPolicyBlockedGroups, generated.TypeInternalPolicy, enums.Blocked)...)
-	perms = append(perms, getGroupPermissions(res.Edges.InternalPolicyCreators, generated.TypeInternalPolicy, enums.Creator)...)
 
 	perms = append(perms, getGroupPermissions(res.Edges.ProcedureEditors, generated.TypeProcedure, enums.Editor)...)
 	perms = append(perms, getGroupPermissions(res.Edges.ProcedureBlockedGroups, generated.TypeProcedure, enums.Blocked)...)
-	perms = append(perms, getGroupPermissions(res.Edges.ProcedureCreators, generated.TypeProcedure, enums.Creator)...)
 
 	perms = append(perms, getGroupPermissions(res.Edges.NarrativeViewers, generated.TypeNarrative, enums.Viewer)...)
 	perms = append(perms, getGroupPermissions(res.Edges.NarrativeEditors, generated.TypeProcedure, enums.Editor)...)
 	perms = append(perms, getGroupPermissions(res.Edges.NarrativeBlockedGroups, generated.TypeProcedure, enums.Blocked)...)
-	perms = append(perms, getGroupPermissions(res.Edges.NarrativeCreators, generated.TypeProcedure, enums.Creator)...)
-
-	perms = append(perms, getGroupPermissions(res.Edges.GroupCreators, generated.TypeGroup, enums.Creator)...)
 
 	return perms, nil
 }

--- a/internal/graphapi/grouppermissionshelpers.go
+++ b/internal/graphapi/grouppermissionshelpers.go
@@ -1,0 +1,68 @@
+package graphapi
+
+import (
+	"encoding/json"
+
+	"github.com/theopenlane/core/internal/graphapi/model"
+	"github.com/theopenlane/core/pkg/enums"
+)
+
+// Permissions for the different types of permissions
+const (
+	editor  = "Editor"
+	viewer  = "Viewer"
+	blocked = "Blocked"
+	creator = "Creator"
+)
+
+// EntObject is a struct that contains the id, displayID, and name of an object
+type EntObject struct {
+	ID        string `json:"id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	DisplayID string `json:"display_id,omitempty"`
+}
+
+// getGroupPermissions returns a slice of GroupPermissions for the given object type and permission
+func getGroupPermissions[T any](obj []T, objectType string, permission enums.Permission) (perms []*model.GroupPermissions) {
+	for _, e := range obj {
+		if permission != enums.Creator {
+			eo, err := convertToEntObject(e)
+			if err != nil {
+				return nil
+			}
+
+			perms = append(perms, &model.GroupPermissions{
+				ObjectType:  objectType,
+				ID:          &eo.ID,
+				Permissions: permission,
+				DisplayID:   &eo.DisplayID,
+				Name:        &eo.Name,
+			})
+		} else {
+			// creator permissions are not specific to an object
+			perms = append(perms, &model.GroupPermissions{
+				ObjectType:  objectType,
+				Permissions: permission,
+			})
+		}
+	}
+	return perms
+}
+
+// convertToEntObject converts an object to an EntObject to be used in the GroupPermissions
+// to get the id, displayID, and name of the object
+func convertToEntObject(obj any) (*EntObject, error) {
+	jsonBytes, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	var entObject EntObject
+	err = json.Unmarshal(jsonBytes, &entObject)
+	if err != nil {
+		return nil, err
+	}
+
+	return &entObject, nil
+
+}

--- a/internal/graphapi/grouppermissionshelpers.go
+++ b/internal/graphapi/grouppermissionshelpers.go
@@ -46,6 +46,7 @@ func getGroupPermissions[T any](obj []T, objectType string, permission enums.Per
 			})
 		}
 	}
+
 	return perms
 }
 
@@ -58,11 +59,11 @@ func convertToEntObject(obj any) (*EntObject, error) {
 	}
 
 	var entObject EntObject
+
 	err = json.Unmarshal(jsonBytes, &entObject)
 	if err != nil {
 		return nil, err
 	}
 
 	return &entObject, nil
-
 }

--- a/internal/graphapi/grouppermissionshelpers.go
+++ b/internal/graphapi/grouppermissionshelpers.go
@@ -7,14 +7,6 @@ import (
 	"github.com/theopenlane/core/pkg/enums"
 )
 
-// Permissions for the different types of permissions
-const (
-	editor  = "Editor"
-	viewer  = "Viewer"
-	blocked = "Blocked"
-	creator = "Creator"
-)
-
 // EntObject is a struct that contains the id, displayID, and name of an object
 type EntObject struct {
 	ID        string `json:"id,omitempty"`
@@ -25,26 +17,18 @@ type EntObject struct {
 // getGroupPermissions returns a slice of GroupPermissions for the given object type and permission
 func getGroupPermissions[T any](obj []T, objectType string, permission enums.Permission) (perms []*model.GroupPermissions) {
 	for _, e := range obj {
-		if permission != enums.Creator {
-			eo, err := convertToEntObject(e)
-			if err != nil {
-				return nil
-			}
-
-			perms = append(perms, &model.GroupPermissions{
-				ObjectType:  objectType,
-				ID:          &eo.ID,
-				Permissions: permission,
-				DisplayID:   &eo.DisplayID,
-				Name:        &eo.Name,
-			})
-		} else {
-			// creator permissions are not specific to an object
-			perms = append(perms, &model.GroupPermissions{
-				ObjectType:  objectType,
-				Permissions: permission,
-			})
+		eo, err := convertToEntObject(e)
+		if err != nil {
+			return nil
 		}
+
+		perms = append(perms, &model.GroupPermissions{
+			ObjectType:  objectType,
+			ID:          &eo.ID,
+			Permissions: permission,
+			DisplayID:   &eo.DisplayID,
+			Name:        &eo.Name,
+		})
 	}
 
 	return perms

--- a/internal/graphapi/internalpolicy_test.go
+++ b/internal/graphapi/internalpolicy_test.go
@@ -145,6 +145,9 @@ func (suite *GraphTestSuite) TestMutationCreateInternalPolicy() {
 
 	anotherGroup := (&GroupBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
+	// group for the view only user
+	groupMember := (&GroupMemberBuilder{client: suite.client, UserID: viewOnlyUser.ID}).MustNew(testUser1.UserCtx, t)
+
 	testCases := []struct {
 		name          string
 		request       openlaneclient.CreateInternalPolicyInput
@@ -248,7 +251,7 @@ func (suite *GraphTestSuite) TestMutationCreateInternalPolicy() {
 			if tc.addGroupToOrg {
 				_, err := suite.client.api.UpdateOrganization(testUser1.UserCtx, testUser1.OrganizationID,
 					openlaneclient.UpdateOrganizationInput{
-						AddInternalPolicyCreatorIDs: []string{viewOnlyUser.GroupID},
+						AddInternalPolicyCreatorIDs: []string{groupMember.GroupID},
 					}, nil)
 				require.NoError(t, err)
 			}

--- a/internal/graphapi/model/gen_models.go
+++ b/internal/graphapi/model/gen_models.go
@@ -438,6 +438,17 @@ type GroupMembershipUpdatePayload struct {
 	GroupMembership *generated.GroupMembership `json:"groupMembership"`
 }
 
+// GroupPermissions contains details for the related object and the permissions
+// the group provides (or removes in the case of blocked) to the object within the
+// organization
+type GroupPermissions struct {
+	ObjectType  string           `json:"objectType"`
+	Permissions enums.Permission `json:"permissions"`
+	ID          *string          `json:"id,omitempty"`
+	DisplayID   *string          `json:"displayID,omitempty"`
+	Name        *string          `json:"name,omitempty"`
+}
+
 type GroupSearchResult struct {
 	Groups []*generated.Group `json:"groups,omitempty"`
 }

--- a/internal/graphapi/narrative_test.go
+++ b/internal/graphapi/narrative_test.go
@@ -170,6 +170,9 @@ func (suite *GraphTestSuite) TestMutationCreateNarrative() {
 	program2 := (&ProgramBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	programAnotherUser := (&ProgramBuilder{client: suite.client}).MustNew(testUser2.UserCtx, t)
 
+	// group for the view only user
+	groupMember := (&GroupMemberBuilder{client: suite.client, UserID: viewOnlyUser.ID}).MustNew(testUser1.UserCtx, t)
+
 	// add adminUser to the program so that they can create a narrative associated with the program1
 	(&ProgramMemberBuilder{client: suite.client, ProgramID: program1.ID,
 		UserID: adminUser.ID, Role: enums.RoleAdmin.String()}).
@@ -296,7 +299,7 @@ func (suite *GraphTestSuite) TestMutationCreateNarrative() {
 			if tc.addGroupToOrg {
 				_, err := suite.client.api.UpdateOrganization(testUser1.UserCtx, testUser1.OrganizationID,
 					openlaneclient.UpdateOrganizationInput{
-						AddNarrativeCreatorIDs: []string{viewOnlyUser.GroupID},
+						AddNarrativeCreatorIDs: []string{groupMember.GroupID},
 					}, nil)
 				require.NoError(t, err)
 			}

--- a/internal/graphapi/organization_test.go
+++ b/internal/graphapi/organization_test.go
@@ -616,7 +616,7 @@ func (suite *GraphTestSuite) TestMutationUpdateOrganization() {
 			},
 			client:   suite.client.api,
 			ctx:      memberUserCtx,
-			errorMsg: "you are not authorized to perform this action",
+			errorMsg: notAuthorizedErrorMsg,
 		},
 		{
 			name:  "update description and avatar file, happy path",

--- a/internal/graphapi/orgextended.resolvers.go
+++ b/internal/graphapi/orgextended.resolvers.go
@@ -16,8 +16,8 @@ import (
 )
 
 // CreateOrganizationWithMembers is the resolver for the createOrganizationWithMembers field.
-func (r *mutationResolver) CreateOrganizationWithMembers(ctx context.Context, organization generated.CreateOrganizationInput, avatarFile *graphql.Upload, members []*model.OrgMembersInput) (*model.OrganizationCreatePayload, error) {
-	res, err := r.CreateOrganization(ctx, organization, nil)
+func (r *mutationResolver) CreateOrganizationWithMembers(ctx context.Context, organizationInput generated.CreateOrganizationInput, avatarFile *graphql.Upload, members []*model.OrgMembersInput) (*model.OrganizationCreatePayload, error) {
+	res, err := r.CreateOrganization(ctx, organizationInput, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/graphapi/procedure_test.go
+++ b/internal/graphapi/procedure_test.go
@@ -145,6 +145,9 @@ func (suite *GraphTestSuite) TestMutationCreateProcedure() {
 
 	anotherGroup := (&GroupBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
+	// group for the view only user
+	groupMember := (&GroupMemberBuilder{client: suite.client, UserID: viewOnlyUser.ID}).MustNew(testUser1.UserCtx, t)
+
 	testCases := []struct {
 		name          string
 		request       openlaneclient.CreateProcedureInput
@@ -250,7 +253,7 @@ func (suite *GraphTestSuite) TestMutationCreateProcedure() {
 			if tc.addGroupToOrg {
 				_, err := suite.client.api.UpdateOrganization(testUser1.UserCtx, testUser1.OrganizationID,
 					openlaneclient.UpdateOrganizationInput{
-						AddProcedureCreatorIDs: []string{viewOnlyUser.GroupID},
+						AddProcedureCreatorIDs: []string{groupMember.GroupID},
 					}, nil)
 				require.NoError(t, err)
 			}

--- a/internal/graphapi/program_test.go
+++ b/internal/graphapi/program_test.go
@@ -160,11 +160,16 @@ func (suite *GraphTestSuite) TestMutationCreateProgram() {
 	startDate := time.Now().AddDate(0, 0, 1)
 	endDate := time.Now().AddDate(0, 0, 360)
 
+	groupMember := (&GroupMemberBuilder{client: suite.client, UserID: viewOnlyUser.ID}).MustNew(testUser1.UserCtx, t)
+
 	// Create some edge objects
 	procedure := (&ProcedureBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	policy := (&InternalPolicyBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	blockedGroup := (&GroupBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	viewerGroup := (&GroupBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+
+	// group that the user does not have access to (for testing permissions)
+	anotherGroup := (&GroupBuilder{client: suite.client}).MustNew(testUser2.UserCtx, t)
 
 	testCases := []struct {
 		name          string
@@ -210,13 +215,23 @@ func (suite *GraphTestSuite) TestMutationCreateProgram() {
 		{
 			name: "add editor group",
 			request: openlaneclient.CreateProgramInput{
-				Name:            "Test Procedure",
+				Name:            "Test Program MITB",
 				EditorIDs:       []string{testUser1.GroupID},
 				BlockedGroupIDs: []string{blockedGroup.ID},
 				ViewerIDs:       []string{viewerGroup.ID},
 			},
 			client: suite.client.api,
 			ctx:    testUser1.UserCtx,
+		},
+		{
+			name: "add editor group, no access to group",
+			request: openlaneclient.CreateProgramInput{
+				Name:      "Test Program Meow",
+				EditorIDs: []string{anotherGroup.ID},
+			},
+			client:      suite.client.api,
+			ctx:         testUser1.UserCtx,
+			expectedErr: notAuthorizedErrorMsg,
 		},
 		{
 			name: "happy path, using pat",
@@ -280,7 +295,7 @@ func (suite *GraphTestSuite) TestMutationCreateProgram() {
 			if tc.addGroupToOrg {
 				_, err := suite.client.api.UpdateOrganization(testUser1.UserCtx, testUser1.OrganizationID,
 					openlaneclient.UpdateOrganizationInput{
-						AddProgramCreatorIDs: []string{viewOnlyUser.GroupID},
+						AddProgramCreatorIDs: []string{groupMember.GroupID},
 					}, nil)
 				require.NoError(t, err)
 			}

--- a/internal/graphapi/program_test.go
+++ b/internal/graphapi/program_test.go
@@ -413,6 +413,7 @@ func (suite *GraphTestSuite) TestMutationUpdateProgram() {
 	// create program user to remove
 	programUser := suite.userBuilder(context.Background())
 	(&OrgMemberBuilder{client: suite.client, UserID: programUser.ID, OrgID: testUser1.OrganizationID}).MustNew(testUser1.UserCtx, t)
+
 	pm := (&ProgramMemberBuilder{client: suite.client, UserID: programUser.ID, ProgramID: program.ID}).MustNew(testUser1.UserCtx, t)
 
 	// Create some edge objects
@@ -491,7 +492,7 @@ func (suite *GraphTestSuite) TestMutationUpdateProgram() {
 		{
 			name: "happy path, remove program member",
 			request: openlaneclient.UpdateProgramInput{
-				RemoveBlockedGroupIDs: []string{pm.ID},
+				RemoveProgramMembers: []string{pm.ID},
 			},
 			client: suite.client.apiWithPAT,
 			ctx:    context.Background(),
@@ -645,9 +646,12 @@ func (suite *GraphTestSuite) TestMutationUpdateProgram() {
 				assert.Equal(t, program.ID, res.Program.ID)
 			}
 
-			// member was removed, ensure there are no members now
+			// member was removed, ensure there is only one member left
 			if len(tc.request.RemoveProgramMembers) > 0 {
-				require.Len(t, resp.UpdateProgram.Program.Members, 0)
+				require.Len(t, resp.UpdateProgram.Program.Members, 1)
+
+				// it should only be the owner left
+				require.Equal(t, testUser1.ID, resp.UpdateProgram.Program.Members[0].User.ID)
 			}
 		})
 	}

--- a/internal/graphapi/query/group.graphql
+++ b/internal/graphapi/query/group.graphql
@@ -84,6 +84,13 @@ mutation CreateGroup($input: CreateGroupInput!) {
         syncToSlack
         visibility
       }
+      permissions {
+        displayID
+        id
+        name
+        objectType
+        permissions
+      }
       members {
         id
         role
@@ -193,6 +200,13 @@ query GetGroupByID($groupId: ID!) {
       updatedBy
       visibility
     }
+    permissions {
+      displayID
+      id
+      name
+      objectType
+      permissions
+    }
     members {
       id
       role
@@ -235,6 +249,13 @@ query GetGroups($where: GroupWhereInput) {
           updatedBy
           visibility
         }
+        permissions {
+          displayID
+          id
+          name
+          objectType
+          permissions
+        }
         members {
           id
           role
@@ -276,6 +297,13 @@ mutation UpdateGroup($updateGroupId: ID!, $input: UpdateGroupInput!) {
         updatedAt
         updatedBy
         visibility
+      }
+      permissions {
+        displayID
+        id
+        name
+        objectType
+        permissions
       }
       members {
         id

--- a/internal/graphapi/query/group.graphql
+++ b/internal/graphapi/query/group.graphql
@@ -97,8 +97,8 @@ mutation CreateGroup($input: CreateGroupInput!) {
   }
 }
 
-mutation CreateGroupWithMembers($group: CreateGroupInput!, $members: [GroupMembersInput!]) {
-  createGroupWithMembers(group: $group, members: $members) {
+mutation CreateGroupWithMembers($groupInput: CreateGroupInput!, $members: [GroupMembersInput!]) {
+  createGroupWithMembers(groupInput: $groupInput, members: $members) {
     group {
       id
       displayID

--- a/internal/graphapi/query/organization.graphql
+++ b/internal/graphapi/query/organization.graphql
@@ -73,8 +73,8 @@ mutation CreateOrganization($input: CreateOrganizationInput!, $avatarFile: Uploa
   }
 }
 
-mutation CreateOrganizationWithMembers($org: CreateOrganizationInput!, $members: [OrgMembersInput!]) {
-  createOrganizationWithMembers(organization: $org, members: $members) {
+mutation CreateOrganizationWithMembers($organizationInput: CreateOrganizationInput!, $members: [OrgMembersInput!]) {
+  createOrganizationWithMembers(organizationInput: $organizationInput, members: $members) {
     organization {
       id
       name

--- a/internal/graphapi/risk_test.go
+++ b/internal/graphapi/risk_test.go
@@ -170,6 +170,9 @@ func (suite *GraphTestSuite) TestMutationCreateRisk() {
 	program2 := (&ProgramBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	programAnotherUser := (&ProgramBuilder{client: suite.client}).MustNew(testUser2.UserCtx, t)
 
+	// group for the view only user
+	groupMember := (&GroupMemberBuilder{client: suite.client, UserID: viewOnlyUser.ID}).MustNew(testUser1.UserCtx, t)
+
 	// add adminUser to the program so that they can create a risk associated with the program1
 	(&ProgramMemberBuilder{client: suite.client, ProgramID: program1.ID,
 		UserID: adminUser.ID, Role: enums.RoleAdmin.String()}).
@@ -302,7 +305,7 @@ func (suite *GraphTestSuite) TestMutationCreateRisk() {
 			if tc.addGroupToOrg {
 				_, err := suite.client.api.UpdateOrganization(testUser1.UserCtx, testUser1.OrganizationID,
 					openlaneclient.UpdateOrganizationInput{
-						AddRiskCreatorIDs: []string{viewOnlyUser.GroupID},
+						AddRiskCreatorIDs: []string{groupMember.GroupID},
 					}, nil)
 				require.NoError(t, err)
 			}

--- a/internal/graphapi/schema/groupextended.graphql
+++ b/internal/graphapi/schema/groupextended.graphql
@@ -37,3 +37,33 @@ extend type Mutation{
         members: [GroupMembersInput!]
     ): GroupCreatePayload!
 }
+
+"""
+Permission is enum for the permissions types
+"""
+enum Permission @goModel(model: "github.com/theopenlane/core/pkg/enums.Permission") {
+  EDITOR
+  VIEWER
+  CREATOR
+  BLOCKED
+}
+
+"""
+GroupPermissions contains details for the related object and the permissions
+the group provides (or removes in the case of blocked) to the object within the
+organization
+"""
+type GroupPermissions {
+  objectType: String!
+  permissions: Permission!
+  id: ID
+  displayID: String
+  name: String
+}
+
+extend type Group {
+  """
+  permissions the group provides
+  """
+  permissions: [GroupPermissions!]
+}

--- a/internal/graphapi/schema/groupextended.graphql
+++ b/internal/graphapi/schema/groupextended.graphql
@@ -28,9 +28,9 @@ extend type Mutation{
     """
     createGroupWithMembers(
         """
-        values of the group
+        values of the group to be created
         """
-        group: CreateGroupInput!
+        groupInput: CreateGroupInput!
         """
         group members to be added to the group
         """

--- a/internal/graphapi/schema/orgextended.graphql
+++ b/internal/graphapi/schema/orgextended.graphql
@@ -28,9 +28,9 @@ extend type Mutation{
     """
     createOrganizationWithMembers(
         """
-        values of the new organization
+        values of the new organization to be created
         """
-        organization: CreateOrganizationInput!
+        organizationInput: CreateOrganizationInput!
         """
         avatar file to Upload
         """

--- a/pkg/enums/permissions.go
+++ b/pkg/enums/permissions.go
@@ -1,0 +1,64 @@
+package enums
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+type Permission string
+
+var (
+	Editor  Permission = "EDITOR"
+	Viewer  Permission = "VIEWER"
+	Blocked Permission = "BLOCKED"
+	Creator Permission = "CREATOR"
+)
+
+// Values returns a slice of strings that represents all the possible values of the Permission enum.
+// Possible default values are "EDITOR", "VIEWER", "BLOCKED", "CREATOR"
+func (Permission) Values() (kinds []string) {
+	for _, s := range []Permission{Editor, Viewer, Blocked, Creator} {
+		kinds = append(kinds, string(s))
+	}
+
+	return
+}
+
+// String returns the permission as a string
+func (r Permission) String() string {
+	return string(r)
+}
+
+// ToPermission returns the Permission based on string input
+func ToPermission(r string) *Permission {
+	switch r := strings.ToUpper(r); r {
+	case Editor.String():
+		return &Editor
+	case Viewer.String():
+		return &Viewer
+	case Blocked.String():
+		return &Blocked
+	case Creator.String():
+		return &Creator
+	default:
+		return nil
+	}
+}
+
+// MarshalGQL implement the Marshaler interface for gqlgen
+func (r Permission) MarshalGQL(w io.Writer) {
+	_, _ = w.Write([]byte(`"` + r.String() + `"`))
+}
+
+// UnmarshalGQL implement the Unmarshaler interface for gqlgen
+func (r *Permission) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("wrong type for Permission, got: %T", v) //nolint:err113
+	}
+
+	*r = Permission(str)
+
+	return nil
+}

--- a/pkg/enums/permissions_test.go
+++ b/pkg/enums/permissions_test.go
@@ -1,0 +1,98 @@
+package enums
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPermissionValues(t *testing.T) {
+	expected := []string{"EDITOR", "VIEWER", "BLOCKED", "CREATOR"}
+	values := Permission("").Values()
+
+	assert.Equal(t, len(expected), len(values))
+
+	for i, v := range values {
+		assert.Equal(t, expected[i], v)
+	}
+}
+
+func TestPermissionString(t *testing.T) {
+	tests := []struct {
+		permission Permission
+		expected   string
+	}{
+		{Editor, "EDITOR"},
+		{Viewer, "VIEWER"},
+		{Blocked, "BLOCKED"},
+		{Creator, "CREATOR"},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.expected, test.permission.String())
+	}
+}
+
+func TestToPermission(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected *Permission
+	}{
+		{"EDITOR", &Editor},
+		{"VIEWER", &Viewer},
+		{"BLOCKED", &Blocked},
+		{"CREATOR", &Creator},
+		{"unknown", nil},
+	}
+
+	for _, test := range tests {
+		result := ToPermission(test.input)
+		assert.Equal(t, test.expected, result)
+	}
+}
+
+func TestPermissionMarshalGQL(t *testing.T) {
+	tests := []struct {
+		permission Permission
+		expected   string
+	}{
+		{Editor, `"EDITOR"`},
+		{Viewer, `"VIEWER"`},
+		{Blocked, `"BLOCKED"`},
+		{Creator, `"CREATOR"`},
+	}
+
+	for _, test := range tests {
+		var writer strings.Builder
+		test.permission.MarshalGQL(&writer)
+
+		assert.Equal(t, test.expected, writer.String())
+	}
+}
+
+func TestPermissionUnmarshalGQL(t *testing.T) {
+	tests := []struct {
+		input    interface{}
+		expected Permission
+		hasError bool
+	}{
+		{"EDITOR", Editor, false},
+		{"VIEWER", Viewer, false},
+		{"BLOCKED", Blocked, false},
+		{"CREATOR", Creator, false},
+		{123, "", true},
+	}
+
+	for _, test := range tests {
+		var p Permission
+		err := p.UnmarshalGQL(test.input)
+		if test.hasError {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, p)
+		}
+	}
+}

--- a/pkg/openlaneclient/graphclient.go
+++ b/pkg/openlaneclient/graphclient.go
@@ -16888,6 +16888,45 @@ func (t *CreateGroup_CreateGroup_Group_Setting) GetVisibility() *enums.Visibilit
 	return &t.Visibility
 }
 
+type CreateGroup_CreateGroup_Group_Permissions struct {
+	DisplayID   *string          "json:\"displayID,omitempty\" graphql:\"displayID\""
+	ID          *string          "json:\"id,omitempty\" graphql:\"id\""
+	Name        *string          "json:\"name,omitempty\" graphql:\"name\""
+	ObjectType  string           "json:\"objectType\" graphql:\"objectType\""
+	Permissions enums.Permission "json:\"permissions\" graphql:\"permissions\""
+}
+
+func (t *CreateGroup_CreateGroup_Group_Permissions) GetDisplayID() *string {
+	if t == nil {
+		t = &CreateGroup_CreateGroup_Group_Permissions{}
+	}
+	return t.DisplayID
+}
+func (t *CreateGroup_CreateGroup_Group_Permissions) GetID() *string {
+	if t == nil {
+		t = &CreateGroup_CreateGroup_Group_Permissions{}
+	}
+	return t.ID
+}
+func (t *CreateGroup_CreateGroup_Group_Permissions) GetName() *string {
+	if t == nil {
+		t = &CreateGroup_CreateGroup_Group_Permissions{}
+	}
+	return t.Name
+}
+func (t *CreateGroup_CreateGroup_Group_Permissions) GetObjectType() string {
+	if t == nil {
+		t = &CreateGroup_CreateGroup_Group_Permissions{}
+	}
+	return t.ObjectType
+}
+func (t *CreateGroup_CreateGroup_Group_Permissions) GetPermissions() *enums.Permission {
+	if t == nil {
+		t = &CreateGroup_CreateGroup_Group_Permissions{}
+	}
+	return &t.Permissions
+}
+
 type CreateGroup_CreateGroup_Group_Members_User struct {
 	FirstName *string "json:\"firstName,omitempty\" graphql:\"firstName\""
 	ID        string  "json:\"id\" graphql:\"id\""
@@ -16939,15 +16978,16 @@ func (t *CreateGroup_CreateGroup_Group_Members) GetUser() *CreateGroup_CreateGro
 }
 
 type CreateGroup_CreateGroup_Group struct {
-	Description *string                                  "json:\"description,omitempty\" graphql:\"description\""
-	DisplayName string                                   "json:\"displayName\" graphql:\"displayName\""
-	ID          string                                   "json:\"id\" graphql:\"id\""
-	LogoURL     *string                                  "json:\"logoURL,omitempty\" graphql:\"logoURL\""
-	Members     []*CreateGroup_CreateGroup_Group_Members "json:\"members,omitempty\" graphql:\"members\""
-	Name        string                                   "json:\"name\" graphql:\"name\""
-	Owner       *CreateGroup_CreateGroup_Group_Owner     "json:\"owner,omitempty\" graphql:\"owner\""
-	Setting     *CreateGroup_CreateGroup_Group_Setting   "json:\"setting,omitempty\" graphql:\"setting\""
-	Tags        []string                                 "json:\"tags,omitempty\" graphql:\"tags\""
+	Description *string                                      "json:\"description,omitempty\" graphql:\"description\""
+	DisplayName string                                       "json:\"displayName\" graphql:\"displayName\""
+	ID          string                                       "json:\"id\" graphql:\"id\""
+	LogoURL     *string                                      "json:\"logoURL,omitempty\" graphql:\"logoURL\""
+	Members     []*CreateGroup_CreateGroup_Group_Members     "json:\"members,omitempty\" graphql:\"members\""
+	Name        string                                       "json:\"name\" graphql:\"name\""
+	Owner       *CreateGroup_CreateGroup_Group_Owner         "json:\"owner,omitempty\" graphql:\"owner\""
+	Permissions []*CreateGroup_CreateGroup_Group_Permissions "json:\"permissions,omitempty\" graphql:\"permissions\""
+	Setting     *CreateGroup_CreateGroup_Group_Setting       "json:\"setting,omitempty\" graphql:\"setting\""
+	Tags        []string                                     "json:\"tags,omitempty\" graphql:\"tags\""
 }
 
 func (t *CreateGroup_CreateGroup_Group) GetDescription() *string {
@@ -16991,6 +17031,12 @@ func (t *CreateGroup_CreateGroup_Group) GetOwner() *CreateGroup_CreateGroup_Grou
 		t = &CreateGroup_CreateGroup_Group{}
 	}
 	return t.Owner
+}
+func (t *CreateGroup_CreateGroup_Group) GetPermissions() []*CreateGroup_CreateGroup_Group_Permissions {
+	if t == nil {
+		t = &CreateGroup_CreateGroup_Group{}
+	}
+	return t.Permissions
 }
 func (t *CreateGroup_CreateGroup_Group) GetSetting() *CreateGroup_CreateGroup_Group_Setting {
 	if t == nil {
@@ -17482,6 +17528,45 @@ func (t *GetGroupByID_Group_Setting) GetVisibility() *enums.Visibility {
 	return &t.Visibility
 }
 
+type GetGroupByID_Group_Permissions struct {
+	DisplayID   *string          "json:\"displayID,omitempty\" graphql:\"displayID\""
+	ID          *string          "json:\"id,omitempty\" graphql:\"id\""
+	Name        *string          "json:\"name,omitempty\" graphql:\"name\""
+	ObjectType  string           "json:\"objectType\" graphql:\"objectType\""
+	Permissions enums.Permission "json:\"permissions\" graphql:\"permissions\""
+}
+
+func (t *GetGroupByID_Group_Permissions) GetDisplayID() *string {
+	if t == nil {
+		t = &GetGroupByID_Group_Permissions{}
+	}
+	return t.DisplayID
+}
+func (t *GetGroupByID_Group_Permissions) GetID() *string {
+	if t == nil {
+		t = &GetGroupByID_Group_Permissions{}
+	}
+	return t.ID
+}
+func (t *GetGroupByID_Group_Permissions) GetName() *string {
+	if t == nil {
+		t = &GetGroupByID_Group_Permissions{}
+	}
+	return t.Name
+}
+func (t *GetGroupByID_Group_Permissions) GetObjectType() string {
+	if t == nil {
+		t = &GetGroupByID_Group_Permissions{}
+	}
+	return t.ObjectType
+}
+func (t *GetGroupByID_Group_Permissions) GetPermissions() *enums.Permission {
+	if t == nil {
+		t = &GetGroupByID_Group_Permissions{}
+	}
+	return &t.Permissions
+}
+
 type GetGroupByID_Group_Members_User struct {
 	FirstName *string "json:\"firstName,omitempty\" graphql:\"firstName\""
 	ID        string  "json:\"id\" graphql:\"id\""
@@ -17533,20 +17618,21 @@ func (t *GetGroupByID_Group_Members) GetUser() *GetGroupByID_Group_Members_User 
 }
 
 type GetGroupByID_Group struct {
-	CreatedAt   *time.Time                    "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy   *string                       "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description *string                       "json:\"description,omitempty\" graphql:\"description\""
-	DisplayName string                        "json:\"displayName\" graphql:\"displayName\""
-	ID          string                        "json:\"id\" graphql:\"id\""
-	IsManaged   *bool                         "json:\"isManaged,omitempty\" graphql:\"isManaged\""
-	LogoURL     *string                       "json:\"logoURL,omitempty\" graphql:\"logoURL\""
-	Members     []*GetGroupByID_Group_Members "json:\"members,omitempty\" graphql:\"members\""
-	Name        string                        "json:\"name\" graphql:\"name\""
-	Owner       *GetGroupByID_Group_Owner     "json:\"owner,omitempty\" graphql:\"owner\""
-	Setting     *GetGroupByID_Group_Setting   "json:\"setting,omitempty\" graphql:\"setting\""
-	Tags        []string                      "json:\"tags,omitempty\" graphql:\"tags\""
-	UpdatedAt   *time.Time                    "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy   *string                       "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	CreatedAt   *time.Time                        "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy   *string                           "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description *string                           "json:\"description,omitempty\" graphql:\"description\""
+	DisplayName string                            "json:\"displayName\" graphql:\"displayName\""
+	ID          string                            "json:\"id\" graphql:\"id\""
+	IsManaged   *bool                             "json:\"isManaged,omitempty\" graphql:\"isManaged\""
+	LogoURL     *string                           "json:\"logoURL,omitempty\" graphql:\"logoURL\""
+	Members     []*GetGroupByID_Group_Members     "json:\"members,omitempty\" graphql:\"members\""
+	Name        string                            "json:\"name\" graphql:\"name\""
+	Owner       *GetGroupByID_Group_Owner         "json:\"owner,omitempty\" graphql:\"owner\""
+	Permissions []*GetGroupByID_Group_Permissions "json:\"permissions,omitempty\" graphql:\"permissions\""
+	Setting     *GetGroupByID_Group_Setting       "json:\"setting,omitempty\" graphql:\"setting\""
+	Tags        []string                          "json:\"tags,omitempty\" graphql:\"tags\""
+	UpdatedAt   *time.Time                        "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy   *string                           "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *GetGroupByID_Group) GetCreatedAt() *time.Time {
@@ -17608,6 +17694,12 @@ func (t *GetGroupByID_Group) GetOwner() *GetGroupByID_Group_Owner {
 		t = &GetGroupByID_Group{}
 	}
 	return t.Owner
+}
+func (t *GetGroupByID_Group) GetPermissions() []*GetGroupByID_Group_Permissions {
+	if t == nil {
+		t = &GetGroupByID_Group{}
+	}
+	return t.Permissions
 }
 func (t *GetGroupByID_Group) GetSetting() *GetGroupByID_Group_Setting {
 	if t == nil {
@@ -17719,6 +17811,45 @@ func (t *GetGroups_Groups_Edges_Node_Setting) GetVisibility() *enums.Visibility 
 	return &t.Visibility
 }
 
+type GetGroups_Groups_Edges_Node_Permissions struct {
+	DisplayID   *string          "json:\"displayID,omitempty\" graphql:\"displayID\""
+	ID          *string          "json:\"id,omitempty\" graphql:\"id\""
+	Name        *string          "json:\"name,omitempty\" graphql:\"name\""
+	ObjectType  string           "json:\"objectType\" graphql:\"objectType\""
+	Permissions enums.Permission "json:\"permissions\" graphql:\"permissions\""
+}
+
+func (t *GetGroups_Groups_Edges_Node_Permissions) GetDisplayID() *string {
+	if t == nil {
+		t = &GetGroups_Groups_Edges_Node_Permissions{}
+	}
+	return t.DisplayID
+}
+func (t *GetGroups_Groups_Edges_Node_Permissions) GetID() *string {
+	if t == nil {
+		t = &GetGroups_Groups_Edges_Node_Permissions{}
+	}
+	return t.ID
+}
+func (t *GetGroups_Groups_Edges_Node_Permissions) GetName() *string {
+	if t == nil {
+		t = &GetGroups_Groups_Edges_Node_Permissions{}
+	}
+	return t.Name
+}
+func (t *GetGroups_Groups_Edges_Node_Permissions) GetObjectType() string {
+	if t == nil {
+		t = &GetGroups_Groups_Edges_Node_Permissions{}
+	}
+	return t.ObjectType
+}
+func (t *GetGroups_Groups_Edges_Node_Permissions) GetPermissions() *enums.Permission {
+	if t == nil {
+		t = &GetGroups_Groups_Edges_Node_Permissions{}
+	}
+	return &t.Permissions
+}
+
 type GetGroups_Groups_Edges_Node_Members_User struct {
 	FirstName *string "json:\"firstName,omitempty\" graphql:\"firstName\""
 	ID        string  "json:\"id\" graphql:\"id\""
@@ -17770,20 +17901,21 @@ func (t *GetGroups_Groups_Edges_Node_Members) GetUser() *GetGroups_Groups_Edges_
 }
 
 type GetGroups_Groups_Edges_Node struct {
-	CreatedAt   *time.Time                             "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy   *string                                "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description *string                                "json:\"description,omitempty\" graphql:\"description\""
-	DisplayName string                                 "json:\"displayName\" graphql:\"displayName\""
-	ID          string                                 "json:\"id\" graphql:\"id\""
-	IsManaged   *bool                                  "json:\"isManaged,omitempty\" graphql:\"isManaged\""
-	LogoURL     *string                                "json:\"logoURL,omitempty\" graphql:\"logoURL\""
-	Members     []*GetGroups_Groups_Edges_Node_Members "json:\"members,omitempty\" graphql:\"members\""
-	Name        string                                 "json:\"name\" graphql:\"name\""
-	Owner       *GetGroups_Groups_Edges_Node_Owner     "json:\"owner,omitempty\" graphql:\"owner\""
-	Setting     *GetGroups_Groups_Edges_Node_Setting   "json:\"setting,omitempty\" graphql:\"setting\""
-	Tags        []string                               "json:\"tags,omitempty\" graphql:\"tags\""
-	UpdatedAt   *time.Time                             "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy   *string                                "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	CreatedAt   *time.Time                                 "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy   *string                                    "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description *string                                    "json:\"description,omitempty\" graphql:\"description\""
+	DisplayName string                                     "json:\"displayName\" graphql:\"displayName\""
+	ID          string                                     "json:\"id\" graphql:\"id\""
+	IsManaged   *bool                                      "json:\"isManaged,omitempty\" graphql:\"isManaged\""
+	LogoURL     *string                                    "json:\"logoURL,omitempty\" graphql:\"logoURL\""
+	Members     []*GetGroups_Groups_Edges_Node_Members     "json:\"members,omitempty\" graphql:\"members\""
+	Name        string                                     "json:\"name\" graphql:\"name\""
+	Owner       *GetGroups_Groups_Edges_Node_Owner         "json:\"owner,omitempty\" graphql:\"owner\""
+	Permissions []*GetGroups_Groups_Edges_Node_Permissions "json:\"permissions,omitempty\" graphql:\"permissions\""
+	Setting     *GetGroups_Groups_Edges_Node_Setting       "json:\"setting,omitempty\" graphql:\"setting\""
+	Tags        []string                                   "json:\"tags,omitempty\" graphql:\"tags\""
+	UpdatedAt   *time.Time                                 "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy   *string                                    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *GetGroups_Groups_Edges_Node) GetCreatedAt() *time.Time {
@@ -17845,6 +17977,12 @@ func (t *GetGroups_Groups_Edges_Node) GetOwner() *GetGroups_Groups_Edges_Node_Ow
 		t = &GetGroups_Groups_Edges_Node{}
 	}
 	return t.Owner
+}
+func (t *GetGroups_Groups_Edges_Node) GetPermissions() []*GetGroups_Groups_Edges_Node_Permissions {
+	if t == nil {
+		t = &GetGroups_Groups_Edges_Node{}
+	}
+	return t.Permissions
 }
 func (t *GetGroups_Groups_Edges_Node) GetSetting() *GetGroups_Groups_Edges_Node_Setting {
 	if t == nil {
@@ -17978,6 +18116,45 @@ func (t *UpdateGroup_UpdateGroup_Group_Setting) GetVisibility() *enums.Visibilit
 	return &t.Visibility
 }
 
+type UpdateGroup_UpdateGroup_Group_Permissions struct {
+	DisplayID   *string          "json:\"displayID,omitempty\" graphql:\"displayID\""
+	ID          *string          "json:\"id,omitempty\" graphql:\"id\""
+	Name        *string          "json:\"name,omitempty\" graphql:\"name\""
+	ObjectType  string           "json:\"objectType\" graphql:\"objectType\""
+	Permissions enums.Permission "json:\"permissions\" graphql:\"permissions\""
+}
+
+func (t *UpdateGroup_UpdateGroup_Group_Permissions) GetDisplayID() *string {
+	if t == nil {
+		t = &UpdateGroup_UpdateGroup_Group_Permissions{}
+	}
+	return t.DisplayID
+}
+func (t *UpdateGroup_UpdateGroup_Group_Permissions) GetID() *string {
+	if t == nil {
+		t = &UpdateGroup_UpdateGroup_Group_Permissions{}
+	}
+	return t.ID
+}
+func (t *UpdateGroup_UpdateGroup_Group_Permissions) GetName() *string {
+	if t == nil {
+		t = &UpdateGroup_UpdateGroup_Group_Permissions{}
+	}
+	return t.Name
+}
+func (t *UpdateGroup_UpdateGroup_Group_Permissions) GetObjectType() string {
+	if t == nil {
+		t = &UpdateGroup_UpdateGroup_Group_Permissions{}
+	}
+	return t.ObjectType
+}
+func (t *UpdateGroup_UpdateGroup_Group_Permissions) GetPermissions() *enums.Permission {
+	if t == nil {
+		t = &UpdateGroup_UpdateGroup_Group_Permissions{}
+	}
+	return &t.Permissions
+}
+
 type UpdateGroup_UpdateGroup_Group_Members_User struct {
 	FirstName *string "json:\"firstName,omitempty\" graphql:\"firstName\""
 	ID        string  "json:\"id\" graphql:\"id\""
@@ -18029,15 +18206,16 @@ func (t *UpdateGroup_UpdateGroup_Group_Members) GetUser() *UpdateGroup_UpdateGro
 }
 
 type UpdateGroup_UpdateGroup_Group struct {
-	Description *string                                  "json:\"description,omitempty\" graphql:\"description\""
-	DisplayName string                                   "json:\"displayName\" graphql:\"displayName\""
-	ID          string                                   "json:\"id\" graphql:\"id\""
-	LogoURL     *string                                  "json:\"logoURL,omitempty\" graphql:\"logoURL\""
-	Members     []*UpdateGroup_UpdateGroup_Group_Members "json:\"members,omitempty\" graphql:\"members\""
-	Name        string                                   "json:\"name\" graphql:\"name\""
-	Owner       *UpdateGroup_UpdateGroup_Group_Owner     "json:\"owner,omitempty\" graphql:\"owner\""
-	Setting     *UpdateGroup_UpdateGroup_Group_Setting   "json:\"setting,omitempty\" graphql:\"setting\""
-	Tags        []string                                 "json:\"tags,omitempty\" graphql:\"tags\""
+	Description *string                                      "json:\"description,omitempty\" graphql:\"description\""
+	DisplayName string                                       "json:\"displayName\" graphql:\"displayName\""
+	ID          string                                       "json:\"id\" graphql:\"id\""
+	LogoURL     *string                                      "json:\"logoURL,omitempty\" graphql:\"logoURL\""
+	Members     []*UpdateGroup_UpdateGroup_Group_Members     "json:\"members,omitempty\" graphql:\"members\""
+	Name        string                                       "json:\"name\" graphql:\"name\""
+	Owner       *UpdateGroup_UpdateGroup_Group_Owner         "json:\"owner,omitempty\" graphql:\"owner\""
+	Permissions []*UpdateGroup_UpdateGroup_Group_Permissions "json:\"permissions,omitempty\" graphql:\"permissions\""
+	Setting     *UpdateGroup_UpdateGroup_Group_Setting       "json:\"setting,omitempty\" graphql:\"setting\""
+	Tags        []string                                     "json:\"tags,omitempty\" graphql:\"tags\""
 }
 
 func (t *UpdateGroup_UpdateGroup_Group) GetDescription() *string {
@@ -18081,6 +18259,12 @@ func (t *UpdateGroup_UpdateGroup_Group) GetOwner() *UpdateGroup_UpdateGroup_Grou
 		t = &UpdateGroup_UpdateGroup_Group{}
 	}
 	return t.Owner
+}
+func (t *UpdateGroup_UpdateGroup_Group) GetPermissions() []*UpdateGroup_UpdateGroup_Group_Permissions {
+	if t == nil {
+		t = &UpdateGroup_UpdateGroup_Group{}
+	}
+	return t.Permissions
 }
 func (t *UpdateGroup_UpdateGroup_Group) GetSetting() *UpdateGroup_UpdateGroup_Group_Setting {
 	if t == nil {
@@ -57619,6 +57803,13 @@ const CreateGroupDocument = `mutation CreateGroup ($input: CreateGroupInput!) {
 				syncToSlack
 				visibility
 			}
+			permissions {
+				displayID
+				id
+				name
+				objectType
+				permissions
+			}
 			members {
 				id
 				role
@@ -57799,6 +57990,13 @@ const GetGroupByIDDocument = `query GetGroupByID ($groupId: ID!) {
 			updatedBy
 			visibility
 		}
+		permissions {
+			displayID
+			id
+			name
+			objectType
+			permissions
+		}
 		members {
 			id
 			role
@@ -57859,6 +58057,13 @@ const GetGroupsDocument = `query GetGroups ($where: GroupWhereInput) {
 					updatedBy
 					visibility
 				}
+				permissions {
+					displayID
+					id
+					name
+					objectType
+					permissions
+				}
 				members {
 					id
 					role
@@ -57918,6 +58123,13 @@ const UpdateGroupDocument = `mutation UpdateGroup ($updateGroupId: ID!, $input: 
 				updatedAt
 				updatedBy
 				visibility
+			}
+			permissions {
+				displayID
+				id
+				name
+				objectType
+				permissions
 			}
 			members {
 				id

--- a/pkg/openlaneclient/graphclient.go
+++ b/pkg/openlaneclient/graphclient.go
@@ -114,7 +114,7 @@ type OpenlaneGraphClient interface {
 	CreateBulkCSVGroup(ctx context.Context, input graphql.Upload, interceptors ...clientv2.RequestInterceptor) (*CreateBulkCSVGroup, error)
 	CreateBulkGroup(ctx context.Context, input []*CreateGroupInput, interceptors ...clientv2.RequestInterceptor) (*CreateBulkGroup, error)
 	CreateGroup(ctx context.Context, input CreateGroupInput, interceptors ...clientv2.RequestInterceptor) (*CreateGroup, error)
-	CreateGroupWithMembers(ctx context.Context, group CreateGroupInput, members []*GroupMembersInput, interceptors ...clientv2.RequestInterceptor) (*CreateGroupWithMembers, error)
+	CreateGroupWithMembers(ctx context.Context, groupInput CreateGroupInput, members []*GroupMembersInput, interceptors ...clientv2.RequestInterceptor) (*CreateGroupWithMembers, error)
 	DeleteGroup(ctx context.Context, deleteGroupID string, interceptors ...clientv2.RequestInterceptor) (*DeleteGroup, error)
 	GetAllGroups(ctx context.Context, interceptors ...clientv2.RequestInterceptor) (*GetAllGroups, error)
 	GetGroupByID(ctx context.Context, groupID string, interceptors ...clientv2.RequestInterceptor) (*GetGroupByID, error)
@@ -187,7 +187,7 @@ type OpenlaneGraphClient interface {
 	CreateBulkCSVOrganization(ctx context.Context, input graphql.Upload, interceptors ...clientv2.RequestInterceptor) (*CreateBulkCSVOrganization, error)
 	CreateBulkOrganization(ctx context.Context, input []*CreateOrganizationInput, interceptors ...clientv2.RequestInterceptor) (*CreateBulkOrganization, error)
 	CreateOrganization(ctx context.Context, input CreateOrganizationInput, avatarFile *graphql.Upload, interceptors ...clientv2.RequestInterceptor) (*CreateOrganization, error)
-	CreateOrganizationWithMembers(ctx context.Context, org CreateOrganizationInput, members []*OrgMembersInput, interceptors ...clientv2.RequestInterceptor) (*CreateOrganizationWithMembers, error)
+	CreateOrganizationWithMembers(ctx context.Context, organizationInput CreateOrganizationInput, members []*OrgMembersInput, interceptors ...clientv2.RequestInterceptor) (*CreateOrganizationWithMembers, error)
 	DeleteOrganization(ctx context.Context, deleteOrganizationID string, interceptors ...clientv2.RequestInterceptor) (*DeleteOrganization, error)
 	GetAllOrganizations(ctx context.Context, interceptors ...clientv2.RequestInterceptor) (*GetAllOrganizations, error)
 	GetOrganizationByID(ctx context.Context, organizationID string, interceptors ...clientv2.RequestInterceptor) (*GetOrganizationByID, error)
@@ -57650,8 +57650,8 @@ func (c *Client) CreateGroup(ctx context.Context, input CreateGroupInput, interc
 	return &res, nil
 }
 
-const CreateGroupWithMembersDocument = `mutation CreateGroupWithMembers ($group: CreateGroupInput!, $members: [GroupMembersInput!]) {
-	createGroupWithMembers(group: $group, members: $members) {
+const CreateGroupWithMembersDocument = `mutation CreateGroupWithMembers ($groupInput: CreateGroupInput!, $members: [GroupMembersInput!]) {
+	createGroupWithMembers(groupInput: $groupInput, members: $members) {
 		group {
 			id
 			displayID
@@ -57673,10 +57673,10 @@ const CreateGroupWithMembersDocument = `mutation CreateGroupWithMembers ($group:
 }
 `
 
-func (c *Client) CreateGroupWithMembers(ctx context.Context, group CreateGroupInput, members []*GroupMembersInput, interceptors ...clientv2.RequestInterceptor) (*CreateGroupWithMembers, error) {
+func (c *Client) CreateGroupWithMembers(ctx context.Context, groupInput CreateGroupInput, members []*GroupMembersInput, interceptors ...clientv2.RequestInterceptor) (*CreateGroupWithMembers, error) {
 	vars := map[string]any{
-		"group":   group,
-		"members": members,
+		"groupInput": groupInput,
+		"members":    members,
 	}
 
 	var res CreateGroupWithMembers
@@ -60611,8 +60611,8 @@ func (c *Client) CreateOrganization(ctx context.Context, input CreateOrganizatio
 	return &res, nil
 }
 
-const CreateOrganizationWithMembersDocument = `mutation CreateOrganizationWithMembers ($org: CreateOrganizationInput!, $members: [OrgMembersInput!]) {
-	createOrganizationWithMembers(organization: $org, members: $members) {
+const CreateOrganizationWithMembersDocument = `mutation CreateOrganizationWithMembers ($organizationInput: CreateOrganizationInput!, $members: [OrgMembersInput!]) {
+	createOrganizationWithMembers(organizationInput: $organizationInput, members: $members) {
 		organization {
 			id
 			name
@@ -60646,10 +60646,10 @@ const CreateOrganizationWithMembersDocument = `mutation CreateOrganizationWithMe
 }
 `
 
-func (c *Client) CreateOrganizationWithMembers(ctx context.Context, org CreateOrganizationInput, members []*OrgMembersInput, interceptors ...clientv2.RequestInterceptor) (*CreateOrganizationWithMembers, error) {
+func (c *Client) CreateOrganizationWithMembers(ctx context.Context, organizationInput CreateOrganizationInput, members []*OrgMembersInput, interceptors ...clientv2.RequestInterceptor) (*CreateOrganizationWithMembers, error) {
 	vars := map[string]any{
-		"org":     org,
-		"members": members,
+		"organizationInput": organizationInput,
+		"members":           members,
 	}
 
 	var res CreateOrganizationWithMembers

--- a/pkg/openlaneclient/models.go
+++ b/pkg/openlaneclient/models.go
@@ -7432,6 +7432,8 @@ type Group struct {
 	Files                         []*File             `json:"files,omitempty"`
 	Tasks                         []*Task             `json:"tasks,omitempty"`
 	Members                       []*GroupMembership  `json:"members,omitempty"`
+	// permissions the group provides
+	Permissions []*GroupPermissions `json:"permissions,omitempty"`
 }
 
 func (Group) IsNode() {}
@@ -8103,6 +8105,17 @@ type GroupOrder struct {
 	Direction OrderDirection `json:"direction"`
 	// The field by which to order Groups.
 	Field GroupOrderField `json:"field"`
+}
+
+// GroupPermissions contains details for the related object and the permissions
+// the group provides (or removes in the case of blocked) to the object within the
+// organization
+type GroupPermissions struct {
+	ObjectType  string           `json:"objectType"`
+	Permissions enums.Permission `json:"permissions"`
+	ID          *string          `json:"id,omitempty"`
+	DisplayID   *string          `json:"displayID,omitempty"`
+	Name        *string          `json:"name,omitempty"`
 }
 
 type GroupSearchResult struct {


### PR DESCRIPTION
Merged https://github.com/theopenlane/core/pull/440 first. This is based off that branch!

- Adds a `Permissions` resolver to groups to collect all permissions that group is giving. This is currently manually maintained but we should be able to generate this in the future based on the GroupPermissions mixin. see https://github.com/theopenlane/core/pull/432/files#diff-469681fdd85ab9c8c4977e8c7317075b136da7b9cb7c28d835ad15f338e5b31a

- Fixes bugs around the ability to add edges that assign permissions when the user does not have access to the object. For example, before the fix, a user could add edit permission to a program via their group, and gain edit access to the program they didn't have access to previously. 

```
go run cmd/cli/main.go group get -i 01JK9HSDCMSS6SR6J819SQXQTE -z json   
{
  "group": {
    "createdAt": "2025-02-04T15:37:41.673083-07:00",
    "createdBy": "01JK9HQES40YMS0406T00J4AH6",
    "description": "",
    "displayName": "Humans",
    "id": "01JK9HSDCMSS6SR6J819SQXQTE",
    "name": "Humans",
    "permissions": [
      {
        "displayID": "CTL-7WA2WG",
        "id": "01JKA2F8ZDP37RQQ12PT8SYMKE",
        "name": "CC2.4",
        "objectType": "Control",
        "permissions": "VIEWER"
      },
      {
        "displayID": "CTL-SSI5FI",
        "id": "01JKA2FPH5PCA69M16768QT6R4",
        "name": "CC1.3",
        "objectType": "Control",
        "permissions": "VIEWER"
      },
      {
        "displayID": "PRG-IF2HCA",
        "id": "01JK9J0GFEQP9KRSBB8R9357JT",
        "name": "Risk Mitigation - 2025",
        "objectType": "Program",
        "permissions": "EDITOR"
      }
    ],
    "setting": {
      "createdAt": "2025-02-04T15:37:41.674143-07:00",
      "createdBy": "01JK9HQES40YMS0406T00J4AH6",
      "id": "01JK9HSDD98NW91801RQSJZ5WK",
      "joinPolicy": "INVITE_OR_APPLICATION",
      "syncToGithub": false,
      "syncToSlack": false,
      "updatedAt": "2025-02-04T15:37:41.673877-07:00",
      "updatedBy": "01JK9HQES40YMS0406T00J4AH6",
      "visibility": "PUBLIC"
    },
    "updatedAt": "2025-02-04T15:50:52.537648-07:00",
    "updatedBy": "01JK9HQES40YMS0406T00J4AH6"
  }
}

```