### PR TITLE
feat: restrict org creation to JWT authentication

### DIFF
--- a/internal/graphapi/errors.go
+++ b/internal/graphapi/errors.go
@@ -31,6 +31,9 @@ var (
 
 	// ErrUnableToDetermineObjectType is returned when the object type up the parent upload object cannot be determined
 	ErrUnableToDetermineObjectType = errors.New("unable to determine parent object type")
+
+	// ErrResourceNotAccessibleWithToken is returned when a resource is not accessible with a personal access token or api token
+	ErrResourceNotAccessibleWithToken = errors.New("resource is not accessible with token authentication")
 )
 
 // NotFoundError is returned when the requested object is not found

--- a/internal/graphapi/onboarding.resolvers.go
+++ b/internal/graphapi/onboarding.resolvers.go
@@ -7,12 +7,20 @@ package graphapi
 import (
 	"context"
 
+	"github.com/rs/zerolog/log"
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/graphapi/model"
+	"github.com/theopenlane/iam/auth"
 )
 
 // CreateOnboarding is the resolver for the createOnboarding field.
 func (r *mutationResolver) CreateOnboarding(ctx context.Context, input generated.CreateOnboardingInput) (*model.OnboardingCreatePayload, error) {
+	if auth.GetAuthTypeFromContext(ctx) != auth.JWTAuthentication {
+		log.Info().Msg("organization attempted to be created with non-JWT auth type")
+
+		return nil, ErrResourceNotAccessibleWithToken
+	}
+
 	res, err := withTransactionalMutation(ctx).Onboarding.Create().SetInput(input).Save(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionCreate, object: "onboarding"})

--- a/internal/graphapi/onboarding_test.go
+++ b/internal/graphapi/onboarding_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/theopenlane/core/internal/graphapi"
 	"github.com/theopenlane/core/pkg/openlaneclient"
 )
 
@@ -60,6 +61,24 @@ func (suite *GraphTestSuite) TestMutationCreateOnboarding() {
 			client:      suite.client.api,
 			ctx:         testUser1.UserCtx,
 			expectedErr: "value is less than the required length",
+		},
+		{
+			name: "not allowed with PAT",
+			request: openlaneclient.CreateOnboardingInput{
+				CompanyName: companyName,
+			},
+			client:      suite.client.apiWithPAT,
+			ctx:         testUser1.UserCtx,
+			expectedErr: graphapi.ErrResourceNotAccessibleWithToken.Error(),
+		},
+		{
+			name: "not allowed with token",
+			request: openlaneclient.CreateOnboardingInput{
+				CompanyName: companyName,
+			},
+			client:      suite.client.apiWithToken,
+			ctx:         testUser1.UserCtx,
+			expectedErr: graphapi.ErrResourceNotAccessibleWithToken.Error(),
 		},
 	}
 

--- a/internal/graphapi/organization.resolvers.go
+++ b/internal/graphapi/organization.resolvers.go
@@ -11,10 +11,17 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/graphapi/model"
+	"github.com/theopenlane/iam/auth"
 )
 
 // CreateOrganization is the resolver for the createOrganization field.
 func (r *mutationResolver) CreateOrganization(ctx context.Context, input generated.CreateOrganizationInput, avatarFile *graphql.Upload) (*model.OrganizationCreatePayload, error) {
+	if auth.GetAuthTypeFromContext(ctx) != auth.JWTAuthentication {
+		log.Info().Msg("organization attempted to be created with non-JWT auth type")
+
+		return nil, ErrResourceNotAccessibleWithToken
+	}
+
 	// set the parent organization in the auth context, used when creating a sub-organization with a personal access token
 	if input.ParentID != nil {
 		if err := setOrganizationInAuthContext(ctx, input.ParentID); err != nil {

--- a/internal/graphapi/organization_test.go
+++ b/internal/graphapi/organization_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/theopenlane/iam/auth"
 
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
+	"github.com/theopenlane/core/internal/graphapi"
 	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/models"
 	"github.com/theopenlane/core/pkg/objects"
@@ -214,21 +215,30 @@ func (suite *GraphTestSuite) TestMutationCreateOrganization() {
 			errorMsg:       notAuthorizedErrorMsg,
 		},
 		{
-			name:           "happy path organization with parent org using personal access token",
+			name:           "organization with parent org using personal access token, not allowed",
 			orgName:        gofakeit.Name(),
 			orgDescription: gofakeit.HipsterSentence(10),
 			parentOrgID:    testUser1.OrganizationID,
 			client:         suite.client.apiWithPAT,
 			ctx:            context.Background(),
+			errorMsg:       graphapi.ErrResourceNotAccessibleWithToken.Error(),
 		},
 		{
-			name:           "organization with parent org using personal access token, no access to parent",
+			name:           "organization with parent org using personal access token, no access to parent, not allowed",
 			orgName:        gofakeit.Name(),
 			orgDescription: gofakeit.HipsterSentence(10),
 			parentOrgID:    testUser2.OrganizationID,
 			client:         suite.client.apiWithPAT,
 			ctx:            context.Background(),
-			errorMsg:       notFoundErrorMsg,
+			errorMsg:       graphapi.ErrResourceNotAccessibleWithToken.Error(),
+		},
+		{
+			name:           "organization create with api token not allowed",
+			orgName:        gofakeit.Name(),
+			orgDescription: gofakeit.HipsterSentence(10),
+			client:         suite.client.apiWithToken,
+			ctx:            context.Background(),
+			errorMsg:       graphapi.ErrResourceNotAccessibleWithToken.Error(),
 		},
 		{
 			name:           "organization with parent personal org",


### PR DESCRIPTION
restricts the org + onboarding create resolvers to require JWT authentication 