### PR TITLE
do not allow bulk org creation

### DIFF
--- a/internal/graphapi/bulk.go
+++ b/internal/graphapi/bulk.go
@@ -332,25 +332,6 @@ func (r *mutationResolver) bulkCreateNarrative(ctx context.Context, input []*gen
 	}, nil
 }
 
-// bulkCreateOrganization uses the CreateBulk function to create multiple Organization entities
-func (r *mutationResolver) bulkCreateOrganization(ctx context.Context, input []*generated.CreateOrganizationInput) (*model.OrganizationBulkCreatePayload, error) {
-	c := withTransactionalMutation(ctx)
-	builders := make([]*generated.OrganizationCreate, len(input))
-	for i, data := range input {
-		builders[i] = c.Organization.Create().SetInput(*data)
-	}
-
-	res, err := c.Organization.CreateBulk(builders...).Save(ctx)
-	if err != nil {
-		return nil, parseRequestError(err, action{action: ActionCreate, object: "organization"})
-	}
-
-	// return response
-	return &model.OrganizationBulkCreatePayload{
-		Organizations: res,
-	}, nil
-}
-
 // bulkCreateOrganizationSetting uses the CreateBulk function to create multiple OrganizationSetting entities
 func (r *mutationResolver) bulkCreateOrganizationSetting(ctx context.Context, input []*generated.CreateOrganizationSettingInput) (*model.OrganizationSettingBulkCreatePayload, error) {
 	c := withTransactionalMutation(ctx)

--- a/internal/graphapi/clientschema/schema.graphql
+++ b/internal/graphapi/clientschema/schema.graphql
@@ -14794,24 +14794,6 @@ type Mutation {
 		input: CreateOrganizationInput!
 	avatarFile: Upload): OrganizationCreatePayload!
 	"""
-	Create multiple new organizations
-	"""
-	createBulkOrganization(
-		"""
-		values of the organization
-		"""
-		input: [CreateOrganizationInput!]
-	): OrganizationBulkCreatePayload!
-	"""
-	Create multiple new organizations via file upload
-	"""
-	createBulkCSVOrganization(
-		"""
-		csv file containing values of the organization
-		"""
-		input: Upload!
-	): OrganizationBulkCreatePayload!
-	"""
 	Update an existing organization
 	"""
 	updateOrganization(

--- a/internal/graphapi/generated/actionplan.generated.go
+++ b/internal/graphapi/generated/actionplan.generated.go
@@ -112,8 +112,6 @@ type MutationResolver interface {
 	UpdateTaskComment(ctx context.Context, id string, input generated.UpdateNoteInput) (*model.TaskUpdatePayload, error)
 	CreateOnboarding(ctx context.Context, input generated.CreateOnboardingInput) (*model.OnboardingCreatePayload, error)
 	CreateOrganization(ctx context.Context, input generated.CreateOrganizationInput, avatarFile *graphql.Upload) (*model.OrganizationCreatePayload, error)
-	CreateBulkOrganization(ctx context.Context, input []*generated.CreateOrganizationInput) (*model.OrganizationBulkCreatePayload, error)
-	CreateBulkCSVOrganization(ctx context.Context, input graphql.Upload) (*model.OrganizationBulkCreatePayload, error)
 	UpdateOrganization(ctx context.Context, id string, input generated.UpdateOrganizationInput, avatarFile *graphql.Upload) (*model.OrganizationUpdatePayload, error)
 	DeleteOrganization(ctx context.Context, id string) (*model.OrganizationDeletePayload, error)
 	CreateOrganizationSetting(ctx context.Context, input generated.CreateOrganizationSettingInput) (*model.OrganizationSettingCreatePayload, error)
@@ -822,34 +820,6 @@ func (ec *executionContext) field_Mutation_createBulkCSVOrganizationSetting_args
 	return args, nil
 }
 func (ec *executionContext) field_Mutation_createBulkCSVOrganizationSetting_argsInput(
-	ctx context.Context,
-	rawArgs map[string]any,
-) (graphql.Upload, error) {
-	if _, ok := rawArgs["input"]; !ok {
-		var zeroVal graphql.Upload
-		return zeroVal, nil
-	}
-
-	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
-	if tmp, ok := rawArgs["input"]; ok {
-		return ec.unmarshalNUpload2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚐUpload(ctx, tmp)
-	}
-
-	var zeroVal graphql.Upload
-	return zeroVal, nil
-}
-
-func (ec *executionContext) field_Mutation_createBulkCSVOrganization_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
-	var err error
-	args := map[string]any{}
-	arg0, err := ec.field_Mutation_createBulkCSVOrganization_argsInput(ctx, rawArgs)
-	if err != nil {
-		return nil, err
-	}
-	args["input"] = arg0
-	return args, nil
-}
-func (ec *executionContext) field_Mutation_createBulkCSVOrganization_argsInput(
 	ctx context.Context,
 	rawArgs map[string]any,
 ) (graphql.Upload, error) {
@@ -1648,34 +1618,6 @@ func (ec *executionContext) field_Mutation_createBulkOrganizationSetting_argsInp
 	}
 
 	var zeroVal []*generated.CreateOrganizationSettingInput
-	return zeroVal, nil
-}
-
-func (ec *executionContext) field_Mutation_createBulkOrganization_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
-	var err error
-	args := map[string]any{}
-	arg0, err := ec.field_Mutation_createBulkOrganization_argsInput(ctx, rawArgs)
-	if err != nil {
-		return nil, err
-	}
-	args["input"] = arg0
-	return args, nil
-}
-func (ec *executionContext) field_Mutation_createBulkOrganization_argsInput(
-	ctx context.Context,
-	rawArgs map[string]any,
-) ([]*generated.CreateOrganizationInput, error) {
-	if _, ok := rawArgs["input"]; !ok {
-		var zeroVal []*generated.CreateOrganizationInput
-		return zeroVal, nil
-	}
-
-	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
-	if tmp, ok := rawArgs["input"]; ok {
-		return ec.unmarshalOCreateOrganizationInput2ᚕᚖgithubᚗcomᚋtheopenlaneᚋcoreᚋinternalᚋentᚋgeneratedᚐCreateOrganizationInputᚄ(ctx, tmp)
-	}
-
-	var zeroVal []*generated.CreateOrganizationInput
 	return zeroVal, nil
 }
 
@@ -11917,124 +11859,6 @@ func (ec *executionContext) fieldContext_Mutation_createOrganization(ctx context
 	return fc, nil
 }
 
-func (ec *executionContext) _Mutation_createBulkOrganization(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Mutation_createBulkOrganization(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().CreateBulkOrganization(rctx, fc.Args["input"].([]*generated.CreateOrganizationInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*model.OrganizationBulkCreatePayload)
-	fc.Result = res
-	return ec.marshalNOrganizationBulkCreatePayload2ᚖgithubᚗcomᚋtheopenlaneᚋcoreᚋinternalᚋgraphapiᚋmodelᚐOrganizationBulkCreatePayload(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Mutation_createBulkOrganization(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Mutation",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "organizations":
-				return ec.fieldContext_OrganizationBulkCreatePayload_organizations(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type OrganizationBulkCreatePayload", field.Name)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Mutation_createBulkOrganization_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Mutation_createBulkCSVOrganization(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Mutation_createBulkCSVOrganization(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().CreateBulkCSVOrganization(rctx, fc.Args["input"].(graphql.Upload))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*model.OrganizationBulkCreatePayload)
-	fc.Result = res
-	return ec.marshalNOrganizationBulkCreatePayload2ᚖgithubᚗcomᚋtheopenlaneᚋcoreᚋinternalᚋgraphapiᚋmodelᚐOrganizationBulkCreatePayload(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Mutation_createBulkCSVOrganization(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Mutation",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "organizations":
-				return ec.fieldContext_OrganizationBulkCreatePayload_organizations(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type OrganizationBulkCreatePayload", field.Name)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Mutation_createBulkCSVOrganization_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _Mutation_updateOrganization(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Mutation_updateOrganization(ctx, field)
 	if err != nil {
@@ -17308,20 +17132,6 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "createOrganization":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_createOrganization(ctx, field)
-			})
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "createBulkOrganization":
-			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Mutation_createBulkOrganization(ctx, field)
-			})
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "createBulkCSVOrganization":
-			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Mutation_createBulkCSVOrganization(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++

--- a/internal/graphapi/generated/organization.generated.go
+++ b/internal/graphapi/generated/organization.generated.go
@@ -719,20 +719,6 @@ func (ec *executionContext) _OrganizationUpdatePayload(ctx context.Context, sel 
 
 // region    ***************************** type.gotpl *****************************
 
-func (ec *executionContext) marshalNOrganizationBulkCreatePayload2githubᚗcomᚋtheopenlaneᚋcoreᚋinternalᚋgraphapiᚋmodelᚐOrganizationBulkCreatePayload(ctx context.Context, sel ast.SelectionSet, v model.OrganizationBulkCreatePayload) graphql.Marshaler {
-	return ec._OrganizationBulkCreatePayload(ctx, sel, &v)
-}
-
-func (ec *executionContext) marshalNOrganizationBulkCreatePayload2ᚖgithubᚗcomᚋtheopenlaneᚋcoreᚋinternalᚋgraphapiᚋmodelᚐOrganizationBulkCreatePayload(ctx context.Context, sel ast.SelectionSet, v *model.OrganizationBulkCreatePayload) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-		return graphql.Null
-	}
-	return ec._OrganizationBulkCreatePayload(ctx, sel, v)
-}
-
 func (ec *executionContext) marshalNOrganizationCreatePayload2githubᚗcomᚋtheopenlaneᚋcoreᚋinternalᚋgraphapiᚋmodelᚐOrganizationCreatePayload(ctx context.Context, sel ast.SelectionSet, v model.OrganizationCreatePayload) graphql.Marshaler {
 	return ec._OrganizationCreatePayload(ctx, sel, &v)
 }

--- a/internal/graphapi/generated/root_.generated.go
+++ b/internal/graphapi/generated/root_.generated.go
@@ -1601,7 +1601,6 @@ type ComplexityRoot struct {
 		CreateBulkCSVInvite              func(childComplexity int, input graphql.Upload) int
 		CreateBulkCSVNarrative           func(childComplexity int, input graphql.Upload) int
 		CreateBulkCSVOrgMembership       func(childComplexity int, input graphql.Upload) int
-		CreateBulkCSVOrganization        func(childComplexity int, input graphql.Upload) int
 		CreateBulkCSVOrganizationSetting func(childComplexity int, input graphql.Upload) int
 		CreateBulkCSVPersonalAccessToken func(childComplexity int, input graphql.Upload) int
 		CreateBulkCSVProcedure           func(childComplexity int, input graphql.Upload) int
@@ -1630,7 +1629,6 @@ type ComplexityRoot struct {
 		CreateBulkInvite                 func(childComplexity int, input []*generated.CreateInviteInput) int
 		CreateBulkNarrative              func(childComplexity int, input []*generated.CreateNarrativeInput) int
 		CreateBulkOrgMembership          func(childComplexity int, input []*generated.CreateOrgMembershipInput) int
-		CreateBulkOrganization           func(childComplexity int, input []*generated.CreateOrganizationInput) int
 		CreateBulkOrganizationSetting    func(childComplexity int, input []*generated.CreateOrganizationSettingInput) int
 		CreateBulkPersonalAccessToken    func(childComplexity int, input []*generated.CreatePersonalAccessTokenInput) int
 		CreateBulkProcedure              func(childComplexity int, input []*generated.CreateProcedureInput) int
@@ -10523,18 +10521,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.CreateBulkCSVOrgMembership(childComplexity, args["input"].(graphql.Upload)), true
 
-	case "Mutation.createBulkCSVOrganization":
-		if e.complexity.Mutation.CreateBulkCSVOrganization == nil {
-			break
-		}
-
-		args, err := ec.field_Mutation_createBulkCSVOrganization_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Mutation.CreateBulkCSVOrganization(childComplexity, args["input"].(graphql.Upload)), true
-
 	case "Mutation.createBulkCSVOrganizationSetting":
 		if e.complexity.Mutation.CreateBulkCSVOrganizationSetting == nil {
 			break
@@ -10870,18 +10856,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.CreateBulkOrgMembership(childComplexity, args["input"].([]*generated.CreateOrgMembershipInput)), true
-
-	case "Mutation.createBulkOrganization":
-		if e.complexity.Mutation.CreateBulkOrganization == nil {
-			break
-		}
-
-		args, err := ec.field_Mutation_createBulkOrganization_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Mutation.CreateBulkOrganization(childComplexity, args["input"].([]*generated.CreateOrganizationInput)), true
 
 	case "Mutation.createBulkOrganizationSetting":
 		if e.complexity.Mutation.CreateBulkOrganizationSetting == nil {
@@ -54226,24 +54200,6 @@ extend type Mutation{
         input: CreateOrganizationInput!
         avatarFile: Upload
     ): OrganizationCreatePayload!
-    """
-    Create multiple new organizations
-    """
-    createBulkOrganization(
-        """
-        values of the organization
-        """
-        input: [CreateOrganizationInput!]
-    ): OrganizationBulkCreatePayload!
-    """
-    Create multiple new organizations via file upload
-    """
-    createBulkCSVOrganization(
-        """
-        csv file containing values of the organization
-        """
-        input: Upload!
-    ): OrganizationBulkCreatePayload!
     """
     Update an existing organization
     """

--- a/internal/graphapi/organization.resolvers.go
+++ b/internal/graphapi/organization.resolvers.go
@@ -41,23 +41,6 @@ func (r *mutationResolver) CreateOrganization(ctx context.Context, input generat
 	}, nil
 }
 
-// CreateBulkOrganization is the resolver for the createBulkOrganization field.
-func (r *mutationResolver) CreateBulkOrganization(ctx context.Context, input []*generated.CreateOrganizationInput) (*model.OrganizationBulkCreatePayload, error) {
-	return r.bulkCreateOrganization(ctx, input)
-}
-
-// CreateBulkCSVOrganization is the resolver for the createBulkCSVOrganization field.
-func (r *mutationResolver) CreateBulkCSVOrganization(ctx context.Context, input graphql.Upload) (*model.OrganizationBulkCreatePayload, error) {
-	data, err := unmarshalBulkData[generated.CreateOrganizationInput](input)
-	if err != nil {
-		log.Error().Err(err).Msg("failed to unmarshal bulk data")
-
-		return nil, err
-	}
-
-	return r.bulkCreateOrganization(ctx, data)
-}
-
 // UpdateOrganization is the resolver for the updateOrganization field.
 func (r *mutationResolver) UpdateOrganization(ctx context.Context, id string, input generated.UpdateOrganizationInput, avatarFile *graphql.Upload) (*model.OrganizationUpdatePayload, error) {
 	res, err := withTransactionalMutation(ctx).Organization.Get(ctx, id)

--- a/internal/graphapi/query/organization.graphql
+++ b/internal/graphapi/query/organization.graphql
@@ -1,29 +1,3 @@
-mutation CreateBulkCSVOrganization($input: Upload!) {
-  createBulkCSVOrganization(input: $input) {
-    organizations {
-      id
-      name
-      displayName
-      description
-      personalOrg
-      tags
-    }
-  }
-}
-
-mutation CreateBulkOrganization($input: [CreateOrganizationInput!]) {
-  createBulkOrganization(input: $input) {
-    organizations {
-      id
-      name
-      displayName
-      description
-      personalOrg
-      tags
-    }
-  }
-}
-
 mutation CreateOrganization($input: CreateOrganizationInput!, $avatarFile: Upload) {
   createOrganization(input: $input, avatarFile: $avatarFile) {
     organization {

--- a/internal/graphapi/schema/organization.graphql
+++ b/internal/graphapi/schema/organization.graphql
@@ -22,24 +22,6 @@ extend type Mutation{
         avatarFile: Upload
     ): OrganizationCreatePayload!
     """
-    Create multiple new organizations
-    """
-    createBulkOrganization(
-        """
-        values of the organization
-        """
-        input: [CreateOrganizationInput!]
-    ): OrganizationBulkCreatePayload!
-    """
-    Create multiple new organizations via file upload
-    """
-    createBulkCSVOrganization(
-        """
-        csv file containing values of the organization
-        """
-        input: Upload!
-    ): OrganizationBulkCreatePayload!
-    """
     Update an existing organization
     """
     updateOrganization(

--- a/pkg/openlaneclient/graphclient.go
+++ b/pkg/openlaneclient/graphclient.go
@@ -187,8 +187,6 @@ type OpenlaneGraphClient interface {
 	GetAllNoteHistories(ctx context.Context, interceptors ...clientv2.RequestInterceptor) (*GetAllNoteHistories, error)
 	GetNoteHistories(ctx context.Context, where *NoteHistoryWhereInput, interceptors ...clientv2.RequestInterceptor) (*GetNoteHistories, error)
 	CreateOnboarding(ctx context.Context, input CreateOnboardingInput, interceptors ...clientv2.RequestInterceptor) (*CreateOnboarding, error)
-	CreateBulkCSVOrganization(ctx context.Context, input graphql.Upload, interceptors ...clientv2.RequestInterceptor) (*CreateBulkCSVOrganization, error)
-	CreateBulkOrganization(ctx context.Context, input []*CreateOrganizationInput, interceptors ...clientv2.RequestInterceptor) (*CreateBulkOrganization, error)
 	CreateOrganization(ctx context.Context, input CreateOrganizationInput, avatarFile *graphql.Upload, interceptors ...clientv2.RequestInterceptor) (*CreateOrganization, error)
 	CreateOrganizationWithMembers(ctx context.Context, organizationInput CreateOrganizationInput, members []*OrgMembersInput, interceptors ...clientv2.RequestInterceptor) (*CreateOrganizationWithMembers, error)
 	DeleteOrganization(ctx context.Context, deleteOrganizationID string, interceptors ...clientv2.RequestInterceptor) (*DeleteOrganization, error)
@@ -25841,120 +25839,6 @@ func (t *CreateOnboarding_CreateOnboarding) GetOnboarding() *CreateOnboarding_Cr
 		t = &CreateOnboarding_CreateOnboarding{}
 	}
 	return &t.Onboarding
-}
-
-type CreateBulkCSVOrganization_CreateBulkCSVOrganization_Organizations struct {
-	Description *string  "json:\"description,omitempty\" graphql:\"description\""
-	DisplayName string   "json:\"displayName\" graphql:\"displayName\""
-	ID          string   "json:\"id\" graphql:\"id\""
-	Name        string   "json:\"name\" graphql:\"name\""
-	PersonalOrg *bool    "json:\"personalOrg,omitempty\" graphql:\"personalOrg\""
-	Tags        []string "json:\"tags,omitempty\" graphql:\"tags\""
-}
-
-func (t *CreateBulkCSVOrganization_CreateBulkCSVOrganization_Organizations) GetDescription() *string {
-	if t == nil {
-		t = &CreateBulkCSVOrganization_CreateBulkCSVOrganization_Organizations{}
-	}
-	return t.Description
-}
-func (t *CreateBulkCSVOrganization_CreateBulkCSVOrganization_Organizations) GetDisplayName() string {
-	if t == nil {
-		t = &CreateBulkCSVOrganization_CreateBulkCSVOrganization_Organizations{}
-	}
-	return t.DisplayName
-}
-func (t *CreateBulkCSVOrganization_CreateBulkCSVOrganization_Organizations) GetID() string {
-	if t == nil {
-		t = &CreateBulkCSVOrganization_CreateBulkCSVOrganization_Organizations{}
-	}
-	return t.ID
-}
-func (t *CreateBulkCSVOrganization_CreateBulkCSVOrganization_Organizations) GetName() string {
-	if t == nil {
-		t = &CreateBulkCSVOrganization_CreateBulkCSVOrganization_Organizations{}
-	}
-	return t.Name
-}
-func (t *CreateBulkCSVOrganization_CreateBulkCSVOrganization_Organizations) GetPersonalOrg() *bool {
-	if t == nil {
-		t = &CreateBulkCSVOrganization_CreateBulkCSVOrganization_Organizations{}
-	}
-	return t.PersonalOrg
-}
-func (t *CreateBulkCSVOrganization_CreateBulkCSVOrganization_Organizations) GetTags() []string {
-	if t == nil {
-		t = &CreateBulkCSVOrganization_CreateBulkCSVOrganization_Organizations{}
-	}
-	return t.Tags
-}
-
-type CreateBulkCSVOrganization_CreateBulkCSVOrganization struct {
-	Organizations []*CreateBulkCSVOrganization_CreateBulkCSVOrganization_Organizations "json:\"organizations,omitempty\" graphql:\"organizations\""
-}
-
-func (t *CreateBulkCSVOrganization_CreateBulkCSVOrganization) GetOrganizations() []*CreateBulkCSVOrganization_CreateBulkCSVOrganization_Organizations {
-	if t == nil {
-		t = &CreateBulkCSVOrganization_CreateBulkCSVOrganization{}
-	}
-	return t.Organizations
-}
-
-type CreateBulkOrganization_CreateBulkOrganization_Organizations struct {
-	Description *string  "json:\"description,omitempty\" graphql:\"description\""
-	DisplayName string   "json:\"displayName\" graphql:\"displayName\""
-	ID          string   "json:\"id\" graphql:\"id\""
-	Name        string   "json:\"name\" graphql:\"name\""
-	PersonalOrg *bool    "json:\"personalOrg,omitempty\" graphql:\"personalOrg\""
-	Tags        []string "json:\"tags,omitempty\" graphql:\"tags\""
-}
-
-func (t *CreateBulkOrganization_CreateBulkOrganization_Organizations) GetDescription() *string {
-	if t == nil {
-		t = &CreateBulkOrganization_CreateBulkOrganization_Organizations{}
-	}
-	return t.Description
-}
-func (t *CreateBulkOrganization_CreateBulkOrganization_Organizations) GetDisplayName() string {
-	if t == nil {
-		t = &CreateBulkOrganization_CreateBulkOrganization_Organizations{}
-	}
-	return t.DisplayName
-}
-func (t *CreateBulkOrganization_CreateBulkOrganization_Organizations) GetID() string {
-	if t == nil {
-		t = &CreateBulkOrganization_CreateBulkOrganization_Organizations{}
-	}
-	return t.ID
-}
-func (t *CreateBulkOrganization_CreateBulkOrganization_Organizations) GetName() string {
-	if t == nil {
-		t = &CreateBulkOrganization_CreateBulkOrganization_Organizations{}
-	}
-	return t.Name
-}
-func (t *CreateBulkOrganization_CreateBulkOrganization_Organizations) GetPersonalOrg() *bool {
-	if t == nil {
-		t = &CreateBulkOrganization_CreateBulkOrganization_Organizations{}
-	}
-	return t.PersonalOrg
-}
-func (t *CreateBulkOrganization_CreateBulkOrganization_Organizations) GetTags() []string {
-	if t == nil {
-		t = &CreateBulkOrganization_CreateBulkOrganization_Organizations{}
-	}
-	return t.Tags
-}
-
-type CreateBulkOrganization_CreateBulkOrganization struct {
-	Organizations []*CreateBulkOrganization_CreateBulkOrganization_Organizations "json:\"organizations,omitempty\" graphql:\"organizations\""
-}
-
-func (t *CreateBulkOrganization_CreateBulkOrganization) GetOrganizations() []*CreateBulkOrganization_CreateBulkOrganization_Organizations {
-	if t == nil {
-		t = &CreateBulkOrganization_CreateBulkOrganization{}
-	}
-	return t.Organizations
 }
 
 type CreateOrganization_CreateOrganization_Organization_AvatarFile struct {
@@ -52458,28 +52342,6 @@ func (t *CreateOnboarding) GetCreateOnboarding() *CreateOnboarding_CreateOnboard
 	return &t.CreateOnboarding
 }
 
-type CreateBulkCSVOrganization struct {
-	CreateBulkCSVOrganization CreateBulkCSVOrganization_CreateBulkCSVOrganization "json:\"createBulkCSVOrganization\" graphql:\"createBulkCSVOrganization\""
-}
-
-func (t *CreateBulkCSVOrganization) GetCreateBulkCSVOrganization() *CreateBulkCSVOrganization_CreateBulkCSVOrganization {
-	if t == nil {
-		t = &CreateBulkCSVOrganization{}
-	}
-	return &t.CreateBulkCSVOrganization
-}
-
-type CreateBulkOrganization struct {
-	CreateBulkOrganization CreateBulkOrganization_CreateBulkOrganization "json:\"createBulkOrganization\" graphql:\"createBulkOrganization\""
-}
-
-func (t *CreateBulkOrganization) GetCreateBulkOrganization() *CreateBulkOrganization_CreateBulkOrganization {
-	if t == nil {
-		t = &CreateBulkOrganization{}
-	}
-	return &t.CreateBulkOrganization
-}
-
 type CreateOrganization struct {
 	CreateOrganization CreateOrganization_CreateOrganization "json:\"createOrganization\" graphql:\"createOrganization\""
 }
@@ -61824,68 +61686,6 @@ func (c *Client) CreateOnboarding(ctx context.Context, input CreateOnboardingInp
 	return &res, nil
 }
 
-const CreateBulkCSVOrganizationDocument = `mutation CreateBulkCSVOrganization ($input: Upload!) {
-	createBulkCSVOrganization(input: $input) {
-		organizations {
-			id
-			name
-			displayName
-			description
-			personalOrg
-			tags
-		}
-	}
-}
-`
-
-func (c *Client) CreateBulkCSVOrganization(ctx context.Context, input graphql.Upload, interceptors ...clientv2.RequestInterceptor) (*CreateBulkCSVOrganization, error) {
-	vars := map[string]any{
-		"input": input,
-	}
-
-	var res CreateBulkCSVOrganization
-	if err := c.Client.Post(ctx, "CreateBulkCSVOrganization", CreateBulkCSVOrganizationDocument, &res, vars, interceptors...); err != nil {
-		if c.Client.ParseDataWhenErrors {
-			return &res, err
-		}
-
-		return nil, err
-	}
-
-	return &res, nil
-}
-
-const CreateBulkOrganizationDocument = `mutation CreateBulkOrganization ($input: [CreateOrganizationInput!]) {
-	createBulkOrganization(input: $input) {
-		organizations {
-			id
-			name
-			displayName
-			description
-			personalOrg
-			tags
-		}
-	}
-}
-`
-
-func (c *Client) CreateBulkOrganization(ctx context.Context, input []*CreateOrganizationInput, interceptors ...clientv2.RequestInterceptor) (*CreateBulkOrganization, error) {
-	vars := map[string]any{
-		"input": input,
-	}
-
-	var res CreateBulkOrganization
-	if err := c.Client.Post(ctx, "CreateBulkOrganization", CreateBulkOrganizationDocument, &res, vars, interceptors...); err != nil {
-		if c.Client.ParseDataWhenErrors {
-			return &res, err
-		}
-
-		return nil, err
-	}
-
-	return &res, nil
-}
-
 const CreateOrganizationDocument = `mutation CreateOrganization ($input: CreateOrganizationInput!, $avatarFile: Upload) {
 	createOrganization(input: $input, avatarFile: $avatarFile) {
 		organization {
@@ -69120,8 +68920,6 @@ var DocumentOperationNames = map[string]string{
 	GetAllNoteHistoriesDocument:                "GetAllNoteHistories",
 	GetNoteHistoriesDocument:                   "GetNoteHistories",
 	CreateOnboardingDocument:                   "CreateOnboarding",
-	CreateBulkCSVOrganizationDocument:          "CreateBulkCSVOrganization",
-	CreateBulkOrganizationDocument:             "CreateBulkOrganization",
 	CreateOrganizationDocument:                 "CreateOrganization",
 	CreateOrganizationWithMembersDocument:      "CreateOrganizationWithMembers",
 	DeleteOrganizationDocument:                 "DeleteOrganization",


### PR DESCRIPTION
removes the ability to bulk create orgs; we recently changes it to only allow org creation via JWT + session authentication and missed these. There should be much of a use case to bulk create organizations from the API so just removing this completely 