### PR TITLE
Schema updates for org subscriptions functionality expansion

### DIFF
--- a/db/migrations-goose-postgres/20250304210058_orgsubscriptionadditions.sql
+++ b/db/migrations-goose-postgres/20250304210058_orgsubscriptionadditions.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+-- modify "api_tokens" table
+ALTER TABLE "api_tokens" ADD COLUMN "is_active" boolean NULL DEFAULT true, ADD COLUMN "revoked_reason" character varying NULL, ADD COLUMN "revoked_by" character varying NULL, ADD COLUMN "revoked_at" timestamptz NULL;
+-- modify "org_subscription_history" table
+ALTER TABLE "org_subscription_history" ADD COLUMN "trial_expires_at" timestamptz NULL, ADD COLUMN "days_until_due" character varying NULL, ADD COLUMN "payment_method_added" boolean NULL;
+-- modify "org_subscriptions" table
+ALTER TABLE "org_subscriptions" ADD COLUMN "trial_expires_at" timestamptz NULL, ADD COLUMN "days_until_due" character varying NULL, ADD COLUMN "payment_method_added" boolean NULL;
+-- modify "personal_access_tokens" table
+ALTER TABLE "personal_access_tokens" ADD COLUMN "is_active" boolean NULL DEFAULT true, ADD COLUMN "revoked_reason" character varying NULL, ADD COLUMN "revoked_by" character varying NULL, ADD COLUMN "revoked_at" timestamptz NULL;
+-- modify "events" table
+ALTER TABLE "events" ADD COLUMN "org_subscription_events" character varying NULL, ADD CONSTRAINT "events_org_subscriptions_events" FOREIGN KEY ("org_subscription_events") REFERENCES "org_subscriptions" ("id") ON UPDATE NO ACTION ON DELETE SET NULL;
+
+-- +goose Down
+-- reverse: modify "events" table
+ALTER TABLE "events" DROP CONSTRAINT "events_org_subscriptions_events", DROP COLUMN "org_subscription_events";
+-- reverse: modify "personal_access_tokens" table
+ALTER TABLE "personal_access_tokens" DROP COLUMN "revoked_at", DROP COLUMN "revoked_by", DROP COLUMN "revoked_reason", DROP COLUMN "is_active";
+-- reverse: modify "org_subscriptions" table
+ALTER TABLE "org_subscriptions" DROP COLUMN "payment_method_added", DROP COLUMN "days_until_due", DROP COLUMN "trial_expires_at";
+-- reverse: modify "org_subscription_history" table
+ALTER TABLE "org_subscription_history" DROP COLUMN "payment_method_added", DROP COLUMN "days_until_due", DROP COLUMN "trial_expires_at";
+-- reverse: modify "api_tokens" table
+ALTER TABLE "api_tokens" DROP COLUMN "revoked_at", DROP COLUMN "revoked_by", DROP COLUMN "revoked_reason", DROP COLUMN "is_active";

--- a/db/migrations-goose-postgres/atlas.sum
+++ b/db/migrations-goose-postgres/atlas.sum
@@ -1,4 +1,4 @@
-h1:n2tOixib3/d0JFgChktlPfG8/xE8MW/A3mcXVQu2Bnc=
+h1:pKLSL18Inrb/Jx3uUSk83q0qL49WgjOQvCHD42lNmQA=
 20241211231032_init.sql h1:Cj6GduEDECy6Y+8DfI6767WosqG2AKWybIyJJ6AgKqA=
 20241212223714_consistent_naming.sql h1:RvnNmsStlHkmAdSCnX1fFh/KYgfj1RMYYEc4iCN9JcQ=
 20250109002850_billing_address.sql h1:m0ek3WXqRgS3+ZbSa/DcIMB16vb8Tjm2MgNqyRll3rU=
@@ -17,3 +17,4 @@ h1:n2tOixib3/d0JFgChktlPfG8/xE8MW/A3mcXVQu2Bnc=
 20250208014430_onboarding.sql h1:q4yecmc+gimy5BwWlgoyvFVHaIMbymc7fnBOGTKEcj8=
 20250220044406_org_settings_email_domains.sql h1:hP8w00BD64oe7OWsXlPJM92cqVtY0NIEIeonbnCsXnU=
 20250224191741_tasks.sql h1:v0CZ5nWgzjconA/hcat9QvZkmSBdxXkc/h84Erdcxnw=
+20250304210058_orgsubscriptionadditions.sql h1:jKVPW1egj+AhIj7rzFkMBnwFJGXI2J7Kjie6vU1PScs=

--- a/db/migrations/20250304210056_orgsubscriptionadditions.sql
+++ b/db/migrations/20250304210056_orgsubscriptionadditions.sql
@@ -1,0 +1,10 @@
+-- Modify "api_tokens" table
+ALTER TABLE "api_tokens" ADD COLUMN "is_active" boolean NULL DEFAULT true, ADD COLUMN "revoked_reason" character varying NULL, ADD COLUMN "revoked_by" character varying NULL, ADD COLUMN "revoked_at" timestamptz NULL;
+-- Modify "org_subscription_history" table
+ALTER TABLE "org_subscription_history" ADD COLUMN "trial_expires_at" timestamptz NULL, ADD COLUMN "days_until_due" character varying NULL, ADD COLUMN "payment_method_added" boolean NULL;
+-- Modify "org_subscriptions" table
+ALTER TABLE "org_subscriptions" ADD COLUMN "trial_expires_at" timestamptz NULL, ADD COLUMN "days_until_due" character varying NULL, ADD COLUMN "payment_method_added" boolean NULL;
+-- Modify "personal_access_tokens" table
+ALTER TABLE "personal_access_tokens" ADD COLUMN "is_active" boolean NULL DEFAULT true, ADD COLUMN "revoked_reason" character varying NULL, ADD COLUMN "revoked_by" character varying NULL, ADD COLUMN "revoked_at" timestamptz NULL;
+-- Modify "events" table
+ALTER TABLE "events" ADD COLUMN "org_subscription_events" character varying NULL, ADD CONSTRAINT "events_org_subscriptions_events" FOREIGN KEY ("org_subscription_events") REFERENCES "org_subscriptions" ("id") ON UPDATE NO ACTION ON DELETE SET NULL;

--- a/db/migrations/atlas.sum
+++ b/db/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Xbkp8VdW7UNlrLXeCV9xvg6I/oYETMhpuz7blOczAm0=
+h1:KnrgYOaq+KGwp40FPH+LNIVqK8hwhOrE1Fu7jSlK+dE=
 20241211231032_init.sql h1:TxjpHzKPB/5L2i7V2JfO1y+Cep/AyQN5wGjhY7saCeE=
 20241212223712_consistent_naming.sql h1:tbdYOtixhW66Jmvy3aCm+X6neI/SRVvItKM0Bdn26TA=
 20250109002849_billing_address.sql h1:mspCGbJ6HVmx3r4j+d/WvruzirJdJ8u5x18WF9R9ESE=
@@ -17,3 +17,4 @@ h1:Xbkp8VdW7UNlrLXeCV9xvg6I/oYETMhpuz7blOczAm0=
 20250208014426_onboarding.sql h1:NEbY2QMiTR/kF2sL8rSpYKrPsBQpZDU+rezOBjTNF+U=
 20250220044404_org_settings_email_domains.sql h1:jo+zo9iDz5waGa5T1xBf6IgIhoUP1hneM7gC/xeLAZU=
 20250224191739_tasks.sql h1:NqeZGfxip4pTItycpisoWL+pk8fvzLZ/NV2Xx8sG0c8=
+20250304210056_orgsubscriptionadditions.sql h1:I1xS6IQ4/Naitj+2MTiuct6AwFamb01Gk8CPutER1uw=

--- a/internal/ent/generated/apitoken/apitoken.go
+++ b/internal/ent/generated/apitoken/apitoken.go
@@ -43,6 +43,14 @@ const (
 	FieldScopes = "scopes"
 	// FieldLastUsedAt holds the string denoting the last_used_at field in the database.
 	FieldLastUsedAt = "last_used_at"
+	// FieldIsActive holds the string denoting the is_active field in the database.
+	FieldIsActive = "is_active"
+	// FieldRevokedReason holds the string denoting the revoked_reason field in the database.
+	FieldRevokedReason = "revoked_reason"
+	// FieldRevokedBy holds the string denoting the revoked_by field in the database.
+	FieldRevokedBy = "revoked_by"
+	// FieldRevokedAt holds the string denoting the revoked_at field in the database.
+	FieldRevokedAt = "revoked_at"
 	// EdgeOwner holds the string denoting the owner edge name in mutations.
 	EdgeOwner = "owner"
 	// Table holds the table name of the apitoken in the database.
@@ -73,6 +81,10 @@ var Columns = []string{
 	FieldDescription,
 	FieldScopes,
 	FieldLastUsedAt,
+	FieldIsActive,
+	FieldRevokedReason,
+	FieldRevokedBy,
+	FieldRevokedAt,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -108,6 +120,8 @@ var (
 	NameValidator func(string) error
 	// DefaultToken holds the default value on creation for the "token" field.
 	DefaultToken func() string
+	// DefaultIsActive holds the default value on creation for the "is_active" field.
+	DefaultIsActive bool
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() string
 )
@@ -178,6 +192,26 @@ func ByDescription(opts ...sql.OrderTermOption) OrderOption {
 // ByLastUsedAt orders the results by the last_used_at field.
 func ByLastUsedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldLastUsedAt, opts...).ToFunc()
+}
+
+// ByIsActive orders the results by the is_active field.
+func ByIsActive(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldIsActive, opts...).ToFunc()
+}
+
+// ByRevokedReason orders the results by the revoked_reason field.
+func ByRevokedReason(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldRevokedReason, opts...).ToFunc()
+}
+
+// ByRevokedBy orders the results by the revoked_by field.
+func ByRevokedBy(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldRevokedBy, opts...).ToFunc()
+}
+
+// ByRevokedAt orders the results by the revoked_at field.
+func ByRevokedAt(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldRevokedAt, opts...).ToFunc()
 }
 
 // ByOwnerField orders the results by owner field.

--- a/internal/ent/generated/apitoken/where.go
+++ b/internal/ent/generated/apitoken/where.go
@@ -127,6 +127,26 @@ func LastUsedAt(v time.Time) predicate.APIToken {
 	return predicate.APIToken(sql.FieldEQ(FieldLastUsedAt, v))
 }
 
+// IsActive applies equality check predicate on the "is_active" field. It's identical to IsActiveEQ.
+func IsActive(v bool) predicate.APIToken {
+	return predicate.APIToken(sql.FieldEQ(FieldIsActive, v))
+}
+
+// RevokedReason applies equality check predicate on the "revoked_reason" field. It's identical to RevokedReasonEQ.
+func RevokedReason(v string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldEQ(FieldRevokedReason, v))
+}
+
+// RevokedBy applies equality check predicate on the "revoked_by" field. It's identical to RevokedByEQ.
+func RevokedBy(v string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldEQ(FieldRevokedBy, v))
+}
+
+// RevokedAt applies equality check predicate on the "revoked_at" field. It's identical to RevokedAtEQ.
+func RevokedAt(v time.Time) predicate.APIToken {
+	return predicate.APIToken(sql.FieldEQ(FieldRevokedAt, v))
+}
+
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
 func CreatedAtEQ(v time.Time) predicate.APIToken {
 	return predicate.APIToken(sql.FieldEQ(FieldCreatedAt, v))
@@ -900,6 +920,226 @@ func LastUsedAtIsNil() predicate.APIToken {
 // LastUsedAtNotNil applies the NotNil predicate on the "last_used_at" field.
 func LastUsedAtNotNil() predicate.APIToken {
 	return predicate.APIToken(sql.FieldNotNull(FieldLastUsedAt))
+}
+
+// IsActiveEQ applies the EQ predicate on the "is_active" field.
+func IsActiveEQ(v bool) predicate.APIToken {
+	return predicate.APIToken(sql.FieldEQ(FieldIsActive, v))
+}
+
+// IsActiveNEQ applies the NEQ predicate on the "is_active" field.
+func IsActiveNEQ(v bool) predicate.APIToken {
+	return predicate.APIToken(sql.FieldNEQ(FieldIsActive, v))
+}
+
+// IsActiveIsNil applies the IsNil predicate on the "is_active" field.
+func IsActiveIsNil() predicate.APIToken {
+	return predicate.APIToken(sql.FieldIsNull(FieldIsActive))
+}
+
+// IsActiveNotNil applies the NotNil predicate on the "is_active" field.
+func IsActiveNotNil() predicate.APIToken {
+	return predicate.APIToken(sql.FieldNotNull(FieldIsActive))
+}
+
+// RevokedReasonEQ applies the EQ predicate on the "revoked_reason" field.
+func RevokedReasonEQ(v string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldEQ(FieldRevokedReason, v))
+}
+
+// RevokedReasonNEQ applies the NEQ predicate on the "revoked_reason" field.
+func RevokedReasonNEQ(v string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldNEQ(FieldRevokedReason, v))
+}
+
+// RevokedReasonIn applies the In predicate on the "revoked_reason" field.
+func RevokedReasonIn(vs ...string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldIn(FieldRevokedReason, vs...))
+}
+
+// RevokedReasonNotIn applies the NotIn predicate on the "revoked_reason" field.
+func RevokedReasonNotIn(vs ...string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldNotIn(FieldRevokedReason, vs...))
+}
+
+// RevokedReasonGT applies the GT predicate on the "revoked_reason" field.
+func RevokedReasonGT(v string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldGT(FieldRevokedReason, v))
+}
+
+// RevokedReasonGTE applies the GTE predicate on the "revoked_reason" field.
+func RevokedReasonGTE(v string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldGTE(FieldRevokedReason, v))
+}
+
+// RevokedReasonLT applies the LT predicate on the "revoked_reason" field.
+func RevokedReasonLT(v string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldLT(FieldRevokedReason, v))
+}
+
+// RevokedReasonLTE applies the LTE predicate on the "revoked_reason" field.
+func RevokedReasonLTE(v string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldLTE(FieldRevokedReason, v))
+}
+
+// RevokedReasonContains applies the Contains predicate on the "revoked_reason" field.
+func RevokedReasonContains(v string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldContains(FieldRevokedReason, v))
+}
+
+// RevokedReasonHasPrefix applies the HasPrefix predicate on the "revoked_reason" field.
+func RevokedReasonHasPrefix(v string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldHasPrefix(FieldRevokedReason, v))
+}
+
+// RevokedReasonHasSuffix applies the HasSuffix predicate on the "revoked_reason" field.
+func RevokedReasonHasSuffix(v string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldHasSuffix(FieldRevokedReason, v))
+}
+
+// RevokedReasonIsNil applies the IsNil predicate on the "revoked_reason" field.
+func RevokedReasonIsNil() predicate.APIToken {
+	return predicate.APIToken(sql.FieldIsNull(FieldRevokedReason))
+}
+
+// RevokedReasonNotNil applies the NotNil predicate on the "revoked_reason" field.
+func RevokedReasonNotNil() predicate.APIToken {
+	return predicate.APIToken(sql.FieldNotNull(FieldRevokedReason))
+}
+
+// RevokedReasonEqualFold applies the EqualFold predicate on the "revoked_reason" field.
+func RevokedReasonEqualFold(v string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldEqualFold(FieldRevokedReason, v))
+}
+
+// RevokedReasonContainsFold applies the ContainsFold predicate on the "revoked_reason" field.
+func RevokedReasonContainsFold(v string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldContainsFold(FieldRevokedReason, v))
+}
+
+// RevokedByEQ applies the EQ predicate on the "revoked_by" field.
+func RevokedByEQ(v string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldEQ(FieldRevokedBy, v))
+}
+
+// RevokedByNEQ applies the NEQ predicate on the "revoked_by" field.
+func RevokedByNEQ(v string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldNEQ(FieldRevokedBy, v))
+}
+
+// RevokedByIn applies the In predicate on the "revoked_by" field.
+func RevokedByIn(vs ...string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldIn(FieldRevokedBy, vs...))
+}
+
+// RevokedByNotIn applies the NotIn predicate on the "revoked_by" field.
+func RevokedByNotIn(vs ...string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldNotIn(FieldRevokedBy, vs...))
+}
+
+// RevokedByGT applies the GT predicate on the "revoked_by" field.
+func RevokedByGT(v string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldGT(FieldRevokedBy, v))
+}
+
+// RevokedByGTE applies the GTE predicate on the "revoked_by" field.
+func RevokedByGTE(v string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldGTE(FieldRevokedBy, v))
+}
+
+// RevokedByLT applies the LT predicate on the "revoked_by" field.
+func RevokedByLT(v string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldLT(FieldRevokedBy, v))
+}
+
+// RevokedByLTE applies the LTE predicate on the "revoked_by" field.
+func RevokedByLTE(v string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldLTE(FieldRevokedBy, v))
+}
+
+// RevokedByContains applies the Contains predicate on the "revoked_by" field.
+func RevokedByContains(v string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldContains(FieldRevokedBy, v))
+}
+
+// RevokedByHasPrefix applies the HasPrefix predicate on the "revoked_by" field.
+func RevokedByHasPrefix(v string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldHasPrefix(FieldRevokedBy, v))
+}
+
+// RevokedByHasSuffix applies the HasSuffix predicate on the "revoked_by" field.
+func RevokedByHasSuffix(v string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldHasSuffix(FieldRevokedBy, v))
+}
+
+// RevokedByIsNil applies the IsNil predicate on the "revoked_by" field.
+func RevokedByIsNil() predicate.APIToken {
+	return predicate.APIToken(sql.FieldIsNull(FieldRevokedBy))
+}
+
+// RevokedByNotNil applies the NotNil predicate on the "revoked_by" field.
+func RevokedByNotNil() predicate.APIToken {
+	return predicate.APIToken(sql.FieldNotNull(FieldRevokedBy))
+}
+
+// RevokedByEqualFold applies the EqualFold predicate on the "revoked_by" field.
+func RevokedByEqualFold(v string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldEqualFold(FieldRevokedBy, v))
+}
+
+// RevokedByContainsFold applies the ContainsFold predicate on the "revoked_by" field.
+func RevokedByContainsFold(v string) predicate.APIToken {
+	return predicate.APIToken(sql.FieldContainsFold(FieldRevokedBy, v))
+}
+
+// RevokedAtEQ applies the EQ predicate on the "revoked_at" field.
+func RevokedAtEQ(v time.Time) predicate.APIToken {
+	return predicate.APIToken(sql.FieldEQ(FieldRevokedAt, v))
+}
+
+// RevokedAtNEQ applies the NEQ predicate on the "revoked_at" field.
+func RevokedAtNEQ(v time.Time) predicate.APIToken {
+	return predicate.APIToken(sql.FieldNEQ(FieldRevokedAt, v))
+}
+
+// RevokedAtIn applies the In predicate on the "revoked_at" field.
+func RevokedAtIn(vs ...time.Time) predicate.APIToken {
+	return predicate.APIToken(sql.FieldIn(FieldRevokedAt, vs...))
+}
+
+// RevokedAtNotIn applies the NotIn predicate on the "revoked_at" field.
+func RevokedAtNotIn(vs ...time.Time) predicate.APIToken {
+	return predicate.APIToken(sql.FieldNotIn(FieldRevokedAt, vs...))
+}
+
+// RevokedAtGT applies the GT predicate on the "revoked_at" field.
+func RevokedAtGT(v time.Time) predicate.APIToken {
+	return predicate.APIToken(sql.FieldGT(FieldRevokedAt, v))
+}
+
+// RevokedAtGTE applies the GTE predicate on the "revoked_at" field.
+func RevokedAtGTE(v time.Time) predicate.APIToken {
+	return predicate.APIToken(sql.FieldGTE(FieldRevokedAt, v))
+}
+
+// RevokedAtLT applies the LT predicate on the "revoked_at" field.
+func RevokedAtLT(v time.Time) predicate.APIToken {
+	return predicate.APIToken(sql.FieldLT(FieldRevokedAt, v))
+}
+
+// RevokedAtLTE applies the LTE predicate on the "revoked_at" field.
+func RevokedAtLTE(v time.Time) predicate.APIToken {
+	return predicate.APIToken(sql.FieldLTE(FieldRevokedAt, v))
+}
+
+// RevokedAtIsNil applies the IsNil predicate on the "revoked_at" field.
+func RevokedAtIsNil() predicate.APIToken {
+	return predicate.APIToken(sql.FieldIsNull(FieldRevokedAt))
+}
+
+// RevokedAtNotNil applies the NotNil predicate on the "revoked_at" field.
+func RevokedAtNotNil() predicate.APIToken {
+	return predicate.APIToken(sql.FieldNotNull(FieldRevokedAt))
 }
 
 // HasOwner applies the HasEdge predicate on the "owner" edge.

--- a/internal/ent/generated/apitoken_create.go
+++ b/internal/ent/generated/apitoken_create.go
@@ -193,6 +193,62 @@ func (atc *APITokenCreate) SetNillableLastUsedAt(t *time.Time) *APITokenCreate {
 	return atc
 }
 
+// SetIsActive sets the "is_active" field.
+func (atc *APITokenCreate) SetIsActive(b bool) *APITokenCreate {
+	atc.mutation.SetIsActive(b)
+	return atc
+}
+
+// SetNillableIsActive sets the "is_active" field if the given value is not nil.
+func (atc *APITokenCreate) SetNillableIsActive(b *bool) *APITokenCreate {
+	if b != nil {
+		atc.SetIsActive(*b)
+	}
+	return atc
+}
+
+// SetRevokedReason sets the "revoked_reason" field.
+func (atc *APITokenCreate) SetRevokedReason(s string) *APITokenCreate {
+	atc.mutation.SetRevokedReason(s)
+	return atc
+}
+
+// SetNillableRevokedReason sets the "revoked_reason" field if the given value is not nil.
+func (atc *APITokenCreate) SetNillableRevokedReason(s *string) *APITokenCreate {
+	if s != nil {
+		atc.SetRevokedReason(*s)
+	}
+	return atc
+}
+
+// SetRevokedBy sets the "revoked_by" field.
+func (atc *APITokenCreate) SetRevokedBy(s string) *APITokenCreate {
+	atc.mutation.SetRevokedBy(s)
+	return atc
+}
+
+// SetNillableRevokedBy sets the "revoked_by" field if the given value is not nil.
+func (atc *APITokenCreate) SetNillableRevokedBy(s *string) *APITokenCreate {
+	if s != nil {
+		atc.SetRevokedBy(*s)
+	}
+	return atc
+}
+
+// SetRevokedAt sets the "revoked_at" field.
+func (atc *APITokenCreate) SetRevokedAt(t time.Time) *APITokenCreate {
+	atc.mutation.SetRevokedAt(t)
+	return atc
+}
+
+// SetNillableRevokedAt sets the "revoked_at" field if the given value is not nil.
+func (atc *APITokenCreate) SetNillableRevokedAt(t *time.Time) *APITokenCreate {
+	if t != nil {
+		atc.SetRevokedAt(*t)
+	}
+	return atc
+}
+
 // SetID sets the "id" field.
 func (atc *APITokenCreate) SetID(s string) *APITokenCreate {
 	atc.mutation.SetID(s)
@@ -273,6 +329,10 @@ func (atc *APITokenCreate) defaults() error {
 		}
 		v := apitoken.DefaultToken()
 		atc.mutation.SetToken(v)
+	}
+	if _, ok := atc.mutation.IsActive(); !ok {
+		v := apitoken.DefaultIsActive
+		atc.mutation.SetIsActive(v)
 	}
 	if _, ok := atc.mutation.ID(); !ok {
 		if apitoken.DefaultID == nil {
@@ -389,6 +449,22 @@ func (atc *APITokenCreate) createSpec() (*APIToken, *sqlgraph.CreateSpec) {
 	if value, ok := atc.mutation.LastUsedAt(); ok {
 		_spec.SetField(apitoken.FieldLastUsedAt, field.TypeTime, value)
 		_node.LastUsedAt = &value
+	}
+	if value, ok := atc.mutation.IsActive(); ok {
+		_spec.SetField(apitoken.FieldIsActive, field.TypeBool, value)
+		_node.IsActive = value
+	}
+	if value, ok := atc.mutation.RevokedReason(); ok {
+		_spec.SetField(apitoken.FieldRevokedReason, field.TypeString, value)
+		_node.RevokedReason = &value
+	}
+	if value, ok := atc.mutation.RevokedBy(); ok {
+		_spec.SetField(apitoken.FieldRevokedBy, field.TypeString, value)
+		_node.RevokedBy = &value
+	}
+	if value, ok := atc.mutation.RevokedAt(); ok {
+		_spec.SetField(apitoken.FieldRevokedAt, field.TypeTime, value)
+		_node.RevokedAt = &value
 	}
 	if nodes := atc.mutation.OwnerIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/internal/ent/generated/apitoken_update.go
+++ b/internal/ent/generated/apitoken_update.go
@@ -235,6 +235,86 @@ func (atu *APITokenUpdate) ClearLastUsedAt() *APITokenUpdate {
 	return atu
 }
 
+// SetIsActive sets the "is_active" field.
+func (atu *APITokenUpdate) SetIsActive(b bool) *APITokenUpdate {
+	atu.mutation.SetIsActive(b)
+	return atu
+}
+
+// SetNillableIsActive sets the "is_active" field if the given value is not nil.
+func (atu *APITokenUpdate) SetNillableIsActive(b *bool) *APITokenUpdate {
+	if b != nil {
+		atu.SetIsActive(*b)
+	}
+	return atu
+}
+
+// ClearIsActive clears the value of the "is_active" field.
+func (atu *APITokenUpdate) ClearIsActive() *APITokenUpdate {
+	atu.mutation.ClearIsActive()
+	return atu
+}
+
+// SetRevokedReason sets the "revoked_reason" field.
+func (atu *APITokenUpdate) SetRevokedReason(s string) *APITokenUpdate {
+	atu.mutation.SetRevokedReason(s)
+	return atu
+}
+
+// SetNillableRevokedReason sets the "revoked_reason" field if the given value is not nil.
+func (atu *APITokenUpdate) SetNillableRevokedReason(s *string) *APITokenUpdate {
+	if s != nil {
+		atu.SetRevokedReason(*s)
+	}
+	return atu
+}
+
+// ClearRevokedReason clears the value of the "revoked_reason" field.
+func (atu *APITokenUpdate) ClearRevokedReason() *APITokenUpdate {
+	atu.mutation.ClearRevokedReason()
+	return atu
+}
+
+// SetRevokedBy sets the "revoked_by" field.
+func (atu *APITokenUpdate) SetRevokedBy(s string) *APITokenUpdate {
+	atu.mutation.SetRevokedBy(s)
+	return atu
+}
+
+// SetNillableRevokedBy sets the "revoked_by" field if the given value is not nil.
+func (atu *APITokenUpdate) SetNillableRevokedBy(s *string) *APITokenUpdate {
+	if s != nil {
+		atu.SetRevokedBy(*s)
+	}
+	return atu
+}
+
+// ClearRevokedBy clears the value of the "revoked_by" field.
+func (atu *APITokenUpdate) ClearRevokedBy() *APITokenUpdate {
+	atu.mutation.ClearRevokedBy()
+	return atu
+}
+
+// SetRevokedAt sets the "revoked_at" field.
+func (atu *APITokenUpdate) SetRevokedAt(t time.Time) *APITokenUpdate {
+	atu.mutation.SetRevokedAt(t)
+	return atu
+}
+
+// SetNillableRevokedAt sets the "revoked_at" field if the given value is not nil.
+func (atu *APITokenUpdate) SetNillableRevokedAt(t *time.Time) *APITokenUpdate {
+	if t != nil {
+		atu.SetRevokedAt(*t)
+	}
+	return atu
+}
+
+// ClearRevokedAt clears the value of the "revoked_at" field.
+func (atu *APITokenUpdate) ClearRevokedAt() *APITokenUpdate {
+	atu.mutation.ClearRevokedAt()
+	return atu
+}
+
 // SetOwner sets the "owner" edge to the Organization entity.
 func (atu *APITokenUpdate) SetOwner(o *Organization) *APITokenUpdate {
 	return atu.SetOwnerID(o.ID)
@@ -398,6 +478,30 @@ func (atu *APITokenUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if atu.mutation.LastUsedAtCleared() {
 		_spec.ClearField(apitoken.FieldLastUsedAt, field.TypeTime)
+	}
+	if value, ok := atu.mutation.IsActive(); ok {
+		_spec.SetField(apitoken.FieldIsActive, field.TypeBool, value)
+	}
+	if atu.mutation.IsActiveCleared() {
+		_spec.ClearField(apitoken.FieldIsActive, field.TypeBool)
+	}
+	if value, ok := atu.mutation.RevokedReason(); ok {
+		_spec.SetField(apitoken.FieldRevokedReason, field.TypeString, value)
+	}
+	if atu.mutation.RevokedReasonCleared() {
+		_spec.ClearField(apitoken.FieldRevokedReason, field.TypeString)
+	}
+	if value, ok := atu.mutation.RevokedBy(); ok {
+		_spec.SetField(apitoken.FieldRevokedBy, field.TypeString, value)
+	}
+	if atu.mutation.RevokedByCleared() {
+		_spec.ClearField(apitoken.FieldRevokedBy, field.TypeString)
+	}
+	if value, ok := atu.mutation.RevokedAt(); ok {
+		_spec.SetField(apitoken.FieldRevokedAt, field.TypeTime, value)
+	}
+	if atu.mutation.RevokedAtCleared() {
+		_spec.ClearField(apitoken.FieldRevokedAt, field.TypeTime)
 	}
 	if atu.mutation.OwnerCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -656,6 +760,86 @@ func (atuo *APITokenUpdateOne) ClearLastUsedAt() *APITokenUpdateOne {
 	return atuo
 }
 
+// SetIsActive sets the "is_active" field.
+func (atuo *APITokenUpdateOne) SetIsActive(b bool) *APITokenUpdateOne {
+	atuo.mutation.SetIsActive(b)
+	return atuo
+}
+
+// SetNillableIsActive sets the "is_active" field if the given value is not nil.
+func (atuo *APITokenUpdateOne) SetNillableIsActive(b *bool) *APITokenUpdateOne {
+	if b != nil {
+		atuo.SetIsActive(*b)
+	}
+	return atuo
+}
+
+// ClearIsActive clears the value of the "is_active" field.
+func (atuo *APITokenUpdateOne) ClearIsActive() *APITokenUpdateOne {
+	atuo.mutation.ClearIsActive()
+	return atuo
+}
+
+// SetRevokedReason sets the "revoked_reason" field.
+func (atuo *APITokenUpdateOne) SetRevokedReason(s string) *APITokenUpdateOne {
+	atuo.mutation.SetRevokedReason(s)
+	return atuo
+}
+
+// SetNillableRevokedReason sets the "revoked_reason" field if the given value is not nil.
+func (atuo *APITokenUpdateOne) SetNillableRevokedReason(s *string) *APITokenUpdateOne {
+	if s != nil {
+		atuo.SetRevokedReason(*s)
+	}
+	return atuo
+}
+
+// ClearRevokedReason clears the value of the "revoked_reason" field.
+func (atuo *APITokenUpdateOne) ClearRevokedReason() *APITokenUpdateOne {
+	atuo.mutation.ClearRevokedReason()
+	return atuo
+}
+
+// SetRevokedBy sets the "revoked_by" field.
+func (atuo *APITokenUpdateOne) SetRevokedBy(s string) *APITokenUpdateOne {
+	atuo.mutation.SetRevokedBy(s)
+	return atuo
+}
+
+// SetNillableRevokedBy sets the "revoked_by" field if the given value is not nil.
+func (atuo *APITokenUpdateOne) SetNillableRevokedBy(s *string) *APITokenUpdateOne {
+	if s != nil {
+		atuo.SetRevokedBy(*s)
+	}
+	return atuo
+}
+
+// ClearRevokedBy clears the value of the "revoked_by" field.
+func (atuo *APITokenUpdateOne) ClearRevokedBy() *APITokenUpdateOne {
+	atuo.mutation.ClearRevokedBy()
+	return atuo
+}
+
+// SetRevokedAt sets the "revoked_at" field.
+func (atuo *APITokenUpdateOne) SetRevokedAt(t time.Time) *APITokenUpdateOne {
+	atuo.mutation.SetRevokedAt(t)
+	return atuo
+}
+
+// SetNillableRevokedAt sets the "revoked_at" field if the given value is not nil.
+func (atuo *APITokenUpdateOne) SetNillableRevokedAt(t *time.Time) *APITokenUpdateOne {
+	if t != nil {
+		atuo.SetRevokedAt(*t)
+	}
+	return atuo
+}
+
+// ClearRevokedAt clears the value of the "revoked_at" field.
+func (atuo *APITokenUpdateOne) ClearRevokedAt() *APITokenUpdateOne {
+	atuo.mutation.ClearRevokedAt()
+	return atuo
+}
+
 // SetOwner sets the "owner" edge to the Organization entity.
 func (atuo *APITokenUpdateOne) SetOwner(o *Organization) *APITokenUpdateOne {
 	return atuo.SetOwnerID(o.ID)
@@ -849,6 +1033,30 @@ func (atuo *APITokenUpdateOne) sqlSave(ctx context.Context) (_node *APIToken, er
 	}
 	if atuo.mutation.LastUsedAtCleared() {
 		_spec.ClearField(apitoken.FieldLastUsedAt, field.TypeTime)
+	}
+	if value, ok := atuo.mutation.IsActive(); ok {
+		_spec.SetField(apitoken.FieldIsActive, field.TypeBool, value)
+	}
+	if atuo.mutation.IsActiveCleared() {
+		_spec.ClearField(apitoken.FieldIsActive, field.TypeBool)
+	}
+	if value, ok := atuo.mutation.RevokedReason(); ok {
+		_spec.SetField(apitoken.FieldRevokedReason, field.TypeString, value)
+	}
+	if atuo.mutation.RevokedReasonCleared() {
+		_spec.ClearField(apitoken.FieldRevokedReason, field.TypeString)
+	}
+	if value, ok := atuo.mutation.RevokedBy(); ok {
+		_spec.SetField(apitoken.FieldRevokedBy, field.TypeString, value)
+	}
+	if atuo.mutation.RevokedByCleared() {
+		_spec.ClearField(apitoken.FieldRevokedBy, field.TypeString)
+	}
+	if value, ok := atuo.mutation.RevokedAt(); ok {
+		_spec.SetField(apitoken.FieldRevokedAt, field.TypeTime, value)
+	}
+	if atuo.mutation.RevokedAtCleared() {
+		_spec.ClearField(apitoken.FieldRevokedAt, field.TypeTime)
 	}
 	if atuo.mutation.OwnerCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/internal/ent/generated/auditing.go
+++ b/internal/ent/generated/auditing.go
@@ -1406,6 +1406,15 @@ func (osh *OrgSubscriptionHistory) changes(new *OrgSubscriptionHistory) []Change
 	if !reflect.DeepEqual(osh.ExpiresAt, new.ExpiresAt) {
 		changes = append(changes, NewChange(orgsubscriptionhistory.FieldExpiresAt, osh.ExpiresAt, new.ExpiresAt))
 	}
+	if !reflect.DeepEqual(osh.TrialExpiresAt, new.TrialExpiresAt) {
+		changes = append(changes, NewChange(orgsubscriptionhistory.FieldTrialExpiresAt, osh.TrialExpiresAt, new.TrialExpiresAt))
+	}
+	if !reflect.DeepEqual(osh.DaysUntilDue, new.DaysUntilDue) {
+		changes = append(changes, NewChange(orgsubscriptionhistory.FieldDaysUntilDue, osh.DaysUntilDue, new.DaysUntilDue))
+	}
+	if !reflect.DeepEqual(osh.PaymentMethodAdded, new.PaymentMethodAdded) {
+		changes = append(changes, NewChange(orgsubscriptionhistory.FieldPaymentMethodAdded, osh.PaymentMethodAdded, new.PaymentMethodAdded))
+	}
 	if !reflect.DeepEqual(osh.Features, new.Features) {
 		changes = append(changes, NewChange(orgsubscriptionhistory.FieldFeatures, osh.Features, new.Features))
 	}

--- a/internal/ent/generated/entql.go
+++ b/internal/ent/generated/entql.go
@@ -98,20 +98,24 @@ var schemaGraph = func() *sqlgraph.Schema {
 		},
 		Type: "APIToken",
 		Fields: map[string]*sqlgraph.FieldSpec{
-			apitoken.FieldCreatedAt:   {Type: field.TypeTime, Column: apitoken.FieldCreatedAt},
-			apitoken.FieldUpdatedAt:   {Type: field.TypeTime, Column: apitoken.FieldUpdatedAt},
-			apitoken.FieldCreatedBy:   {Type: field.TypeString, Column: apitoken.FieldCreatedBy},
-			apitoken.FieldUpdatedBy:   {Type: field.TypeString, Column: apitoken.FieldUpdatedBy},
-			apitoken.FieldDeletedAt:   {Type: field.TypeTime, Column: apitoken.FieldDeletedAt},
-			apitoken.FieldDeletedBy:   {Type: field.TypeString, Column: apitoken.FieldDeletedBy},
-			apitoken.FieldTags:        {Type: field.TypeJSON, Column: apitoken.FieldTags},
-			apitoken.FieldOwnerID:     {Type: field.TypeString, Column: apitoken.FieldOwnerID},
-			apitoken.FieldName:        {Type: field.TypeString, Column: apitoken.FieldName},
-			apitoken.FieldToken:       {Type: field.TypeString, Column: apitoken.FieldToken},
-			apitoken.FieldExpiresAt:   {Type: field.TypeTime, Column: apitoken.FieldExpiresAt},
-			apitoken.FieldDescription: {Type: field.TypeString, Column: apitoken.FieldDescription},
-			apitoken.FieldScopes:      {Type: field.TypeJSON, Column: apitoken.FieldScopes},
-			apitoken.FieldLastUsedAt:  {Type: field.TypeTime, Column: apitoken.FieldLastUsedAt},
+			apitoken.FieldCreatedAt:     {Type: field.TypeTime, Column: apitoken.FieldCreatedAt},
+			apitoken.FieldUpdatedAt:     {Type: field.TypeTime, Column: apitoken.FieldUpdatedAt},
+			apitoken.FieldCreatedBy:     {Type: field.TypeString, Column: apitoken.FieldCreatedBy},
+			apitoken.FieldUpdatedBy:     {Type: field.TypeString, Column: apitoken.FieldUpdatedBy},
+			apitoken.FieldDeletedAt:     {Type: field.TypeTime, Column: apitoken.FieldDeletedAt},
+			apitoken.FieldDeletedBy:     {Type: field.TypeString, Column: apitoken.FieldDeletedBy},
+			apitoken.FieldTags:          {Type: field.TypeJSON, Column: apitoken.FieldTags},
+			apitoken.FieldOwnerID:       {Type: field.TypeString, Column: apitoken.FieldOwnerID},
+			apitoken.FieldName:          {Type: field.TypeString, Column: apitoken.FieldName},
+			apitoken.FieldToken:         {Type: field.TypeString, Column: apitoken.FieldToken},
+			apitoken.FieldExpiresAt:     {Type: field.TypeTime, Column: apitoken.FieldExpiresAt},
+			apitoken.FieldDescription:   {Type: field.TypeString, Column: apitoken.FieldDescription},
+			apitoken.FieldScopes:        {Type: field.TypeJSON, Column: apitoken.FieldScopes},
+			apitoken.FieldLastUsedAt:    {Type: field.TypeTime, Column: apitoken.FieldLastUsedAt},
+			apitoken.FieldIsActive:      {Type: field.TypeBool, Column: apitoken.FieldIsActive},
+			apitoken.FieldRevokedReason: {Type: field.TypeString, Column: apitoken.FieldRevokedReason},
+			apitoken.FieldRevokedBy:     {Type: field.TypeString, Column: apitoken.FieldRevokedBy},
+			apitoken.FieldRevokedAt:     {Type: field.TypeTime, Column: apitoken.FieldRevokedAt},
 		},
 	}
 	graph.Nodes[1] = &sqlgraph.Node{
@@ -1281,6 +1285,9 @@ var schemaGraph = func() *sqlgraph.Schema {
 			orgsubscription.FieldActive:                   {Type: field.TypeBool, Column: orgsubscription.FieldActive},
 			orgsubscription.FieldStripeCustomerID:         {Type: field.TypeString, Column: orgsubscription.FieldStripeCustomerID},
 			orgsubscription.FieldExpiresAt:                {Type: field.TypeTime, Column: orgsubscription.FieldExpiresAt},
+			orgsubscription.FieldTrialExpiresAt:           {Type: field.TypeTime, Column: orgsubscription.FieldTrialExpiresAt},
+			orgsubscription.FieldDaysUntilDue:             {Type: field.TypeString, Column: orgsubscription.FieldDaysUntilDue},
+			orgsubscription.FieldPaymentMethodAdded:       {Type: field.TypeBool, Column: orgsubscription.FieldPaymentMethodAdded},
 			orgsubscription.FieldFeatures:                 {Type: field.TypeJSON, Column: orgsubscription.FieldFeatures},
 			orgsubscription.FieldFeatureLookupKeys:        {Type: field.TypeJSON, Column: orgsubscription.FieldFeatureLookupKeys},
 		},
@@ -1315,6 +1322,9 @@ var schemaGraph = func() *sqlgraph.Schema {
 			orgsubscriptionhistory.FieldActive:                   {Type: field.TypeBool, Column: orgsubscriptionhistory.FieldActive},
 			orgsubscriptionhistory.FieldStripeCustomerID:         {Type: field.TypeString, Column: orgsubscriptionhistory.FieldStripeCustomerID},
 			orgsubscriptionhistory.FieldExpiresAt:                {Type: field.TypeTime, Column: orgsubscriptionhistory.FieldExpiresAt},
+			orgsubscriptionhistory.FieldTrialExpiresAt:           {Type: field.TypeTime, Column: orgsubscriptionhistory.FieldTrialExpiresAt},
+			orgsubscriptionhistory.FieldDaysUntilDue:             {Type: field.TypeString, Column: orgsubscriptionhistory.FieldDaysUntilDue},
+			orgsubscriptionhistory.FieldPaymentMethodAdded:       {Type: field.TypeBool, Column: orgsubscriptionhistory.FieldPaymentMethodAdded},
 			orgsubscriptionhistory.FieldFeatures:                 {Type: field.TypeJSON, Column: orgsubscriptionhistory.FieldFeatures},
 			orgsubscriptionhistory.FieldFeatureLookupKeys:        {Type: field.TypeJSON, Column: orgsubscriptionhistory.FieldFeatureLookupKeys},
 		},
@@ -1478,20 +1488,24 @@ var schemaGraph = func() *sqlgraph.Schema {
 		},
 		Type: "PersonalAccessToken",
 		Fields: map[string]*sqlgraph.FieldSpec{
-			personalaccesstoken.FieldCreatedAt:   {Type: field.TypeTime, Column: personalaccesstoken.FieldCreatedAt},
-			personalaccesstoken.FieldUpdatedAt:   {Type: field.TypeTime, Column: personalaccesstoken.FieldUpdatedAt},
-			personalaccesstoken.FieldCreatedBy:   {Type: field.TypeString, Column: personalaccesstoken.FieldCreatedBy},
-			personalaccesstoken.FieldUpdatedBy:   {Type: field.TypeString, Column: personalaccesstoken.FieldUpdatedBy},
-			personalaccesstoken.FieldDeletedAt:   {Type: field.TypeTime, Column: personalaccesstoken.FieldDeletedAt},
-			personalaccesstoken.FieldDeletedBy:   {Type: field.TypeString, Column: personalaccesstoken.FieldDeletedBy},
-			personalaccesstoken.FieldTags:        {Type: field.TypeJSON, Column: personalaccesstoken.FieldTags},
-			personalaccesstoken.FieldOwnerID:     {Type: field.TypeString, Column: personalaccesstoken.FieldOwnerID},
-			personalaccesstoken.FieldName:        {Type: field.TypeString, Column: personalaccesstoken.FieldName},
-			personalaccesstoken.FieldToken:       {Type: field.TypeString, Column: personalaccesstoken.FieldToken},
-			personalaccesstoken.FieldExpiresAt:   {Type: field.TypeTime, Column: personalaccesstoken.FieldExpiresAt},
-			personalaccesstoken.FieldDescription: {Type: field.TypeString, Column: personalaccesstoken.FieldDescription},
-			personalaccesstoken.FieldScopes:      {Type: field.TypeJSON, Column: personalaccesstoken.FieldScopes},
-			personalaccesstoken.FieldLastUsedAt:  {Type: field.TypeTime, Column: personalaccesstoken.FieldLastUsedAt},
+			personalaccesstoken.FieldCreatedAt:     {Type: field.TypeTime, Column: personalaccesstoken.FieldCreatedAt},
+			personalaccesstoken.FieldUpdatedAt:     {Type: field.TypeTime, Column: personalaccesstoken.FieldUpdatedAt},
+			personalaccesstoken.FieldCreatedBy:     {Type: field.TypeString, Column: personalaccesstoken.FieldCreatedBy},
+			personalaccesstoken.FieldUpdatedBy:     {Type: field.TypeString, Column: personalaccesstoken.FieldUpdatedBy},
+			personalaccesstoken.FieldDeletedAt:     {Type: field.TypeTime, Column: personalaccesstoken.FieldDeletedAt},
+			personalaccesstoken.FieldDeletedBy:     {Type: field.TypeString, Column: personalaccesstoken.FieldDeletedBy},
+			personalaccesstoken.FieldTags:          {Type: field.TypeJSON, Column: personalaccesstoken.FieldTags},
+			personalaccesstoken.FieldOwnerID:       {Type: field.TypeString, Column: personalaccesstoken.FieldOwnerID},
+			personalaccesstoken.FieldName:          {Type: field.TypeString, Column: personalaccesstoken.FieldName},
+			personalaccesstoken.FieldToken:         {Type: field.TypeString, Column: personalaccesstoken.FieldToken},
+			personalaccesstoken.FieldExpiresAt:     {Type: field.TypeTime, Column: personalaccesstoken.FieldExpiresAt},
+			personalaccesstoken.FieldDescription:   {Type: field.TypeString, Column: personalaccesstoken.FieldDescription},
+			personalaccesstoken.FieldScopes:        {Type: field.TypeJSON, Column: personalaccesstoken.FieldScopes},
+			personalaccesstoken.FieldLastUsedAt:    {Type: field.TypeTime, Column: personalaccesstoken.FieldLastUsedAt},
+			personalaccesstoken.FieldIsActive:      {Type: field.TypeBool, Column: personalaccesstoken.FieldIsActive},
+			personalaccesstoken.FieldRevokedReason: {Type: field.TypeString, Column: personalaccesstoken.FieldRevokedReason},
+			personalaccesstoken.FieldRevokedBy:     {Type: field.TypeString, Column: personalaccesstoken.FieldRevokedBy},
+			personalaccesstoken.FieldRevokedAt:     {Type: field.TypeTime, Column: personalaccesstoken.FieldRevokedAt},
 		},
 	}
 	graph.Nodes[50] = &sqlgraph.Node{
@@ -3957,6 +3971,18 @@ var schemaGraph = func() *sqlgraph.Schema {
 		"Organization",
 	)
 	graph.MustAddE(
+		"events",
+		&sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   orgsubscription.EventsTable,
+			Columns: []string{orgsubscription.EventsColumn},
+			Bidi:    false,
+		},
+		"OrgSubscription",
+		"Event",
+	)
+	graph.MustAddE(
 		"control_creators",
 		&sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.O2M,
@@ -5717,6 +5743,26 @@ func (f *APITokenFilter) WhereScopes(p entql.BytesP) {
 // WhereLastUsedAt applies the entql time.Time predicate on the last_used_at field.
 func (f *APITokenFilter) WhereLastUsedAt(p entql.TimeP) {
 	f.Where(p.Field(apitoken.FieldLastUsedAt))
+}
+
+// WhereIsActive applies the entql bool predicate on the is_active field.
+func (f *APITokenFilter) WhereIsActive(p entql.BoolP) {
+	f.Where(p.Field(apitoken.FieldIsActive))
+}
+
+// WhereRevokedReason applies the entql string predicate on the revoked_reason field.
+func (f *APITokenFilter) WhereRevokedReason(p entql.StringP) {
+	f.Where(p.Field(apitoken.FieldRevokedReason))
+}
+
+// WhereRevokedBy applies the entql string predicate on the revoked_by field.
+func (f *APITokenFilter) WhereRevokedBy(p entql.StringP) {
+	f.Where(p.Field(apitoken.FieldRevokedBy))
+}
+
+// WhereRevokedAt applies the entql time.Time predicate on the revoked_at field.
+func (f *APITokenFilter) WhereRevokedAt(p entql.TimeP) {
+	f.Where(p.Field(apitoken.FieldRevokedAt))
 }
 
 // WhereHasOwner applies a predicate to check if query has an edge owner.
@@ -12530,6 +12576,21 @@ func (f *OrgSubscriptionFilter) WhereExpiresAt(p entql.TimeP) {
 	f.Where(p.Field(orgsubscription.FieldExpiresAt))
 }
 
+// WhereTrialExpiresAt applies the entql time.Time predicate on the trial_expires_at field.
+func (f *OrgSubscriptionFilter) WhereTrialExpiresAt(p entql.TimeP) {
+	f.Where(p.Field(orgsubscription.FieldTrialExpiresAt))
+}
+
+// WhereDaysUntilDue applies the entql string predicate on the days_until_due field.
+func (f *OrgSubscriptionFilter) WhereDaysUntilDue(p entql.StringP) {
+	f.Where(p.Field(orgsubscription.FieldDaysUntilDue))
+}
+
+// WherePaymentMethodAdded applies the entql bool predicate on the payment_method_added field.
+func (f *OrgSubscriptionFilter) WherePaymentMethodAdded(p entql.BoolP) {
+	f.Where(p.Field(orgsubscription.FieldPaymentMethodAdded))
+}
+
 // WhereFeatures applies the entql json.RawMessage predicate on the features field.
 func (f *OrgSubscriptionFilter) WhereFeatures(p entql.BytesP) {
 	f.Where(p.Field(orgsubscription.FieldFeatures))
@@ -12548,6 +12609,20 @@ func (f *OrgSubscriptionFilter) WhereHasOwner() {
 // WhereHasOwnerWith applies a predicate to check if query has an edge owner with a given conditions (other predicates).
 func (f *OrgSubscriptionFilter) WhereHasOwnerWith(preds ...predicate.Organization) {
 	f.Where(entql.HasEdgeWith("owner", sqlgraph.WrapFunc(func(s *sql.Selector) {
+		for _, p := range preds {
+			p(s)
+		}
+	})))
+}
+
+// WhereHasEvents applies a predicate to check if query has an edge events.
+func (f *OrgSubscriptionFilter) WhereHasEvents() {
+	f.Where(entql.HasEdge("events"))
+}
+
+// WhereHasEventsWith applies a predicate to check if query has an edge events with a given conditions (other predicates).
+func (f *OrgSubscriptionFilter) WhereHasEventsWith(preds ...predicate.Event) {
+	f.Where(entql.HasEdgeWith("events", sqlgraph.WrapFunc(func(s *sql.Selector) {
 		for _, p := range preds {
 			p(s)
 		}
@@ -12687,6 +12762,21 @@ func (f *OrgSubscriptionHistoryFilter) WhereStripeCustomerID(p entql.StringP) {
 // WhereExpiresAt applies the entql time.Time predicate on the expires_at field.
 func (f *OrgSubscriptionHistoryFilter) WhereExpiresAt(p entql.TimeP) {
 	f.Where(p.Field(orgsubscriptionhistory.FieldExpiresAt))
+}
+
+// WhereTrialExpiresAt applies the entql time.Time predicate on the trial_expires_at field.
+func (f *OrgSubscriptionHistoryFilter) WhereTrialExpiresAt(p entql.TimeP) {
+	f.Where(p.Field(orgsubscriptionhistory.FieldTrialExpiresAt))
+}
+
+// WhereDaysUntilDue applies the entql string predicate on the days_until_due field.
+func (f *OrgSubscriptionHistoryFilter) WhereDaysUntilDue(p entql.StringP) {
+	f.Where(p.Field(orgsubscriptionhistory.FieldDaysUntilDue))
+}
+
+// WherePaymentMethodAdded applies the entql bool predicate on the payment_method_added field.
+func (f *OrgSubscriptionHistoryFilter) WherePaymentMethodAdded(p entql.BoolP) {
+	f.Where(p.Field(orgsubscriptionhistory.FieldPaymentMethodAdded))
 }
 
 // WhereFeatures applies the entql json.RawMessage predicate on the features field.
@@ -14038,6 +14128,26 @@ func (f *PersonalAccessTokenFilter) WhereScopes(p entql.BytesP) {
 // WhereLastUsedAt applies the entql time.Time predicate on the last_used_at field.
 func (f *PersonalAccessTokenFilter) WhereLastUsedAt(p entql.TimeP) {
 	f.Where(p.Field(personalaccesstoken.FieldLastUsedAt))
+}
+
+// WhereIsActive applies the entql bool predicate on the is_active field.
+func (f *PersonalAccessTokenFilter) WhereIsActive(p entql.BoolP) {
+	f.Where(p.Field(personalaccesstoken.FieldIsActive))
+}
+
+// WhereRevokedReason applies the entql string predicate on the revoked_reason field.
+func (f *PersonalAccessTokenFilter) WhereRevokedReason(p entql.StringP) {
+	f.Where(p.Field(personalaccesstoken.FieldRevokedReason))
+}
+
+// WhereRevokedBy applies the entql string predicate on the revoked_by field.
+func (f *PersonalAccessTokenFilter) WhereRevokedBy(p entql.StringP) {
+	f.Where(p.Field(personalaccesstoken.FieldRevokedBy))
+}
+
+// WhereRevokedAt applies the entql time.Time predicate on the revoked_at field.
+func (f *PersonalAccessTokenFilter) WhereRevokedAt(p entql.TimeP) {
+	f.Where(p.Field(personalaccesstoken.FieldRevokedAt))
 }
 
 // WhereHasOwner applies a predicate to check if query has an edge owner.

--- a/internal/ent/generated/event/event.go
+++ b/internal/ent/generated/event/event.go
@@ -128,6 +128,12 @@ var Columns = []string{
 	FieldMetadata,
 }
 
+// ForeignKeys holds the SQL foreign-keys that are owned by the "events"
+// table and are not defined as standalone fields in the schema.
+var ForeignKeys = []string{
+	"org_subscription_events",
+}
+
 var (
 	// UserPrimaryKey and UserColumn2 are the table columns denoting the
 	// primary key for the user relation (M2M).
@@ -168,6 +174,11 @@ var (
 func ValidColumn(column string) bool {
 	for i := range Columns {
 		if column == Columns[i] {
+			return true
+		}
+	}
+	for i := range ForeignKeys {
+		if column == ForeignKeys[i] {
 			return true
 		}
 	}

--- a/internal/ent/generated/event_query.go
+++ b/internal/ent/generated/event_query.go
@@ -47,6 +47,7 @@ type EventQuery struct {
 	withGroupmembership          *GroupMembershipQuery
 	withSubscriber               *SubscriberQuery
 	withFile                     *FileQuery
+	withFKs                      bool
 	loadTotal                    []func(context.Context, []*Event) error
 	modifiers                    []func(*sql.Selector)
 	withNamedUser                map[string]*UserQuery
@@ -779,6 +780,7 @@ func (eq *EventQuery) prepareQuery(ctx context.Context) error {
 func (eq *EventQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Event, error) {
 	var (
 		nodes       = []*Event{}
+		withFKs     = eq.withFKs
 		_spec       = eq.querySpec()
 		loadedTypes = [11]bool{
 			eq.withUser != nil,
@@ -794,6 +796,9 @@ func (eq *EventQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Event,
 			eq.withFile != nil,
 		}
 	)
+	if withFKs {
+		_spec.Node.Columns = append(_spec.Node.Columns, event.ForeignKeys...)
+	}
 	_spec.ScanValues = func(columns []string) ([]any, error) {
 		return (*Event).scanValues(nil, columns)
 	}

--- a/internal/ent/generated/gql_collection.go
+++ b/internal/ent/generated/gql_collection.go
@@ -188,6 +188,26 @@ func (at *APITokenQuery) collectField(ctx context.Context, oneNode bool, opCtx *
 				selectedFields = append(selectedFields, apitoken.FieldLastUsedAt)
 				fieldSeen[apitoken.FieldLastUsedAt] = struct{}{}
 			}
+		case "isActive":
+			if _, ok := fieldSeen[apitoken.FieldIsActive]; !ok {
+				selectedFields = append(selectedFields, apitoken.FieldIsActive)
+				fieldSeen[apitoken.FieldIsActive] = struct{}{}
+			}
+		case "revokedReason":
+			if _, ok := fieldSeen[apitoken.FieldRevokedReason]; !ok {
+				selectedFields = append(selectedFields, apitoken.FieldRevokedReason)
+				fieldSeen[apitoken.FieldRevokedReason] = struct{}{}
+			}
+		case "revokedBy":
+			if _, ok := fieldSeen[apitoken.FieldRevokedBy]; !ok {
+				selectedFields = append(selectedFields, apitoken.FieldRevokedBy)
+				fieldSeen[apitoken.FieldRevokedBy] = struct{}{}
+			}
+		case "revokedAt":
+			if _, ok := fieldSeen[apitoken.FieldRevokedAt]; !ok {
+				selectedFields = append(selectedFields, apitoken.FieldRevokedAt)
+				fieldSeen[apitoken.FieldRevokedAt] = struct{}{}
+			}
 		case "id":
 		case "__typename":
 		default:
@@ -7786,6 +7806,19 @@ func (os *OrgSubscriptionQuery) collectField(ctx context.Context, oneNode bool, 
 				selectedFields = append(selectedFields, orgsubscription.FieldOwnerID)
 				fieldSeen[orgsubscription.FieldOwnerID] = struct{}{}
 			}
+
+		case "events":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&EventClient{config: os.config}).Query()
+			)
+			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, eventImplementors)...); err != nil {
+				return err
+			}
+			os.WithNamedEvents(alias, func(wq *EventQuery) {
+				*wq = *query
+			})
 		case "createdAt":
 			if _, ok := fieldSeen[orgsubscription.FieldCreatedAt]; !ok {
 				selectedFields = append(selectedFields, orgsubscription.FieldCreatedAt)
@@ -7865,6 +7898,21 @@ func (os *OrgSubscriptionQuery) collectField(ctx context.Context, oneNode bool, 
 			if _, ok := fieldSeen[orgsubscription.FieldExpiresAt]; !ok {
 				selectedFields = append(selectedFields, orgsubscription.FieldExpiresAt)
 				fieldSeen[orgsubscription.FieldExpiresAt] = struct{}{}
+			}
+		case "trialExpiresAt":
+			if _, ok := fieldSeen[orgsubscription.FieldTrialExpiresAt]; !ok {
+				selectedFields = append(selectedFields, orgsubscription.FieldTrialExpiresAt)
+				fieldSeen[orgsubscription.FieldTrialExpiresAt] = struct{}{}
+			}
+		case "daysUntilDue":
+			if _, ok := fieldSeen[orgsubscription.FieldDaysUntilDue]; !ok {
+				selectedFields = append(selectedFields, orgsubscription.FieldDaysUntilDue)
+				fieldSeen[orgsubscription.FieldDaysUntilDue] = struct{}{}
+			}
+		case "paymentMethodAdded":
+			if _, ok := fieldSeen[orgsubscription.FieldPaymentMethodAdded]; !ok {
+				selectedFields = append(selectedFields, orgsubscription.FieldPaymentMethodAdded)
+				fieldSeen[orgsubscription.FieldPaymentMethodAdded] = struct{}{}
 			}
 		case "features":
 			if _, ok := fieldSeen[orgsubscription.FieldFeatures]; !ok {
@@ -8032,6 +8080,21 @@ func (osh *OrgSubscriptionHistoryQuery) collectField(ctx context.Context, oneNod
 			if _, ok := fieldSeen[orgsubscriptionhistory.FieldExpiresAt]; !ok {
 				selectedFields = append(selectedFields, orgsubscriptionhistory.FieldExpiresAt)
 				fieldSeen[orgsubscriptionhistory.FieldExpiresAt] = struct{}{}
+			}
+		case "trialExpiresAt":
+			if _, ok := fieldSeen[orgsubscriptionhistory.FieldTrialExpiresAt]; !ok {
+				selectedFields = append(selectedFields, orgsubscriptionhistory.FieldTrialExpiresAt)
+				fieldSeen[orgsubscriptionhistory.FieldTrialExpiresAt] = struct{}{}
+			}
+		case "daysUntilDue":
+			if _, ok := fieldSeen[orgsubscriptionhistory.FieldDaysUntilDue]; !ok {
+				selectedFields = append(selectedFields, orgsubscriptionhistory.FieldDaysUntilDue)
+				fieldSeen[orgsubscriptionhistory.FieldDaysUntilDue] = struct{}{}
+			}
+		case "paymentMethodAdded":
+			if _, ok := fieldSeen[orgsubscriptionhistory.FieldPaymentMethodAdded]; !ok {
+				selectedFields = append(selectedFields, orgsubscriptionhistory.FieldPaymentMethodAdded)
+				fieldSeen[orgsubscriptionhistory.FieldPaymentMethodAdded] = struct{}{}
 			}
 		case "features":
 			if _, ok := fieldSeen[orgsubscriptionhistory.FieldFeatures]; !ok {
@@ -9491,6 +9554,26 @@ func (pat *PersonalAccessTokenQuery) collectField(ctx context.Context, oneNode b
 			if _, ok := fieldSeen[personalaccesstoken.FieldLastUsedAt]; !ok {
 				selectedFields = append(selectedFields, personalaccesstoken.FieldLastUsedAt)
 				fieldSeen[personalaccesstoken.FieldLastUsedAt] = struct{}{}
+			}
+		case "isActive":
+			if _, ok := fieldSeen[personalaccesstoken.FieldIsActive]; !ok {
+				selectedFields = append(selectedFields, personalaccesstoken.FieldIsActive)
+				fieldSeen[personalaccesstoken.FieldIsActive] = struct{}{}
+			}
+		case "revokedReason":
+			if _, ok := fieldSeen[personalaccesstoken.FieldRevokedReason]; !ok {
+				selectedFields = append(selectedFields, personalaccesstoken.FieldRevokedReason)
+				fieldSeen[personalaccesstoken.FieldRevokedReason] = struct{}{}
+			}
+		case "revokedBy":
+			if _, ok := fieldSeen[personalaccesstoken.FieldRevokedBy]; !ok {
+				selectedFields = append(selectedFields, personalaccesstoken.FieldRevokedBy)
+				fieldSeen[personalaccesstoken.FieldRevokedBy] = struct{}{}
+			}
+		case "revokedAt":
+			if _, ok := fieldSeen[personalaccesstoken.FieldRevokedAt]; !ok {
+				selectedFields = append(selectedFields, personalaccesstoken.FieldRevokedAt)
+				fieldSeen[personalaccesstoken.FieldRevokedAt] = struct{}{}
 			}
 		case "id":
 		case "__typename":

--- a/internal/ent/generated/gql_edge.go
+++ b/internal/ent/generated/gql_edge.go
@@ -1624,6 +1624,18 @@ func (os *OrgSubscription) Owner(ctx context.Context) (*Organization, error) {
 	return result, MaskNotFound(err)
 }
 
+func (os *OrgSubscription) Events(ctx context.Context) (result []*Event, err error) {
+	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
+		result, err = os.NamedEvents(graphql.GetFieldContext(ctx).Field.Alias)
+	} else {
+		result, err = os.Edges.EventsOrErr()
+	}
+	if IsNotLoaded(err) {
+		result, err = os.QueryEvents().All(ctx)
+	}
+	return result, err
+}
+
 func (o *Organization) ControlCreators(ctx context.Context) (result []*Group, err error) {
 	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
 		result, err = o.NamedControlCreators(graphql.GetFieldContext(ctx).Field.Alias)

--- a/internal/ent/generated/gql_mutation_input.go
+++ b/internal/ent/generated/gql_mutation_input.go
@@ -12,13 +12,17 @@ import (
 
 // CreateAPITokenInput represents a mutation input for creating apitokens.
 type CreateAPITokenInput struct {
-	Tags        []string
-	Name        string
-	ExpiresAt   *time.Time
-	Description *string
-	Scopes      []string
-	LastUsedAt  *time.Time
-	OwnerID     *string
+	Tags          []string
+	Name          string
+	ExpiresAt     *time.Time
+	Description   *string
+	Scopes        []string
+	LastUsedAt    *time.Time
+	IsActive      *bool
+	RevokedReason *string
+	RevokedBy     *string
+	RevokedAt     *time.Time
+	OwnerID       *string
 }
 
 // Mutate applies the CreateAPITokenInput on the APITokenMutation builder.
@@ -39,6 +43,18 @@ func (i *CreateAPITokenInput) Mutate(m *APITokenMutation) {
 	if v := i.LastUsedAt; v != nil {
 		m.SetLastUsedAt(*v)
 	}
+	if v := i.IsActive; v != nil {
+		m.SetIsActive(*v)
+	}
+	if v := i.RevokedReason; v != nil {
+		m.SetRevokedReason(*v)
+	}
+	if v := i.RevokedBy; v != nil {
+		m.SetRevokedBy(*v)
+	}
+	if v := i.RevokedAt; v != nil {
+		m.SetRevokedAt(*v)
+	}
 	if v := i.OwnerID; v != nil {
 		m.SetOwnerID(*v)
 	}
@@ -52,19 +68,27 @@ func (c *APITokenCreate) SetInput(i CreateAPITokenInput) *APITokenCreate {
 
 // UpdateAPITokenInput represents a mutation input for updating apitokens.
 type UpdateAPITokenInput struct {
-	ClearTags        bool
-	Tags             []string
-	AppendTags       []string
-	Name             *string
-	ClearDescription bool
-	Description      *string
-	ClearScopes      bool
-	Scopes           []string
-	AppendScopes     []string
-	ClearLastUsedAt  bool
-	LastUsedAt       *time.Time
-	ClearOwner       bool
-	OwnerID          *string
+	ClearTags          bool
+	Tags               []string
+	AppendTags         []string
+	Name               *string
+	ClearDescription   bool
+	Description        *string
+	ClearScopes        bool
+	Scopes             []string
+	AppendScopes       []string
+	ClearLastUsedAt    bool
+	LastUsedAt         *time.Time
+	ClearIsActive      bool
+	IsActive           *bool
+	ClearRevokedReason bool
+	RevokedReason      *string
+	ClearRevokedBy     bool
+	RevokedBy          *string
+	ClearRevokedAt     bool
+	RevokedAt          *time.Time
+	ClearOwner         bool
+	OwnerID            *string
 }
 
 // Mutate applies the UpdateAPITokenInput on the APITokenMutation builder.
@@ -101,6 +125,30 @@ func (i *UpdateAPITokenInput) Mutate(m *APITokenMutation) {
 	}
 	if v := i.LastUsedAt; v != nil {
 		m.SetLastUsedAt(*v)
+	}
+	if i.ClearIsActive {
+		m.ClearIsActive()
+	}
+	if v := i.IsActive; v != nil {
+		m.SetIsActive(*v)
+	}
+	if i.ClearRevokedReason {
+		m.ClearRevokedReason()
+	}
+	if v := i.RevokedReason; v != nil {
+		m.SetRevokedReason(*v)
+	}
+	if i.ClearRevokedBy {
+		m.ClearRevokedBy()
+	}
+	if v := i.RevokedBy; v != nil {
+		m.SetRevokedBy(*v)
+	}
+	if i.ClearRevokedAt {
+		m.ClearRevokedAt()
+	}
+	if v := i.RevokedAt; v != nil {
+		m.SetRevokedAt(*v)
 	}
 	if i.ClearOwner {
 		m.ClearOwner()
@@ -5100,6 +5148,10 @@ type CreatePersonalAccessTokenInput struct {
 	Description     *string
 	Scopes          []string
 	LastUsedAt      *time.Time
+	IsActive        *bool
+	RevokedReason   *string
+	RevokedBy       *string
+	RevokedAt       *time.Time
 	OwnerID         string
 	OrganizationIDs []string
 	EventIDs        []string
@@ -5122,6 +5174,18 @@ func (i *CreatePersonalAccessTokenInput) Mutate(m *PersonalAccessTokenMutation) 
 	}
 	if v := i.LastUsedAt; v != nil {
 		m.SetLastUsedAt(*v)
+	}
+	if v := i.IsActive; v != nil {
+		m.SetIsActive(*v)
+	}
+	if v := i.RevokedReason; v != nil {
+		m.SetRevokedReason(*v)
+	}
+	if v := i.RevokedBy; v != nil {
+		m.SetRevokedBy(*v)
+	}
+	if v := i.RevokedAt; v != nil {
+		m.SetRevokedAt(*v)
 	}
 	m.SetOwnerID(i.OwnerID)
 	if v := i.OrganizationIDs; len(v) > 0 {
@@ -5151,6 +5215,14 @@ type UpdatePersonalAccessTokenInput struct {
 	AppendScopes          []string
 	ClearLastUsedAt       bool
 	LastUsedAt            *time.Time
+	ClearIsActive         bool
+	IsActive              *bool
+	ClearRevokedReason    bool
+	RevokedReason         *string
+	ClearRevokedBy        bool
+	RevokedBy             *string
+	ClearRevokedAt        bool
+	RevokedAt             *time.Time
 	ClearOrganizations    bool
 	AddOrganizationIDs    []string
 	RemoveOrganizationIDs []string
@@ -5193,6 +5265,30 @@ func (i *UpdatePersonalAccessTokenInput) Mutate(m *PersonalAccessTokenMutation) 
 	}
 	if v := i.LastUsedAt; v != nil {
 		m.SetLastUsedAt(*v)
+	}
+	if i.ClearIsActive {
+		m.ClearIsActive()
+	}
+	if v := i.IsActive; v != nil {
+		m.SetIsActive(*v)
+	}
+	if i.ClearRevokedReason {
+		m.ClearRevokedReason()
+	}
+	if v := i.RevokedReason; v != nil {
+		m.SetRevokedReason(*v)
+	}
+	if i.ClearRevokedBy {
+		m.ClearRevokedBy()
+	}
+	if v := i.RevokedBy; v != nil {
+		m.SetRevokedBy(*v)
+	}
+	if i.ClearRevokedAt {
+		m.ClearRevokedAt()
+	}
+	if v := i.RevokedAt; v != nil {
+		m.SetRevokedAt(*v)
 	}
 	if i.ClearOrganizations {
 		m.ClearOrganizations()

--- a/internal/ent/generated/gql_where_input.go
+++ b/internal/ent/generated/gql_where_input.go
@@ -244,6 +244,58 @@ type APITokenWhereInput struct {
 	LastUsedAtIsNil  bool        `json:"lastUsedAtIsNil,omitempty"`
 	LastUsedAtNotNil bool        `json:"lastUsedAtNotNil,omitempty"`
 
+	// "is_active" field predicates.
+	IsActive       *bool `json:"isActive,omitempty"`
+	IsActiveNEQ    *bool `json:"isActiveNEQ,omitempty"`
+	IsActiveIsNil  bool  `json:"isActiveIsNil,omitempty"`
+	IsActiveNotNil bool  `json:"isActiveNotNil,omitempty"`
+
+	// "revoked_reason" field predicates.
+	RevokedReason             *string  `json:"revokedReason,omitempty"`
+	RevokedReasonNEQ          *string  `json:"revokedReasonNEQ,omitempty"`
+	RevokedReasonIn           []string `json:"revokedReasonIn,omitempty"`
+	RevokedReasonNotIn        []string `json:"revokedReasonNotIn,omitempty"`
+	RevokedReasonGT           *string  `json:"revokedReasonGT,omitempty"`
+	RevokedReasonGTE          *string  `json:"revokedReasonGTE,omitempty"`
+	RevokedReasonLT           *string  `json:"revokedReasonLT,omitempty"`
+	RevokedReasonLTE          *string  `json:"revokedReasonLTE,omitempty"`
+	RevokedReasonContains     *string  `json:"revokedReasonContains,omitempty"`
+	RevokedReasonHasPrefix    *string  `json:"revokedReasonHasPrefix,omitempty"`
+	RevokedReasonHasSuffix    *string  `json:"revokedReasonHasSuffix,omitempty"`
+	RevokedReasonIsNil        bool     `json:"revokedReasonIsNil,omitempty"`
+	RevokedReasonNotNil       bool     `json:"revokedReasonNotNil,omitempty"`
+	RevokedReasonEqualFold    *string  `json:"revokedReasonEqualFold,omitempty"`
+	RevokedReasonContainsFold *string  `json:"revokedReasonContainsFold,omitempty"`
+
+	// "revoked_by" field predicates.
+	RevokedBy             *string  `json:"revokedBy,omitempty"`
+	RevokedByNEQ          *string  `json:"revokedByNEQ,omitempty"`
+	RevokedByIn           []string `json:"revokedByIn,omitempty"`
+	RevokedByNotIn        []string `json:"revokedByNotIn,omitempty"`
+	RevokedByGT           *string  `json:"revokedByGT,omitempty"`
+	RevokedByGTE          *string  `json:"revokedByGTE,omitempty"`
+	RevokedByLT           *string  `json:"revokedByLT,omitempty"`
+	RevokedByLTE          *string  `json:"revokedByLTE,omitempty"`
+	RevokedByContains     *string  `json:"revokedByContains,omitempty"`
+	RevokedByHasPrefix    *string  `json:"revokedByHasPrefix,omitempty"`
+	RevokedByHasSuffix    *string  `json:"revokedByHasSuffix,omitempty"`
+	RevokedByIsNil        bool     `json:"revokedByIsNil,omitempty"`
+	RevokedByNotNil       bool     `json:"revokedByNotNil,omitempty"`
+	RevokedByEqualFold    *string  `json:"revokedByEqualFold,omitempty"`
+	RevokedByContainsFold *string  `json:"revokedByContainsFold,omitempty"`
+
+	// "revoked_at" field predicates.
+	RevokedAt       *time.Time  `json:"revokedAt,omitempty"`
+	RevokedAtNEQ    *time.Time  `json:"revokedAtNEQ,omitempty"`
+	RevokedAtIn     []time.Time `json:"revokedAtIn,omitempty"`
+	RevokedAtNotIn  []time.Time `json:"revokedAtNotIn,omitempty"`
+	RevokedAtGT     *time.Time  `json:"revokedAtGT,omitempty"`
+	RevokedAtGTE    *time.Time  `json:"revokedAtGTE,omitempty"`
+	RevokedAtLT     *time.Time  `json:"revokedAtLT,omitempty"`
+	RevokedAtLTE    *time.Time  `json:"revokedAtLTE,omitempty"`
+	RevokedAtIsNil  bool        `json:"revokedAtIsNil,omitempty"`
+	RevokedAtNotNil bool        `json:"revokedAtNotNil,omitempty"`
+
 	// "owner" edge predicates.
 	HasOwner     *bool                     `json:"hasOwner,omitempty"`
 	HasOwnerWith []*OrganizationWhereInput `json:"hasOwnerWith,omitempty"`
@@ -718,6 +770,138 @@ func (i *APITokenWhereInput) P() (predicate.APIToken, error) {
 	}
 	if i.LastUsedAtNotNil {
 		predicates = append(predicates, apitoken.LastUsedAtNotNil())
+	}
+	if i.IsActive != nil {
+		predicates = append(predicates, apitoken.IsActiveEQ(*i.IsActive))
+	}
+	if i.IsActiveNEQ != nil {
+		predicates = append(predicates, apitoken.IsActiveNEQ(*i.IsActiveNEQ))
+	}
+	if i.IsActiveIsNil {
+		predicates = append(predicates, apitoken.IsActiveIsNil())
+	}
+	if i.IsActiveNotNil {
+		predicates = append(predicates, apitoken.IsActiveNotNil())
+	}
+	if i.RevokedReason != nil {
+		predicates = append(predicates, apitoken.RevokedReasonEQ(*i.RevokedReason))
+	}
+	if i.RevokedReasonNEQ != nil {
+		predicates = append(predicates, apitoken.RevokedReasonNEQ(*i.RevokedReasonNEQ))
+	}
+	if len(i.RevokedReasonIn) > 0 {
+		predicates = append(predicates, apitoken.RevokedReasonIn(i.RevokedReasonIn...))
+	}
+	if len(i.RevokedReasonNotIn) > 0 {
+		predicates = append(predicates, apitoken.RevokedReasonNotIn(i.RevokedReasonNotIn...))
+	}
+	if i.RevokedReasonGT != nil {
+		predicates = append(predicates, apitoken.RevokedReasonGT(*i.RevokedReasonGT))
+	}
+	if i.RevokedReasonGTE != nil {
+		predicates = append(predicates, apitoken.RevokedReasonGTE(*i.RevokedReasonGTE))
+	}
+	if i.RevokedReasonLT != nil {
+		predicates = append(predicates, apitoken.RevokedReasonLT(*i.RevokedReasonLT))
+	}
+	if i.RevokedReasonLTE != nil {
+		predicates = append(predicates, apitoken.RevokedReasonLTE(*i.RevokedReasonLTE))
+	}
+	if i.RevokedReasonContains != nil {
+		predicates = append(predicates, apitoken.RevokedReasonContains(*i.RevokedReasonContains))
+	}
+	if i.RevokedReasonHasPrefix != nil {
+		predicates = append(predicates, apitoken.RevokedReasonHasPrefix(*i.RevokedReasonHasPrefix))
+	}
+	if i.RevokedReasonHasSuffix != nil {
+		predicates = append(predicates, apitoken.RevokedReasonHasSuffix(*i.RevokedReasonHasSuffix))
+	}
+	if i.RevokedReasonIsNil {
+		predicates = append(predicates, apitoken.RevokedReasonIsNil())
+	}
+	if i.RevokedReasonNotNil {
+		predicates = append(predicates, apitoken.RevokedReasonNotNil())
+	}
+	if i.RevokedReasonEqualFold != nil {
+		predicates = append(predicates, apitoken.RevokedReasonEqualFold(*i.RevokedReasonEqualFold))
+	}
+	if i.RevokedReasonContainsFold != nil {
+		predicates = append(predicates, apitoken.RevokedReasonContainsFold(*i.RevokedReasonContainsFold))
+	}
+	if i.RevokedBy != nil {
+		predicates = append(predicates, apitoken.RevokedByEQ(*i.RevokedBy))
+	}
+	if i.RevokedByNEQ != nil {
+		predicates = append(predicates, apitoken.RevokedByNEQ(*i.RevokedByNEQ))
+	}
+	if len(i.RevokedByIn) > 0 {
+		predicates = append(predicates, apitoken.RevokedByIn(i.RevokedByIn...))
+	}
+	if len(i.RevokedByNotIn) > 0 {
+		predicates = append(predicates, apitoken.RevokedByNotIn(i.RevokedByNotIn...))
+	}
+	if i.RevokedByGT != nil {
+		predicates = append(predicates, apitoken.RevokedByGT(*i.RevokedByGT))
+	}
+	if i.RevokedByGTE != nil {
+		predicates = append(predicates, apitoken.RevokedByGTE(*i.RevokedByGTE))
+	}
+	if i.RevokedByLT != nil {
+		predicates = append(predicates, apitoken.RevokedByLT(*i.RevokedByLT))
+	}
+	if i.RevokedByLTE != nil {
+		predicates = append(predicates, apitoken.RevokedByLTE(*i.RevokedByLTE))
+	}
+	if i.RevokedByContains != nil {
+		predicates = append(predicates, apitoken.RevokedByContains(*i.RevokedByContains))
+	}
+	if i.RevokedByHasPrefix != nil {
+		predicates = append(predicates, apitoken.RevokedByHasPrefix(*i.RevokedByHasPrefix))
+	}
+	if i.RevokedByHasSuffix != nil {
+		predicates = append(predicates, apitoken.RevokedByHasSuffix(*i.RevokedByHasSuffix))
+	}
+	if i.RevokedByIsNil {
+		predicates = append(predicates, apitoken.RevokedByIsNil())
+	}
+	if i.RevokedByNotNil {
+		predicates = append(predicates, apitoken.RevokedByNotNil())
+	}
+	if i.RevokedByEqualFold != nil {
+		predicates = append(predicates, apitoken.RevokedByEqualFold(*i.RevokedByEqualFold))
+	}
+	if i.RevokedByContainsFold != nil {
+		predicates = append(predicates, apitoken.RevokedByContainsFold(*i.RevokedByContainsFold))
+	}
+	if i.RevokedAt != nil {
+		predicates = append(predicates, apitoken.RevokedAtEQ(*i.RevokedAt))
+	}
+	if i.RevokedAtNEQ != nil {
+		predicates = append(predicates, apitoken.RevokedAtNEQ(*i.RevokedAtNEQ))
+	}
+	if len(i.RevokedAtIn) > 0 {
+		predicates = append(predicates, apitoken.RevokedAtIn(i.RevokedAtIn...))
+	}
+	if len(i.RevokedAtNotIn) > 0 {
+		predicates = append(predicates, apitoken.RevokedAtNotIn(i.RevokedAtNotIn...))
+	}
+	if i.RevokedAtGT != nil {
+		predicates = append(predicates, apitoken.RevokedAtGT(*i.RevokedAtGT))
+	}
+	if i.RevokedAtGTE != nil {
+		predicates = append(predicates, apitoken.RevokedAtGTE(*i.RevokedAtGTE))
+	}
+	if i.RevokedAtLT != nil {
+		predicates = append(predicates, apitoken.RevokedAtLT(*i.RevokedAtLT))
+	}
+	if i.RevokedAtLTE != nil {
+		predicates = append(predicates, apitoken.RevokedAtLTE(*i.RevokedAtLTE))
+	}
+	if i.RevokedAtIsNil {
+		predicates = append(predicates, apitoken.RevokedAtIsNil())
+	}
+	if i.RevokedAtNotNil {
+		predicates = append(predicates, apitoken.RevokedAtNotNil())
 	}
 
 	if i.HasOwner != nil {
@@ -36862,9 +37046,48 @@ type OrgSubscriptionWhereInput struct {
 	ExpiresAtIsNil  bool        `json:"expiresAtIsNil,omitempty"`
 	ExpiresAtNotNil bool        `json:"expiresAtNotNil,omitempty"`
 
+	// "trial_expires_at" field predicates.
+	TrialExpiresAt       *time.Time  `json:"trialExpiresAt,omitempty"`
+	TrialExpiresAtNEQ    *time.Time  `json:"trialExpiresAtNEQ,omitempty"`
+	TrialExpiresAtIn     []time.Time `json:"trialExpiresAtIn,omitempty"`
+	TrialExpiresAtNotIn  []time.Time `json:"trialExpiresAtNotIn,omitempty"`
+	TrialExpiresAtGT     *time.Time  `json:"trialExpiresAtGT,omitempty"`
+	TrialExpiresAtGTE    *time.Time  `json:"trialExpiresAtGTE,omitempty"`
+	TrialExpiresAtLT     *time.Time  `json:"trialExpiresAtLT,omitempty"`
+	TrialExpiresAtLTE    *time.Time  `json:"trialExpiresAtLTE,omitempty"`
+	TrialExpiresAtIsNil  bool        `json:"trialExpiresAtIsNil,omitempty"`
+	TrialExpiresAtNotNil bool        `json:"trialExpiresAtNotNil,omitempty"`
+
+	// "days_until_due" field predicates.
+	DaysUntilDue             *string  `json:"daysUntilDue,omitempty"`
+	DaysUntilDueNEQ          *string  `json:"daysUntilDueNEQ,omitempty"`
+	DaysUntilDueIn           []string `json:"daysUntilDueIn,omitempty"`
+	DaysUntilDueNotIn        []string `json:"daysUntilDueNotIn,omitempty"`
+	DaysUntilDueGT           *string  `json:"daysUntilDueGT,omitempty"`
+	DaysUntilDueGTE          *string  `json:"daysUntilDueGTE,omitempty"`
+	DaysUntilDueLT           *string  `json:"daysUntilDueLT,omitempty"`
+	DaysUntilDueLTE          *string  `json:"daysUntilDueLTE,omitempty"`
+	DaysUntilDueContains     *string  `json:"daysUntilDueContains,omitempty"`
+	DaysUntilDueHasPrefix    *string  `json:"daysUntilDueHasPrefix,omitempty"`
+	DaysUntilDueHasSuffix    *string  `json:"daysUntilDueHasSuffix,omitempty"`
+	DaysUntilDueIsNil        bool     `json:"daysUntilDueIsNil,omitempty"`
+	DaysUntilDueNotNil       bool     `json:"daysUntilDueNotNil,omitempty"`
+	DaysUntilDueEqualFold    *string  `json:"daysUntilDueEqualFold,omitempty"`
+	DaysUntilDueContainsFold *string  `json:"daysUntilDueContainsFold,omitempty"`
+
+	// "payment_method_added" field predicates.
+	PaymentMethodAdded       *bool `json:"paymentMethodAdded,omitempty"`
+	PaymentMethodAddedNEQ    *bool `json:"paymentMethodAddedNEQ,omitempty"`
+	PaymentMethodAddedIsNil  bool  `json:"paymentMethodAddedIsNil,omitempty"`
+	PaymentMethodAddedNotNil bool  `json:"paymentMethodAddedNotNil,omitempty"`
+
 	// "owner" edge predicates.
 	HasOwner     *bool                     `json:"hasOwner,omitempty"`
 	HasOwnerWith []*OrganizationWhereInput `json:"hasOwnerWith,omitempty"`
+
+	// "events" edge predicates.
+	HasEvents     *bool              `json:"hasEvents,omitempty"`
+	HasEventsWith []*EventWhereInput `json:"hasEventsWith,omitempty"`
 }
 
 // AddPredicates adds custom predicates to the where input to be used during the filtering phase.
@@ -37499,6 +37722,93 @@ func (i *OrgSubscriptionWhereInput) P() (predicate.OrgSubscription, error) {
 	if i.ExpiresAtNotNil {
 		predicates = append(predicates, orgsubscription.ExpiresAtNotNil())
 	}
+	if i.TrialExpiresAt != nil {
+		predicates = append(predicates, orgsubscription.TrialExpiresAtEQ(*i.TrialExpiresAt))
+	}
+	if i.TrialExpiresAtNEQ != nil {
+		predicates = append(predicates, orgsubscription.TrialExpiresAtNEQ(*i.TrialExpiresAtNEQ))
+	}
+	if len(i.TrialExpiresAtIn) > 0 {
+		predicates = append(predicates, orgsubscription.TrialExpiresAtIn(i.TrialExpiresAtIn...))
+	}
+	if len(i.TrialExpiresAtNotIn) > 0 {
+		predicates = append(predicates, orgsubscription.TrialExpiresAtNotIn(i.TrialExpiresAtNotIn...))
+	}
+	if i.TrialExpiresAtGT != nil {
+		predicates = append(predicates, orgsubscription.TrialExpiresAtGT(*i.TrialExpiresAtGT))
+	}
+	if i.TrialExpiresAtGTE != nil {
+		predicates = append(predicates, orgsubscription.TrialExpiresAtGTE(*i.TrialExpiresAtGTE))
+	}
+	if i.TrialExpiresAtLT != nil {
+		predicates = append(predicates, orgsubscription.TrialExpiresAtLT(*i.TrialExpiresAtLT))
+	}
+	if i.TrialExpiresAtLTE != nil {
+		predicates = append(predicates, orgsubscription.TrialExpiresAtLTE(*i.TrialExpiresAtLTE))
+	}
+	if i.TrialExpiresAtIsNil {
+		predicates = append(predicates, orgsubscription.TrialExpiresAtIsNil())
+	}
+	if i.TrialExpiresAtNotNil {
+		predicates = append(predicates, orgsubscription.TrialExpiresAtNotNil())
+	}
+	if i.DaysUntilDue != nil {
+		predicates = append(predicates, orgsubscription.DaysUntilDueEQ(*i.DaysUntilDue))
+	}
+	if i.DaysUntilDueNEQ != nil {
+		predicates = append(predicates, orgsubscription.DaysUntilDueNEQ(*i.DaysUntilDueNEQ))
+	}
+	if len(i.DaysUntilDueIn) > 0 {
+		predicates = append(predicates, orgsubscription.DaysUntilDueIn(i.DaysUntilDueIn...))
+	}
+	if len(i.DaysUntilDueNotIn) > 0 {
+		predicates = append(predicates, orgsubscription.DaysUntilDueNotIn(i.DaysUntilDueNotIn...))
+	}
+	if i.DaysUntilDueGT != nil {
+		predicates = append(predicates, orgsubscription.DaysUntilDueGT(*i.DaysUntilDueGT))
+	}
+	if i.DaysUntilDueGTE != nil {
+		predicates = append(predicates, orgsubscription.DaysUntilDueGTE(*i.DaysUntilDueGTE))
+	}
+	if i.DaysUntilDueLT != nil {
+		predicates = append(predicates, orgsubscription.DaysUntilDueLT(*i.DaysUntilDueLT))
+	}
+	if i.DaysUntilDueLTE != nil {
+		predicates = append(predicates, orgsubscription.DaysUntilDueLTE(*i.DaysUntilDueLTE))
+	}
+	if i.DaysUntilDueContains != nil {
+		predicates = append(predicates, orgsubscription.DaysUntilDueContains(*i.DaysUntilDueContains))
+	}
+	if i.DaysUntilDueHasPrefix != nil {
+		predicates = append(predicates, orgsubscription.DaysUntilDueHasPrefix(*i.DaysUntilDueHasPrefix))
+	}
+	if i.DaysUntilDueHasSuffix != nil {
+		predicates = append(predicates, orgsubscription.DaysUntilDueHasSuffix(*i.DaysUntilDueHasSuffix))
+	}
+	if i.DaysUntilDueIsNil {
+		predicates = append(predicates, orgsubscription.DaysUntilDueIsNil())
+	}
+	if i.DaysUntilDueNotNil {
+		predicates = append(predicates, orgsubscription.DaysUntilDueNotNil())
+	}
+	if i.DaysUntilDueEqualFold != nil {
+		predicates = append(predicates, orgsubscription.DaysUntilDueEqualFold(*i.DaysUntilDueEqualFold))
+	}
+	if i.DaysUntilDueContainsFold != nil {
+		predicates = append(predicates, orgsubscription.DaysUntilDueContainsFold(*i.DaysUntilDueContainsFold))
+	}
+	if i.PaymentMethodAdded != nil {
+		predicates = append(predicates, orgsubscription.PaymentMethodAddedEQ(*i.PaymentMethodAdded))
+	}
+	if i.PaymentMethodAddedNEQ != nil {
+		predicates = append(predicates, orgsubscription.PaymentMethodAddedNEQ(*i.PaymentMethodAddedNEQ))
+	}
+	if i.PaymentMethodAddedIsNil {
+		predicates = append(predicates, orgsubscription.PaymentMethodAddedIsNil())
+	}
+	if i.PaymentMethodAddedNotNil {
+		predicates = append(predicates, orgsubscription.PaymentMethodAddedNotNil())
+	}
 
 	if i.HasOwner != nil {
 		p := orgsubscription.HasOwner()
@@ -37517,6 +37827,24 @@ func (i *OrgSubscriptionWhereInput) P() (predicate.OrgSubscription, error) {
 			with = append(with, p)
 		}
 		predicates = append(predicates, orgsubscription.HasOwnerWith(with...))
+	}
+	if i.HasEvents != nil {
+		p := orgsubscription.HasEvents()
+		if !*i.HasEvents {
+			p = orgsubscription.Not(p)
+		}
+		predicates = append(predicates, p)
+	}
+	if len(i.HasEventsWith) > 0 {
+		with := make([]predicate.Event, 0, len(i.HasEventsWith))
+		for _, w := range i.HasEventsWith {
+			p, err := w.P()
+			if err != nil {
+				return nil, fmt.Errorf("%w: field 'HasEventsWith'", err)
+			}
+			with = append(with, p)
+		}
+		predicates = append(predicates, orgsubscription.HasEventsWith(with...))
 	}
 	switch len(predicates) {
 	case 0:
@@ -37784,6 +38112,41 @@ type OrgSubscriptionHistoryWhereInput struct {
 	ExpiresAtLTE    *time.Time  `json:"expiresAtLTE,omitempty"`
 	ExpiresAtIsNil  bool        `json:"expiresAtIsNil,omitempty"`
 	ExpiresAtNotNil bool        `json:"expiresAtNotNil,omitempty"`
+
+	// "trial_expires_at" field predicates.
+	TrialExpiresAt       *time.Time  `json:"trialExpiresAt,omitempty"`
+	TrialExpiresAtNEQ    *time.Time  `json:"trialExpiresAtNEQ,omitempty"`
+	TrialExpiresAtIn     []time.Time `json:"trialExpiresAtIn,omitempty"`
+	TrialExpiresAtNotIn  []time.Time `json:"trialExpiresAtNotIn,omitempty"`
+	TrialExpiresAtGT     *time.Time  `json:"trialExpiresAtGT,omitempty"`
+	TrialExpiresAtGTE    *time.Time  `json:"trialExpiresAtGTE,omitempty"`
+	TrialExpiresAtLT     *time.Time  `json:"trialExpiresAtLT,omitempty"`
+	TrialExpiresAtLTE    *time.Time  `json:"trialExpiresAtLTE,omitempty"`
+	TrialExpiresAtIsNil  bool        `json:"trialExpiresAtIsNil,omitempty"`
+	TrialExpiresAtNotNil bool        `json:"trialExpiresAtNotNil,omitempty"`
+
+	// "days_until_due" field predicates.
+	DaysUntilDue             *string  `json:"daysUntilDue,omitempty"`
+	DaysUntilDueNEQ          *string  `json:"daysUntilDueNEQ,omitempty"`
+	DaysUntilDueIn           []string `json:"daysUntilDueIn,omitempty"`
+	DaysUntilDueNotIn        []string `json:"daysUntilDueNotIn,omitempty"`
+	DaysUntilDueGT           *string  `json:"daysUntilDueGT,omitempty"`
+	DaysUntilDueGTE          *string  `json:"daysUntilDueGTE,omitempty"`
+	DaysUntilDueLT           *string  `json:"daysUntilDueLT,omitempty"`
+	DaysUntilDueLTE          *string  `json:"daysUntilDueLTE,omitempty"`
+	DaysUntilDueContains     *string  `json:"daysUntilDueContains,omitempty"`
+	DaysUntilDueHasPrefix    *string  `json:"daysUntilDueHasPrefix,omitempty"`
+	DaysUntilDueHasSuffix    *string  `json:"daysUntilDueHasSuffix,omitempty"`
+	DaysUntilDueIsNil        bool     `json:"daysUntilDueIsNil,omitempty"`
+	DaysUntilDueNotNil       bool     `json:"daysUntilDueNotNil,omitempty"`
+	DaysUntilDueEqualFold    *string  `json:"daysUntilDueEqualFold,omitempty"`
+	DaysUntilDueContainsFold *string  `json:"daysUntilDueContainsFold,omitempty"`
+
+	// "payment_method_added" field predicates.
+	PaymentMethodAdded       *bool `json:"paymentMethodAdded,omitempty"`
+	PaymentMethodAddedNEQ    *bool `json:"paymentMethodAddedNEQ,omitempty"`
+	PaymentMethodAddedIsNil  bool  `json:"paymentMethodAddedIsNil,omitempty"`
+	PaymentMethodAddedNotNil bool  `json:"paymentMethodAddedNotNil,omitempty"`
 }
 
 // AddPredicates adds custom predicates to the where input to be used during the filtering phase.
@@ -38498,6 +38861,93 @@ func (i *OrgSubscriptionHistoryWhereInput) P() (predicate.OrgSubscriptionHistory
 	}
 	if i.ExpiresAtNotNil {
 		predicates = append(predicates, orgsubscriptionhistory.ExpiresAtNotNil())
+	}
+	if i.TrialExpiresAt != nil {
+		predicates = append(predicates, orgsubscriptionhistory.TrialExpiresAtEQ(*i.TrialExpiresAt))
+	}
+	if i.TrialExpiresAtNEQ != nil {
+		predicates = append(predicates, orgsubscriptionhistory.TrialExpiresAtNEQ(*i.TrialExpiresAtNEQ))
+	}
+	if len(i.TrialExpiresAtIn) > 0 {
+		predicates = append(predicates, orgsubscriptionhistory.TrialExpiresAtIn(i.TrialExpiresAtIn...))
+	}
+	if len(i.TrialExpiresAtNotIn) > 0 {
+		predicates = append(predicates, orgsubscriptionhistory.TrialExpiresAtNotIn(i.TrialExpiresAtNotIn...))
+	}
+	if i.TrialExpiresAtGT != nil {
+		predicates = append(predicates, orgsubscriptionhistory.TrialExpiresAtGT(*i.TrialExpiresAtGT))
+	}
+	if i.TrialExpiresAtGTE != nil {
+		predicates = append(predicates, orgsubscriptionhistory.TrialExpiresAtGTE(*i.TrialExpiresAtGTE))
+	}
+	if i.TrialExpiresAtLT != nil {
+		predicates = append(predicates, orgsubscriptionhistory.TrialExpiresAtLT(*i.TrialExpiresAtLT))
+	}
+	if i.TrialExpiresAtLTE != nil {
+		predicates = append(predicates, orgsubscriptionhistory.TrialExpiresAtLTE(*i.TrialExpiresAtLTE))
+	}
+	if i.TrialExpiresAtIsNil {
+		predicates = append(predicates, orgsubscriptionhistory.TrialExpiresAtIsNil())
+	}
+	if i.TrialExpiresAtNotNil {
+		predicates = append(predicates, orgsubscriptionhistory.TrialExpiresAtNotNil())
+	}
+	if i.DaysUntilDue != nil {
+		predicates = append(predicates, orgsubscriptionhistory.DaysUntilDueEQ(*i.DaysUntilDue))
+	}
+	if i.DaysUntilDueNEQ != nil {
+		predicates = append(predicates, orgsubscriptionhistory.DaysUntilDueNEQ(*i.DaysUntilDueNEQ))
+	}
+	if len(i.DaysUntilDueIn) > 0 {
+		predicates = append(predicates, orgsubscriptionhistory.DaysUntilDueIn(i.DaysUntilDueIn...))
+	}
+	if len(i.DaysUntilDueNotIn) > 0 {
+		predicates = append(predicates, orgsubscriptionhistory.DaysUntilDueNotIn(i.DaysUntilDueNotIn...))
+	}
+	if i.DaysUntilDueGT != nil {
+		predicates = append(predicates, orgsubscriptionhistory.DaysUntilDueGT(*i.DaysUntilDueGT))
+	}
+	if i.DaysUntilDueGTE != nil {
+		predicates = append(predicates, orgsubscriptionhistory.DaysUntilDueGTE(*i.DaysUntilDueGTE))
+	}
+	if i.DaysUntilDueLT != nil {
+		predicates = append(predicates, orgsubscriptionhistory.DaysUntilDueLT(*i.DaysUntilDueLT))
+	}
+	if i.DaysUntilDueLTE != nil {
+		predicates = append(predicates, orgsubscriptionhistory.DaysUntilDueLTE(*i.DaysUntilDueLTE))
+	}
+	if i.DaysUntilDueContains != nil {
+		predicates = append(predicates, orgsubscriptionhistory.DaysUntilDueContains(*i.DaysUntilDueContains))
+	}
+	if i.DaysUntilDueHasPrefix != nil {
+		predicates = append(predicates, orgsubscriptionhistory.DaysUntilDueHasPrefix(*i.DaysUntilDueHasPrefix))
+	}
+	if i.DaysUntilDueHasSuffix != nil {
+		predicates = append(predicates, orgsubscriptionhistory.DaysUntilDueHasSuffix(*i.DaysUntilDueHasSuffix))
+	}
+	if i.DaysUntilDueIsNil {
+		predicates = append(predicates, orgsubscriptionhistory.DaysUntilDueIsNil())
+	}
+	if i.DaysUntilDueNotNil {
+		predicates = append(predicates, orgsubscriptionhistory.DaysUntilDueNotNil())
+	}
+	if i.DaysUntilDueEqualFold != nil {
+		predicates = append(predicates, orgsubscriptionhistory.DaysUntilDueEqualFold(*i.DaysUntilDueEqualFold))
+	}
+	if i.DaysUntilDueContainsFold != nil {
+		predicates = append(predicates, orgsubscriptionhistory.DaysUntilDueContainsFold(*i.DaysUntilDueContainsFold))
+	}
+	if i.PaymentMethodAdded != nil {
+		predicates = append(predicates, orgsubscriptionhistory.PaymentMethodAddedEQ(*i.PaymentMethodAdded))
+	}
+	if i.PaymentMethodAddedNEQ != nil {
+		predicates = append(predicates, orgsubscriptionhistory.PaymentMethodAddedNEQ(*i.PaymentMethodAddedNEQ))
+	}
+	if i.PaymentMethodAddedIsNil {
+		predicates = append(predicates, orgsubscriptionhistory.PaymentMethodAddedIsNil())
+	}
+	if i.PaymentMethodAddedNotNil {
+		predicates = append(predicates, orgsubscriptionhistory.PaymentMethodAddedNotNil())
 	}
 
 	switch len(predicates) {
@@ -42897,6 +43347,58 @@ type PersonalAccessTokenWhereInput struct {
 	LastUsedAtIsNil  bool        `json:"lastUsedAtIsNil,omitempty"`
 	LastUsedAtNotNil bool        `json:"lastUsedAtNotNil,omitempty"`
 
+	// "is_active" field predicates.
+	IsActive       *bool `json:"isActive,omitempty"`
+	IsActiveNEQ    *bool `json:"isActiveNEQ,omitempty"`
+	IsActiveIsNil  bool  `json:"isActiveIsNil,omitempty"`
+	IsActiveNotNil bool  `json:"isActiveNotNil,omitempty"`
+
+	// "revoked_reason" field predicates.
+	RevokedReason             *string  `json:"revokedReason,omitempty"`
+	RevokedReasonNEQ          *string  `json:"revokedReasonNEQ,omitempty"`
+	RevokedReasonIn           []string `json:"revokedReasonIn,omitempty"`
+	RevokedReasonNotIn        []string `json:"revokedReasonNotIn,omitempty"`
+	RevokedReasonGT           *string  `json:"revokedReasonGT,omitempty"`
+	RevokedReasonGTE          *string  `json:"revokedReasonGTE,omitempty"`
+	RevokedReasonLT           *string  `json:"revokedReasonLT,omitempty"`
+	RevokedReasonLTE          *string  `json:"revokedReasonLTE,omitempty"`
+	RevokedReasonContains     *string  `json:"revokedReasonContains,omitempty"`
+	RevokedReasonHasPrefix    *string  `json:"revokedReasonHasPrefix,omitempty"`
+	RevokedReasonHasSuffix    *string  `json:"revokedReasonHasSuffix,omitempty"`
+	RevokedReasonIsNil        bool     `json:"revokedReasonIsNil,omitempty"`
+	RevokedReasonNotNil       bool     `json:"revokedReasonNotNil,omitempty"`
+	RevokedReasonEqualFold    *string  `json:"revokedReasonEqualFold,omitempty"`
+	RevokedReasonContainsFold *string  `json:"revokedReasonContainsFold,omitempty"`
+
+	// "revoked_by" field predicates.
+	RevokedBy             *string  `json:"revokedBy,omitempty"`
+	RevokedByNEQ          *string  `json:"revokedByNEQ,omitempty"`
+	RevokedByIn           []string `json:"revokedByIn,omitempty"`
+	RevokedByNotIn        []string `json:"revokedByNotIn,omitempty"`
+	RevokedByGT           *string  `json:"revokedByGT,omitempty"`
+	RevokedByGTE          *string  `json:"revokedByGTE,omitempty"`
+	RevokedByLT           *string  `json:"revokedByLT,omitempty"`
+	RevokedByLTE          *string  `json:"revokedByLTE,omitempty"`
+	RevokedByContains     *string  `json:"revokedByContains,omitempty"`
+	RevokedByHasPrefix    *string  `json:"revokedByHasPrefix,omitempty"`
+	RevokedByHasSuffix    *string  `json:"revokedByHasSuffix,omitempty"`
+	RevokedByIsNil        bool     `json:"revokedByIsNil,omitempty"`
+	RevokedByNotNil       bool     `json:"revokedByNotNil,omitempty"`
+	RevokedByEqualFold    *string  `json:"revokedByEqualFold,omitempty"`
+	RevokedByContainsFold *string  `json:"revokedByContainsFold,omitempty"`
+
+	// "revoked_at" field predicates.
+	RevokedAt       *time.Time  `json:"revokedAt,omitempty"`
+	RevokedAtNEQ    *time.Time  `json:"revokedAtNEQ,omitempty"`
+	RevokedAtIn     []time.Time `json:"revokedAtIn,omitempty"`
+	RevokedAtNotIn  []time.Time `json:"revokedAtNotIn,omitempty"`
+	RevokedAtGT     *time.Time  `json:"revokedAtGT,omitempty"`
+	RevokedAtGTE    *time.Time  `json:"revokedAtGTE,omitempty"`
+	RevokedAtLT     *time.Time  `json:"revokedAtLT,omitempty"`
+	RevokedAtLTE    *time.Time  `json:"revokedAtLTE,omitempty"`
+	RevokedAtIsNil  bool        `json:"revokedAtIsNil,omitempty"`
+	RevokedAtNotNil bool        `json:"revokedAtNotNil,omitempty"`
+
 	// "owner" edge predicates.
 	HasOwner     *bool             `json:"hasOwner,omitempty"`
 	HasOwnerWith []*UserWhereInput `json:"hasOwnerWith,omitempty"`
@@ -43334,6 +43836,138 @@ func (i *PersonalAccessTokenWhereInput) P() (predicate.PersonalAccessToken, erro
 	}
 	if i.LastUsedAtNotNil {
 		predicates = append(predicates, personalaccesstoken.LastUsedAtNotNil())
+	}
+	if i.IsActive != nil {
+		predicates = append(predicates, personalaccesstoken.IsActiveEQ(*i.IsActive))
+	}
+	if i.IsActiveNEQ != nil {
+		predicates = append(predicates, personalaccesstoken.IsActiveNEQ(*i.IsActiveNEQ))
+	}
+	if i.IsActiveIsNil {
+		predicates = append(predicates, personalaccesstoken.IsActiveIsNil())
+	}
+	if i.IsActiveNotNil {
+		predicates = append(predicates, personalaccesstoken.IsActiveNotNil())
+	}
+	if i.RevokedReason != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedReasonEQ(*i.RevokedReason))
+	}
+	if i.RevokedReasonNEQ != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedReasonNEQ(*i.RevokedReasonNEQ))
+	}
+	if len(i.RevokedReasonIn) > 0 {
+		predicates = append(predicates, personalaccesstoken.RevokedReasonIn(i.RevokedReasonIn...))
+	}
+	if len(i.RevokedReasonNotIn) > 0 {
+		predicates = append(predicates, personalaccesstoken.RevokedReasonNotIn(i.RevokedReasonNotIn...))
+	}
+	if i.RevokedReasonGT != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedReasonGT(*i.RevokedReasonGT))
+	}
+	if i.RevokedReasonGTE != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedReasonGTE(*i.RevokedReasonGTE))
+	}
+	if i.RevokedReasonLT != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedReasonLT(*i.RevokedReasonLT))
+	}
+	if i.RevokedReasonLTE != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedReasonLTE(*i.RevokedReasonLTE))
+	}
+	if i.RevokedReasonContains != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedReasonContains(*i.RevokedReasonContains))
+	}
+	if i.RevokedReasonHasPrefix != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedReasonHasPrefix(*i.RevokedReasonHasPrefix))
+	}
+	if i.RevokedReasonHasSuffix != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedReasonHasSuffix(*i.RevokedReasonHasSuffix))
+	}
+	if i.RevokedReasonIsNil {
+		predicates = append(predicates, personalaccesstoken.RevokedReasonIsNil())
+	}
+	if i.RevokedReasonNotNil {
+		predicates = append(predicates, personalaccesstoken.RevokedReasonNotNil())
+	}
+	if i.RevokedReasonEqualFold != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedReasonEqualFold(*i.RevokedReasonEqualFold))
+	}
+	if i.RevokedReasonContainsFold != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedReasonContainsFold(*i.RevokedReasonContainsFold))
+	}
+	if i.RevokedBy != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedByEQ(*i.RevokedBy))
+	}
+	if i.RevokedByNEQ != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedByNEQ(*i.RevokedByNEQ))
+	}
+	if len(i.RevokedByIn) > 0 {
+		predicates = append(predicates, personalaccesstoken.RevokedByIn(i.RevokedByIn...))
+	}
+	if len(i.RevokedByNotIn) > 0 {
+		predicates = append(predicates, personalaccesstoken.RevokedByNotIn(i.RevokedByNotIn...))
+	}
+	if i.RevokedByGT != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedByGT(*i.RevokedByGT))
+	}
+	if i.RevokedByGTE != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedByGTE(*i.RevokedByGTE))
+	}
+	if i.RevokedByLT != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedByLT(*i.RevokedByLT))
+	}
+	if i.RevokedByLTE != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedByLTE(*i.RevokedByLTE))
+	}
+	if i.RevokedByContains != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedByContains(*i.RevokedByContains))
+	}
+	if i.RevokedByHasPrefix != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedByHasPrefix(*i.RevokedByHasPrefix))
+	}
+	if i.RevokedByHasSuffix != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedByHasSuffix(*i.RevokedByHasSuffix))
+	}
+	if i.RevokedByIsNil {
+		predicates = append(predicates, personalaccesstoken.RevokedByIsNil())
+	}
+	if i.RevokedByNotNil {
+		predicates = append(predicates, personalaccesstoken.RevokedByNotNil())
+	}
+	if i.RevokedByEqualFold != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedByEqualFold(*i.RevokedByEqualFold))
+	}
+	if i.RevokedByContainsFold != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedByContainsFold(*i.RevokedByContainsFold))
+	}
+	if i.RevokedAt != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedAtEQ(*i.RevokedAt))
+	}
+	if i.RevokedAtNEQ != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedAtNEQ(*i.RevokedAtNEQ))
+	}
+	if len(i.RevokedAtIn) > 0 {
+		predicates = append(predicates, personalaccesstoken.RevokedAtIn(i.RevokedAtIn...))
+	}
+	if len(i.RevokedAtNotIn) > 0 {
+		predicates = append(predicates, personalaccesstoken.RevokedAtNotIn(i.RevokedAtNotIn...))
+	}
+	if i.RevokedAtGT != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedAtGT(*i.RevokedAtGT))
+	}
+	if i.RevokedAtGTE != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedAtGTE(*i.RevokedAtGTE))
+	}
+	if i.RevokedAtLT != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedAtLT(*i.RevokedAtLT))
+	}
+	if i.RevokedAtLTE != nil {
+		predicates = append(predicates, personalaccesstoken.RevokedAtLTE(*i.RevokedAtLTE))
+	}
+	if i.RevokedAtIsNil {
+		predicates = append(predicates, personalaccesstoken.RevokedAtIsNil())
+	}
+	if i.RevokedAtNotNil {
+		predicates = append(predicates, personalaccesstoken.RevokedAtNotNil())
 	}
 
 	if i.HasOwner != nil {

--- a/internal/ent/generated/history_from_mutation.go
+++ b/internal/ent/generated/history_from_mutation.go
@@ -4581,6 +4581,18 @@ func (m *OrgSubscriptionMutation) CreateHistoryFromCreate(ctx context.Context) e
 		create = create.SetNillableExpiresAt(&expiresAt)
 	}
 
+	if trialExpiresAt, exists := m.TrialExpiresAt(); exists {
+		create = create.SetNillableTrialExpiresAt(&trialExpiresAt)
+	}
+
+	if daysUntilDue, exists := m.DaysUntilDue(); exists {
+		create = create.SetNillableDaysUntilDue(&daysUntilDue)
+	}
+
+	if paymentMethodAdded, exists := m.PaymentMethodAdded(); exists {
+		create = create.SetNillablePaymentMethodAdded(&paymentMethodAdded)
+	}
+
 	if features, exists := m.Features(); exists {
 		create = create.SetFeatures(features)
 	}
@@ -4715,6 +4727,24 @@ func (m *OrgSubscriptionMutation) CreateHistoryFromUpdate(ctx context.Context) e
 			create = create.SetNillableExpiresAt(orgsubscription.ExpiresAt)
 		}
 
+		if trialExpiresAt, exists := m.TrialExpiresAt(); exists {
+			create = create.SetNillableTrialExpiresAt(&trialExpiresAt)
+		} else {
+			create = create.SetNillableTrialExpiresAt(orgsubscription.TrialExpiresAt)
+		}
+
+		if daysUntilDue, exists := m.DaysUntilDue(); exists {
+			create = create.SetNillableDaysUntilDue(&daysUntilDue)
+		} else {
+			create = create.SetNillableDaysUntilDue(orgsubscription.DaysUntilDue)
+		}
+
+		if paymentMethodAdded, exists := m.PaymentMethodAdded(); exists {
+			create = create.SetNillablePaymentMethodAdded(&paymentMethodAdded)
+		} else {
+			create = create.SetNillablePaymentMethodAdded(orgsubscription.PaymentMethodAdded)
+		}
+
 		if features, exists := m.Features(); exists {
 			create = create.SetFeatures(features)
 		} else {
@@ -4775,6 +4805,9 @@ func (m *OrgSubscriptionMutation) CreateHistoryFromDelete(ctx context.Context) e
 			SetActive(orgsubscription.Active).
 			SetStripeCustomerID(orgsubscription.StripeCustomerID).
 			SetNillableExpiresAt(orgsubscription.ExpiresAt).
+			SetNillableTrialExpiresAt(orgsubscription.TrialExpiresAt).
+			SetNillableDaysUntilDue(orgsubscription.DaysUntilDue).
+			SetNillablePaymentMethodAdded(orgsubscription.PaymentMethodAdded).
 			SetFeatures(orgsubscription.Features).
 			SetFeatureLookupKeys(orgsubscription.FeatureLookupKeys).
 			Save(ctx)

--- a/internal/ent/generated/migrate/schema.go
+++ b/internal/ent/generated/migrate/schema.go
@@ -25,6 +25,10 @@ var (
 		{Name: "description", Type: field.TypeString, Nullable: true},
 		{Name: "scopes", Type: field.TypeJSON, Nullable: true},
 		{Name: "last_used_at", Type: field.TypeTime, Nullable: true},
+		{Name: "is_active", Type: field.TypeBool, Nullable: true, Default: true},
+		{Name: "revoked_reason", Type: field.TypeString, Nullable: true},
+		{Name: "revoked_by", Type: field.TypeString, Nullable: true},
+		{Name: "revoked_at", Type: field.TypeTime, Nullable: true},
 		{Name: "owner_id", Type: field.TypeString, Nullable: true},
 	}
 	// APITokensTable holds the schema information for the "api_tokens" table.
@@ -35,7 +39,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "api_tokens_organizations_api_tokens",
-				Columns:    []*schema.Column{APITokensColumns[14]},
+				Columns:    []*schema.Column{APITokensColumns[18]},
 				RefColumns: []*schema.Column{OrganizationsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -641,12 +645,21 @@ var (
 		{Name: "correlation_id", Type: field.TypeString, Nullable: true},
 		{Name: "event_type", Type: field.TypeString},
 		{Name: "metadata", Type: field.TypeJSON, Nullable: true},
+		{Name: "org_subscription_events", Type: field.TypeString, Nullable: true},
 	}
 	// EventsTable holds the schema information for the "events" table.
 	EventsTable = &schema.Table{
 		Name:       "events",
 		Columns:    EventsColumns,
 		PrimaryKey: []*schema.Column{EventsColumns[0]},
+		ForeignKeys: []*schema.ForeignKey{
+			{
+				Symbol:     "events_org_subscriptions_events",
+				Columns:    []*schema.Column{EventsColumns[10]},
+				RefColumns: []*schema.Column{OrgSubscriptionsColumns[0]},
+				OnDelete:   schema.SetNull,
+			},
+		},
 	}
 	// EventHistoryColumns holds the columns for the "event_history" table.
 	EventHistoryColumns = []*schema.Column{
@@ -1627,6 +1640,9 @@ var (
 		{Name: "active", Type: field.TypeBool, Default: true},
 		{Name: "stripe_customer_id", Type: field.TypeString, Unique: true, Nullable: true},
 		{Name: "expires_at", Type: field.TypeTime, Nullable: true},
+		{Name: "trial_expires_at", Type: field.TypeTime, Nullable: true},
+		{Name: "days_until_due", Type: field.TypeString, Nullable: true},
+		{Name: "payment_method_added", Type: field.TypeBool, Nullable: true},
 		{Name: "features", Type: field.TypeJSON, Nullable: true},
 		{Name: "feature_lookup_keys", Type: field.TypeJSON, Nullable: true},
 		{Name: "owner_id", Type: field.TypeString, Nullable: true},
@@ -1639,7 +1655,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "org_subscriptions_organizations_org_subscriptions",
-				Columns:    []*schema.Column{OrgSubscriptionsColumns[18]},
+				Columns:    []*schema.Column{OrgSubscriptionsColumns[21]},
 				RefColumns: []*schema.Column{OrganizationsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -1667,6 +1683,9 @@ var (
 		{Name: "active", Type: field.TypeBool, Default: true},
 		{Name: "stripe_customer_id", Type: field.TypeString, Nullable: true},
 		{Name: "expires_at", Type: field.TypeTime, Nullable: true},
+		{Name: "trial_expires_at", Type: field.TypeTime, Nullable: true},
+		{Name: "days_until_due", Type: field.TypeString, Nullable: true},
+		{Name: "payment_method_added", Type: field.TypeBool, Nullable: true},
 		{Name: "features", Type: field.TypeJSON, Nullable: true},
 		{Name: "feature_lookup_keys", Type: field.TypeJSON, Nullable: true},
 	}
@@ -1896,6 +1915,10 @@ var (
 		{Name: "description", Type: field.TypeString, Nullable: true},
 		{Name: "scopes", Type: field.TypeJSON, Nullable: true},
 		{Name: "last_used_at", Type: field.TypeTime, Nullable: true},
+		{Name: "is_active", Type: field.TypeBool, Nullable: true, Default: true},
+		{Name: "revoked_reason", Type: field.TypeString, Nullable: true},
+		{Name: "revoked_by", Type: field.TypeString, Nullable: true},
+		{Name: "revoked_at", Type: field.TypeTime, Nullable: true},
 		{Name: "owner_id", Type: field.TypeString},
 	}
 	// PersonalAccessTokensTable holds the schema information for the "personal_access_tokens" table.
@@ -1906,7 +1929,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "personal_access_tokens_users_personal_access_tokens",
-				Columns:    []*schema.Column{PersonalAccessTokensColumns[14]},
+				Columns:    []*schema.Column{PersonalAccessTokensColumns[18]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -5167,6 +5190,7 @@ func init() {
 	EntityTypeHistoryTable.Annotation = &entsql.Annotation{
 		Table: "entity_type_history",
 	}
+	EventsTable.ForeignKeys[0].RefTable = OrgSubscriptionsTable
 	EventHistoryTable.Annotation = &entsql.Annotation{
 		Table: "event_history",
 	}

--- a/internal/ent/generated/mutation.go
+++ b/internal/ent/generated/mutation.go
@@ -178,30 +178,34 @@ const (
 // APITokenMutation represents an operation that mutates the APIToken nodes in the graph.
 type APITokenMutation struct {
 	config
-	op            Op
-	typ           string
-	id            *string
-	created_at    *time.Time
-	updated_at    *time.Time
-	created_by    *string
-	updated_by    *string
-	deleted_at    *time.Time
-	deleted_by    *string
-	tags          *[]string
-	appendtags    []string
-	name          *string
-	token         *string
-	expires_at    *time.Time
-	description   *string
-	scopes        *[]string
-	appendscopes  []string
-	last_used_at  *time.Time
-	clearedFields map[string]struct{}
-	owner         *string
-	clearedowner  bool
-	done          bool
-	oldValue      func(context.Context) (*APIToken, error)
-	predicates    []predicate.APIToken
+	op             Op
+	typ            string
+	id             *string
+	created_at     *time.Time
+	updated_at     *time.Time
+	created_by     *string
+	updated_by     *string
+	deleted_at     *time.Time
+	deleted_by     *string
+	tags           *[]string
+	appendtags     []string
+	name           *string
+	token          *string
+	expires_at     *time.Time
+	description    *string
+	scopes         *[]string
+	appendscopes   []string
+	last_used_at   *time.Time
+	is_active      *bool
+	revoked_reason *string
+	revoked_by     *string
+	revoked_at     *time.Time
+	clearedFields  map[string]struct{}
+	owner          *string
+	clearedowner   bool
+	done           bool
+	oldValue       func(context.Context) (*APIToken, error)
+	predicates     []predicate.APIToken
 }
 
 var _ ent.Mutation = (*APITokenMutation)(nil)
@@ -1000,6 +1004,202 @@ func (m *APITokenMutation) ResetLastUsedAt() {
 	delete(m.clearedFields, apitoken.FieldLastUsedAt)
 }
 
+// SetIsActive sets the "is_active" field.
+func (m *APITokenMutation) SetIsActive(b bool) {
+	m.is_active = &b
+}
+
+// IsActive returns the value of the "is_active" field in the mutation.
+func (m *APITokenMutation) IsActive() (r bool, exists bool) {
+	v := m.is_active
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldIsActive returns the old "is_active" field's value of the APIToken entity.
+// If the APIToken object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *APITokenMutation) OldIsActive(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldIsActive is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldIsActive requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldIsActive: %w", err)
+	}
+	return oldValue.IsActive, nil
+}
+
+// ClearIsActive clears the value of the "is_active" field.
+func (m *APITokenMutation) ClearIsActive() {
+	m.is_active = nil
+	m.clearedFields[apitoken.FieldIsActive] = struct{}{}
+}
+
+// IsActiveCleared returns if the "is_active" field was cleared in this mutation.
+func (m *APITokenMutation) IsActiveCleared() bool {
+	_, ok := m.clearedFields[apitoken.FieldIsActive]
+	return ok
+}
+
+// ResetIsActive resets all changes to the "is_active" field.
+func (m *APITokenMutation) ResetIsActive() {
+	m.is_active = nil
+	delete(m.clearedFields, apitoken.FieldIsActive)
+}
+
+// SetRevokedReason sets the "revoked_reason" field.
+func (m *APITokenMutation) SetRevokedReason(s string) {
+	m.revoked_reason = &s
+}
+
+// RevokedReason returns the value of the "revoked_reason" field in the mutation.
+func (m *APITokenMutation) RevokedReason() (r string, exists bool) {
+	v := m.revoked_reason
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldRevokedReason returns the old "revoked_reason" field's value of the APIToken entity.
+// If the APIToken object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *APITokenMutation) OldRevokedReason(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldRevokedReason is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldRevokedReason requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldRevokedReason: %w", err)
+	}
+	return oldValue.RevokedReason, nil
+}
+
+// ClearRevokedReason clears the value of the "revoked_reason" field.
+func (m *APITokenMutation) ClearRevokedReason() {
+	m.revoked_reason = nil
+	m.clearedFields[apitoken.FieldRevokedReason] = struct{}{}
+}
+
+// RevokedReasonCleared returns if the "revoked_reason" field was cleared in this mutation.
+func (m *APITokenMutation) RevokedReasonCleared() bool {
+	_, ok := m.clearedFields[apitoken.FieldRevokedReason]
+	return ok
+}
+
+// ResetRevokedReason resets all changes to the "revoked_reason" field.
+func (m *APITokenMutation) ResetRevokedReason() {
+	m.revoked_reason = nil
+	delete(m.clearedFields, apitoken.FieldRevokedReason)
+}
+
+// SetRevokedBy sets the "revoked_by" field.
+func (m *APITokenMutation) SetRevokedBy(s string) {
+	m.revoked_by = &s
+}
+
+// RevokedBy returns the value of the "revoked_by" field in the mutation.
+func (m *APITokenMutation) RevokedBy() (r string, exists bool) {
+	v := m.revoked_by
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldRevokedBy returns the old "revoked_by" field's value of the APIToken entity.
+// If the APIToken object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *APITokenMutation) OldRevokedBy(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldRevokedBy is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldRevokedBy requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldRevokedBy: %w", err)
+	}
+	return oldValue.RevokedBy, nil
+}
+
+// ClearRevokedBy clears the value of the "revoked_by" field.
+func (m *APITokenMutation) ClearRevokedBy() {
+	m.revoked_by = nil
+	m.clearedFields[apitoken.FieldRevokedBy] = struct{}{}
+}
+
+// RevokedByCleared returns if the "revoked_by" field was cleared in this mutation.
+func (m *APITokenMutation) RevokedByCleared() bool {
+	_, ok := m.clearedFields[apitoken.FieldRevokedBy]
+	return ok
+}
+
+// ResetRevokedBy resets all changes to the "revoked_by" field.
+func (m *APITokenMutation) ResetRevokedBy() {
+	m.revoked_by = nil
+	delete(m.clearedFields, apitoken.FieldRevokedBy)
+}
+
+// SetRevokedAt sets the "revoked_at" field.
+func (m *APITokenMutation) SetRevokedAt(t time.Time) {
+	m.revoked_at = &t
+}
+
+// RevokedAt returns the value of the "revoked_at" field in the mutation.
+func (m *APITokenMutation) RevokedAt() (r time.Time, exists bool) {
+	v := m.revoked_at
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldRevokedAt returns the old "revoked_at" field's value of the APIToken entity.
+// If the APIToken object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *APITokenMutation) OldRevokedAt(ctx context.Context) (v *time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldRevokedAt is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldRevokedAt requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldRevokedAt: %w", err)
+	}
+	return oldValue.RevokedAt, nil
+}
+
+// ClearRevokedAt clears the value of the "revoked_at" field.
+func (m *APITokenMutation) ClearRevokedAt() {
+	m.revoked_at = nil
+	m.clearedFields[apitoken.FieldRevokedAt] = struct{}{}
+}
+
+// RevokedAtCleared returns if the "revoked_at" field was cleared in this mutation.
+func (m *APITokenMutation) RevokedAtCleared() bool {
+	_, ok := m.clearedFields[apitoken.FieldRevokedAt]
+	return ok
+}
+
+// ResetRevokedAt resets all changes to the "revoked_at" field.
+func (m *APITokenMutation) ResetRevokedAt() {
+	m.revoked_at = nil
+	delete(m.clearedFields, apitoken.FieldRevokedAt)
+}
+
 // ClearOwner clears the "owner" edge to the Organization entity.
 func (m *APITokenMutation) ClearOwner() {
 	m.clearedowner = true
@@ -1061,7 +1261,7 @@ func (m *APITokenMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *APITokenMutation) Fields() []string {
-	fields := make([]string, 0, 14)
+	fields := make([]string, 0, 18)
 	if m.created_at != nil {
 		fields = append(fields, apitoken.FieldCreatedAt)
 	}
@@ -1104,6 +1304,18 @@ func (m *APITokenMutation) Fields() []string {
 	if m.last_used_at != nil {
 		fields = append(fields, apitoken.FieldLastUsedAt)
 	}
+	if m.is_active != nil {
+		fields = append(fields, apitoken.FieldIsActive)
+	}
+	if m.revoked_reason != nil {
+		fields = append(fields, apitoken.FieldRevokedReason)
+	}
+	if m.revoked_by != nil {
+		fields = append(fields, apitoken.FieldRevokedBy)
+	}
+	if m.revoked_at != nil {
+		fields = append(fields, apitoken.FieldRevokedAt)
+	}
 	return fields
 }
 
@@ -1140,6 +1352,14 @@ func (m *APITokenMutation) Field(name string) (ent.Value, bool) {
 		return m.Scopes()
 	case apitoken.FieldLastUsedAt:
 		return m.LastUsedAt()
+	case apitoken.FieldIsActive:
+		return m.IsActive()
+	case apitoken.FieldRevokedReason:
+		return m.RevokedReason()
+	case apitoken.FieldRevokedBy:
+		return m.RevokedBy()
+	case apitoken.FieldRevokedAt:
+		return m.RevokedAt()
 	}
 	return nil, false
 }
@@ -1177,6 +1397,14 @@ func (m *APITokenMutation) OldField(ctx context.Context, name string) (ent.Value
 		return m.OldScopes(ctx)
 	case apitoken.FieldLastUsedAt:
 		return m.OldLastUsedAt(ctx)
+	case apitoken.FieldIsActive:
+		return m.OldIsActive(ctx)
+	case apitoken.FieldRevokedReason:
+		return m.OldRevokedReason(ctx)
+	case apitoken.FieldRevokedBy:
+		return m.OldRevokedBy(ctx)
+	case apitoken.FieldRevokedAt:
+		return m.OldRevokedAt(ctx)
 	}
 	return nil, fmt.Errorf("unknown APIToken field %s", name)
 }
@@ -1284,6 +1512,34 @@ func (m *APITokenMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetLastUsedAt(v)
 		return nil
+	case apitoken.FieldIsActive:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetIsActive(v)
+		return nil
+	case apitoken.FieldRevokedReason:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetRevokedReason(v)
+		return nil
+	case apitoken.FieldRevokedBy:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetRevokedBy(v)
+		return nil
+	case apitoken.FieldRevokedAt:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetRevokedAt(v)
+		return nil
 	}
 	return fmt.Errorf("unknown APIToken field %s", name)
 }
@@ -1350,6 +1606,18 @@ func (m *APITokenMutation) ClearedFields() []string {
 	if m.FieldCleared(apitoken.FieldLastUsedAt) {
 		fields = append(fields, apitoken.FieldLastUsedAt)
 	}
+	if m.FieldCleared(apitoken.FieldIsActive) {
+		fields = append(fields, apitoken.FieldIsActive)
+	}
+	if m.FieldCleared(apitoken.FieldRevokedReason) {
+		fields = append(fields, apitoken.FieldRevokedReason)
+	}
+	if m.FieldCleared(apitoken.FieldRevokedBy) {
+		fields = append(fields, apitoken.FieldRevokedBy)
+	}
+	if m.FieldCleared(apitoken.FieldRevokedAt) {
+		fields = append(fields, apitoken.FieldRevokedAt)
+	}
 	return fields
 }
 
@@ -1400,6 +1668,18 @@ func (m *APITokenMutation) ClearField(name string) error {
 	case apitoken.FieldLastUsedAt:
 		m.ClearLastUsedAt()
 		return nil
+	case apitoken.FieldIsActive:
+		m.ClearIsActive()
+		return nil
+	case apitoken.FieldRevokedReason:
+		m.ClearRevokedReason()
+		return nil
+	case apitoken.FieldRevokedBy:
+		m.ClearRevokedBy()
+		return nil
+	case apitoken.FieldRevokedAt:
+		m.ClearRevokedAt()
+		return nil
 	}
 	return fmt.Errorf("unknown APIToken nullable field %s", name)
 }
@@ -1449,6 +1729,18 @@ func (m *APITokenMutation) ResetField(name string) error {
 		return nil
 	case apitoken.FieldLastUsedAt:
 		m.ResetLastUsedAt()
+		return nil
+	case apitoken.FieldIsActive:
+		m.ResetIsActive()
+		return nil
+	case apitoken.FieldRevokedReason:
+		m.ResetRevokedReason()
+		return nil
+	case apitoken.FieldRevokedBy:
+		m.ResetRevokedBy()
+		return nil
+	case apitoken.FieldRevokedAt:
+		m.ResetRevokedAt()
 		return nil
 	}
 	return fmt.Errorf("unknown APIToken field %s", name)
@@ -66964,6 +67256,9 @@ type OrgSubscriptionMutation struct {
 	active                     *bool
 	stripe_customer_id         *string
 	expires_at                 *time.Time
+	trial_expires_at           *time.Time
+	days_until_due             *string
+	payment_method_added       *bool
 	features                   *[]string
 	appendfeatures             []string
 	feature_lookup_keys        *[]string
@@ -66971,6 +67266,9 @@ type OrgSubscriptionMutation struct {
 	clearedFields              map[string]struct{}
 	owner                      *string
 	clearedowner               bool
+	events                     map[string]struct{}
+	removedevents              map[string]struct{}
+	clearedevents              bool
 	done                       bool
 	oldValue                   func(context.Context) (*OrgSubscription, error)
 	predicates                 []predicate.OrgSubscription
@@ -67867,6 +68165,153 @@ func (m *OrgSubscriptionMutation) ResetExpiresAt() {
 	delete(m.clearedFields, orgsubscription.FieldExpiresAt)
 }
 
+// SetTrialExpiresAt sets the "trial_expires_at" field.
+func (m *OrgSubscriptionMutation) SetTrialExpiresAt(t time.Time) {
+	m.trial_expires_at = &t
+}
+
+// TrialExpiresAt returns the value of the "trial_expires_at" field in the mutation.
+func (m *OrgSubscriptionMutation) TrialExpiresAt() (r time.Time, exists bool) {
+	v := m.trial_expires_at
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldTrialExpiresAt returns the old "trial_expires_at" field's value of the OrgSubscription entity.
+// If the OrgSubscription object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *OrgSubscriptionMutation) OldTrialExpiresAt(ctx context.Context) (v *time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldTrialExpiresAt is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldTrialExpiresAt requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldTrialExpiresAt: %w", err)
+	}
+	return oldValue.TrialExpiresAt, nil
+}
+
+// ClearTrialExpiresAt clears the value of the "trial_expires_at" field.
+func (m *OrgSubscriptionMutation) ClearTrialExpiresAt() {
+	m.trial_expires_at = nil
+	m.clearedFields[orgsubscription.FieldTrialExpiresAt] = struct{}{}
+}
+
+// TrialExpiresAtCleared returns if the "trial_expires_at" field was cleared in this mutation.
+func (m *OrgSubscriptionMutation) TrialExpiresAtCleared() bool {
+	_, ok := m.clearedFields[orgsubscription.FieldTrialExpiresAt]
+	return ok
+}
+
+// ResetTrialExpiresAt resets all changes to the "trial_expires_at" field.
+func (m *OrgSubscriptionMutation) ResetTrialExpiresAt() {
+	m.trial_expires_at = nil
+	delete(m.clearedFields, orgsubscription.FieldTrialExpiresAt)
+}
+
+// SetDaysUntilDue sets the "days_until_due" field.
+func (m *OrgSubscriptionMutation) SetDaysUntilDue(s string) {
+	m.days_until_due = &s
+}
+
+// DaysUntilDue returns the value of the "days_until_due" field in the mutation.
+func (m *OrgSubscriptionMutation) DaysUntilDue() (r string, exists bool) {
+	v := m.days_until_due
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDaysUntilDue returns the old "days_until_due" field's value of the OrgSubscription entity.
+// If the OrgSubscription object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *OrgSubscriptionMutation) OldDaysUntilDue(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDaysUntilDue is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDaysUntilDue requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDaysUntilDue: %w", err)
+	}
+	return oldValue.DaysUntilDue, nil
+}
+
+// ClearDaysUntilDue clears the value of the "days_until_due" field.
+func (m *OrgSubscriptionMutation) ClearDaysUntilDue() {
+	m.days_until_due = nil
+	m.clearedFields[orgsubscription.FieldDaysUntilDue] = struct{}{}
+}
+
+// DaysUntilDueCleared returns if the "days_until_due" field was cleared in this mutation.
+func (m *OrgSubscriptionMutation) DaysUntilDueCleared() bool {
+	_, ok := m.clearedFields[orgsubscription.FieldDaysUntilDue]
+	return ok
+}
+
+// ResetDaysUntilDue resets all changes to the "days_until_due" field.
+func (m *OrgSubscriptionMutation) ResetDaysUntilDue() {
+	m.days_until_due = nil
+	delete(m.clearedFields, orgsubscription.FieldDaysUntilDue)
+}
+
+// SetPaymentMethodAdded sets the "payment_method_added" field.
+func (m *OrgSubscriptionMutation) SetPaymentMethodAdded(b bool) {
+	m.payment_method_added = &b
+}
+
+// PaymentMethodAdded returns the value of the "payment_method_added" field in the mutation.
+func (m *OrgSubscriptionMutation) PaymentMethodAdded() (r bool, exists bool) {
+	v := m.payment_method_added
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldPaymentMethodAdded returns the old "payment_method_added" field's value of the OrgSubscription entity.
+// If the OrgSubscription object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *OrgSubscriptionMutation) OldPaymentMethodAdded(ctx context.Context) (v *bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldPaymentMethodAdded is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldPaymentMethodAdded requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldPaymentMethodAdded: %w", err)
+	}
+	return oldValue.PaymentMethodAdded, nil
+}
+
+// ClearPaymentMethodAdded clears the value of the "payment_method_added" field.
+func (m *OrgSubscriptionMutation) ClearPaymentMethodAdded() {
+	m.payment_method_added = nil
+	m.clearedFields[orgsubscription.FieldPaymentMethodAdded] = struct{}{}
+}
+
+// PaymentMethodAddedCleared returns if the "payment_method_added" field was cleared in this mutation.
+func (m *OrgSubscriptionMutation) PaymentMethodAddedCleared() bool {
+	_, ok := m.clearedFields[orgsubscription.FieldPaymentMethodAdded]
+	return ok
+}
+
+// ResetPaymentMethodAdded resets all changes to the "payment_method_added" field.
+func (m *OrgSubscriptionMutation) ResetPaymentMethodAdded() {
+	m.payment_method_added = nil
+	delete(m.clearedFields, orgsubscription.FieldPaymentMethodAdded)
+}
+
 // SetFeatures sets the "features" field.
 func (m *OrgSubscriptionMutation) SetFeatures(s []string) {
 	m.features = &s
@@ -68024,6 +68469,60 @@ func (m *OrgSubscriptionMutation) ResetOwner() {
 	m.clearedowner = false
 }
 
+// AddEventIDs adds the "events" edge to the Event entity by ids.
+func (m *OrgSubscriptionMutation) AddEventIDs(ids ...string) {
+	if m.events == nil {
+		m.events = make(map[string]struct{})
+	}
+	for i := range ids {
+		m.events[ids[i]] = struct{}{}
+	}
+}
+
+// ClearEvents clears the "events" edge to the Event entity.
+func (m *OrgSubscriptionMutation) ClearEvents() {
+	m.clearedevents = true
+}
+
+// EventsCleared reports if the "events" edge to the Event entity was cleared.
+func (m *OrgSubscriptionMutation) EventsCleared() bool {
+	return m.clearedevents
+}
+
+// RemoveEventIDs removes the "events" edge to the Event entity by IDs.
+func (m *OrgSubscriptionMutation) RemoveEventIDs(ids ...string) {
+	if m.removedevents == nil {
+		m.removedevents = make(map[string]struct{})
+	}
+	for i := range ids {
+		delete(m.events, ids[i])
+		m.removedevents[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedEvents returns the removed IDs of the "events" edge to the Event entity.
+func (m *OrgSubscriptionMutation) RemovedEventsIDs() (ids []string) {
+	for id := range m.removedevents {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// EventsIDs returns the "events" edge IDs in the mutation.
+func (m *OrgSubscriptionMutation) EventsIDs() (ids []string) {
+	for id := range m.events {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetEvents resets all changes to the "events" edge.
+func (m *OrgSubscriptionMutation) ResetEvents() {
+	m.events = nil
+	m.clearedevents = false
+	m.removedevents = nil
+}
+
 // Where appends a list predicates to the OrgSubscriptionMutation builder.
 func (m *OrgSubscriptionMutation) Where(ps ...predicate.OrgSubscription) {
 	m.predicates = append(m.predicates, ps...)
@@ -68058,7 +68557,7 @@ func (m *OrgSubscriptionMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *OrgSubscriptionMutation) Fields() []string {
-	fields := make([]string, 0, 18)
+	fields := make([]string, 0, 21)
 	if m.created_at != nil {
 		fields = append(fields, orgsubscription.FieldCreatedAt)
 	}
@@ -68107,6 +68606,15 @@ func (m *OrgSubscriptionMutation) Fields() []string {
 	if m.expires_at != nil {
 		fields = append(fields, orgsubscription.FieldExpiresAt)
 	}
+	if m.trial_expires_at != nil {
+		fields = append(fields, orgsubscription.FieldTrialExpiresAt)
+	}
+	if m.days_until_due != nil {
+		fields = append(fields, orgsubscription.FieldDaysUntilDue)
+	}
+	if m.payment_method_added != nil {
+		fields = append(fields, orgsubscription.FieldPaymentMethodAdded)
+	}
 	if m.features != nil {
 		fields = append(fields, orgsubscription.FieldFeatures)
 	}
@@ -68153,6 +68661,12 @@ func (m *OrgSubscriptionMutation) Field(name string) (ent.Value, bool) {
 		return m.StripeCustomerID()
 	case orgsubscription.FieldExpiresAt:
 		return m.ExpiresAt()
+	case orgsubscription.FieldTrialExpiresAt:
+		return m.TrialExpiresAt()
+	case orgsubscription.FieldDaysUntilDue:
+		return m.DaysUntilDue()
+	case orgsubscription.FieldPaymentMethodAdded:
+		return m.PaymentMethodAdded()
 	case orgsubscription.FieldFeatures:
 		return m.Features()
 	case orgsubscription.FieldFeatureLookupKeys:
@@ -68198,6 +68712,12 @@ func (m *OrgSubscriptionMutation) OldField(ctx context.Context, name string) (en
 		return m.OldStripeCustomerID(ctx)
 	case orgsubscription.FieldExpiresAt:
 		return m.OldExpiresAt(ctx)
+	case orgsubscription.FieldTrialExpiresAt:
+		return m.OldTrialExpiresAt(ctx)
+	case orgsubscription.FieldDaysUntilDue:
+		return m.OldDaysUntilDue(ctx)
+	case orgsubscription.FieldPaymentMethodAdded:
+		return m.OldPaymentMethodAdded(ctx)
 	case orgsubscription.FieldFeatures:
 		return m.OldFeatures(ctx)
 	case orgsubscription.FieldFeatureLookupKeys:
@@ -68323,6 +68843,27 @@ func (m *OrgSubscriptionMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetExpiresAt(v)
 		return nil
+	case orgsubscription.FieldTrialExpiresAt:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetTrialExpiresAt(v)
+		return nil
+	case orgsubscription.FieldDaysUntilDue:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDaysUntilDue(v)
+		return nil
+	case orgsubscription.FieldPaymentMethodAdded:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetPaymentMethodAdded(v)
+		return nil
 	case orgsubscription.FieldFeatures:
 		v, ok := value.([]string)
 		if !ok {
@@ -68412,6 +68953,15 @@ func (m *OrgSubscriptionMutation) ClearedFields() []string {
 	if m.FieldCleared(orgsubscription.FieldExpiresAt) {
 		fields = append(fields, orgsubscription.FieldExpiresAt)
 	}
+	if m.FieldCleared(orgsubscription.FieldTrialExpiresAt) {
+		fields = append(fields, orgsubscription.FieldTrialExpiresAt)
+	}
+	if m.FieldCleared(orgsubscription.FieldDaysUntilDue) {
+		fields = append(fields, orgsubscription.FieldDaysUntilDue)
+	}
+	if m.FieldCleared(orgsubscription.FieldPaymentMethodAdded) {
+		fields = append(fields, orgsubscription.FieldPaymentMethodAdded)
+	}
 	if m.FieldCleared(orgsubscription.FieldFeatures) {
 		fields = append(fields, orgsubscription.FieldFeatures)
 	}
@@ -68477,6 +69027,15 @@ func (m *OrgSubscriptionMutation) ClearField(name string) error {
 	case orgsubscription.FieldExpiresAt:
 		m.ClearExpiresAt()
 		return nil
+	case orgsubscription.FieldTrialExpiresAt:
+		m.ClearTrialExpiresAt()
+		return nil
+	case orgsubscription.FieldDaysUntilDue:
+		m.ClearDaysUntilDue()
+		return nil
+	case orgsubscription.FieldPaymentMethodAdded:
+		m.ClearPaymentMethodAdded()
+		return nil
 	case orgsubscription.FieldFeatures:
 		m.ClearFeatures()
 		return nil
@@ -68539,6 +69098,15 @@ func (m *OrgSubscriptionMutation) ResetField(name string) error {
 	case orgsubscription.FieldExpiresAt:
 		m.ResetExpiresAt()
 		return nil
+	case orgsubscription.FieldTrialExpiresAt:
+		m.ResetTrialExpiresAt()
+		return nil
+	case orgsubscription.FieldDaysUntilDue:
+		m.ResetDaysUntilDue()
+		return nil
+	case orgsubscription.FieldPaymentMethodAdded:
+		m.ResetPaymentMethodAdded()
+		return nil
 	case orgsubscription.FieldFeatures:
 		m.ResetFeatures()
 		return nil
@@ -68551,9 +69119,12 @@ func (m *OrgSubscriptionMutation) ResetField(name string) error {
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *OrgSubscriptionMutation) AddedEdges() []string {
-	edges := make([]string, 0, 1)
+	edges := make([]string, 0, 2)
 	if m.owner != nil {
 		edges = append(edges, orgsubscription.EdgeOwner)
+	}
+	if m.events != nil {
+		edges = append(edges, orgsubscription.EdgeEvents)
 	}
 	return edges
 }
@@ -68566,27 +69137,47 @@ func (m *OrgSubscriptionMutation) AddedIDs(name string) []ent.Value {
 		if id := m.owner; id != nil {
 			return []ent.Value{*id}
 		}
+	case orgsubscription.EdgeEvents:
+		ids := make([]ent.Value, 0, len(m.events))
+		for id := range m.events {
+			ids = append(ids, id)
+		}
+		return ids
 	}
 	return nil
 }
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *OrgSubscriptionMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 1)
+	edges := make([]string, 0, 2)
+	if m.removedevents != nil {
+		edges = append(edges, orgsubscription.EdgeEvents)
+	}
 	return edges
 }
 
 // RemovedIDs returns all IDs (to other nodes) that were removed for the edge with
 // the given name in this mutation.
 func (m *OrgSubscriptionMutation) RemovedIDs(name string) []ent.Value {
+	switch name {
+	case orgsubscription.EdgeEvents:
+		ids := make([]ent.Value, 0, len(m.removedevents))
+		for id := range m.removedevents {
+			ids = append(ids, id)
+		}
+		return ids
+	}
 	return nil
 }
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *OrgSubscriptionMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 1)
+	edges := make([]string, 0, 2)
 	if m.clearedowner {
 		edges = append(edges, orgsubscription.EdgeOwner)
+	}
+	if m.clearedevents {
+		edges = append(edges, orgsubscription.EdgeEvents)
 	}
 	return edges
 }
@@ -68597,6 +69188,8 @@ func (m *OrgSubscriptionMutation) EdgeCleared(name string) bool {
 	switch name {
 	case orgsubscription.EdgeOwner:
 		return m.clearedowner
+	case orgsubscription.EdgeEvents:
+		return m.clearedevents
 	}
 	return false
 }
@@ -68618,6 +69211,9 @@ func (m *OrgSubscriptionMutation) ResetEdge(name string) error {
 	switch name {
 	case orgsubscription.EdgeOwner:
 		m.ResetOwner()
+		return nil
+	case orgsubscription.EdgeEvents:
+		m.ResetEvents()
 		return nil
 	}
 	return fmt.Errorf("unknown OrgSubscription edge %s", name)
@@ -68649,6 +69245,9 @@ type OrgSubscriptionHistoryMutation struct {
 	active                     *bool
 	stripe_customer_id         *string
 	expires_at                 *time.Time
+	trial_expires_at           *time.Time
+	days_until_due             *string
+	payment_method_added       *bool
 	features                   *[]string
 	appendfeatures             []string
 	feature_lookup_keys        *[]string
@@ -69671,6 +70270,153 @@ func (m *OrgSubscriptionHistoryMutation) ResetExpiresAt() {
 	delete(m.clearedFields, orgsubscriptionhistory.FieldExpiresAt)
 }
 
+// SetTrialExpiresAt sets the "trial_expires_at" field.
+func (m *OrgSubscriptionHistoryMutation) SetTrialExpiresAt(t time.Time) {
+	m.trial_expires_at = &t
+}
+
+// TrialExpiresAt returns the value of the "trial_expires_at" field in the mutation.
+func (m *OrgSubscriptionHistoryMutation) TrialExpiresAt() (r time.Time, exists bool) {
+	v := m.trial_expires_at
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldTrialExpiresAt returns the old "trial_expires_at" field's value of the OrgSubscriptionHistory entity.
+// If the OrgSubscriptionHistory object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *OrgSubscriptionHistoryMutation) OldTrialExpiresAt(ctx context.Context) (v *time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldTrialExpiresAt is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldTrialExpiresAt requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldTrialExpiresAt: %w", err)
+	}
+	return oldValue.TrialExpiresAt, nil
+}
+
+// ClearTrialExpiresAt clears the value of the "trial_expires_at" field.
+func (m *OrgSubscriptionHistoryMutation) ClearTrialExpiresAt() {
+	m.trial_expires_at = nil
+	m.clearedFields[orgsubscriptionhistory.FieldTrialExpiresAt] = struct{}{}
+}
+
+// TrialExpiresAtCleared returns if the "trial_expires_at" field was cleared in this mutation.
+func (m *OrgSubscriptionHistoryMutation) TrialExpiresAtCleared() bool {
+	_, ok := m.clearedFields[orgsubscriptionhistory.FieldTrialExpiresAt]
+	return ok
+}
+
+// ResetTrialExpiresAt resets all changes to the "trial_expires_at" field.
+func (m *OrgSubscriptionHistoryMutation) ResetTrialExpiresAt() {
+	m.trial_expires_at = nil
+	delete(m.clearedFields, orgsubscriptionhistory.FieldTrialExpiresAt)
+}
+
+// SetDaysUntilDue sets the "days_until_due" field.
+func (m *OrgSubscriptionHistoryMutation) SetDaysUntilDue(s string) {
+	m.days_until_due = &s
+}
+
+// DaysUntilDue returns the value of the "days_until_due" field in the mutation.
+func (m *OrgSubscriptionHistoryMutation) DaysUntilDue() (r string, exists bool) {
+	v := m.days_until_due
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDaysUntilDue returns the old "days_until_due" field's value of the OrgSubscriptionHistory entity.
+// If the OrgSubscriptionHistory object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *OrgSubscriptionHistoryMutation) OldDaysUntilDue(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDaysUntilDue is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDaysUntilDue requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDaysUntilDue: %w", err)
+	}
+	return oldValue.DaysUntilDue, nil
+}
+
+// ClearDaysUntilDue clears the value of the "days_until_due" field.
+func (m *OrgSubscriptionHistoryMutation) ClearDaysUntilDue() {
+	m.days_until_due = nil
+	m.clearedFields[orgsubscriptionhistory.FieldDaysUntilDue] = struct{}{}
+}
+
+// DaysUntilDueCleared returns if the "days_until_due" field was cleared in this mutation.
+func (m *OrgSubscriptionHistoryMutation) DaysUntilDueCleared() bool {
+	_, ok := m.clearedFields[orgsubscriptionhistory.FieldDaysUntilDue]
+	return ok
+}
+
+// ResetDaysUntilDue resets all changes to the "days_until_due" field.
+func (m *OrgSubscriptionHistoryMutation) ResetDaysUntilDue() {
+	m.days_until_due = nil
+	delete(m.clearedFields, orgsubscriptionhistory.FieldDaysUntilDue)
+}
+
+// SetPaymentMethodAdded sets the "payment_method_added" field.
+func (m *OrgSubscriptionHistoryMutation) SetPaymentMethodAdded(b bool) {
+	m.payment_method_added = &b
+}
+
+// PaymentMethodAdded returns the value of the "payment_method_added" field in the mutation.
+func (m *OrgSubscriptionHistoryMutation) PaymentMethodAdded() (r bool, exists bool) {
+	v := m.payment_method_added
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldPaymentMethodAdded returns the old "payment_method_added" field's value of the OrgSubscriptionHistory entity.
+// If the OrgSubscriptionHistory object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *OrgSubscriptionHistoryMutation) OldPaymentMethodAdded(ctx context.Context) (v *bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldPaymentMethodAdded is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldPaymentMethodAdded requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldPaymentMethodAdded: %w", err)
+	}
+	return oldValue.PaymentMethodAdded, nil
+}
+
+// ClearPaymentMethodAdded clears the value of the "payment_method_added" field.
+func (m *OrgSubscriptionHistoryMutation) ClearPaymentMethodAdded() {
+	m.payment_method_added = nil
+	m.clearedFields[orgsubscriptionhistory.FieldPaymentMethodAdded] = struct{}{}
+}
+
+// PaymentMethodAddedCleared returns if the "payment_method_added" field was cleared in this mutation.
+func (m *OrgSubscriptionHistoryMutation) PaymentMethodAddedCleared() bool {
+	_, ok := m.clearedFields[orgsubscriptionhistory.FieldPaymentMethodAdded]
+	return ok
+}
+
+// ResetPaymentMethodAdded resets all changes to the "payment_method_added" field.
+func (m *OrgSubscriptionHistoryMutation) ResetPaymentMethodAdded() {
+	m.payment_method_added = nil
+	delete(m.clearedFields, orgsubscriptionhistory.FieldPaymentMethodAdded)
+}
+
 // SetFeatures sets the "features" field.
 func (m *OrgSubscriptionHistoryMutation) SetFeatures(s []string) {
 	m.features = &s
@@ -69835,7 +70581,7 @@ func (m *OrgSubscriptionHistoryMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *OrgSubscriptionHistoryMutation) Fields() []string {
-	fields := make([]string, 0, 21)
+	fields := make([]string, 0, 24)
 	if m.history_time != nil {
 		fields = append(fields, orgsubscriptionhistory.FieldHistoryTime)
 	}
@@ -69893,6 +70639,15 @@ func (m *OrgSubscriptionHistoryMutation) Fields() []string {
 	if m.expires_at != nil {
 		fields = append(fields, orgsubscriptionhistory.FieldExpiresAt)
 	}
+	if m.trial_expires_at != nil {
+		fields = append(fields, orgsubscriptionhistory.FieldTrialExpiresAt)
+	}
+	if m.days_until_due != nil {
+		fields = append(fields, orgsubscriptionhistory.FieldDaysUntilDue)
+	}
+	if m.payment_method_added != nil {
+		fields = append(fields, orgsubscriptionhistory.FieldPaymentMethodAdded)
+	}
 	if m.features != nil {
 		fields = append(fields, orgsubscriptionhistory.FieldFeatures)
 	}
@@ -69945,6 +70700,12 @@ func (m *OrgSubscriptionHistoryMutation) Field(name string) (ent.Value, bool) {
 		return m.StripeCustomerID()
 	case orgsubscriptionhistory.FieldExpiresAt:
 		return m.ExpiresAt()
+	case orgsubscriptionhistory.FieldTrialExpiresAt:
+		return m.TrialExpiresAt()
+	case orgsubscriptionhistory.FieldDaysUntilDue:
+		return m.DaysUntilDue()
+	case orgsubscriptionhistory.FieldPaymentMethodAdded:
+		return m.PaymentMethodAdded()
 	case orgsubscriptionhistory.FieldFeatures:
 		return m.Features()
 	case orgsubscriptionhistory.FieldFeatureLookupKeys:
@@ -69996,6 +70757,12 @@ func (m *OrgSubscriptionHistoryMutation) OldField(ctx context.Context, name stri
 		return m.OldStripeCustomerID(ctx)
 	case orgsubscriptionhistory.FieldExpiresAt:
 		return m.OldExpiresAt(ctx)
+	case orgsubscriptionhistory.FieldTrialExpiresAt:
+		return m.OldTrialExpiresAt(ctx)
+	case orgsubscriptionhistory.FieldDaysUntilDue:
+		return m.OldDaysUntilDue(ctx)
+	case orgsubscriptionhistory.FieldPaymentMethodAdded:
+		return m.OldPaymentMethodAdded(ctx)
 	case orgsubscriptionhistory.FieldFeatures:
 		return m.OldFeatures(ctx)
 	case orgsubscriptionhistory.FieldFeatureLookupKeys:
@@ -70142,6 +70909,27 @@ func (m *OrgSubscriptionHistoryMutation) SetField(name string, value ent.Value) 
 		}
 		m.SetExpiresAt(v)
 		return nil
+	case orgsubscriptionhistory.FieldTrialExpiresAt:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetTrialExpiresAt(v)
+		return nil
+	case orgsubscriptionhistory.FieldDaysUntilDue:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDaysUntilDue(v)
+		return nil
+	case orgsubscriptionhistory.FieldPaymentMethodAdded:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetPaymentMethodAdded(v)
+		return nil
 	case orgsubscriptionhistory.FieldFeatures:
 		v, ok := value.([]string)
 		if !ok {
@@ -70234,6 +71022,15 @@ func (m *OrgSubscriptionHistoryMutation) ClearedFields() []string {
 	if m.FieldCleared(orgsubscriptionhistory.FieldExpiresAt) {
 		fields = append(fields, orgsubscriptionhistory.FieldExpiresAt)
 	}
+	if m.FieldCleared(orgsubscriptionhistory.FieldTrialExpiresAt) {
+		fields = append(fields, orgsubscriptionhistory.FieldTrialExpiresAt)
+	}
+	if m.FieldCleared(orgsubscriptionhistory.FieldDaysUntilDue) {
+		fields = append(fields, orgsubscriptionhistory.FieldDaysUntilDue)
+	}
+	if m.FieldCleared(orgsubscriptionhistory.FieldPaymentMethodAdded) {
+		fields = append(fields, orgsubscriptionhistory.FieldPaymentMethodAdded)
+	}
 	if m.FieldCleared(orgsubscriptionhistory.FieldFeatures) {
 		fields = append(fields, orgsubscriptionhistory.FieldFeatures)
 	}
@@ -70301,6 +71098,15 @@ func (m *OrgSubscriptionHistoryMutation) ClearField(name string) error {
 		return nil
 	case orgsubscriptionhistory.FieldExpiresAt:
 		m.ClearExpiresAt()
+		return nil
+	case orgsubscriptionhistory.FieldTrialExpiresAt:
+		m.ClearTrialExpiresAt()
+		return nil
+	case orgsubscriptionhistory.FieldDaysUntilDue:
+		m.ClearDaysUntilDue()
+		return nil
+	case orgsubscriptionhistory.FieldPaymentMethodAdded:
+		m.ClearPaymentMethodAdded()
 		return nil
 	case orgsubscriptionhistory.FieldFeatures:
 		m.ClearFeatures()
@@ -70372,6 +71178,15 @@ func (m *OrgSubscriptionHistoryMutation) ResetField(name string) error {
 		return nil
 	case orgsubscriptionhistory.FieldExpiresAt:
 		m.ResetExpiresAt()
+		return nil
+	case orgsubscriptionhistory.FieldTrialExpiresAt:
+		m.ResetTrialExpiresAt()
+		return nil
+	case orgsubscriptionhistory.FieldDaysUntilDue:
+		m.ResetDaysUntilDue()
+		return nil
+	case orgsubscriptionhistory.FieldPaymentMethodAdded:
+		m.ResetPaymentMethodAdded()
 		return nil
 	case orgsubscriptionhistory.FieldFeatures:
 		m.ResetFeatures()
@@ -81263,6 +82078,10 @@ type PersonalAccessTokenMutation struct {
 	scopes               *[]string
 	appendscopes         []string
 	last_used_at         *time.Time
+	is_active            *bool
+	revoked_reason       *string
+	revoked_by           *string
+	revoked_at           *time.Time
 	clearedFields        map[string]struct{}
 	owner                *string
 	clearedowner         bool
@@ -82060,6 +82879,202 @@ func (m *PersonalAccessTokenMutation) ResetLastUsedAt() {
 	delete(m.clearedFields, personalaccesstoken.FieldLastUsedAt)
 }
 
+// SetIsActive sets the "is_active" field.
+func (m *PersonalAccessTokenMutation) SetIsActive(b bool) {
+	m.is_active = &b
+}
+
+// IsActive returns the value of the "is_active" field in the mutation.
+func (m *PersonalAccessTokenMutation) IsActive() (r bool, exists bool) {
+	v := m.is_active
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldIsActive returns the old "is_active" field's value of the PersonalAccessToken entity.
+// If the PersonalAccessToken object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *PersonalAccessTokenMutation) OldIsActive(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldIsActive is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldIsActive requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldIsActive: %w", err)
+	}
+	return oldValue.IsActive, nil
+}
+
+// ClearIsActive clears the value of the "is_active" field.
+func (m *PersonalAccessTokenMutation) ClearIsActive() {
+	m.is_active = nil
+	m.clearedFields[personalaccesstoken.FieldIsActive] = struct{}{}
+}
+
+// IsActiveCleared returns if the "is_active" field was cleared in this mutation.
+func (m *PersonalAccessTokenMutation) IsActiveCleared() bool {
+	_, ok := m.clearedFields[personalaccesstoken.FieldIsActive]
+	return ok
+}
+
+// ResetIsActive resets all changes to the "is_active" field.
+func (m *PersonalAccessTokenMutation) ResetIsActive() {
+	m.is_active = nil
+	delete(m.clearedFields, personalaccesstoken.FieldIsActive)
+}
+
+// SetRevokedReason sets the "revoked_reason" field.
+func (m *PersonalAccessTokenMutation) SetRevokedReason(s string) {
+	m.revoked_reason = &s
+}
+
+// RevokedReason returns the value of the "revoked_reason" field in the mutation.
+func (m *PersonalAccessTokenMutation) RevokedReason() (r string, exists bool) {
+	v := m.revoked_reason
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldRevokedReason returns the old "revoked_reason" field's value of the PersonalAccessToken entity.
+// If the PersonalAccessToken object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *PersonalAccessTokenMutation) OldRevokedReason(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldRevokedReason is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldRevokedReason requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldRevokedReason: %w", err)
+	}
+	return oldValue.RevokedReason, nil
+}
+
+// ClearRevokedReason clears the value of the "revoked_reason" field.
+func (m *PersonalAccessTokenMutation) ClearRevokedReason() {
+	m.revoked_reason = nil
+	m.clearedFields[personalaccesstoken.FieldRevokedReason] = struct{}{}
+}
+
+// RevokedReasonCleared returns if the "revoked_reason" field was cleared in this mutation.
+func (m *PersonalAccessTokenMutation) RevokedReasonCleared() bool {
+	_, ok := m.clearedFields[personalaccesstoken.FieldRevokedReason]
+	return ok
+}
+
+// ResetRevokedReason resets all changes to the "revoked_reason" field.
+func (m *PersonalAccessTokenMutation) ResetRevokedReason() {
+	m.revoked_reason = nil
+	delete(m.clearedFields, personalaccesstoken.FieldRevokedReason)
+}
+
+// SetRevokedBy sets the "revoked_by" field.
+func (m *PersonalAccessTokenMutation) SetRevokedBy(s string) {
+	m.revoked_by = &s
+}
+
+// RevokedBy returns the value of the "revoked_by" field in the mutation.
+func (m *PersonalAccessTokenMutation) RevokedBy() (r string, exists bool) {
+	v := m.revoked_by
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldRevokedBy returns the old "revoked_by" field's value of the PersonalAccessToken entity.
+// If the PersonalAccessToken object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *PersonalAccessTokenMutation) OldRevokedBy(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldRevokedBy is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldRevokedBy requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldRevokedBy: %w", err)
+	}
+	return oldValue.RevokedBy, nil
+}
+
+// ClearRevokedBy clears the value of the "revoked_by" field.
+func (m *PersonalAccessTokenMutation) ClearRevokedBy() {
+	m.revoked_by = nil
+	m.clearedFields[personalaccesstoken.FieldRevokedBy] = struct{}{}
+}
+
+// RevokedByCleared returns if the "revoked_by" field was cleared in this mutation.
+func (m *PersonalAccessTokenMutation) RevokedByCleared() bool {
+	_, ok := m.clearedFields[personalaccesstoken.FieldRevokedBy]
+	return ok
+}
+
+// ResetRevokedBy resets all changes to the "revoked_by" field.
+func (m *PersonalAccessTokenMutation) ResetRevokedBy() {
+	m.revoked_by = nil
+	delete(m.clearedFields, personalaccesstoken.FieldRevokedBy)
+}
+
+// SetRevokedAt sets the "revoked_at" field.
+func (m *PersonalAccessTokenMutation) SetRevokedAt(t time.Time) {
+	m.revoked_at = &t
+}
+
+// RevokedAt returns the value of the "revoked_at" field in the mutation.
+func (m *PersonalAccessTokenMutation) RevokedAt() (r time.Time, exists bool) {
+	v := m.revoked_at
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldRevokedAt returns the old "revoked_at" field's value of the PersonalAccessToken entity.
+// If the PersonalAccessToken object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *PersonalAccessTokenMutation) OldRevokedAt(ctx context.Context) (v *time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldRevokedAt is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldRevokedAt requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldRevokedAt: %w", err)
+	}
+	return oldValue.RevokedAt, nil
+}
+
+// ClearRevokedAt clears the value of the "revoked_at" field.
+func (m *PersonalAccessTokenMutation) ClearRevokedAt() {
+	m.revoked_at = nil
+	m.clearedFields[personalaccesstoken.FieldRevokedAt] = struct{}{}
+}
+
+// RevokedAtCleared returns if the "revoked_at" field was cleared in this mutation.
+func (m *PersonalAccessTokenMutation) RevokedAtCleared() bool {
+	_, ok := m.clearedFields[personalaccesstoken.FieldRevokedAt]
+	return ok
+}
+
+// ResetRevokedAt resets all changes to the "revoked_at" field.
+func (m *PersonalAccessTokenMutation) ResetRevokedAt() {
+	m.revoked_at = nil
+	delete(m.clearedFields, personalaccesstoken.FieldRevokedAt)
+}
+
 // ClearOwner clears the "owner" edge to the User entity.
 func (m *PersonalAccessTokenMutation) ClearOwner() {
 	m.clearedowner = true
@@ -82229,7 +83244,7 @@ func (m *PersonalAccessTokenMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *PersonalAccessTokenMutation) Fields() []string {
-	fields := make([]string, 0, 14)
+	fields := make([]string, 0, 18)
 	if m.created_at != nil {
 		fields = append(fields, personalaccesstoken.FieldCreatedAt)
 	}
@@ -82272,6 +83287,18 @@ func (m *PersonalAccessTokenMutation) Fields() []string {
 	if m.last_used_at != nil {
 		fields = append(fields, personalaccesstoken.FieldLastUsedAt)
 	}
+	if m.is_active != nil {
+		fields = append(fields, personalaccesstoken.FieldIsActive)
+	}
+	if m.revoked_reason != nil {
+		fields = append(fields, personalaccesstoken.FieldRevokedReason)
+	}
+	if m.revoked_by != nil {
+		fields = append(fields, personalaccesstoken.FieldRevokedBy)
+	}
+	if m.revoked_at != nil {
+		fields = append(fields, personalaccesstoken.FieldRevokedAt)
+	}
 	return fields
 }
 
@@ -82308,6 +83335,14 @@ func (m *PersonalAccessTokenMutation) Field(name string) (ent.Value, bool) {
 		return m.Scopes()
 	case personalaccesstoken.FieldLastUsedAt:
 		return m.LastUsedAt()
+	case personalaccesstoken.FieldIsActive:
+		return m.IsActive()
+	case personalaccesstoken.FieldRevokedReason:
+		return m.RevokedReason()
+	case personalaccesstoken.FieldRevokedBy:
+		return m.RevokedBy()
+	case personalaccesstoken.FieldRevokedAt:
+		return m.RevokedAt()
 	}
 	return nil, false
 }
@@ -82345,6 +83380,14 @@ func (m *PersonalAccessTokenMutation) OldField(ctx context.Context, name string)
 		return m.OldScopes(ctx)
 	case personalaccesstoken.FieldLastUsedAt:
 		return m.OldLastUsedAt(ctx)
+	case personalaccesstoken.FieldIsActive:
+		return m.OldIsActive(ctx)
+	case personalaccesstoken.FieldRevokedReason:
+		return m.OldRevokedReason(ctx)
+	case personalaccesstoken.FieldRevokedBy:
+		return m.OldRevokedBy(ctx)
+	case personalaccesstoken.FieldRevokedAt:
+		return m.OldRevokedAt(ctx)
 	}
 	return nil, fmt.Errorf("unknown PersonalAccessToken field %s", name)
 }
@@ -82452,6 +83495,34 @@ func (m *PersonalAccessTokenMutation) SetField(name string, value ent.Value) err
 		}
 		m.SetLastUsedAt(v)
 		return nil
+	case personalaccesstoken.FieldIsActive:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetIsActive(v)
+		return nil
+	case personalaccesstoken.FieldRevokedReason:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetRevokedReason(v)
+		return nil
+	case personalaccesstoken.FieldRevokedBy:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetRevokedBy(v)
+		return nil
+	case personalaccesstoken.FieldRevokedAt:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetRevokedAt(v)
+		return nil
 	}
 	return fmt.Errorf("unknown PersonalAccessToken field %s", name)
 }
@@ -82515,6 +83586,18 @@ func (m *PersonalAccessTokenMutation) ClearedFields() []string {
 	if m.FieldCleared(personalaccesstoken.FieldLastUsedAt) {
 		fields = append(fields, personalaccesstoken.FieldLastUsedAt)
 	}
+	if m.FieldCleared(personalaccesstoken.FieldIsActive) {
+		fields = append(fields, personalaccesstoken.FieldIsActive)
+	}
+	if m.FieldCleared(personalaccesstoken.FieldRevokedReason) {
+		fields = append(fields, personalaccesstoken.FieldRevokedReason)
+	}
+	if m.FieldCleared(personalaccesstoken.FieldRevokedBy) {
+		fields = append(fields, personalaccesstoken.FieldRevokedBy)
+	}
+	if m.FieldCleared(personalaccesstoken.FieldRevokedAt) {
+		fields = append(fields, personalaccesstoken.FieldRevokedAt)
+	}
 	return fields
 }
 
@@ -82561,6 +83644,18 @@ func (m *PersonalAccessTokenMutation) ClearField(name string) error {
 		return nil
 	case personalaccesstoken.FieldLastUsedAt:
 		m.ClearLastUsedAt()
+		return nil
+	case personalaccesstoken.FieldIsActive:
+		m.ClearIsActive()
+		return nil
+	case personalaccesstoken.FieldRevokedReason:
+		m.ClearRevokedReason()
+		return nil
+	case personalaccesstoken.FieldRevokedBy:
+		m.ClearRevokedBy()
+		return nil
+	case personalaccesstoken.FieldRevokedAt:
+		m.ClearRevokedAt()
 		return nil
 	}
 	return fmt.Errorf("unknown PersonalAccessToken nullable field %s", name)
@@ -82611,6 +83706,18 @@ func (m *PersonalAccessTokenMutation) ResetField(name string) error {
 		return nil
 	case personalaccesstoken.FieldLastUsedAt:
 		m.ResetLastUsedAt()
+		return nil
+	case personalaccesstoken.FieldIsActive:
+		m.ResetIsActive()
+		return nil
+	case personalaccesstoken.FieldRevokedReason:
+		m.ResetRevokedReason()
+		return nil
+	case personalaccesstoken.FieldRevokedBy:
+		m.ResetRevokedBy()
+		return nil
+	case personalaccesstoken.FieldRevokedAt:
+		m.ResetRevokedAt()
 		return nil
 	}
 	return fmt.Errorf("unknown PersonalAccessToken field %s", name)

--- a/internal/ent/generated/orgsubscription/where.go
+++ b/internal/ent/generated/orgsubscription/where.go
@@ -137,6 +137,21 @@ func ExpiresAt(v time.Time) predicate.OrgSubscription {
 	return predicate.OrgSubscription(sql.FieldEQ(FieldExpiresAt, v))
 }
 
+// TrialExpiresAt applies equality check predicate on the "trial_expires_at" field. It's identical to TrialExpiresAtEQ.
+func TrialExpiresAt(v time.Time) predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldEQ(FieldTrialExpiresAt, v))
+}
+
+// DaysUntilDue applies equality check predicate on the "days_until_due" field. It's identical to DaysUntilDueEQ.
+func DaysUntilDue(v string) predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldEQ(FieldDaysUntilDue, v))
+}
+
+// PaymentMethodAdded applies equality check predicate on the "payment_method_added" field. It's identical to PaymentMethodAddedEQ.
+func PaymentMethodAdded(v bool) predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldEQ(FieldPaymentMethodAdded, v))
+}
+
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
 func CreatedAtEQ(v time.Time) predicate.OrgSubscription {
 	return predicate.OrgSubscription(sql.FieldEQ(FieldCreatedAt, v))
@@ -1042,6 +1057,151 @@ func ExpiresAtNotNil() predicate.OrgSubscription {
 	return predicate.OrgSubscription(sql.FieldNotNull(FieldExpiresAt))
 }
 
+// TrialExpiresAtEQ applies the EQ predicate on the "trial_expires_at" field.
+func TrialExpiresAtEQ(v time.Time) predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldEQ(FieldTrialExpiresAt, v))
+}
+
+// TrialExpiresAtNEQ applies the NEQ predicate on the "trial_expires_at" field.
+func TrialExpiresAtNEQ(v time.Time) predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldNEQ(FieldTrialExpiresAt, v))
+}
+
+// TrialExpiresAtIn applies the In predicate on the "trial_expires_at" field.
+func TrialExpiresAtIn(vs ...time.Time) predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldIn(FieldTrialExpiresAt, vs...))
+}
+
+// TrialExpiresAtNotIn applies the NotIn predicate on the "trial_expires_at" field.
+func TrialExpiresAtNotIn(vs ...time.Time) predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldNotIn(FieldTrialExpiresAt, vs...))
+}
+
+// TrialExpiresAtGT applies the GT predicate on the "trial_expires_at" field.
+func TrialExpiresAtGT(v time.Time) predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldGT(FieldTrialExpiresAt, v))
+}
+
+// TrialExpiresAtGTE applies the GTE predicate on the "trial_expires_at" field.
+func TrialExpiresAtGTE(v time.Time) predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldGTE(FieldTrialExpiresAt, v))
+}
+
+// TrialExpiresAtLT applies the LT predicate on the "trial_expires_at" field.
+func TrialExpiresAtLT(v time.Time) predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldLT(FieldTrialExpiresAt, v))
+}
+
+// TrialExpiresAtLTE applies the LTE predicate on the "trial_expires_at" field.
+func TrialExpiresAtLTE(v time.Time) predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldLTE(FieldTrialExpiresAt, v))
+}
+
+// TrialExpiresAtIsNil applies the IsNil predicate on the "trial_expires_at" field.
+func TrialExpiresAtIsNil() predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldIsNull(FieldTrialExpiresAt))
+}
+
+// TrialExpiresAtNotNil applies the NotNil predicate on the "trial_expires_at" field.
+func TrialExpiresAtNotNil() predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldNotNull(FieldTrialExpiresAt))
+}
+
+// DaysUntilDueEQ applies the EQ predicate on the "days_until_due" field.
+func DaysUntilDueEQ(v string) predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldEQ(FieldDaysUntilDue, v))
+}
+
+// DaysUntilDueNEQ applies the NEQ predicate on the "days_until_due" field.
+func DaysUntilDueNEQ(v string) predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldNEQ(FieldDaysUntilDue, v))
+}
+
+// DaysUntilDueIn applies the In predicate on the "days_until_due" field.
+func DaysUntilDueIn(vs ...string) predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldIn(FieldDaysUntilDue, vs...))
+}
+
+// DaysUntilDueNotIn applies the NotIn predicate on the "days_until_due" field.
+func DaysUntilDueNotIn(vs ...string) predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldNotIn(FieldDaysUntilDue, vs...))
+}
+
+// DaysUntilDueGT applies the GT predicate on the "days_until_due" field.
+func DaysUntilDueGT(v string) predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldGT(FieldDaysUntilDue, v))
+}
+
+// DaysUntilDueGTE applies the GTE predicate on the "days_until_due" field.
+func DaysUntilDueGTE(v string) predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldGTE(FieldDaysUntilDue, v))
+}
+
+// DaysUntilDueLT applies the LT predicate on the "days_until_due" field.
+func DaysUntilDueLT(v string) predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldLT(FieldDaysUntilDue, v))
+}
+
+// DaysUntilDueLTE applies the LTE predicate on the "days_until_due" field.
+func DaysUntilDueLTE(v string) predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldLTE(FieldDaysUntilDue, v))
+}
+
+// DaysUntilDueContains applies the Contains predicate on the "days_until_due" field.
+func DaysUntilDueContains(v string) predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldContains(FieldDaysUntilDue, v))
+}
+
+// DaysUntilDueHasPrefix applies the HasPrefix predicate on the "days_until_due" field.
+func DaysUntilDueHasPrefix(v string) predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldHasPrefix(FieldDaysUntilDue, v))
+}
+
+// DaysUntilDueHasSuffix applies the HasSuffix predicate on the "days_until_due" field.
+func DaysUntilDueHasSuffix(v string) predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldHasSuffix(FieldDaysUntilDue, v))
+}
+
+// DaysUntilDueIsNil applies the IsNil predicate on the "days_until_due" field.
+func DaysUntilDueIsNil() predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldIsNull(FieldDaysUntilDue))
+}
+
+// DaysUntilDueNotNil applies the NotNil predicate on the "days_until_due" field.
+func DaysUntilDueNotNil() predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldNotNull(FieldDaysUntilDue))
+}
+
+// DaysUntilDueEqualFold applies the EqualFold predicate on the "days_until_due" field.
+func DaysUntilDueEqualFold(v string) predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldEqualFold(FieldDaysUntilDue, v))
+}
+
+// DaysUntilDueContainsFold applies the ContainsFold predicate on the "days_until_due" field.
+func DaysUntilDueContainsFold(v string) predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldContainsFold(FieldDaysUntilDue, v))
+}
+
+// PaymentMethodAddedEQ applies the EQ predicate on the "payment_method_added" field.
+func PaymentMethodAddedEQ(v bool) predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldEQ(FieldPaymentMethodAdded, v))
+}
+
+// PaymentMethodAddedNEQ applies the NEQ predicate on the "payment_method_added" field.
+func PaymentMethodAddedNEQ(v bool) predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldNEQ(FieldPaymentMethodAdded, v))
+}
+
+// PaymentMethodAddedIsNil applies the IsNil predicate on the "payment_method_added" field.
+func PaymentMethodAddedIsNil() predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldIsNull(FieldPaymentMethodAdded))
+}
+
+// PaymentMethodAddedNotNil applies the NotNil predicate on the "payment_method_added" field.
+func PaymentMethodAddedNotNil() predicate.OrgSubscription {
+	return predicate.OrgSubscription(sql.FieldNotNull(FieldPaymentMethodAdded))
+}
+
 // FeaturesIsNil applies the IsNil predicate on the "features" field.
 func FeaturesIsNil() predicate.OrgSubscription {
 	return predicate.OrgSubscription(sql.FieldIsNull(FieldFeatures))
@@ -1083,6 +1243,35 @@ func HasOwnerWith(preds ...predicate.Organization) predicate.OrgSubscription {
 		schemaConfig := internal.SchemaConfigFromContext(s.Context())
 		step.To.Schema = schemaConfig.Organization
 		step.Edge.Schema = schemaConfig.OrgSubscription
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasEvents applies the HasEdge predicate on the "events" edge.
+func HasEvents() predicate.OrgSubscription {
+	return predicate.OrgSubscription(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, EventsTable, EventsColumn),
+		)
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Event
+		step.Edge.Schema = schemaConfig.Event
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasEventsWith applies the HasEdge predicate on the "events" edge with a given conditions (other predicates).
+func HasEventsWith(preds ...predicate.Event) predicate.OrgSubscription {
+	return predicate.OrgSubscription(func(s *sql.Selector) {
+		step := newEventsStep()
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Event
+		step.Edge.Schema = schemaConfig.Event
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/internal/ent/generated/orgsubscription_create.go
+++ b/internal/ent/generated/orgsubscription_create.go
@@ -10,6 +10,7 @@ import (
 
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/theopenlane/core/internal/ent/generated/event"
 	"github.com/theopenlane/core/internal/ent/generated/organization"
 	"github.com/theopenlane/core/internal/ent/generated/orgsubscription"
 	"github.com/theopenlane/core/pkg/models"
@@ -238,6 +239,48 @@ func (osc *OrgSubscriptionCreate) SetNillableExpiresAt(t *time.Time) *OrgSubscri
 	return osc
 }
 
+// SetTrialExpiresAt sets the "trial_expires_at" field.
+func (osc *OrgSubscriptionCreate) SetTrialExpiresAt(t time.Time) *OrgSubscriptionCreate {
+	osc.mutation.SetTrialExpiresAt(t)
+	return osc
+}
+
+// SetNillableTrialExpiresAt sets the "trial_expires_at" field if the given value is not nil.
+func (osc *OrgSubscriptionCreate) SetNillableTrialExpiresAt(t *time.Time) *OrgSubscriptionCreate {
+	if t != nil {
+		osc.SetTrialExpiresAt(*t)
+	}
+	return osc
+}
+
+// SetDaysUntilDue sets the "days_until_due" field.
+func (osc *OrgSubscriptionCreate) SetDaysUntilDue(s string) *OrgSubscriptionCreate {
+	osc.mutation.SetDaysUntilDue(s)
+	return osc
+}
+
+// SetNillableDaysUntilDue sets the "days_until_due" field if the given value is not nil.
+func (osc *OrgSubscriptionCreate) SetNillableDaysUntilDue(s *string) *OrgSubscriptionCreate {
+	if s != nil {
+		osc.SetDaysUntilDue(*s)
+	}
+	return osc
+}
+
+// SetPaymentMethodAdded sets the "payment_method_added" field.
+func (osc *OrgSubscriptionCreate) SetPaymentMethodAdded(b bool) *OrgSubscriptionCreate {
+	osc.mutation.SetPaymentMethodAdded(b)
+	return osc
+}
+
+// SetNillablePaymentMethodAdded sets the "payment_method_added" field if the given value is not nil.
+func (osc *OrgSubscriptionCreate) SetNillablePaymentMethodAdded(b *bool) *OrgSubscriptionCreate {
+	if b != nil {
+		osc.SetPaymentMethodAdded(*b)
+	}
+	return osc
+}
+
 // SetFeatures sets the "features" field.
 func (osc *OrgSubscriptionCreate) SetFeatures(s []string) *OrgSubscriptionCreate {
 	osc.mutation.SetFeatures(s)
@@ -267,6 +310,21 @@ func (osc *OrgSubscriptionCreate) SetNillableID(s *string) *OrgSubscriptionCreat
 // SetOwner sets the "owner" edge to the Organization entity.
 func (osc *OrgSubscriptionCreate) SetOwner(o *Organization) *OrgSubscriptionCreate {
 	return osc.SetOwnerID(o.ID)
+}
+
+// AddEventIDs adds the "events" edge to the Event entity by IDs.
+func (osc *OrgSubscriptionCreate) AddEventIDs(ids ...string) *OrgSubscriptionCreate {
+	osc.mutation.AddEventIDs(ids...)
+	return osc
+}
+
+// AddEvents adds the "events" edges to the Event entity.
+func (osc *OrgSubscriptionCreate) AddEvents(e ...*Event) *OrgSubscriptionCreate {
+	ids := make([]string, len(e))
+	for i := range e {
+		ids[i] = e[i].ID
+	}
+	return osc.AddEventIDs(ids...)
 }
 
 // Mutation returns the OrgSubscriptionMutation object of the builder.
@@ -444,6 +502,18 @@ func (osc *OrgSubscriptionCreate) createSpec() (*OrgSubscription, *sqlgraph.Crea
 		_spec.SetField(orgsubscription.FieldExpiresAt, field.TypeTime, value)
 		_node.ExpiresAt = &value
 	}
+	if value, ok := osc.mutation.TrialExpiresAt(); ok {
+		_spec.SetField(orgsubscription.FieldTrialExpiresAt, field.TypeTime, value)
+		_node.TrialExpiresAt = &value
+	}
+	if value, ok := osc.mutation.DaysUntilDue(); ok {
+		_spec.SetField(orgsubscription.FieldDaysUntilDue, field.TypeString, value)
+		_node.DaysUntilDue = &value
+	}
+	if value, ok := osc.mutation.PaymentMethodAdded(); ok {
+		_spec.SetField(orgsubscription.FieldPaymentMethodAdded, field.TypeBool, value)
+		_node.PaymentMethodAdded = &value
+	}
 	if value, ok := osc.mutation.Features(); ok {
 		_spec.SetField(orgsubscription.FieldFeatures, field.TypeJSON, value)
 		_node.Features = value
@@ -468,6 +538,23 @@ func (osc *OrgSubscriptionCreate) createSpec() (*OrgSubscription, *sqlgraph.Crea
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
 		_node.OwnerID = nodes[0]
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := osc.mutation.EventsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   orgsubscription.EventsTable,
+			Columns: []string{orgsubscription.EventsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(event.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = osc.schemaConfig.Event
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	return _node, _spec

--- a/internal/ent/generated/orgsubscription_update.go
+++ b/internal/ent/generated/orgsubscription_update.go
@@ -12,6 +12,7 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/dialect/sql/sqljson"
 	"entgo.io/ent/schema/field"
+	"github.com/theopenlane/core/internal/ent/generated/event"
 	"github.com/theopenlane/core/internal/ent/generated/organization"
 	"github.com/theopenlane/core/internal/ent/generated/orgsubscription"
 	"github.com/theopenlane/core/internal/ent/generated/predicate"
@@ -298,6 +299,66 @@ func (osu *OrgSubscriptionUpdate) ClearExpiresAt() *OrgSubscriptionUpdate {
 	return osu
 }
 
+// SetTrialExpiresAt sets the "trial_expires_at" field.
+func (osu *OrgSubscriptionUpdate) SetTrialExpiresAt(t time.Time) *OrgSubscriptionUpdate {
+	osu.mutation.SetTrialExpiresAt(t)
+	return osu
+}
+
+// SetNillableTrialExpiresAt sets the "trial_expires_at" field if the given value is not nil.
+func (osu *OrgSubscriptionUpdate) SetNillableTrialExpiresAt(t *time.Time) *OrgSubscriptionUpdate {
+	if t != nil {
+		osu.SetTrialExpiresAt(*t)
+	}
+	return osu
+}
+
+// ClearTrialExpiresAt clears the value of the "trial_expires_at" field.
+func (osu *OrgSubscriptionUpdate) ClearTrialExpiresAt() *OrgSubscriptionUpdate {
+	osu.mutation.ClearTrialExpiresAt()
+	return osu
+}
+
+// SetDaysUntilDue sets the "days_until_due" field.
+func (osu *OrgSubscriptionUpdate) SetDaysUntilDue(s string) *OrgSubscriptionUpdate {
+	osu.mutation.SetDaysUntilDue(s)
+	return osu
+}
+
+// SetNillableDaysUntilDue sets the "days_until_due" field if the given value is not nil.
+func (osu *OrgSubscriptionUpdate) SetNillableDaysUntilDue(s *string) *OrgSubscriptionUpdate {
+	if s != nil {
+		osu.SetDaysUntilDue(*s)
+	}
+	return osu
+}
+
+// ClearDaysUntilDue clears the value of the "days_until_due" field.
+func (osu *OrgSubscriptionUpdate) ClearDaysUntilDue() *OrgSubscriptionUpdate {
+	osu.mutation.ClearDaysUntilDue()
+	return osu
+}
+
+// SetPaymentMethodAdded sets the "payment_method_added" field.
+func (osu *OrgSubscriptionUpdate) SetPaymentMethodAdded(b bool) *OrgSubscriptionUpdate {
+	osu.mutation.SetPaymentMethodAdded(b)
+	return osu
+}
+
+// SetNillablePaymentMethodAdded sets the "payment_method_added" field if the given value is not nil.
+func (osu *OrgSubscriptionUpdate) SetNillablePaymentMethodAdded(b *bool) *OrgSubscriptionUpdate {
+	if b != nil {
+		osu.SetPaymentMethodAdded(*b)
+	}
+	return osu
+}
+
+// ClearPaymentMethodAdded clears the value of the "payment_method_added" field.
+func (osu *OrgSubscriptionUpdate) ClearPaymentMethodAdded() *OrgSubscriptionUpdate {
+	osu.mutation.ClearPaymentMethodAdded()
+	return osu
+}
+
 // SetFeatures sets the "features" field.
 func (osu *OrgSubscriptionUpdate) SetFeatures(s []string) *OrgSubscriptionUpdate {
 	osu.mutation.SetFeatures(s)
@@ -339,6 +400,21 @@ func (osu *OrgSubscriptionUpdate) SetOwner(o *Organization) *OrgSubscriptionUpda
 	return osu.SetOwnerID(o.ID)
 }
 
+// AddEventIDs adds the "events" edge to the Event entity by IDs.
+func (osu *OrgSubscriptionUpdate) AddEventIDs(ids ...string) *OrgSubscriptionUpdate {
+	osu.mutation.AddEventIDs(ids...)
+	return osu
+}
+
+// AddEvents adds the "events" edges to the Event entity.
+func (osu *OrgSubscriptionUpdate) AddEvents(e ...*Event) *OrgSubscriptionUpdate {
+	ids := make([]string, len(e))
+	for i := range e {
+		ids[i] = e[i].ID
+	}
+	return osu.AddEventIDs(ids...)
+}
+
 // Mutation returns the OrgSubscriptionMutation object of the builder.
 func (osu *OrgSubscriptionUpdate) Mutation() *OrgSubscriptionMutation {
 	return osu.mutation
@@ -348,6 +424,27 @@ func (osu *OrgSubscriptionUpdate) Mutation() *OrgSubscriptionMutation {
 func (osu *OrgSubscriptionUpdate) ClearOwner() *OrgSubscriptionUpdate {
 	osu.mutation.ClearOwner()
 	return osu
+}
+
+// ClearEvents clears all "events" edges to the Event entity.
+func (osu *OrgSubscriptionUpdate) ClearEvents() *OrgSubscriptionUpdate {
+	osu.mutation.ClearEvents()
+	return osu
+}
+
+// RemoveEventIDs removes the "events" edge to Event entities by IDs.
+func (osu *OrgSubscriptionUpdate) RemoveEventIDs(ids ...string) *OrgSubscriptionUpdate {
+	osu.mutation.RemoveEventIDs(ids...)
+	return osu
+}
+
+// RemoveEvents removes "events" edges to Event entities.
+func (osu *OrgSubscriptionUpdate) RemoveEvents(e ...*Event) *OrgSubscriptionUpdate {
+	ids := make([]string, len(e))
+	for i := range e {
+		ids[i] = e[i].ID
+	}
+	return osu.RemoveEventIDs(ids...)
 }
 
 // Save executes the query and returns the number of nodes affected by the update operation.
@@ -506,6 +603,24 @@ func (osu *OrgSubscriptionUpdate) sqlSave(ctx context.Context) (n int, err error
 	if osu.mutation.ExpiresAtCleared() {
 		_spec.ClearField(orgsubscription.FieldExpiresAt, field.TypeTime)
 	}
+	if value, ok := osu.mutation.TrialExpiresAt(); ok {
+		_spec.SetField(orgsubscription.FieldTrialExpiresAt, field.TypeTime, value)
+	}
+	if osu.mutation.TrialExpiresAtCleared() {
+		_spec.ClearField(orgsubscription.FieldTrialExpiresAt, field.TypeTime)
+	}
+	if value, ok := osu.mutation.DaysUntilDue(); ok {
+		_spec.SetField(orgsubscription.FieldDaysUntilDue, field.TypeString, value)
+	}
+	if osu.mutation.DaysUntilDueCleared() {
+		_spec.ClearField(orgsubscription.FieldDaysUntilDue, field.TypeString)
+	}
+	if value, ok := osu.mutation.PaymentMethodAdded(); ok {
+		_spec.SetField(orgsubscription.FieldPaymentMethodAdded, field.TypeBool, value)
+	}
+	if osu.mutation.PaymentMethodAddedCleared() {
+		_spec.ClearField(orgsubscription.FieldPaymentMethodAdded, field.TypeBool)
+	}
 	if value, ok := osu.mutation.Features(); ok {
 		_spec.SetField(orgsubscription.FieldFeatures, field.TypeJSON, value)
 	}
@@ -554,6 +669,54 @@ func (osu *OrgSubscriptionUpdate) sqlSave(ctx context.Context) (n int, err error
 			},
 		}
 		edge.Schema = osu.schemaConfig.OrgSubscription
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if osu.mutation.EventsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   orgsubscription.EventsTable,
+			Columns: []string{orgsubscription.EventsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(event.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = osu.schemaConfig.Event
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := osu.mutation.RemovedEventsIDs(); len(nodes) > 0 && !osu.mutation.EventsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   orgsubscription.EventsTable,
+			Columns: []string{orgsubscription.EventsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(event.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = osu.schemaConfig.Event
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := osu.mutation.EventsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   orgsubscription.EventsTable,
+			Columns: []string{orgsubscription.EventsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(event.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = osu.schemaConfig.Event
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
@@ -847,6 +1010,66 @@ func (osuo *OrgSubscriptionUpdateOne) ClearExpiresAt() *OrgSubscriptionUpdateOne
 	return osuo
 }
 
+// SetTrialExpiresAt sets the "trial_expires_at" field.
+func (osuo *OrgSubscriptionUpdateOne) SetTrialExpiresAt(t time.Time) *OrgSubscriptionUpdateOne {
+	osuo.mutation.SetTrialExpiresAt(t)
+	return osuo
+}
+
+// SetNillableTrialExpiresAt sets the "trial_expires_at" field if the given value is not nil.
+func (osuo *OrgSubscriptionUpdateOne) SetNillableTrialExpiresAt(t *time.Time) *OrgSubscriptionUpdateOne {
+	if t != nil {
+		osuo.SetTrialExpiresAt(*t)
+	}
+	return osuo
+}
+
+// ClearTrialExpiresAt clears the value of the "trial_expires_at" field.
+func (osuo *OrgSubscriptionUpdateOne) ClearTrialExpiresAt() *OrgSubscriptionUpdateOne {
+	osuo.mutation.ClearTrialExpiresAt()
+	return osuo
+}
+
+// SetDaysUntilDue sets the "days_until_due" field.
+func (osuo *OrgSubscriptionUpdateOne) SetDaysUntilDue(s string) *OrgSubscriptionUpdateOne {
+	osuo.mutation.SetDaysUntilDue(s)
+	return osuo
+}
+
+// SetNillableDaysUntilDue sets the "days_until_due" field if the given value is not nil.
+func (osuo *OrgSubscriptionUpdateOne) SetNillableDaysUntilDue(s *string) *OrgSubscriptionUpdateOne {
+	if s != nil {
+		osuo.SetDaysUntilDue(*s)
+	}
+	return osuo
+}
+
+// ClearDaysUntilDue clears the value of the "days_until_due" field.
+func (osuo *OrgSubscriptionUpdateOne) ClearDaysUntilDue() *OrgSubscriptionUpdateOne {
+	osuo.mutation.ClearDaysUntilDue()
+	return osuo
+}
+
+// SetPaymentMethodAdded sets the "payment_method_added" field.
+func (osuo *OrgSubscriptionUpdateOne) SetPaymentMethodAdded(b bool) *OrgSubscriptionUpdateOne {
+	osuo.mutation.SetPaymentMethodAdded(b)
+	return osuo
+}
+
+// SetNillablePaymentMethodAdded sets the "payment_method_added" field if the given value is not nil.
+func (osuo *OrgSubscriptionUpdateOne) SetNillablePaymentMethodAdded(b *bool) *OrgSubscriptionUpdateOne {
+	if b != nil {
+		osuo.SetPaymentMethodAdded(*b)
+	}
+	return osuo
+}
+
+// ClearPaymentMethodAdded clears the value of the "payment_method_added" field.
+func (osuo *OrgSubscriptionUpdateOne) ClearPaymentMethodAdded() *OrgSubscriptionUpdateOne {
+	osuo.mutation.ClearPaymentMethodAdded()
+	return osuo
+}
+
 // SetFeatures sets the "features" field.
 func (osuo *OrgSubscriptionUpdateOne) SetFeatures(s []string) *OrgSubscriptionUpdateOne {
 	osuo.mutation.SetFeatures(s)
@@ -888,6 +1111,21 @@ func (osuo *OrgSubscriptionUpdateOne) SetOwner(o *Organization) *OrgSubscription
 	return osuo.SetOwnerID(o.ID)
 }
 
+// AddEventIDs adds the "events" edge to the Event entity by IDs.
+func (osuo *OrgSubscriptionUpdateOne) AddEventIDs(ids ...string) *OrgSubscriptionUpdateOne {
+	osuo.mutation.AddEventIDs(ids...)
+	return osuo
+}
+
+// AddEvents adds the "events" edges to the Event entity.
+func (osuo *OrgSubscriptionUpdateOne) AddEvents(e ...*Event) *OrgSubscriptionUpdateOne {
+	ids := make([]string, len(e))
+	for i := range e {
+		ids[i] = e[i].ID
+	}
+	return osuo.AddEventIDs(ids...)
+}
+
 // Mutation returns the OrgSubscriptionMutation object of the builder.
 func (osuo *OrgSubscriptionUpdateOne) Mutation() *OrgSubscriptionMutation {
 	return osuo.mutation
@@ -897,6 +1135,27 @@ func (osuo *OrgSubscriptionUpdateOne) Mutation() *OrgSubscriptionMutation {
 func (osuo *OrgSubscriptionUpdateOne) ClearOwner() *OrgSubscriptionUpdateOne {
 	osuo.mutation.ClearOwner()
 	return osuo
+}
+
+// ClearEvents clears all "events" edges to the Event entity.
+func (osuo *OrgSubscriptionUpdateOne) ClearEvents() *OrgSubscriptionUpdateOne {
+	osuo.mutation.ClearEvents()
+	return osuo
+}
+
+// RemoveEventIDs removes the "events" edge to Event entities by IDs.
+func (osuo *OrgSubscriptionUpdateOne) RemoveEventIDs(ids ...string) *OrgSubscriptionUpdateOne {
+	osuo.mutation.RemoveEventIDs(ids...)
+	return osuo
+}
+
+// RemoveEvents removes "events" edges to Event entities.
+func (osuo *OrgSubscriptionUpdateOne) RemoveEvents(e ...*Event) *OrgSubscriptionUpdateOne {
+	ids := make([]string, len(e))
+	for i := range e {
+		ids[i] = e[i].ID
+	}
+	return osuo.RemoveEventIDs(ids...)
 }
 
 // Where appends a list predicates to the OrgSubscriptionUpdate builder.
@@ -1085,6 +1344,24 @@ func (osuo *OrgSubscriptionUpdateOne) sqlSave(ctx context.Context) (_node *OrgSu
 	if osuo.mutation.ExpiresAtCleared() {
 		_spec.ClearField(orgsubscription.FieldExpiresAt, field.TypeTime)
 	}
+	if value, ok := osuo.mutation.TrialExpiresAt(); ok {
+		_spec.SetField(orgsubscription.FieldTrialExpiresAt, field.TypeTime, value)
+	}
+	if osuo.mutation.TrialExpiresAtCleared() {
+		_spec.ClearField(orgsubscription.FieldTrialExpiresAt, field.TypeTime)
+	}
+	if value, ok := osuo.mutation.DaysUntilDue(); ok {
+		_spec.SetField(orgsubscription.FieldDaysUntilDue, field.TypeString, value)
+	}
+	if osuo.mutation.DaysUntilDueCleared() {
+		_spec.ClearField(orgsubscription.FieldDaysUntilDue, field.TypeString)
+	}
+	if value, ok := osuo.mutation.PaymentMethodAdded(); ok {
+		_spec.SetField(orgsubscription.FieldPaymentMethodAdded, field.TypeBool, value)
+	}
+	if osuo.mutation.PaymentMethodAddedCleared() {
+		_spec.ClearField(orgsubscription.FieldPaymentMethodAdded, field.TypeBool)
+	}
 	if value, ok := osuo.mutation.Features(); ok {
 		_spec.SetField(orgsubscription.FieldFeatures, field.TypeJSON, value)
 	}
@@ -1133,6 +1410,54 @@ func (osuo *OrgSubscriptionUpdateOne) sqlSave(ctx context.Context) (_node *OrgSu
 			},
 		}
 		edge.Schema = osuo.schemaConfig.OrgSubscription
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if osuo.mutation.EventsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   orgsubscription.EventsTable,
+			Columns: []string{orgsubscription.EventsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(event.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = osuo.schemaConfig.Event
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := osuo.mutation.RemovedEventsIDs(); len(nodes) > 0 && !osuo.mutation.EventsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   orgsubscription.EventsTable,
+			Columns: []string{orgsubscription.EventsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(event.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = osuo.schemaConfig.Event
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := osuo.mutation.EventsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   orgsubscription.EventsTable,
+			Columns: []string{orgsubscription.EventsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(event.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = osuo.schemaConfig.Event
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}

--- a/internal/ent/generated/orgsubscriptionhistory/orgsubscriptionhistory.go
+++ b/internal/ent/generated/orgsubscriptionhistory/orgsubscriptionhistory.go
@@ -54,6 +54,12 @@ const (
 	FieldStripeCustomerID = "stripe_customer_id"
 	// FieldExpiresAt holds the string denoting the expires_at field in the database.
 	FieldExpiresAt = "expires_at"
+	// FieldTrialExpiresAt holds the string denoting the trial_expires_at field in the database.
+	FieldTrialExpiresAt = "trial_expires_at"
+	// FieldDaysUntilDue holds the string denoting the days_until_due field in the database.
+	FieldDaysUntilDue = "days_until_due"
+	// FieldPaymentMethodAdded holds the string denoting the payment_method_added field in the database.
+	FieldPaymentMethodAdded = "payment_method_added"
 	// FieldFeatures holds the string denoting the features field in the database.
 	FieldFeatures = "features"
 	// FieldFeatureLookupKeys holds the string denoting the feature_lookup_keys field in the database.
@@ -84,6 +90,9 @@ var Columns = []string{
 	FieldActive,
 	FieldStripeCustomerID,
 	FieldExpiresAt,
+	FieldTrialExpiresAt,
+	FieldDaysUntilDue,
+	FieldPaymentMethodAdded,
 	FieldFeatures,
 	FieldFeatureLookupKeys,
 }
@@ -216,6 +225,21 @@ func ByStripeCustomerID(opts ...sql.OrderTermOption) OrderOption {
 // ByExpiresAt orders the results by the expires_at field.
 func ByExpiresAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldExpiresAt, opts...).ToFunc()
+}
+
+// ByTrialExpiresAt orders the results by the trial_expires_at field.
+func ByTrialExpiresAt(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldTrialExpiresAt, opts...).ToFunc()
+}
+
+// ByDaysUntilDue orders the results by the days_until_due field.
+func ByDaysUntilDue(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDaysUntilDue, opts...).ToFunc()
+}
+
+// ByPaymentMethodAdded orders the results by the payment_method_added field.
+func ByPaymentMethodAdded(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldPaymentMethodAdded, opts...).ToFunc()
 }
 
 var (

--- a/internal/ent/generated/orgsubscriptionhistory/where.go
+++ b/internal/ent/generated/orgsubscriptionhistory/where.go
@@ -145,6 +145,21 @@ func ExpiresAt(v time.Time) predicate.OrgSubscriptionHistory {
 	return predicate.OrgSubscriptionHistory(sql.FieldEQ(FieldExpiresAt, v))
 }
 
+// TrialExpiresAt applies equality check predicate on the "trial_expires_at" field. It's identical to TrialExpiresAtEQ.
+func TrialExpiresAt(v time.Time) predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldEQ(FieldTrialExpiresAt, v))
+}
+
+// DaysUntilDue applies equality check predicate on the "days_until_due" field. It's identical to DaysUntilDueEQ.
+func DaysUntilDue(v string) predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldEQ(FieldDaysUntilDue, v))
+}
+
+// PaymentMethodAdded applies equality check predicate on the "payment_method_added" field. It's identical to PaymentMethodAddedEQ.
+func PaymentMethodAdded(v bool) predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldEQ(FieldPaymentMethodAdded, v))
+}
+
 // HistoryTimeEQ applies the EQ predicate on the "history_time" field.
 func HistoryTimeEQ(v time.Time) predicate.OrgSubscriptionHistory {
 	return predicate.OrgSubscriptionHistory(sql.FieldEQ(FieldHistoryTime, v))
@@ -1183,6 +1198,151 @@ func ExpiresAtIsNil() predicate.OrgSubscriptionHistory {
 // ExpiresAtNotNil applies the NotNil predicate on the "expires_at" field.
 func ExpiresAtNotNil() predicate.OrgSubscriptionHistory {
 	return predicate.OrgSubscriptionHistory(sql.FieldNotNull(FieldExpiresAt))
+}
+
+// TrialExpiresAtEQ applies the EQ predicate on the "trial_expires_at" field.
+func TrialExpiresAtEQ(v time.Time) predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldEQ(FieldTrialExpiresAt, v))
+}
+
+// TrialExpiresAtNEQ applies the NEQ predicate on the "trial_expires_at" field.
+func TrialExpiresAtNEQ(v time.Time) predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldNEQ(FieldTrialExpiresAt, v))
+}
+
+// TrialExpiresAtIn applies the In predicate on the "trial_expires_at" field.
+func TrialExpiresAtIn(vs ...time.Time) predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldIn(FieldTrialExpiresAt, vs...))
+}
+
+// TrialExpiresAtNotIn applies the NotIn predicate on the "trial_expires_at" field.
+func TrialExpiresAtNotIn(vs ...time.Time) predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldNotIn(FieldTrialExpiresAt, vs...))
+}
+
+// TrialExpiresAtGT applies the GT predicate on the "trial_expires_at" field.
+func TrialExpiresAtGT(v time.Time) predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldGT(FieldTrialExpiresAt, v))
+}
+
+// TrialExpiresAtGTE applies the GTE predicate on the "trial_expires_at" field.
+func TrialExpiresAtGTE(v time.Time) predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldGTE(FieldTrialExpiresAt, v))
+}
+
+// TrialExpiresAtLT applies the LT predicate on the "trial_expires_at" field.
+func TrialExpiresAtLT(v time.Time) predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldLT(FieldTrialExpiresAt, v))
+}
+
+// TrialExpiresAtLTE applies the LTE predicate on the "trial_expires_at" field.
+func TrialExpiresAtLTE(v time.Time) predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldLTE(FieldTrialExpiresAt, v))
+}
+
+// TrialExpiresAtIsNil applies the IsNil predicate on the "trial_expires_at" field.
+func TrialExpiresAtIsNil() predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldIsNull(FieldTrialExpiresAt))
+}
+
+// TrialExpiresAtNotNil applies the NotNil predicate on the "trial_expires_at" field.
+func TrialExpiresAtNotNil() predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldNotNull(FieldTrialExpiresAt))
+}
+
+// DaysUntilDueEQ applies the EQ predicate on the "days_until_due" field.
+func DaysUntilDueEQ(v string) predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldEQ(FieldDaysUntilDue, v))
+}
+
+// DaysUntilDueNEQ applies the NEQ predicate on the "days_until_due" field.
+func DaysUntilDueNEQ(v string) predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldNEQ(FieldDaysUntilDue, v))
+}
+
+// DaysUntilDueIn applies the In predicate on the "days_until_due" field.
+func DaysUntilDueIn(vs ...string) predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldIn(FieldDaysUntilDue, vs...))
+}
+
+// DaysUntilDueNotIn applies the NotIn predicate on the "days_until_due" field.
+func DaysUntilDueNotIn(vs ...string) predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldNotIn(FieldDaysUntilDue, vs...))
+}
+
+// DaysUntilDueGT applies the GT predicate on the "days_until_due" field.
+func DaysUntilDueGT(v string) predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldGT(FieldDaysUntilDue, v))
+}
+
+// DaysUntilDueGTE applies the GTE predicate on the "days_until_due" field.
+func DaysUntilDueGTE(v string) predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldGTE(FieldDaysUntilDue, v))
+}
+
+// DaysUntilDueLT applies the LT predicate on the "days_until_due" field.
+func DaysUntilDueLT(v string) predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldLT(FieldDaysUntilDue, v))
+}
+
+// DaysUntilDueLTE applies the LTE predicate on the "days_until_due" field.
+func DaysUntilDueLTE(v string) predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldLTE(FieldDaysUntilDue, v))
+}
+
+// DaysUntilDueContains applies the Contains predicate on the "days_until_due" field.
+func DaysUntilDueContains(v string) predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldContains(FieldDaysUntilDue, v))
+}
+
+// DaysUntilDueHasPrefix applies the HasPrefix predicate on the "days_until_due" field.
+func DaysUntilDueHasPrefix(v string) predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldHasPrefix(FieldDaysUntilDue, v))
+}
+
+// DaysUntilDueHasSuffix applies the HasSuffix predicate on the "days_until_due" field.
+func DaysUntilDueHasSuffix(v string) predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldHasSuffix(FieldDaysUntilDue, v))
+}
+
+// DaysUntilDueIsNil applies the IsNil predicate on the "days_until_due" field.
+func DaysUntilDueIsNil() predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldIsNull(FieldDaysUntilDue))
+}
+
+// DaysUntilDueNotNil applies the NotNil predicate on the "days_until_due" field.
+func DaysUntilDueNotNil() predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldNotNull(FieldDaysUntilDue))
+}
+
+// DaysUntilDueEqualFold applies the EqualFold predicate on the "days_until_due" field.
+func DaysUntilDueEqualFold(v string) predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldEqualFold(FieldDaysUntilDue, v))
+}
+
+// DaysUntilDueContainsFold applies the ContainsFold predicate on the "days_until_due" field.
+func DaysUntilDueContainsFold(v string) predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldContainsFold(FieldDaysUntilDue, v))
+}
+
+// PaymentMethodAddedEQ applies the EQ predicate on the "payment_method_added" field.
+func PaymentMethodAddedEQ(v bool) predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldEQ(FieldPaymentMethodAdded, v))
+}
+
+// PaymentMethodAddedNEQ applies the NEQ predicate on the "payment_method_added" field.
+func PaymentMethodAddedNEQ(v bool) predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldNEQ(FieldPaymentMethodAdded, v))
+}
+
+// PaymentMethodAddedIsNil applies the IsNil predicate on the "payment_method_added" field.
+func PaymentMethodAddedIsNil() predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldIsNull(FieldPaymentMethodAdded))
+}
+
+// PaymentMethodAddedNotNil applies the NotNil predicate on the "payment_method_added" field.
+func PaymentMethodAddedNotNil() predicate.OrgSubscriptionHistory {
+	return predicate.OrgSubscriptionHistory(sql.FieldNotNull(FieldPaymentMethodAdded))
 }
 
 // FeaturesIsNil applies the IsNil predicate on the "features" field.

--- a/internal/ent/generated/orgsubscriptionhistory_create.go
+++ b/internal/ent/generated/orgsubscriptionhistory_create.go
@@ -272,6 +272,48 @@ func (oshc *OrgSubscriptionHistoryCreate) SetNillableExpiresAt(t *time.Time) *Or
 	return oshc
 }
 
+// SetTrialExpiresAt sets the "trial_expires_at" field.
+func (oshc *OrgSubscriptionHistoryCreate) SetTrialExpiresAt(t time.Time) *OrgSubscriptionHistoryCreate {
+	oshc.mutation.SetTrialExpiresAt(t)
+	return oshc
+}
+
+// SetNillableTrialExpiresAt sets the "trial_expires_at" field if the given value is not nil.
+func (oshc *OrgSubscriptionHistoryCreate) SetNillableTrialExpiresAt(t *time.Time) *OrgSubscriptionHistoryCreate {
+	if t != nil {
+		oshc.SetTrialExpiresAt(*t)
+	}
+	return oshc
+}
+
+// SetDaysUntilDue sets the "days_until_due" field.
+func (oshc *OrgSubscriptionHistoryCreate) SetDaysUntilDue(s string) *OrgSubscriptionHistoryCreate {
+	oshc.mutation.SetDaysUntilDue(s)
+	return oshc
+}
+
+// SetNillableDaysUntilDue sets the "days_until_due" field if the given value is not nil.
+func (oshc *OrgSubscriptionHistoryCreate) SetNillableDaysUntilDue(s *string) *OrgSubscriptionHistoryCreate {
+	if s != nil {
+		oshc.SetDaysUntilDue(*s)
+	}
+	return oshc
+}
+
+// SetPaymentMethodAdded sets the "payment_method_added" field.
+func (oshc *OrgSubscriptionHistoryCreate) SetPaymentMethodAdded(b bool) *OrgSubscriptionHistoryCreate {
+	oshc.mutation.SetPaymentMethodAdded(b)
+	return oshc
+}
+
+// SetNillablePaymentMethodAdded sets the "payment_method_added" field if the given value is not nil.
+func (oshc *OrgSubscriptionHistoryCreate) SetNillablePaymentMethodAdded(b *bool) *OrgSubscriptionHistoryCreate {
+	if b != nil {
+		oshc.SetPaymentMethodAdded(*b)
+	}
+	return oshc
+}
+
 // SetFeatures sets the "features" field.
 func (oshc *OrgSubscriptionHistoryCreate) SetFeatures(s []string) *OrgSubscriptionHistoryCreate {
 	oshc.mutation.SetFeatures(s)
@@ -486,6 +528,18 @@ func (oshc *OrgSubscriptionHistoryCreate) createSpec() (*OrgSubscriptionHistory,
 	if value, ok := oshc.mutation.ExpiresAt(); ok {
 		_spec.SetField(orgsubscriptionhistory.FieldExpiresAt, field.TypeTime, value)
 		_node.ExpiresAt = &value
+	}
+	if value, ok := oshc.mutation.TrialExpiresAt(); ok {
+		_spec.SetField(orgsubscriptionhistory.FieldTrialExpiresAt, field.TypeTime, value)
+		_node.TrialExpiresAt = &value
+	}
+	if value, ok := oshc.mutation.DaysUntilDue(); ok {
+		_spec.SetField(orgsubscriptionhistory.FieldDaysUntilDue, field.TypeString, value)
+		_node.DaysUntilDue = &value
+	}
+	if value, ok := oshc.mutation.PaymentMethodAdded(); ok {
+		_spec.SetField(orgsubscriptionhistory.FieldPaymentMethodAdded, field.TypeBool, value)
+		_node.PaymentMethodAdded = &value
 	}
 	if value, ok := oshc.mutation.Features(); ok {
 		_spec.SetField(orgsubscriptionhistory.FieldFeatures, field.TypeJSON, value)

--- a/internal/ent/generated/orgsubscriptionhistory_update.go
+++ b/internal/ent/generated/orgsubscriptionhistory_update.go
@@ -297,6 +297,66 @@ func (oshu *OrgSubscriptionHistoryUpdate) ClearExpiresAt() *OrgSubscriptionHisto
 	return oshu
 }
 
+// SetTrialExpiresAt sets the "trial_expires_at" field.
+func (oshu *OrgSubscriptionHistoryUpdate) SetTrialExpiresAt(t time.Time) *OrgSubscriptionHistoryUpdate {
+	oshu.mutation.SetTrialExpiresAt(t)
+	return oshu
+}
+
+// SetNillableTrialExpiresAt sets the "trial_expires_at" field if the given value is not nil.
+func (oshu *OrgSubscriptionHistoryUpdate) SetNillableTrialExpiresAt(t *time.Time) *OrgSubscriptionHistoryUpdate {
+	if t != nil {
+		oshu.SetTrialExpiresAt(*t)
+	}
+	return oshu
+}
+
+// ClearTrialExpiresAt clears the value of the "trial_expires_at" field.
+func (oshu *OrgSubscriptionHistoryUpdate) ClearTrialExpiresAt() *OrgSubscriptionHistoryUpdate {
+	oshu.mutation.ClearTrialExpiresAt()
+	return oshu
+}
+
+// SetDaysUntilDue sets the "days_until_due" field.
+func (oshu *OrgSubscriptionHistoryUpdate) SetDaysUntilDue(s string) *OrgSubscriptionHistoryUpdate {
+	oshu.mutation.SetDaysUntilDue(s)
+	return oshu
+}
+
+// SetNillableDaysUntilDue sets the "days_until_due" field if the given value is not nil.
+func (oshu *OrgSubscriptionHistoryUpdate) SetNillableDaysUntilDue(s *string) *OrgSubscriptionHistoryUpdate {
+	if s != nil {
+		oshu.SetDaysUntilDue(*s)
+	}
+	return oshu
+}
+
+// ClearDaysUntilDue clears the value of the "days_until_due" field.
+func (oshu *OrgSubscriptionHistoryUpdate) ClearDaysUntilDue() *OrgSubscriptionHistoryUpdate {
+	oshu.mutation.ClearDaysUntilDue()
+	return oshu
+}
+
+// SetPaymentMethodAdded sets the "payment_method_added" field.
+func (oshu *OrgSubscriptionHistoryUpdate) SetPaymentMethodAdded(b bool) *OrgSubscriptionHistoryUpdate {
+	oshu.mutation.SetPaymentMethodAdded(b)
+	return oshu
+}
+
+// SetNillablePaymentMethodAdded sets the "payment_method_added" field if the given value is not nil.
+func (oshu *OrgSubscriptionHistoryUpdate) SetNillablePaymentMethodAdded(b *bool) *OrgSubscriptionHistoryUpdate {
+	if b != nil {
+		oshu.SetPaymentMethodAdded(*b)
+	}
+	return oshu
+}
+
+// ClearPaymentMethodAdded clears the value of the "payment_method_added" field.
+func (oshu *OrgSubscriptionHistoryUpdate) ClearPaymentMethodAdded() *OrgSubscriptionHistoryUpdate {
+	oshu.mutation.ClearPaymentMethodAdded()
+	return oshu
+}
+
 // SetFeatures sets the "features" field.
 func (oshu *OrgSubscriptionHistoryUpdate) SetFeatures(s []string) *OrgSubscriptionHistoryUpdate {
 	oshu.mutation.SetFeatures(s)
@@ -483,6 +543,24 @@ func (oshu *OrgSubscriptionHistoryUpdate) sqlSave(ctx context.Context) (n int, e
 	}
 	if oshu.mutation.ExpiresAtCleared() {
 		_spec.ClearField(orgsubscriptionhistory.FieldExpiresAt, field.TypeTime)
+	}
+	if value, ok := oshu.mutation.TrialExpiresAt(); ok {
+		_spec.SetField(orgsubscriptionhistory.FieldTrialExpiresAt, field.TypeTime, value)
+	}
+	if oshu.mutation.TrialExpiresAtCleared() {
+		_spec.ClearField(orgsubscriptionhistory.FieldTrialExpiresAt, field.TypeTime)
+	}
+	if value, ok := oshu.mutation.DaysUntilDue(); ok {
+		_spec.SetField(orgsubscriptionhistory.FieldDaysUntilDue, field.TypeString, value)
+	}
+	if oshu.mutation.DaysUntilDueCleared() {
+		_spec.ClearField(orgsubscriptionhistory.FieldDaysUntilDue, field.TypeString)
+	}
+	if value, ok := oshu.mutation.PaymentMethodAdded(); ok {
+		_spec.SetField(orgsubscriptionhistory.FieldPaymentMethodAdded, field.TypeBool, value)
+	}
+	if oshu.mutation.PaymentMethodAddedCleared() {
+		_spec.ClearField(orgsubscriptionhistory.FieldPaymentMethodAdded, field.TypeBool)
 	}
 	if value, ok := oshu.mutation.Features(); ok {
 		_spec.SetField(orgsubscriptionhistory.FieldFeatures, field.TypeJSON, value)
@@ -794,6 +872,66 @@ func (oshuo *OrgSubscriptionHistoryUpdateOne) ClearExpiresAt() *OrgSubscriptionH
 	return oshuo
 }
 
+// SetTrialExpiresAt sets the "trial_expires_at" field.
+func (oshuo *OrgSubscriptionHistoryUpdateOne) SetTrialExpiresAt(t time.Time) *OrgSubscriptionHistoryUpdateOne {
+	oshuo.mutation.SetTrialExpiresAt(t)
+	return oshuo
+}
+
+// SetNillableTrialExpiresAt sets the "trial_expires_at" field if the given value is not nil.
+func (oshuo *OrgSubscriptionHistoryUpdateOne) SetNillableTrialExpiresAt(t *time.Time) *OrgSubscriptionHistoryUpdateOne {
+	if t != nil {
+		oshuo.SetTrialExpiresAt(*t)
+	}
+	return oshuo
+}
+
+// ClearTrialExpiresAt clears the value of the "trial_expires_at" field.
+func (oshuo *OrgSubscriptionHistoryUpdateOne) ClearTrialExpiresAt() *OrgSubscriptionHistoryUpdateOne {
+	oshuo.mutation.ClearTrialExpiresAt()
+	return oshuo
+}
+
+// SetDaysUntilDue sets the "days_until_due" field.
+func (oshuo *OrgSubscriptionHistoryUpdateOne) SetDaysUntilDue(s string) *OrgSubscriptionHistoryUpdateOne {
+	oshuo.mutation.SetDaysUntilDue(s)
+	return oshuo
+}
+
+// SetNillableDaysUntilDue sets the "days_until_due" field if the given value is not nil.
+func (oshuo *OrgSubscriptionHistoryUpdateOne) SetNillableDaysUntilDue(s *string) *OrgSubscriptionHistoryUpdateOne {
+	if s != nil {
+		oshuo.SetDaysUntilDue(*s)
+	}
+	return oshuo
+}
+
+// ClearDaysUntilDue clears the value of the "days_until_due" field.
+func (oshuo *OrgSubscriptionHistoryUpdateOne) ClearDaysUntilDue() *OrgSubscriptionHistoryUpdateOne {
+	oshuo.mutation.ClearDaysUntilDue()
+	return oshuo
+}
+
+// SetPaymentMethodAdded sets the "payment_method_added" field.
+func (oshuo *OrgSubscriptionHistoryUpdateOne) SetPaymentMethodAdded(b bool) *OrgSubscriptionHistoryUpdateOne {
+	oshuo.mutation.SetPaymentMethodAdded(b)
+	return oshuo
+}
+
+// SetNillablePaymentMethodAdded sets the "payment_method_added" field if the given value is not nil.
+func (oshuo *OrgSubscriptionHistoryUpdateOne) SetNillablePaymentMethodAdded(b *bool) *OrgSubscriptionHistoryUpdateOne {
+	if b != nil {
+		oshuo.SetPaymentMethodAdded(*b)
+	}
+	return oshuo
+}
+
+// ClearPaymentMethodAdded clears the value of the "payment_method_added" field.
+func (oshuo *OrgSubscriptionHistoryUpdateOne) ClearPaymentMethodAdded() *OrgSubscriptionHistoryUpdateOne {
+	oshuo.mutation.ClearPaymentMethodAdded()
+	return oshuo
+}
+
 // SetFeatures sets the "features" field.
 func (oshuo *OrgSubscriptionHistoryUpdateOne) SetFeatures(s []string) *OrgSubscriptionHistoryUpdateOne {
 	oshuo.mutation.SetFeatures(s)
@@ -1010,6 +1148,24 @@ func (oshuo *OrgSubscriptionHistoryUpdateOne) sqlSave(ctx context.Context) (_nod
 	}
 	if oshuo.mutation.ExpiresAtCleared() {
 		_spec.ClearField(orgsubscriptionhistory.FieldExpiresAt, field.TypeTime)
+	}
+	if value, ok := oshuo.mutation.TrialExpiresAt(); ok {
+		_spec.SetField(orgsubscriptionhistory.FieldTrialExpiresAt, field.TypeTime, value)
+	}
+	if oshuo.mutation.TrialExpiresAtCleared() {
+		_spec.ClearField(orgsubscriptionhistory.FieldTrialExpiresAt, field.TypeTime)
+	}
+	if value, ok := oshuo.mutation.DaysUntilDue(); ok {
+		_spec.SetField(orgsubscriptionhistory.FieldDaysUntilDue, field.TypeString, value)
+	}
+	if oshuo.mutation.DaysUntilDueCleared() {
+		_spec.ClearField(orgsubscriptionhistory.FieldDaysUntilDue, field.TypeString)
+	}
+	if value, ok := oshuo.mutation.PaymentMethodAdded(); ok {
+		_spec.SetField(orgsubscriptionhistory.FieldPaymentMethodAdded, field.TypeBool, value)
+	}
+	if oshuo.mutation.PaymentMethodAddedCleared() {
+		_spec.ClearField(orgsubscriptionhistory.FieldPaymentMethodAdded, field.TypeBool)
 	}
 	if value, ok := oshuo.mutation.Features(); ok {
 		_spec.SetField(orgsubscriptionhistory.FieldFeatures, field.TypeJSON, value)

--- a/internal/ent/generated/personalaccesstoken/personalaccesstoken.go
+++ b/internal/ent/generated/personalaccesstoken/personalaccesstoken.go
@@ -43,6 +43,14 @@ const (
 	FieldScopes = "scopes"
 	// FieldLastUsedAt holds the string denoting the last_used_at field in the database.
 	FieldLastUsedAt = "last_used_at"
+	// FieldIsActive holds the string denoting the is_active field in the database.
+	FieldIsActive = "is_active"
+	// FieldRevokedReason holds the string denoting the revoked_reason field in the database.
+	FieldRevokedReason = "revoked_reason"
+	// FieldRevokedBy holds the string denoting the revoked_by field in the database.
+	FieldRevokedBy = "revoked_by"
+	// FieldRevokedAt holds the string denoting the revoked_at field in the database.
+	FieldRevokedAt = "revoked_at"
 	// EdgeOwner holds the string denoting the owner edge name in mutations.
 	EdgeOwner = "owner"
 	// EdgeOrganizations holds the string denoting the organizations edge name in mutations.
@@ -87,6 +95,10 @@ var Columns = []string{
 	FieldDescription,
 	FieldScopes,
 	FieldLastUsedAt,
+	FieldIsActive,
+	FieldRevokedReason,
+	FieldRevokedBy,
+	FieldRevokedAt,
 }
 
 var (
@@ -129,6 +141,8 @@ var (
 	NameValidator func(string) error
 	// DefaultToken holds the default value on creation for the "token" field.
 	DefaultToken func() string
+	// DefaultIsActive holds the default value on creation for the "is_active" field.
+	DefaultIsActive bool
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() string
 )
@@ -199,6 +213,26 @@ func ByDescription(opts ...sql.OrderTermOption) OrderOption {
 // ByLastUsedAt orders the results by the last_used_at field.
 func ByLastUsedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldLastUsedAt, opts...).ToFunc()
+}
+
+// ByIsActive orders the results by the is_active field.
+func ByIsActive(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldIsActive, opts...).ToFunc()
+}
+
+// ByRevokedReason orders the results by the revoked_reason field.
+func ByRevokedReason(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldRevokedReason, opts...).ToFunc()
+}
+
+// ByRevokedBy orders the results by the revoked_by field.
+func ByRevokedBy(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldRevokedBy, opts...).ToFunc()
+}
+
+// ByRevokedAt orders the results by the revoked_at field.
+func ByRevokedAt(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldRevokedAt, opts...).ToFunc()
 }
 
 // ByOwnerField orders the results by owner field.

--- a/internal/ent/generated/personalaccesstoken/where.go
+++ b/internal/ent/generated/personalaccesstoken/where.go
@@ -127,6 +127,26 @@ func LastUsedAt(v time.Time) predicate.PersonalAccessToken {
 	return predicate.PersonalAccessToken(sql.FieldEQ(FieldLastUsedAt, v))
 }
 
+// IsActive applies equality check predicate on the "is_active" field. It's identical to IsActiveEQ.
+func IsActive(v bool) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldEQ(FieldIsActive, v))
+}
+
+// RevokedReason applies equality check predicate on the "revoked_reason" field. It's identical to RevokedReasonEQ.
+func RevokedReason(v string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldEQ(FieldRevokedReason, v))
+}
+
+// RevokedBy applies equality check predicate on the "revoked_by" field. It's identical to RevokedByEQ.
+func RevokedBy(v string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldEQ(FieldRevokedBy, v))
+}
+
+// RevokedAt applies equality check predicate on the "revoked_at" field. It's identical to RevokedAtEQ.
+func RevokedAt(v time.Time) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldEQ(FieldRevokedAt, v))
+}
+
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
 func CreatedAtEQ(v time.Time) predicate.PersonalAccessToken {
 	return predicate.PersonalAccessToken(sql.FieldEQ(FieldCreatedAt, v))
@@ -890,6 +910,226 @@ func LastUsedAtIsNil() predicate.PersonalAccessToken {
 // LastUsedAtNotNil applies the NotNil predicate on the "last_used_at" field.
 func LastUsedAtNotNil() predicate.PersonalAccessToken {
 	return predicate.PersonalAccessToken(sql.FieldNotNull(FieldLastUsedAt))
+}
+
+// IsActiveEQ applies the EQ predicate on the "is_active" field.
+func IsActiveEQ(v bool) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldEQ(FieldIsActive, v))
+}
+
+// IsActiveNEQ applies the NEQ predicate on the "is_active" field.
+func IsActiveNEQ(v bool) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldNEQ(FieldIsActive, v))
+}
+
+// IsActiveIsNil applies the IsNil predicate on the "is_active" field.
+func IsActiveIsNil() predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldIsNull(FieldIsActive))
+}
+
+// IsActiveNotNil applies the NotNil predicate on the "is_active" field.
+func IsActiveNotNil() predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldNotNull(FieldIsActive))
+}
+
+// RevokedReasonEQ applies the EQ predicate on the "revoked_reason" field.
+func RevokedReasonEQ(v string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldEQ(FieldRevokedReason, v))
+}
+
+// RevokedReasonNEQ applies the NEQ predicate on the "revoked_reason" field.
+func RevokedReasonNEQ(v string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldNEQ(FieldRevokedReason, v))
+}
+
+// RevokedReasonIn applies the In predicate on the "revoked_reason" field.
+func RevokedReasonIn(vs ...string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldIn(FieldRevokedReason, vs...))
+}
+
+// RevokedReasonNotIn applies the NotIn predicate on the "revoked_reason" field.
+func RevokedReasonNotIn(vs ...string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldNotIn(FieldRevokedReason, vs...))
+}
+
+// RevokedReasonGT applies the GT predicate on the "revoked_reason" field.
+func RevokedReasonGT(v string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldGT(FieldRevokedReason, v))
+}
+
+// RevokedReasonGTE applies the GTE predicate on the "revoked_reason" field.
+func RevokedReasonGTE(v string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldGTE(FieldRevokedReason, v))
+}
+
+// RevokedReasonLT applies the LT predicate on the "revoked_reason" field.
+func RevokedReasonLT(v string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldLT(FieldRevokedReason, v))
+}
+
+// RevokedReasonLTE applies the LTE predicate on the "revoked_reason" field.
+func RevokedReasonLTE(v string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldLTE(FieldRevokedReason, v))
+}
+
+// RevokedReasonContains applies the Contains predicate on the "revoked_reason" field.
+func RevokedReasonContains(v string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldContains(FieldRevokedReason, v))
+}
+
+// RevokedReasonHasPrefix applies the HasPrefix predicate on the "revoked_reason" field.
+func RevokedReasonHasPrefix(v string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldHasPrefix(FieldRevokedReason, v))
+}
+
+// RevokedReasonHasSuffix applies the HasSuffix predicate on the "revoked_reason" field.
+func RevokedReasonHasSuffix(v string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldHasSuffix(FieldRevokedReason, v))
+}
+
+// RevokedReasonIsNil applies the IsNil predicate on the "revoked_reason" field.
+func RevokedReasonIsNil() predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldIsNull(FieldRevokedReason))
+}
+
+// RevokedReasonNotNil applies the NotNil predicate on the "revoked_reason" field.
+func RevokedReasonNotNil() predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldNotNull(FieldRevokedReason))
+}
+
+// RevokedReasonEqualFold applies the EqualFold predicate on the "revoked_reason" field.
+func RevokedReasonEqualFold(v string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldEqualFold(FieldRevokedReason, v))
+}
+
+// RevokedReasonContainsFold applies the ContainsFold predicate on the "revoked_reason" field.
+func RevokedReasonContainsFold(v string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldContainsFold(FieldRevokedReason, v))
+}
+
+// RevokedByEQ applies the EQ predicate on the "revoked_by" field.
+func RevokedByEQ(v string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldEQ(FieldRevokedBy, v))
+}
+
+// RevokedByNEQ applies the NEQ predicate on the "revoked_by" field.
+func RevokedByNEQ(v string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldNEQ(FieldRevokedBy, v))
+}
+
+// RevokedByIn applies the In predicate on the "revoked_by" field.
+func RevokedByIn(vs ...string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldIn(FieldRevokedBy, vs...))
+}
+
+// RevokedByNotIn applies the NotIn predicate on the "revoked_by" field.
+func RevokedByNotIn(vs ...string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldNotIn(FieldRevokedBy, vs...))
+}
+
+// RevokedByGT applies the GT predicate on the "revoked_by" field.
+func RevokedByGT(v string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldGT(FieldRevokedBy, v))
+}
+
+// RevokedByGTE applies the GTE predicate on the "revoked_by" field.
+func RevokedByGTE(v string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldGTE(FieldRevokedBy, v))
+}
+
+// RevokedByLT applies the LT predicate on the "revoked_by" field.
+func RevokedByLT(v string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldLT(FieldRevokedBy, v))
+}
+
+// RevokedByLTE applies the LTE predicate on the "revoked_by" field.
+func RevokedByLTE(v string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldLTE(FieldRevokedBy, v))
+}
+
+// RevokedByContains applies the Contains predicate on the "revoked_by" field.
+func RevokedByContains(v string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldContains(FieldRevokedBy, v))
+}
+
+// RevokedByHasPrefix applies the HasPrefix predicate on the "revoked_by" field.
+func RevokedByHasPrefix(v string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldHasPrefix(FieldRevokedBy, v))
+}
+
+// RevokedByHasSuffix applies the HasSuffix predicate on the "revoked_by" field.
+func RevokedByHasSuffix(v string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldHasSuffix(FieldRevokedBy, v))
+}
+
+// RevokedByIsNil applies the IsNil predicate on the "revoked_by" field.
+func RevokedByIsNil() predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldIsNull(FieldRevokedBy))
+}
+
+// RevokedByNotNil applies the NotNil predicate on the "revoked_by" field.
+func RevokedByNotNil() predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldNotNull(FieldRevokedBy))
+}
+
+// RevokedByEqualFold applies the EqualFold predicate on the "revoked_by" field.
+func RevokedByEqualFold(v string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldEqualFold(FieldRevokedBy, v))
+}
+
+// RevokedByContainsFold applies the ContainsFold predicate on the "revoked_by" field.
+func RevokedByContainsFold(v string) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldContainsFold(FieldRevokedBy, v))
+}
+
+// RevokedAtEQ applies the EQ predicate on the "revoked_at" field.
+func RevokedAtEQ(v time.Time) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldEQ(FieldRevokedAt, v))
+}
+
+// RevokedAtNEQ applies the NEQ predicate on the "revoked_at" field.
+func RevokedAtNEQ(v time.Time) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldNEQ(FieldRevokedAt, v))
+}
+
+// RevokedAtIn applies the In predicate on the "revoked_at" field.
+func RevokedAtIn(vs ...time.Time) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldIn(FieldRevokedAt, vs...))
+}
+
+// RevokedAtNotIn applies the NotIn predicate on the "revoked_at" field.
+func RevokedAtNotIn(vs ...time.Time) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldNotIn(FieldRevokedAt, vs...))
+}
+
+// RevokedAtGT applies the GT predicate on the "revoked_at" field.
+func RevokedAtGT(v time.Time) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldGT(FieldRevokedAt, v))
+}
+
+// RevokedAtGTE applies the GTE predicate on the "revoked_at" field.
+func RevokedAtGTE(v time.Time) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldGTE(FieldRevokedAt, v))
+}
+
+// RevokedAtLT applies the LT predicate on the "revoked_at" field.
+func RevokedAtLT(v time.Time) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldLT(FieldRevokedAt, v))
+}
+
+// RevokedAtLTE applies the LTE predicate on the "revoked_at" field.
+func RevokedAtLTE(v time.Time) predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldLTE(FieldRevokedAt, v))
+}
+
+// RevokedAtIsNil applies the IsNil predicate on the "revoked_at" field.
+func RevokedAtIsNil() predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldIsNull(FieldRevokedAt))
+}
+
+// RevokedAtNotNil applies the NotNil predicate on the "revoked_at" field.
+func RevokedAtNotNil() predicate.PersonalAccessToken {
+	return predicate.PersonalAccessToken(sql.FieldNotNull(FieldRevokedAt))
 }
 
 // HasOwner applies the HasEdge predicate on the "owner" edge.

--- a/internal/ent/generated/personalaccesstoken_create.go
+++ b/internal/ent/generated/personalaccesstoken_create.go
@@ -187,6 +187,62 @@ func (patc *PersonalAccessTokenCreate) SetNillableLastUsedAt(t *time.Time) *Pers
 	return patc
 }
 
+// SetIsActive sets the "is_active" field.
+func (patc *PersonalAccessTokenCreate) SetIsActive(b bool) *PersonalAccessTokenCreate {
+	patc.mutation.SetIsActive(b)
+	return patc
+}
+
+// SetNillableIsActive sets the "is_active" field if the given value is not nil.
+func (patc *PersonalAccessTokenCreate) SetNillableIsActive(b *bool) *PersonalAccessTokenCreate {
+	if b != nil {
+		patc.SetIsActive(*b)
+	}
+	return patc
+}
+
+// SetRevokedReason sets the "revoked_reason" field.
+func (patc *PersonalAccessTokenCreate) SetRevokedReason(s string) *PersonalAccessTokenCreate {
+	patc.mutation.SetRevokedReason(s)
+	return patc
+}
+
+// SetNillableRevokedReason sets the "revoked_reason" field if the given value is not nil.
+func (patc *PersonalAccessTokenCreate) SetNillableRevokedReason(s *string) *PersonalAccessTokenCreate {
+	if s != nil {
+		patc.SetRevokedReason(*s)
+	}
+	return patc
+}
+
+// SetRevokedBy sets the "revoked_by" field.
+func (patc *PersonalAccessTokenCreate) SetRevokedBy(s string) *PersonalAccessTokenCreate {
+	patc.mutation.SetRevokedBy(s)
+	return patc
+}
+
+// SetNillableRevokedBy sets the "revoked_by" field if the given value is not nil.
+func (patc *PersonalAccessTokenCreate) SetNillableRevokedBy(s *string) *PersonalAccessTokenCreate {
+	if s != nil {
+		patc.SetRevokedBy(*s)
+	}
+	return patc
+}
+
+// SetRevokedAt sets the "revoked_at" field.
+func (patc *PersonalAccessTokenCreate) SetRevokedAt(t time.Time) *PersonalAccessTokenCreate {
+	patc.mutation.SetRevokedAt(t)
+	return patc
+}
+
+// SetNillableRevokedAt sets the "revoked_at" field if the given value is not nil.
+func (patc *PersonalAccessTokenCreate) SetNillableRevokedAt(t *time.Time) *PersonalAccessTokenCreate {
+	if t != nil {
+		patc.SetRevokedAt(*t)
+	}
+	return patc
+}
+
 // SetID sets the "id" field.
 func (patc *PersonalAccessTokenCreate) SetID(s string) *PersonalAccessTokenCreate {
 	patc.mutation.SetID(s)
@@ -297,6 +353,10 @@ func (patc *PersonalAccessTokenCreate) defaults() error {
 		}
 		v := personalaccesstoken.DefaultToken()
 		patc.mutation.SetToken(v)
+	}
+	if _, ok := patc.mutation.IsActive(); !ok {
+		v := personalaccesstoken.DefaultIsActive
+		patc.mutation.SetIsActive(v)
 	}
 	if _, ok := patc.mutation.ID(); !ok {
 		if personalaccesstoken.DefaultID == nil {
@@ -414,6 +474,22 @@ func (patc *PersonalAccessTokenCreate) createSpec() (*PersonalAccessToken, *sqlg
 	if value, ok := patc.mutation.LastUsedAt(); ok {
 		_spec.SetField(personalaccesstoken.FieldLastUsedAt, field.TypeTime, value)
 		_node.LastUsedAt = &value
+	}
+	if value, ok := patc.mutation.IsActive(); ok {
+		_spec.SetField(personalaccesstoken.FieldIsActive, field.TypeBool, value)
+		_node.IsActive = value
+	}
+	if value, ok := patc.mutation.RevokedReason(); ok {
+		_spec.SetField(personalaccesstoken.FieldRevokedReason, field.TypeString, value)
+		_node.RevokedReason = &value
+	}
+	if value, ok := patc.mutation.RevokedBy(); ok {
+		_spec.SetField(personalaccesstoken.FieldRevokedBy, field.TypeString, value)
+		_node.RevokedBy = &value
+	}
+	if value, ok := patc.mutation.RevokedAt(); ok {
+		_spec.SetField(personalaccesstoken.FieldRevokedAt, field.TypeTime, value)
+		_node.RevokedAt = &value
 	}
 	if nodes := patc.mutation.OwnerIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/internal/ent/generated/personalaccesstoken_update.go
+++ b/internal/ent/generated/personalaccesstoken_update.go
@@ -231,6 +231,86 @@ func (patu *PersonalAccessTokenUpdate) ClearLastUsedAt() *PersonalAccessTokenUpd
 	return patu
 }
 
+// SetIsActive sets the "is_active" field.
+func (patu *PersonalAccessTokenUpdate) SetIsActive(b bool) *PersonalAccessTokenUpdate {
+	patu.mutation.SetIsActive(b)
+	return patu
+}
+
+// SetNillableIsActive sets the "is_active" field if the given value is not nil.
+func (patu *PersonalAccessTokenUpdate) SetNillableIsActive(b *bool) *PersonalAccessTokenUpdate {
+	if b != nil {
+		patu.SetIsActive(*b)
+	}
+	return patu
+}
+
+// ClearIsActive clears the value of the "is_active" field.
+func (patu *PersonalAccessTokenUpdate) ClearIsActive() *PersonalAccessTokenUpdate {
+	patu.mutation.ClearIsActive()
+	return patu
+}
+
+// SetRevokedReason sets the "revoked_reason" field.
+func (patu *PersonalAccessTokenUpdate) SetRevokedReason(s string) *PersonalAccessTokenUpdate {
+	patu.mutation.SetRevokedReason(s)
+	return patu
+}
+
+// SetNillableRevokedReason sets the "revoked_reason" field if the given value is not nil.
+func (patu *PersonalAccessTokenUpdate) SetNillableRevokedReason(s *string) *PersonalAccessTokenUpdate {
+	if s != nil {
+		patu.SetRevokedReason(*s)
+	}
+	return patu
+}
+
+// ClearRevokedReason clears the value of the "revoked_reason" field.
+func (patu *PersonalAccessTokenUpdate) ClearRevokedReason() *PersonalAccessTokenUpdate {
+	patu.mutation.ClearRevokedReason()
+	return patu
+}
+
+// SetRevokedBy sets the "revoked_by" field.
+func (patu *PersonalAccessTokenUpdate) SetRevokedBy(s string) *PersonalAccessTokenUpdate {
+	patu.mutation.SetRevokedBy(s)
+	return patu
+}
+
+// SetNillableRevokedBy sets the "revoked_by" field if the given value is not nil.
+func (patu *PersonalAccessTokenUpdate) SetNillableRevokedBy(s *string) *PersonalAccessTokenUpdate {
+	if s != nil {
+		patu.SetRevokedBy(*s)
+	}
+	return patu
+}
+
+// ClearRevokedBy clears the value of the "revoked_by" field.
+func (patu *PersonalAccessTokenUpdate) ClearRevokedBy() *PersonalAccessTokenUpdate {
+	patu.mutation.ClearRevokedBy()
+	return patu
+}
+
+// SetRevokedAt sets the "revoked_at" field.
+func (patu *PersonalAccessTokenUpdate) SetRevokedAt(t time.Time) *PersonalAccessTokenUpdate {
+	patu.mutation.SetRevokedAt(t)
+	return patu
+}
+
+// SetNillableRevokedAt sets the "revoked_at" field if the given value is not nil.
+func (patu *PersonalAccessTokenUpdate) SetNillableRevokedAt(t *time.Time) *PersonalAccessTokenUpdate {
+	if t != nil {
+		patu.SetRevokedAt(*t)
+	}
+	return patu
+}
+
+// ClearRevokedAt clears the value of the "revoked_at" field.
+func (patu *PersonalAccessTokenUpdate) ClearRevokedAt() *PersonalAccessTokenUpdate {
+	patu.mutation.ClearRevokedAt()
+	return patu
+}
+
 // SetOwner sets the "owner" edge to the User entity.
 func (patu *PersonalAccessTokenUpdate) SetOwner(u *User) *PersonalAccessTokenUpdate {
 	return patu.SetOwnerID(u.ID)
@@ -464,6 +544,30 @@ func (patu *PersonalAccessTokenUpdate) sqlSave(ctx context.Context) (n int, err 
 	}
 	if patu.mutation.LastUsedAtCleared() {
 		_spec.ClearField(personalaccesstoken.FieldLastUsedAt, field.TypeTime)
+	}
+	if value, ok := patu.mutation.IsActive(); ok {
+		_spec.SetField(personalaccesstoken.FieldIsActive, field.TypeBool, value)
+	}
+	if patu.mutation.IsActiveCleared() {
+		_spec.ClearField(personalaccesstoken.FieldIsActive, field.TypeBool)
+	}
+	if value, ok := patu.mutation.RevokedReason(); ok {
+		_spec.SetField(personalaccesstoken.FieldRevokedReason, field.TypeString, value)
+	}
+	if patu.mutation.RevokedReasonCleared() {
+		_spec.ClearField(personalaccesstoken.FieldRevokedReason, field.TypeString)
+	}
+	if value, ok := patu.mutation.RevokedBy(); ok {
+		_spec.SetField(personalaccesstoken.FieldRevokedBy, field.TypeString, value)
+	}
+	if patu.mutation.RevokedByCleared() {
+		_spec.ClearField(personalaccesstoken.FieldRevokedBy, field.TypeString)
+	}
+	if value, ok := patu.mutation.RevokedAt(); ok {
+		_spec.SetField(personalaccesstoken.FieldRevokedAt, field.TypeTime, value)
+	}
+	if patu.mutation.RevokedAtCleared() {
+		_spec.ClearField(personalaccesstoken.FieldRevokedAt, field.TypeTime)
 	}
 	if patu.mutation.OwnerCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -812,6 +916,86 @@ func (patuo *PersonalAccessTokenUpdateOne) ClearLastUsedAt() *PersonalAccessToke
 	return patuo
 }
 
+// SetIsActive sets the "is_active" field.
+func (patuo *PersonalAccessTokenUpdateOne) SetIsActive(b bool) *PersonalAccessTokenUpdateOne {
+	patuo.mutation.SetIsActive(b)
+	return patuo
+}
+
+// SetNillableIsActive sets the "is_active" field if the given value is not nil.
+func (patuo *PersonalAccessTokenUpdateOne) SetNillableIsActive(b *bool) *PersonalAccessTokenUpdateOne {
+	if b != nil {
+		patuo.SetIsActive(*b)
+	}
+	return patuo
+}
+
+// ClearIsActive clears the value of the "is_active" field.
+func (patuo *PersonalAccessTokenUpdateOne) ClearIsActive() *PersonalAccessTokenUpdateOne {
+	patuo.mutation.ClearIsActive()
+	return patuo
+}
+
+// SetRevokedReason sets the "revoked_reason" field.
+func (patuo *PersonalAccessTokenUpdateOne) SetRevokedReason(s string) *PersonalAccessTokenUpdateOne {
+	patuo.mutation.SetRevokedReason(s)
+	return patuo
+}
+
+// SetNillableRevokedReason sets the "revoked_reason" field if the given value is not nil.
+func (patuo *PersonalAccessTokenUpdateOne) SetNillableRevokedReason(s *string) *PersonalAccessTokenUpdateOne {
+	if s != nil {
+		patuo.SetRevokedReason(*s)
+	}
+	return patuo
+}
+
+// ClearRevokedReason clears the value of the "revoked_reason" field.
+func (patuo *PersonalAccessTokenUpdateOne) ClearRevokedReason() *PersonalAccessTokenUpdateOne {
+	patuo.mutation.ClearRevokedReason()
+	return patuo
+}
+
+// SetRevokedBy sets the "revoked_by" field.
+func (patuo *PersonalAccessTokenUpdateOne) SetRevokedBy(s string) *PersonalAccessTokenUpdateOne {
+	patuo.mutation.SetRevokedBy(s)
+	return patuo
+}
+
+// SetNillableRevokedBy sets the "revoked_by" field if the given value is not nil.
+func (patuo *PersonalAccessTokenUpdateOne) SetNillableRevokedBy(s *string) *PersonalAccessTokenUpdateOne {
+	if s != nil {
+		patuo.SetRevokedBy(*s)
+	}
+	return patuo
+}
+
+// ClearRevokedBy clears the value of the "revoked_by" field.
+func (patuo *PersonalAccessTokenUpdateOne) ClearRevokedBy() *PersonalAccessTokenUpdateOne {
+	patuo.mutation.ClearRevokedBy()
+	return patuo
+}
+
+// SetRevokedAt sets the "revoked_at" field.
+func (patuo *PersonalAccessTokenUpdateOne) SetRevokedAt(t time.Time) *PersonalAccessTokenUpdateOne {
+	patuo.mutation.SetRevokedAt(t)
+	return patuo
+}
+
+// SetNillableRevokedAt sets the "revoked_at" field if the given value is not nil.
+func (patuo *PersonalAccessTokenUpdateOne) SetNillableRevokedAt(t *time.Time) *PersonalAccessTokenUpdateOne {
+	if t != nil {
+		patuo.SetRevokedAt(*t)
+	}
+	return patuo
+}
+
+// ClearRevokedAt clears the value of the "revoked_at" field.
+func (patuo *PersonalAccessTokenUpdateOne) ClearRevokedAt() *PersonalAccessTokenUpdateOne {
+	patuo.mutation.ClearRevokedAt()
+	return patuo
+}
+
 // SetOwner sets the "owner" edge to the User entity.
 func (patuo *PersonalAccessTokenUpdateOne) SetOwner(u *User) *PersonalAccessTokenUpdateOne {
 	return patuo.SetOwnerID(u.ID)
@@ -1075,6 +1259,30 @@ func (patuo *PersonalAccessTokenUpdateOne) sqlSave(ctx context.Context) (_node *
 	}
 	if patuo.mutation.LastUsedAtCleared() {
 		_spec.ClearField(personalaccesstoken.FieldLastUsedAt, field.TypeTime)
+	}
+	if value, ok := patuo.mutation.IsActive(); ok {
+		_spec.SetField(personalaccesstoken.FieldIsActive, field.TypeBool, value)
+	}
+	if patuo.mutation.IsActiveCleared() {
+		_spec.ClearField(personalaccesstoken.FieldIsActive, field.TypeBool)
+	}
+	if value, ok := patuo.mutation.RevokedReason(); ok {
+		_spec.SetField(personalaccesstoken.FieldRevokedReason, field.TypeString, value)
+	}
+	if patuo.mutation.RevokedReasonCleared() {
+		_spec.ClearField(personalaccesstoken.FieldRevokedReason, field.TypeString)
+	}
+	if value, ok := patuo.mutation.RevokedBy(); ok {
+		_spec.SetField(personalaccesstoken.FieldRevokedBy, field.TypeString, value)
+	}
+	if patuo.mutation.RevokedByCleared() {
+		_spec.ClearField(personalaccesstoken.FieldRevokedBy, field.TypeString)
+	}
+	if value, ok := patuo.mutation.RevokedAt(); ok {
+		_spec.SetField(personalaccesstoken.FieldRevokedAt, field.TypeTime, value)
+	}
+	if patuo.mutation.RevokedAtCleared() {
+		_spec.ClearField(personalaccesstoken.FieldRevokedAt, field.TypeTime)
 	}
 	if patuo.mutation.OwnerCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/internal/ent/generated/runtime/runtime.go
+++ b/internal/ent/generated/runtime/runtime.go
@@ -155,6 +155,10 @@ func init() {
 	apitokenDescToken := apitokenFields[1].Descriptor()
 	// apitoken.DefaultToken holds the default value on creation for the token field.
 	apitoken.DefaultToken = apitokenDescToken.Default.(func() string)
+	// apitokenDescIsActive is the schema descriptor for is_active field.
+	apitokenDescIsActive := apitokenFields[6].Descriptor()
+	// apitoken.DefaultIsActive holds the default value on creation for the is_active field.
+	apitoken.DefaultIsActive = apitokenDescIsActive.Default.(bool)
 	// apitokenDescID is the schema descriptor for id field.
 	apitokenDescID := apitokenMixinFields2[0].Descriptor()
 	// apitoken.DefaultID holds the default value on creation for the id field.
@@ -2583,6 +2587,10 @@ func init() {
 	personalaccesstokenDescToken := personalaccesstokenFields[1].Descriptor()
 	// personalaccesstoken.DefaultToken holds the default value on creation for the token field.
 	personalaccesstoken.DefaultToken = personalaccesstokenDescToken.Default.(func() string)
+	// personalaccesstokenDescIsActive is the schema descriptor for is_active field.
+	personalaccesstokenDescIsActive := personalaccesstokenFields[6].Descriptor()
+	// personalaccesstoken.DefaultIsActive holds the default value on creation for the is_active field.
+	personalaccesstoken.DefaultIsActive = personalaccesstokenDescIsActive.Default.(bool)
 	// personalaccesstokenDescID is the schema descriptor for id field.
 	personalaccesstokenDescID := personalaccesstokenMixinFields2[0].Descriptor()
 	// personalaccesstoken.DefaultID holds the default value on creation for the id field.

--- a/internal/ent/schema/apitoken.go
+++ b/internal/ent/schema/apitoken.go
@@ -61,6 +61,22 @@ func (APIToken) Fields() []ent.Field {
 		field.Time("last_used_at").
 			Optional().
 			Nillable(),
+		field.Bool("is_active").
+			Default(true).
+			Comment("whether the token is active").
+			Optional(),
+		field.String("revoked_reason").
+			Comment("the reason the token was revoked").
+			Optional().
+			Nillable(),
+		field.String("revoked_by").
+			Comment("the user who revoked the token").
+			Optional().
+			Nillable(),
+		field.Time("revoked_at").
+			Comment("when the token was revoked").
+			Optional().
+			Nillable(),
 	}
 }
 

--- a/internal/ent/schema/orgsubscription.go
+++ b/internal/ent/schema/orgsubscription.go
@@ -4,6 +4,7 @@ import (
 	"entgo.io/contrib/entgql"
 	"entgo.io/ent"
 	"entgo.io/ent/schema"
+	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 
 	emixin "github.com/theopenlane/entx/mixin"
@@ -47,6 +48,18 @@ func (OrgSubscription) Fields() []ent.Field {
 			Comment("the time the subscription is set to expire; only populated if subscription is cancelled").
 			Nillable().
 			Optional(),
+		field.Time("trial_expires_at").
+			Comment("the time the trial is set to expire").
+			Nillable().
+			Optional(),
+		field.String("days_until_due").
+			Comment("number of days until there is a due payment").
+			Nillable().
+			Optional(),
+		field.Bool("payment_method_added").
+			Comment("whether or not a payment method has been added to the account").
+			Nillable().
+			Optional(),
 		field.JSON("features", []string{}).
 			Comment("the features associated with the subscription").
 			Optional(),
@@ -81,5 +94,12 @@ func (OrgSubscription) Annotations() []schema.Annotation {
 func (OrgSubscription) Interceptors() []ent.Interceptor {
 	return []ent.Interceptor{
 		interceptors.InterceptorSubscriptionURL(),
+	}
+}
+
+// Edges of the OrgSubscription
+func (OrgSubscription) Edges() []ent.Edge {
+	return []ent.Edge{
+		edge.To("events", Event.Type),
 	}
 }

--- a/internal/ent/schema/personalaccesstoken.go
+++ b/internal/ent/schema/personalaccesstoken.go
@@ -60,6 +60,22 @@ func (PersonalAccessToken) Fields() []ent.Field {
 		field.Time("last_used_at").
 			Optional().
 			Nillable(),
+		field.Bool("is_active").
+			Default(true).
+			Comment("whether the token is active").
+			Optional(),
+		field.String("revoked_reason").
+			Comment("the reason the token was revoked").
+			Optional().
+			Nillable(),
+		field.String("revoked_by").
+			Comment("the user who revoked the token").
+			Optional().
+			Nillable(),
+		field.Time("revoked_at").
+			Comment("when the token was revoked").
+			Optional().
+			Nillable(),
 	}
 }
 

--- a/internal/graphapi/clientschema/schema.graphql
+++ b/internal/graphapi/clientschema/schema.graphql
@@ -32,6 +32,22 @@ type APIToken implements Node {
 	description: String
 	scopes: [String!]
 	lastUsedAt: Time
+	"""
+	whether the token is active
+	"""
+	isActive: Boolean
+	"""
+	the reason the token was revoked
+	"""
+	revokedReason: String
+	"""
+	the user who revoked the token
+	"""
+	revokedBy: String
+	"""
+	when the token was revoked
+	"""
+	revokedAt: Time
 	owner: Organization
 }
 """
@@ -277,6 +293,62 @@ input APITokenWhereInput {
 	lastUsedAtLTE: Time
 	lastUsedAtIsNil: Boolean
 	lastUsedAtNotNil: Boolean
+	"""
+	is_active field predicates
+	"""
+	isActive: Boolean
+	isActiveNEQ: Boolean
+	isActiveIsNil: Boolean
+	isActiveNotNil: Boolean
+	"""
+	revoked_reason field predicates
+	"""
+	revokedReason: String
+	revokedReasonNEQ: String
+	revokedReasonIn: [String!]
+	revokedReasonNotIn: [String!]
+	revokedReasonGT: String
+	revokedReasonGTE: String
+	revokedReasonLT: String
+	revokedReasonLTE: String
+	revokedReasonContains: String
+	revokedReasonHasPrefix: String
+	revokedReasonHasSuffix: String
+	revokedReasonIsNil: Boolean
+	revokedReasonNotNil: Boolean
+	revokedReasonEqualFold: String
+	revokedReasonContainsFold: String
+	"""
+	revoked_by field predicates
+	"""
+	revokedBy: String
+	revokedByNEQ: String
+	revokedByIn: [String!]
+	revokedByNotIn: [String!]
+	revokedByGT: String
+	revokedByGTE: String
+	revokedByLT: String
+	revokedByLTE: String
+	revokedByContains: String
+	revokedByHasPrefix: String
+	revokedByHasSuffix: String
+	revokedByIsNil: Boolean
+	revokedByNotNil: Boolean
+	revokedByEqualFold: String
+	revokedByContainsFold: String
+	"""
+	revoked_at field predicates
+	"""
+	revokedAt: Time
+	revokedAtNEQ: Time
+	revokedAtIn: [Time!]
+	revokedAtNotIn: [Time!]
+	revokedAtGT: Time
+	revokedAtGTE: Time
+	revokedAtLT: Time
+	revokedAtLTE: Time
+	revokedAtIsNil: Boolean
+	revokedAtNotNil: Boolean
 	"""
 	owner edge predicates
 	"""
@@ -3987,6 +4059,22 @@ input CreateAPITokenInput {
 	description: String
 	scopes: [String!]
 	lastUsedAt: Time
+	"""
+	whether the token is active
+	"""
+	isActive: Boolean
+	"""
+	the reason the token was revoked
+	"""
+	revokedReason: String
+	"""
+	the user who revoked the token
+	"""
+	revokedBy: String
+	"""
+	when the token was revoked
+	"""
+	revokedAt: Time
 	ownerID: ID
 }
 """
@@ -4908,6 +4996,22 @@ input CreatePersonalAccessTokenInput {
 	description: String
 	scopes: [String!]
 	lastUsedAt: Time
+	"""
+	whether the token is active
+	"""
+	isActive: Boolean
+	"""
+	the reason the token was revoked
+	"""
+	revokedReason: String
+	"""
+	the user who revoked the token
+	"""
+	revokedBy: String
+	"""
+	when the token was revoked
+	"""
+	revokedAt: Time
 	ownerID: ID!
 	organizationIDs: [ID!]
 	eventIDs: [ID!]
@@ -17407,6 +17511,18 @@ type OrgSubscription implements Node {
 	"""
 	expiresAt: Time
 	"""
+	the time the trial is set to expire
+	"""
+	trialExpiresAt: Time
+	"""
+	number of days until there is a due payment
+	"""
+	daysUntilDue: String
+	"""
+	whether or not a payment method has been added to the account
+	"""
+	paymentMethodAdded: Boolean
+	"""
 	the features associated with the subscription
 	"""
 	features: [String!]
@@ -17415,6 +17531,7 @@ type OrgSubscription implements Node {
 	"""
 	featureLookupKeys: [String!]
 	owner: Organization
+	events: [Event!]
 	subscriptionURL: String
 }
 """
@@ -17498,6 +17615,18 @@ type OrgSubscriptionHistory implements Node {
 	the time the subscription is set to expire; only populated if subscription is cancelled
 	"""
 	expiresAt: Time
+	"""
+	the time the trial is set to expire
+	"""
+	trialExpiresAt: Time
+	"""
+	number of days until there is a due payment
+	"""
+	daysUntilDue: String
+	"""
+	whether or not a payment method has been added to the account
+	"""
+	paymentMethodAdded: Boolean
 	"""
 	the features associated with the subscription
 	"""
@@ -17821,6 +17950,44 @@ input OrgSubscriptionHistoryWhereInput {
 	expiresAtLTE: Time
 	expiresAtIsNil: Boolean
 	expiresAtNotNil: Boolean
+	"""
+	trial_expires_at field predicates
+	"""
+	trialExpiresAt: Time
+	trialExpiresAtNEQ: Time
+	trialExpiresAtIn: [Time!]
+	trialExpiresAtNotIn: [Time!]
+	trialExpiresAtGT: Time
+	trialExpiresAtGTE: Time
+	trialExpiresAtLT: Time
+	trialExpiresAtLTE: Time
+	trialExpiresAtIsNil: Boolean
+	trialExpiresAtNotNil: Boolean
+	"""
+	days_until_due field predicates
+	"""
+	daysUntilDue: String
+	daysUntilDueNEQ: String
+	daysUntilDueIn: [String!]
+	daysUntilDueNotIn: [String!]
+	daysUntilDueGT: String
+	daysUntilDueGTE: String
+	daysUntilDueLT: String
+	daysUntilDueLTE: String
+	daysUntilDueContains: String
+	daysUntilDueHasPrefix: String
+	daysUntilDueHasSuffix: String
+	daysUntilDueIsNil: Boolean
+	daysUntilDueNotNil: Boolean
+	daysUntilDueEqualFold: String
+	daysUntilDueContainsFold: String
+	"""
+	payment_method_added field predicates
+	"""
+	paymentMethodAdded: Boolean
+	paymentMethodAddedNEQ: Boolean
+	paymentMethodAddedIsNil: Boolean
+	paymentMethodAddedNotNil: Boolean
 }
 type OrgSubscriptionSearchResult {
 	orgSubscriptions: [OrgSubscription!]
@@ -18066,10 +18233,53 @@ input OrgSubscriptionWhereInput {
 	expiresAtIsNil: Boolean
 	expiresAtNotNil: Boolean
 	"""
+	trial_expires_at field predicates
+	"""
+	trialExpiresAt: Time
+	trialExpiresAtNEQ: Time
+	trialExpiresAtIn: [Time!]
+	trialExpiresAtNotIn: [Time!]
+	trialExpiresAtGT: Time
+	trialExpiresAtGTE: Time
+	trialExpiresAtLT: Time
+	trialExpiresAtLTE: Time
+	trialExpiresAtIsNil: Boolean
+	trialExpiresAtNotNil: Boolean
+	"""
+	days_until_due field predicates
+	"""
+	daysUntilDue: String
+	daysUntilDueNEQ: String
+	daysUntilDueIn: [String!]
+	daysUntilDueNotIn: [String!]
+	daysUntilDueGT: String
+	daysUntilDueGTE: String
+	daysUntilDueLT: String
+	daysUntilDueLTE: String
+	daysUntilDueContains: String
+	daysUntilDueHasPrefix: String
+	daysUntilDueHasSuffix: String
+	daysUntilDueIsNil: Boolean
+	daysUntilDueNotNil: Boolean
+	daysUntilDueEqualFold: String
+	daysUntilDueContainsFold: String
+	"""
+	payment_method_added field predicates
+	"""
+	paymentMethodAdded: Boolean
+	paymentMethodAddedNEQ: Boolean
+	paymentMethodAddedIsNil: Boolean
+	paymentMethodAddedNotNil: Boolean
+	"""
 	owner edge predicates
 	"""
 	hasOwner: Boolean
 	hasOwnerWith: [OrganizationWhereInput!]
+	"""
+	events edge predicates
+	"""
+	hasEvents: Boolean
+	hasEventsWith: [EventWhereInput!]
 }
 type Organization implements Node {
 	id: ID!
@@ -19836,6 +20046,22 @@ type PersonalAccessToken implements Node {
 	description: String
 	scopes: [String!]
 	lastUsedAt: Time
+	"""
+	whether the token is active
+	"""
+	isActive: Boolean
+	"""
+	the reason the token was revoked
+	"""
+	revokedReason: String
+	"""
+	the user who revoked the token
+	"""
+	revokedBy: String
+	"""
+	when the token was revoked
+	"""
+	revokedAt: Time
 	owner: User!
 	"""
 	the organization(s) the token is associated with
@@ -20068,6 +20294,62 @@ input PersonalAccessTokenWhereInput {
 	lastUsedAtLTE: Time
 	lastUsedAtIsNil: Boolean
 	lastUsedAtNotNil: Boolean
+	"""
+	is_active field predicates
+	"""
+	isActive: Boolean
+	isActiveNEQ: Boolean
+	isActiveIsNil: Boolean
+	isActiveNotNil: Boolean
+	"""
+	revoked_reason field predicates
+	"""
+	revokedReason: String
+	revokedReasonNEQ: String
+	revokedReasonIn: [String!]
+	revokedReasonNotIn: [String!]
+	revokedReasonGT: String
+	revokedReasonGTE: String
+	revokedReasonLT: String
+	revokedReasonLTE: String
+	revokedReasonContains: String
+	revokedReasonHasPrefix: String
+	revokedReasonHasSuffix: String
+	revokedReasonIsNil: Boolean
+	revokedReasonNotNil: Boolean
+	revokedReasonEqualFold: String
+	revokedReasonContainsFold: String
+	"""
+	revoked_by field predicates
+	"""
+	revokedBy: String
+	revokedByNEQ: String
+	revokedByIn: [String!]
+	revokedByNotIn: [String!]
+	revokedByGT: String
+	revokedByGTE: String
+	revokedByLT: String
+	revokedByLTE: String
+	revokedByContains: String
+	revokedByHasPrefix: String
+	revokedByHasSuffix: String
+	revokedByIsNil: Boolean
+	revokedByNotNil: Boolean
+	revokedByEqualFold: String
+	revokedByContainsFold: String
+	"""
+	revoked_at field predicates
+	"""
+	revokedAt: Time
+	revokedAtNEQ: Time
+	revokedAtIn: [Time!]
+	revokedAtNotIn: [Time!]
+	revokedAtGT: Time
+	revokedAtGTE: Time
+	revokedAtLT: Time
+	revokedAtLTE: Time
+	revokedAtIsNil: Boolean
+	revokedAtNotNil: Boolean
 	"""
 	owner edge predicates
 	"""
@@ -30230,6 +30512,26 @@ input UpdateAPITokenInput {
 	clearScopes: Boolean
 	lastUsedAt: Time
 	clearLastUsedAt: Boolean
+	"""
+	whether the token is active
+	"""
+	isActive: Boolean
+	clearIsActive: Boolean
+	"""
+	the reason the token was revoked
+	"""
+	revokedReason: String
+	clearRevokedReason: Boolean
+	"""
+	the user who revoked the token
+	"""
+	revokedBy: String
+	clearRevokedBy: Boolean
+	"""
+	when the token was revoked
+	"""
+	revokedAt: Time
+	clearRevokedAt: Boolean
 	ownerID: ID
 	clearOwner: Boolean
 }
@@ -31523,6 +31825,26 @@ input UpdatePersonalAccessTokenInput {
 	clearScopes: Boolean
 	lastUsedAt: Time
 	clearLastUsedAt: Boolean
+	"""
+	whether the token is active
+	"""
+	isActive: Boolean
+	clearIsActive: Boolean
+	"""
+	the reason the token was revoked
+	"""
+	revokedReason: String
+	clearRevokedReason: Boolean
+	"""
+	the user who revoked the token
+	"""
+	revokedBy: String
+	clearRevokedBy: Boolean
+	"""
+	when the token was revoked
+	"""
+	revokedAt: Time
+	clearRevokedAt: Boolean
 	addOrganizationIDs: [ID!]
 	removeOrganizationIDs: [ID!]
 	clearOrganizations: Boolean

--- a/internal/graphapi/generated/apitoken.generated.go
+++ b/internal/graphapi/generated/apitoken.generated.go
@@ -95,6 +95,14 @@ func (ec *executionContext) fieldContext_APITokenBulkCreatePayload_apiTokens(_ c
 				return ec.fieldContext_APIToken_scopes(ctx, field)
 			case "lastUsedAt":
 				return ec.fieldContext_APIToken_lastUsedAt(ctx, field)
+			case "isActive":
+				return ec.fieldContext_APIToken_isActive(ctx, field)
+			case "revokedReason":
+				return ec.fieldContext_APIToken_revokedReason(ctx, field)
+			case "revokedBy":
+				return ec.fieldContext_APIToken_revokedBy(ctx, field)
+			case "revokedAt":
+				return ec.fieldContext_APIToken_revokedAt(ctx, field)
 			case "owner":
 				return ec.fieldContext_APIToken_owner(ctx, field)
 			}
@@ -173,6 +181,14 @@ func (ec *executionContext) fieldContext_APITokenCreatePayload_apiToken(_ contex
 				return ec.fieldContext_APIToken_scopes(ctx, field)
 			case "lastUsedAt":
 				return ec.fieldContext_APIToken_lastUsedAt(ctx, field)
+			case "isActive":
+				return ec.fieldContext_APIToken_isActive(ctx, field)
+			case "revokedReason":
+				return ec.fieldContext_APIToken_revokedReason(ctx, field)
+			case "revokedBy":
+				return ec.fieldContext_APIToken_revokedBy(ctx, field)
+			case "revokedAt":
+				return ec.fieldContext_APIToken_revokedAt(ctx, field)
 			case "owner":
 				return ec.fieldContext_APIToken_owner(ctx, field)
 			}
@@ -295,6 +311,14 @@ func (ec *executionContext) fieldContext_APITokenUpdatePayload_apiToken(_ contex
 				return ec.fieldContext_APIToken_scopes(ctx, field)
 			case "lastUsedAt":
 				return ec.fieldContext_APIToken_lastUsedAt(ctx, field)
+			case "isActive":
+				return ec.fieldContext_APIToken_isActive(ctx, field)
+			case "revokedReason":
+				return ec.fieldContext_APIToken_revokedReason(ctx, field)
+			case "revokedBy":
+				return ec.fieldContext_APIToken_revokedBy(ctx, field)
+			case "revokedAt":
+				return ec.fieldContext_APIToken_revokedAt(ctx, field)
 			case "owner":
 				return ec.fieldContext_APIToken_owner(ctx, field)
 			}

--- a/internal/graphapi/generated/personalaccesstoken.generated.go
+++ b/internal/graphapi/generated/personalaccesstoken.generated.go
@@ -93,6 +93,14 @@ func (ec *executionContext) fieldContext_PersonalAccessTokenBulkCreatePayload_pe
 				return ec.fieldContext_PersonalAccessToken_scopes(ctx, field)
 			case "lastUsedAt":
 				return ec.fieldContext_PersonalAccessToken_lastUsedAt(ctx, field)
+			case "isActive":
+				return ec.fieldContext_PersonalAccessToken_isActive(ctx, field)
+			case "revokedReason":
+				return ec.fieldContext_PersonalAccessToken_revokedReason(ctx, field)
+			case "revokedBy":
+				return ec.fieldContext_PersonalAccessToken_revokedBy(ctx, field)
+			case "revokedAt":
+				return ec.fieldContext_PersonalAccessToken_revokedAt(ctx, field)
 			case "owner":
 				return ec.fieldContext_PersonalAccessToken_owner(ctx, field)
 			case "organizations":
@@ -173,6 +181,14 @@ func (ec *executionContext) fieldContext_PersonalAccessTokenCreatePayload_person
 				return ec.fieldContext_PersonalAccessToken_scopes(ctx, field)
 			case "lastUsedAt":
 				return ec.fieldContext_PersonalAccessToken_lastUsedAt(ctx, field)
+			case "isActive":
+				return ec.fieldContext_PersonalAccessToken_isActive(ctx, field)
+			case "revokedReason":
+				return ec.fieldContext_PersonalAccessToken_revokedReason(ctx, field)
+			case "revokedBy":
+				return ec.fieldContext_PersonalAccessToken_revokedBy(ctx, field)
+			case "revokedAt":
+				return ec.fieldContext_PersonalAccessToken_revokedAt(ctx, field)
 			case "owner":
 				return ec.fieldContext_PersonalAccessToken_owner(ctx, field)
 			case "organizations":
@@ -297,6 +313,14 @@ func (ec *executionContext) fieldContext_PersonalAccessTokenUpdatePayload_person
 				return ec.fieldContext_PersonalAccessToken_scopes(ctx, field)
 			case "lastUsedAt":
 				return ec.fieldContext_PersonalAccessToken_lastUsedAt(ctx, field)
+			case "isActive":
+				return ec.fieldContext_PersonalAccessToken_isActive(ctx, field)
+			case "revokedReason":
+				return ec.fieldContext_PersonalAccessToken_revokedReason(ctx, field)
+			case "revokedBy":
+				return ec.fieldContext_PersonalAccessToken_revokedBy(ctx, field)
+			case "revokedAt":
+				return ec.fieldContext_PersonalAccessToken_revokedAt(ctx, field)
 			case "owner":
 				return ec.fieldContext_PersonalAccessToken_owner(ctx, field)
 			case "organizations":

--- a/internal/graphapi/generated/root_.generated.go
+++ b/internal/graphapi/generated/root_.generated.go
@@ -55,22 +55,26 @@ type DirectiveRoot struct {
 
 type ComplexityRoot struct {
 	APIToken struct {
-		CreatedAt   func(childComplexity int) int
-		CreatedBy   func(childComplexity int) int
-		DeletedAt   func(childComplexity int) int
-		DeletedBy   func(childComplexity int) int
-		Description func(childComplexity int) int
-		ExpiresAt   func(childComplexity int) int
-		ID          func(childComplexity int) int
-		LastUsedAt  func(childComplexity int) int
-		Name        func(childComplexity int) int
-		Owner       func(childComplexity int) int
-		OwnerID     func(childComplexity int) int
-		Scopes      func(childComplexity int) int
-		Tags        func(childComplexity int) int
-		Token       func(childComplexity int) int
-		UpdatedAt   func(childComplexity int) int
-		UpdatedBy   func(childComplexity int) int
+		CreatedAt     func(childComplexity int) int
+		CreatedBy     func(childComplexity int) int
+		DeletedAt     func(childComplexity int) int
+		DeletedBy     func(childComplexity int) int
+		Description   func(childComplexity int) int
+		ExpiresAt     func(childComplexity int) int
+		ID            func(childComplexity int) int
+		IsActive      func(childComplexity int) int
+		LastUsedAt    func(childComplexity int) int
+		Name          func(childComplexity int) int
+		Owner         func(childComplexity int) int
+		OwnerID       func(childComplexity int) int
+		RevokedAt     func(childComplexity int) int
+		RevokedBy     func(childComplexity int) int
+		RevokedReason func(childComplexity int) int
+		Scopes        func(childComplexity int) int
+		Tags          func(childComplexity int) int
+		Token         func(childComplexity int) int
+		UpdatedAt     func(childComplexity int) int
+		UpdatedBy     func(childComplexity int) int
 	}
 
 	APITokenBulkCreatePayload struct {
@@ -1982,14 +1986,17 @@ type ComplexityRoot struct {
 		Active                   func(childComplexity int) int
 		CreatedAt                func(childComplexity int) int
 		CreatedBy                func(childComplexity int) int
+		DaysUntilDue             func(childComplexity int) int
 		DeletedAt                func(childComplexity int) int
 		DeletedBy                func(childComplexity int) int
+		Events                   func(childComplexity int) int
 		ExpiresAt                func(childComplexity int) int
 		FeatureLookupKeys        func(childComplexity int) int
 		Features                 func(childComplexity int) int
 		ID                       func(childComplexity int) int
 		Owner                    func(childComplexity int) int
 		OwnerID                  func(childComplexity int) int
+		PaymentMethodAdded       func(childComplexity int) int
 		ProductPrice             func(childComplexity int) int
 		ProductTier              func(childComplexity int) int
 		StripeCustomerID         func(childComplexity int) int
@@ -1998,6 +2005,7 @@ type ComplexityRoot struct {
 		StripeSubscriptionStatus func(childComplexity int) int
 		SubscriptionURL          func(childComplexity int) int
 		Tags                     func(childComplexity int) int
+		TrialExpiresAt           func(childComplexity int) int
 		UpdatedAt                func(childComplexity int) int
 		UpdatedBy                func(childComplexity int) int
 	}
@@ -2017,6 +2025,7 @@ type ComplexityRoot struct {
 		Active                   func(childComplexity int) int
 		CreatedAt                func(childComplexity int) int
 		CreatedBy                func(childComplexity int) int
+		DaysUntilDue             func(childComplexity int) int
 		DeletedAt                func(childComplexity int) int
 		DeletedBy                func(childComplexity int) int
 		ExpiresAt                func(childComplexity int) int
@@ -2026,6 +2035,7 @@ type ComplexityRoot struct {
 		ID                       func(childComplexity int) int
 		Operation                func(childComplexity int) int
 		OwnerID                  func(childComplexity int) int
+		PaymentMethodAdded       func(childComplexity int) int
 		ProductPrice             func(childComplexity int) int
 		ProductTier              func(childComplexity int) int
 		Ref                      func(childComplexity int) int
@@ -2034,6 +2044,7 @@ type ComplexityRoot struct {
 		StripeSubscriptionID     func(childComplexity int) int
 		StripeSubscriptionStatus func(childComplexity int) int
 		Tags                     func(childComplexity int) int
+		TrialExpiresAt           func(childComplexity int) int
 		UpdatedAt                func(childComplexity int) int
 		UpdatedBy                func(childComplexity int) int
 	}
@@ -2282,10 +2293,14 @@ type ComplexityRoot struct {
 		Events        func(childComplexity int) int
 		ExpiresAt     func(childComplexity int) int
 		ID            func(childComplexity int) int
+		IsActive      func(childComplexity int) int
 		LastUsedAt    func(childComplexity int) int
 		Name          func(childComplexity int) int
 		Organizations func(childComplexity int) int
 		Owner         func(childComplexity int) int
+		RevokedAt     func(childComplexity int) int
+		RevokedBy     func(childComplexity int) int
+		RevokedReason func(childComplexity int) int
 		Scopes        func(childComplexity int) int
 		Tags          func(childComplexity int) int
 		Token         func(childComplexity int) int
@@ -3607,6 +3622,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.APIToken.ID(childComplexity), true
 
+	case "APIToken.isActive":
+		if e.complexity.APIToken.IsActive == nil {
+			break
+		}
+
+		return e.complexity.APIToken.IsActive(childComplexity), true
+
 	case "APIToken.lastUsedAt":
 		if e.complexity.APIToken.LastUsedAt == nil {
 			break
@@ -3634,6 +3656,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.APIToken.OwnerID(childComplexity), true
+
+	case "APIToken.revokedAt":
+		if e.complexity.APIToken.RevokedAt == nil {
+			break
+		}
+
+		return e.complexity.APIToken.RevokedAt(childComplexity), true
+
+	case "APIToken.revokedBy":
+		if e.complexity.APIToken.RevokedBy == nil {
+			break
+		}
+
+		return e.complexity.APIToken.RevokedBy(childComplexity), true
+
+	case "APIToken.revokedReason":
+		if e.complexity.APIToken.RevokedReason == nil {
+			break
+		}
+
+		return e.complexity.APIToken.RevokedReason(childComplexity), true
 
 	case "APIToken.scopes":
 		if e.complexity.APIToken.Scopes == nil {
@@ -13293,6 +13336,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.OrgSubscription.CreatedBy(childComplexity), true
 
+	case "OrgSubscription.daysUntilDue":
+		if e.complexity.OrgSubscription.DaysUntilDue == nil {
+			break
+		}
+
+		return e.complexity.OrgSubscription.DaysUntilDue(childComplexity), true
+
 	case "OrgSubscription.deletedAt":
 		if e.complexity.OrgSubscription.DeletedAt == nil {
 			break
@@ -13306,6 +13356,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.OrgSubscription.DeletedBy(childComplexity), true
+
+	case "OrgSubscription.events":
+		if e.complexity.OrgSubscription.Events == nil {
+			break
+		}
+
+		return e.complexity.OrgSubscription.Events(childComplexity), true
 
 	case "OrgSubscription.expiresAt":
 		if e.complexity.OrgSubscription.ExpiresAt == nil {
@@ -13348,6 +13405,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.OrgSubscription.OwnerID(childComplexity), true
+
+	case "OrgSubscription.paymentMethodAdded":
+		if e.complexity.OrgSubscription.PaymentMethodAdded == nil {
+			break
+		}
+
+		return e.complexity.OrgSubscription.PaymentMethodAdded(childComplexity), true
 
 	case "OrgSubscription.productPrice":
 		if e.complexity.OrgSubscription.ProductPrice == nil {
@@ -13404,6 +13468,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.OrgSubscription.Tags(childComplexity), true
+
+	case "OrgSubscription.trialExpiresAt":
+		if e.complexity.OrgSubscription.TrialExpiresAt == nil {
+			break
+		}
+
+		return e.complexity.OrgSubscription.TrialExpiresAt(childComplexity), true
 
 	case "OrgSubscription.updatedAt":
 		if e.complexity.OrgSubscription.UpdatedAt == nil {
@@ -13475,6 +13546,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.OrgSubscriptionHistory.CreatedBy(childComplexity), true
 
+	case "OrgSubscriptionHistory.daysUntilDue":
+		if e.complexity.OrgSubscriptionHistory.DaysUntilDue == nil {
+			break
+		}
+
+		return e.complexity.OrgSubscriptionHistory.DaysUntilDue(childComplexity), true
+
 	case "OrgSubscriptionHistory.deletedAt":
 		if e.complexity.OrgSubscriptionHistory.DeletedAt == nil {
 			break
@@ -13538,6 +13616,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.OrgSubscriptionHistory.OwnerID(childComplexity), true
 
+	case "OrgSubscriptionHistory.paymentMethodAdded":
+		if e.complexity.OrgSubscriptionHistory.PaymentMethodAdded == nil {
+			break
+		}
+
+		return e.complexity.OrgSubscriptionHistory.PaymentMethodAdded(childComplexity), true
+
 	case "OrgSubscriptionHistory.productPrice":
 		if e.complexity.OrgSubscriptionHistory.ProductPrice == nil {
 			break
@@ -13593,6 +13678,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.OrgSubscriptionHistory.Tags(childComplexity), true
+
+	case "OrgSubscriptionHistory.trialExpiresAt":
+		if e.complexity.OrgSubscriptionHistory.TrialExpiresAt == nil {
+			break
+		}
+
+		return e.complexity.OrgSubscriptionHistory.TrialExpiresAt(childComplexity), true
 
 	case "OrgSubscriptionHistory.updatedAt":
 		if e.complexity.OrgSubscriptionHistory.UpdatedAt == nil {
@@ -14768,6 +14860,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.PersonalAccessToken.ID(childComplexity), true
 
+	case "PersonalAccessToken.isActive":
+		if e.complexity.PersonalAccessToken.IsActive == nil {
+			break
+		}
+
+		return e.complexity.PersonalAccessToken.IsActive(childComplexity), true
+
 	case "PersonalAccessToken.lastUsedAt":
 		if e.complexity.PersonalAccessToken.LastUsedAt == nil {
 			break
@@ -14795,6 +14894,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.PersonalAccessToken.Owner(childComplexity), true
+
+	case "PersonalAccessToken.revokedAt":
+		if e.complexity.PersonalAccessToken.RevokedAt == nil {
+			break
+		}
+
+		return e.complexity.PersonalAccessToken.RevokedAt(childComplexity), true
+
+	case "PersonalAccessToken.revokedBy":
+		if e.complexity.PersonalAccessToken.RevokedBy == nil {
+			break
+		}
+
+		return e.complexity.PersonalAccessToken.RevokedBy(childComplexity), true
+
+	case "PersonalAccessToken.revokedReason":
+		if e.complexity.PersonalAccessToken.RevokedReason == nil {
+			break
+		}
+
+		return e.complexity.PersonalAccessToken.RevokedReason(childComplexity), true
 
 	case "PersonalAccessToken.scopes":
 		if e.complexity.PersonalAccessToken.Scopes == nil {
@@ -22926,6 +23046,22 @@ type APIToken implements Node {
   description: String
   scopes: [String!]
   lastUsedAt: Time
+  """
+  whether the token is active
+  """
+  isActive: Boolean
+  """
+  the reason the token was revoked
+  """
+  revokedReason: String
+  """
+  the user who revoked the token
+  """
+  revokedBy: String
+  """
+  when the token was revoked
+  """
+  revokedAt: Time
   owner: Organization
 }
 """
@@ -23132,6 +23268,62 @@ input APITokenWhereInput {
   lastUsedAtLTE: Time
   lastUsedAtIsNil: Boolean
   lastUsedAtNotNil: Boolean
+  """
+  is_active field predicates
+  """
+  isActive: Boolean
+  isActiveNEQ: Boolean
+  isActiveIsNil: Boolean
+  isActiveNotNil: Boolean
+  """
+  revoked_reason field predicates
+  """
+  revokedReason: String
+  revokedReasonNEQ: String
+  revokedReasonIn: [String!]
+  revokedReasonNotIn: [String!]
+  revokedReasonGT: String
+  revokedReasonGTE: String
+  revokedReasonLT: String
+  revokedReasonLTE: String
+  revokedReasonContains: String
+  revokedReasonHasPrefix: String
+  revokedReasonHasSuffix: String
+  revokedReasonIsNil: Boolean
+  revokedReasonNotNil: Boolean
+  revokedReasonEqualFold: String
+  revokedReasonContainsFold: String
+  """
+  revoked_by field predicates
+  """
+  revokedBy: String
+  revokedByNEQ: String
+  revokedByIn: [String!]
+  revokedByNotIn: [String!]
+  revokedByGT: String
+  revokedByGTE: String
+  revokedByLT: String
+  revokedByLTE: String
+  revokedByContains: String
+  revokedByHasPrefix: String
+  revokedByHasSuffix: String
+  revokedByIsNil: Boolean
+  revokedByNotNil: Boolean
+  revokedByEqualFold: String
+  revokedByContainsFold: String
+  """
+  revoked_at field predicates
+  """
+  revokedAt: Time
+  revokedAtNEQ: Time
+  revokedAtIn: [Time!]
+  revokedAtNotIn: [Time!]
+  revokedAtGT: Time
+  revokedAtGTE: Time
+  revokedAtLT: Time
+  revokedAtLTE: Time
+  revokedAtIsNil: Boolean
+  revokedAtNotNil: Boolean
   """
   owner edge predicates
   """
@@ -26639,6 +26831,22 @@ input CreateAPITokenInput {
   description: String
   scopes: [String!]
   lastUsedAt: Time
+  """
+  whether the token is active
+  """
+  isActive: Boolean
+  """
+  the reason the token was revoked
+  """
+  revokedReason: String
+  """
+  the user who revoked the token
+  """
+  revokedBy: String
+  """
+  when the token was revoked
+  """
+  revokedAt: Time
   ownerID: ID
 }
 """
@@ -27540,6 +27748,22 @@ input CreatePersonalAccessTokenInput {
   description: String
   scopes: [String!]
   lastUsedAt: Time
+  """
+  whether the token is active
+  """
+  isActive: Boolean
+  """
+  the reason the token was revoked
+  """
+  revokedReason: String
+  """
+  the user who revoked the token
+  """
+  revokedBy: String
+  """
+  when the token was revoked
+  """
+  revokedAt: Time
   ownerID: ID!
   organizationIDs: [ID!]
   eventIDs: [ID!]
@@ -37716,6 +37940,18 @@ type OrgSubscription implements Node {
   """
   expiresAt: Time
   """
+  the time the trial is set to expire
+  """
+  trialExpiresAt: Time
+  """
+  number of days until there is a due payment
+  """
+  daysUntilDue: String
+  """
+  whether or not a payment method has been added to the account
+  """
+  paymentMethodAdded: Boolean
+  """
   the features associated with the subscription
   """
   features: [String!]
@@ -37724,6 +37960,7 @@ type OrgSubscription implements Node {
   """
   featureLookupKeys: [String!]
   owner: Organization
+  events: [Event!]
 }
 """
 A connection to a list of items.
@@ -37806,6 +38043,18 @@ type OrgSubscriptionHistory implements Node {
   the time the subscription is set to expire; only populated if subscription is cancelled
   """
   expiresAt: Time
+  """
+  the time the trial is set to expire
+  """
+  trialExpiresAt: Time
+  """
+  number of days until there is a due payment
+  """
+  daysUntilDue: String
+  """
+  whether or not a payment method has been added to the account
+  """
+  paymentMethodAdded: Boolean
   """
   the features associated with the subscription
   """
@@ -38129,6 +38378,44 @@ input OrgSubscriptionHistoryWhereInput {
   expiresAtLTE: Time
   expiresAtIsNil: Boolean
   expiresAtNotNil: Boolean
+  """
+  trial_expires_at field predicates
+  """
+  trialExpiresAt: Time
+  trialExpiresAtNEQ: Time
+  trialExpiresAtIn: [Time!]
+  trialExpiresAtNotIn: [Time!]
+  trialExpiresAtGT: Time
+  trialExpiresAtGTE: Time
+  trialExpiresAtLT: Time
+  trialExpiresAtLTE: Time
+  trialExpiresAtIsNil: Boolean
+  trialExpiresAtNotNil: Boolean
+  """
+  days_until_due field predicates
+  """
+  daysUntilDue: String
+  daysUntilDueNEQ: String
+  daysUntilDueIn: [String!]
+  daysUntilDueNotIn: [String!]
+  daysUntilDueGT: String
+  daysUntilDueGTE: String
+  daysUntilDueLT: String
+  daysUntilDueLTE: String
+  daysUntilDueContains: String
+  daysUntilDueHasPrefix: String
+  daysUntilDueHasSuffix: String
+  daysUntilDueIsNil: Boolean
+  daysUntilDueNotNil: Boolean
+  daysUntilDueEqualFold: String
+  daysUntilDueContainsFold: String
+  """
+  payment_method_added field predicates
+  """
+  paymentMethodAdded: Boolean
+  paymentMethodAddedNEQ: Boolean
+  paymentMethodAddedIsNil: Boolean
+  paymentMethodAddedNotNil: Boolean
 }
 """
 OrgSubscriptionWhereInput is used for filtering OrgSubscription objects.
@@ -38371,10 +38658,53 @@ input OrgSubscriptionWhereInput {
   expiresAtIsNil: Boolean
   expiresAtNotNil: Boolean
   """
+  trial_expires_at field predicates
+  """
+  trialExpiresAt: Time
+  trialExpiresAtNEQ: Time
+  trialExpiresAtIn: [Time!]
+  trialExpiresAtNotIn: [Time!]
+  trialExpiresAtGT: Time
+  trialExpiresAtGTE: Time
+  trialExpiresAtLT: Time
+  trialExpiresAtLTE: Time
+  trialExpiresAtIsNil: Boolean
+  trialExpiresAtNotNil: Boolean
+  """
+  days_until_due field predicates
+  """
+  daysUntilDue: String
+  daysUntilDueNEQ: String
+  daysUntilDueIn: [String!]
+  daysUntilDueNotIn: [String!]
+  daysUntilDueGT: String
+  daysUntilDueGTE: String
+  daysUntilDueLT: String
+  daysUntilDueLTE: String
+  daysUntilDueContains: String
+  daysUntilDueHasPrefix: String
+  daysUntilDueHasSuffix: String
+  daysUntilDueIsNil: Boolean
+  daysUntilDueNotNil: Boolean
+  daysUntilDueEqualFold: String
+  daysUntilDueContainsFold: String
+  """
+  payment_method_added field predicates
+  """
+  paymentMethodAdded: Boolean
+  paymentMethodAddedNEQ: Boolean
+  paymentMethodAddedIsNil: Boolean
+  paymentMethodAddedNotNil: Boolean
+  """
   owner edge predicates
   """
   hasOwner: Boolean
   hasOwnerWith: [OrganizationWhereInput!]
+  """
+  events edge predicates
+  """
+  hasEvents: Boolean
+  hasEventsWith: [EventWhereInput!]
 }
 type Organization implements Node {
   id: ID!
@@ -40054,6 +40384,22 @@ type PersonalAccessToken implements Node {
   description: String
   scopes: [String!]
   lastUsedAt: Time
+  """
+  whether the token is active
+  """
+  isActive: Boolean
+  """
+  the reason the token was revoked
+  """
+  revokedReason: String
+  """
+  the user who revoked the token
+  """
+  revokedBy: String
+  """
+  when the token was revoked
+  """
+  revokedAt: Time
   owner: User!
   """
   the organization(s) the token is associated with
@@ -40247,6 +40593,62 @@ input PersonalAccessTokenWhereInput {
   lastUsedAtLTE: Time
   lastUsedAtIsNil: Boolean
   lastUsedAtNotNil: Boolean
+  """
+  is_active field predicates
+  """
+  isActive: Boolean
+  isActiveNEQ: Boolean
+  isActiveIsNil: Boolean
+  isActiveNotNil: Boolean
+  """
+  revoked_reason field predicates
+  """
+  revokedReason: String
+  revokedReasonNEQ: String
+  revokedReasonIn: [String!]
+  revokedReasonNotIn: [String!]
+  revokedReasonGT: String
+  revokedReasonGTE: String
+  revokedReasonLT: String
+  revokedReasonLTE: String
+  revokedReasonContains: String
+  revokedReasonHasPrefix: String
+  revokedReasonHasSuffix: String
+  revokedReasonIsNil: Boolean
+  revokedReasonNotNil: Boolean
+  revokedReasonEqualFold: String
+  revokedReasonContainsFold: String
+  """
+  revoked_by field predicates
+  """
+  revokedBy: String
+  revokedByNEQ: String
+  revokedByIn: [String!]
+  revokedByNotIn: [String!]
+  revokedByGT: String
+  revokedByGTE: String
+  revokedByLT: String
+  revokedByLTE: String
+  revokedByContains: String
+  revokedByHasPrefix: String
+  revokedByHasSuffix: String
+  revokedByIsNil: Boolean
+  revokedByNotNil: Boolean
+  revokedByEqualFold: String
+  revokedByContainsFold: String
+  """
+  revoked_at field predicates
+  """
+  revokedAt: Time
+  revokedAtNEQ: Time
+  revokedAtIn: [Time!]
+  revokedAtNotIn: [Time!]
+  revokedAtGT: Time
+  revokedAtGTE: Time
+  revokedAtLT: Time
+  revokedAtLTE: Time
+  revokedAtIsNil: Boolean
+  revokedAtNotNil: Boolean
   """
   owner edge predicates
   """
@@ -49117,6 +49519,26 @@ input UpdateAPITokenInput {
   clearScopes: Boolean
   lastUsedAt: Time
   clearLastUsedAt: Boolean
+  """
+  whether the token is active
+  """
+  isActive: Boolean
+  clearIsActive: Boolean
+  """
+  the reason the token was revoked
+  """
+  revokedReason: String
+  clearRevokedReason: Boolean
+  """
+  the user who revoked the token
+  """
+  revokedBy: String
+  clearRevokedBy: Boolean
+  """
+  when the token was revoked
+  """
+  revokedAt: Time
+  clearRevokedAt: Boolean
   ownerID: ID
   clearOwner: Boolean
 }
@@ -50398,6 +50820,26 @@ input UpdatePersonalAccessTokenInput {
   clearScopes: Boolean
   lastUsedAt: Time
   clearLastUsedAt: Boolean
+  """
+  whether the token is active
+  """
+  isActive: Boolean
+  clearIsActive: Boolean
+  """
+  the reason the token was revoked
+  """
+  revokedReason: String
+  clearRevokedReason: Boolean
+  """
+  the user who revoked the token
+  """
+  revokedBy: String
+  clearRevokedBy: Boolean
+  """
+  when the token was revoked
+  """
+  revokedAt: Time
+  clearRevokedAt: Boolean
   addOrganizationIDs: [ID!]
   removeOrganizationIDs: [ID!]
   clearOrganizations: Boolean

--- a/internal/graphapi/generated/search.generated.go
+++ b/internal/graphapi/generated/search.generated.go
@@ -97,6 +97,14 @@ func (ec *executionContext) fieldContext_APITokenSearchResult_apiTokens(_ contex
 				return ec.fieldContext_APIToken_scopes(ctx, field)
 			case "lastUsedAt":
 				return ec.fieldContext_APIToken_lastUsedAt(ctx, field)
+			case "isActive":
+				return ec.fieldContext_APIToken_isActive(ctx, field)
+			case "revokedReason":
+				return ec.fieldContext_APIToken_revokedReason(ctx, field)
+			case "revokedBy":
+				return ec.fieldContext_APIToken_revokedBy(ctx, field)
+			case "revokedAt":
+				return ec.fieldContext_APIToken_revokedAt(ctx, field)
 			case "owner":
 				return ec.fieldContext_APIToken_owner(ctx, field)
 			}
@@ -1478,12 +1486,20 @@ func (ec *executionContext) fieldContext_OrgSubscriptionSearchResult_orgSubscrip
 				return ec.fieldContext_OrgSubscription_stripeCustomerID(ctx, field)
 			case "expiresAt":
 				return ec.fieldContext_OrgSubscription_expiresAt(ctx, field)
+			case "trialExpiresAt":
+				return ec.fieldContext_OrgSubscription_trialExpiresAt(ctx, field)
+			case "daysUntilDue":
+				return ec.fieldContext_OrgSubscription_daysUntilDue(ctx, field)
+			case "paymentMethodAdded":
+				return ec.fieldContext_OrgSubscription_paymentMethodAdded(ctx, field)
 			case "features":
 				return ec.fieldContext_OrgSubscription_features(ctx, field)
 			case "featureLookupKeys":
 				return ec.fieldContext_OrgSubscription_featureLookupKeys(ctx, field)
 			case "owner":
 				return ec.fieldContext_OrgSubscription_owner(ctx, field)
+			case "events":
+				return ec.fieldContext_OrgSubscription_events(ctx, field)
 			case "subscriptionURL":
 				return ec.fieldContext_OrgSubscription_subscriptionURL(ctx, field)
 			}
@@ -1797,6 +1813,14 @@ func (ec *executionContext) fieldContext_PersonalAccessTokenSearchResult_persona
 				return ec.fieldContext_PersonalAccessToken_scopes(ctx, field)
 			case "lastUsedAt":
 				return ec.fieldContext_PersonalAccessToken_lastUsedAt(ctx, field)
+			case "isActive":
+				return ec.fieldContext_PersonalAccessToken_isActive(ctx, field)
+			case "revokedReason":
+				return ec.fieldContext_PersonalAccessToken_revokedReason(ctx, field)
+			case "revokedBy":
+				return ec.fieldContext_PersonalAccessToken_revokedBy(ctx, field)
+			case "revokedAt":
+				return ec.fieldContext_PersonalAccessToken_revokedAt(ctx, field)
 			case "owner":
 				return ec.fieldContext_PersonalAccessToken_owner(ctx, field)
 			case "organizations":

--- a/internal/graphapi/query/adminsearch.graphql
+++ b/internal/graphapi/query/adminsearch.graphql
@@ -9,6 +9,8 @@ query AdminSearch($query: String!) {
           ownerID
           name
           scopes
+          revokedReason
+          revokedBy
         }
       }
       ... on ActionPlanSearchResult {
@@ -219,6 +221,7 @@ query AdminSearch($query: String!) {
           stripeProductTierID
           stripeSubscriptionStatus
           stripeCustomerID
+          daysUntilDue
           features
           featureLookupKeys
         }
@@ -256,6 +259,8 @@ query AdminSearch($query: String!) {
           tags
           name
           scopes
+          revokedReason
+          revokedBy
         }
       }
       ... on ProcedureSearchResult {

--- a/internal/graphapi/schema/ent.graphql
+++ b/internal/graphapi/schema/ent.graphql
@@ -31,6 +31,22 @@ type APIToken implements Node {
   description: String
   scopes: [String!]
   lastUsedAt: Time
+  """
+  whether the token is active
+  """
+  isActive: Boolean
+  """
+  the reason the token was revoked
+  """
+  revokedReason: String
+  """
+  the user who revoked the token
+  """
+  revokedBy: String
+  """
+  when the token was revoked
+  """
+  revokedAt: Time
   owner: Organization
 }
 """
@@ -237,6 +253,62 @@ input APITokenWhereInput {
   lastUsedAtLTE: Time
   lastUsedAtIsNil: Boolean
   lastUsedAtNotNil: Boolean
+  """
+  is_active field predicates
+  """
+  isActive: Boolean
+  isActiveNEQ: Boolean
+  isActiveIsNil: Boolean
+  isActiveNotNil: Boolean
+  """
+  revoked_reason field predicates
+  """
+  revokedReason: String
+  revokedReasonNEQ: String
+  revokedReasonIn: [String!]
+  revokedReasonNotIn: [String!]
+  revokedReasonGT: String
+  revokedReasonGTE: String
+  revokedReasonLT: String
+  revokedReasonLTE: String
+  revokedReasonContains: String
+  revokedReasonHasPrefix: String
+  revokedReasonHasSuffix: String
+  revokedReasonIsNil: Boolean
+  revokedReasonNotNil: Boolean
+  revokedReasonEqualFold: String
+  revokedReasonContainsFold: String
+  """
+  revoked_by field predicates
+  """
+  revokedBy: String
+  revokedByNEQ: String
+  revokedByIn: [String!]
+  revokedByNotIn: [String!]
+  revokedByGT: String
+  revokedByGTE: String
+  revokedByLT: String
+  revokedByLTE: String
+  revokedByContains: String
+  revokedByHasPrefix: String
+  revokedByHasSuffix: String
+  revokedByIsNil: Boolean
+  revokedByNotNil: Boolean
+  revokedByEqualFold: String
+  revokedByContainsFold: String
+  """
+  revoked_at field predicates
+  """
+  revokedAt: Time
+  revokedAtNEQ: Time
+  revokedAtIn: [Time!]
+  revokedAtNotIn: [Time!]
+  revokedAtGT: Time
+  revokedAtGTE: Time
+  revokedAtLT: Time
+  revokedAtLTE: Time
+  revokedAtIsNil: Boolean
+  revokedAtNotNil: Boolean
   """
   owner edge predicates
   """
@@ -3744,6 +3816,22 @@ input CreateAPITokenInput {
   description: String
   scopes: [String!]
   lastUsedAt: Time
+  """
+  whether the token is active
+  """
+  isActive: Boolean
+  """
+  the reason the token was revoked
+  """
+  revokedReason: String
+  """
+  the user who revoked the token
+  """
+  revokedBy: String
+  """
+  when the token was revoked
+  """
+  revokedAt: Time
   ownerID: ID
 }
 """
@@ -4645,6 +4733,22 @@ input CreatePersonalAccessTokenInput {
   description: String
   scopes: [String!]
   lastUsedAt: Time
+  """
+  whether the token is active
+  """
+  isActive: Boolean
+  """
+  the reason the token was revoked
+  """
+  revokedReason: String
+  """
+  the user who revoked the token
+  """
+  revokedBy: String
+  """
+  when the token was revoked
+  """
+  revokedAt: Time
   ownerID: ID!
   organizationIDs: [ID!]
   eventIDs: [ID!]
@@ -14821,6 +14925,18 @@ type OrgSubscription implements Node {
   """
   expiresAt: Time
   """
+  the time the trial is set to expire
+  """
+  trialExpiresAt: Time
+  """
+  number of days until there is a due payment
+  """
+  daysUntilDue: String
+  """
+  whether or not a payment method has been added to the account
+  """
+  paymentMethodAdded: Boolean
+  """
   the features associated with the subscription
   """
   features: [String!]
@@ -14829,6 +14945,7 @@ type OrgSubscription implements Node {
   """
   featureLookupKeys: [String!]
   owner: Organization
+  events: [Event!]
 }
 """
 A connection to a list of items.
@@ -14911,6 +15028,18 @@ type OrgSubscriptionHistory implements Node {
   the time the subscription is set to expire; only populated if subscription is cancelled
   """
   expiresAt: Time
+  """
+  the time the trial is set to expire
+  """
+  trialExpiresAt: Time
+  """
+  number of days until there is a due payment
+  """
+  daysUntilDue: String
+  """
+  whether or not a payment method has been added to the account
+  """
+  paymentMethodAdded: Boolean
   """
   the features associated with the subscription
   """
@@ -15234,6 +15363,44 @@ input OrgSubscriptionHistoryWhereInput {
   expiresAtLTE: Time
   expiresAtIsNil: Boolean
   expiresAtNotNil: Boolean
+  """
+  trial_expires_at field predicates
+  """
+  trialExpiresAt: Time
+  trialExpiresAtNEQ: Time
+  trialExpiresAtIn: [Time!]
+  trialExpiresAtNotIn: [Time!]
+  trialExpiresAtGT: Time
+  trialExpiresAtGTE: Time
+  trialExpiresAtLT: Time
+  trialExpiresAtLTE: Time
+  trialExpiresAtIsNil: Boolean
+  trialExpiresAtNotNil: Boolean
+  """
+  days_until_due field predicates
+  """
+  daysUntilDue: String
+  daysUntilDueNEQ: String
+  daysUntilDueIn: [String!]
+  daysUntilDueNotIn: [String!]
+  daysUntilDueGT: String
+  daysUntilDueGTE: String
+  daysUntilDueLT: String
+  daysUntilDueLTE: String
+  daysUntilDueContains: String
+  daysUntilDueHasPrefix: String
+  daysUntilDueHasSuffix: String
+  daysUntilDueIsNil: Boolean
+  daysUntilDueNotNil: Boolean
+  daysUntilDueEqualFold: String
+  daysUntilDueContainsFold: String
+  """
+  payment_method_added field predicates
+  """
+  paymentMethodAdded: Boolean
+  paymentMethodAddedNEQ: Boolean
+  paymentMethodAddedIsNil: Boolean
+  paymentMethodAddedNotNil: Boolean
 }
 """
 OrgSubscriptionWhereInput is used for filtering OrgSubscription objects.
@@ -15476,10 +15643,53 @@ input OrgSubscriptionWhereInput {
   expiresAtIsNil: Boolean
   expiresAtNotNil: Boolean
   """
+  trial_expires_at field predicates
+  """
+  trialExpiresAt: Time
+  trialExpiresAtNEQ: Time
+  trialExpiresAtIn: [Time!]
+  trialExpiresAtNotIn: [Time!]
+  trialExpiresAtGT: Time
+  trialExpiresAtGTE: Time
+  trialExpiresAtLT: Time
+  trialExpiresAtLTE: Time
+  trialExpiresAtIsNil: Boolean
+  trialExpiresAtNotNil: Boolean
+  """
+  days_until_due field predicates
+  """
+  daysUntilDue: String
+  daysUntilDueNEQ: String
+  daysUntilDueIn: [String!]
+  daysUntilDueNotIn: [String!]
+  daysUntilDueGT: String
+  daysUntilDueGTE: String
+  daysUntilDueLT: String
+  daysUntilDueLTE: String
+  daysUntilDueContains: String
+  daysUntilDueHasPrefix: String
+  daysUntilDueHasSuffix: String
+  daysUntilDueIsNil: Boolean
+  daysUntilDueNotNil: Boolean
+  daysUntilDueEqualFold: String
+  daysUntilDueContainsFold: String
+  """
+  payment_method_added field predicates
+  """
+  paymentMethodAdded: Boolean
+  paymentMethodAddedNEQ: Boolean
+  paymentMethodAddedIsNil: Boolean
+  paymentMethodAddedNotNil: Boolean
+  """
   owner edge predicates
   """
   hasOwner: Boolean
   hasOwnerWith: [OrganizationWhereInput!]
+  """
+  events edge predicates
+  """
+  hasEvents: Boolean
+  hasEventsWith: [EventWhereInput!]
 }
 type Organization implements Node {
   id: ID!
@@ -17159,6 +17369,22 @@ type PersonalAccessToken implements Node {
   description: String
   scopes: [String!]
   lastUsedAt: Time
+  """
+  whether the token is active
+  """
+  isActive: Boolean
+  """
+  the reason the token was revoked
+  """
+  revokedReason: String
+  """
+  the user who revoked the token
+  """
+  revokedBy: String
+  """
+  when the token was revoked
+  """
+  revokedAt: Time
   owner: User!
   """
   the organization(s) the token is associated with
@@ -17352,6 +17578,62 @@ input PersonalAccessTokenWhereInput {
   lastUsedAtLTE: Time
   lastUsedAtIsNil: Boolean
   lastUsedAtNotNil: Boolean
+  """
+  is_active field predicates
+  """
+  isActive: Boolean
+  isActiveNEQ: Boolean
+  isActiveIsNil: Boolean
+  isActiveNotNil: Boolean
+  """
+  revoked_reason field predicates
+  """
+  revokedReason: String
+  revokedReasonNEQ: String
+  revokedReasonIn: [String!]
+  revokedReasonNotIn: [String!]
+  revokedReasonGT: String
+  revokedReasonGTE: String
+  revokedReasonLT: String
+  revokedReasonLTE: String
+  revokedReasonContains: String
+  revokedReasonHasPrefix: String
+  revokedReasonHasSuffix: String
+  revokedReasonIsNil: Boolean
+  revokedReasonNotNil: Boolean
+  revokedReasonEqualFold: String
+  revokedReasonContainsFold: String
+  """
+  revoked_by field predicates
+  """
+  revokedBy: String
+  revokedByNEQ: String
+  revokedByIn: [String!]
+  revokedByNotIn: [String!]
+  revokedByGT: String
+  revokedByGTE: String
+  revokedByLT: String
+  revokedByLTE: String
+  revokedByContains: String
+  revokedByHasPrefix: String
+  revokedByHasSuffix: String
+  revokedByIsNil: Boolean
+  revokedByNotNil: Boolean
+  revokedByEqualFold: String
+  revokedByContainsFold: String
+  """
+  revoked_at field predicates
+  """
+  revokedAt: Time
+  revokedAtNEQ: Time
+  revokedAtIn: [Time!]
+  revokedAtNotIn: [Time!]
+  revokedAtGT: Time
+  revokedAtGTE: Time
+  revokedAtLT: Time
+  revokedAtLTE: Time
+  revokedAtIsNil: Boolean
+  revokedAtNotNil: Boolean
   """
   owner edge predicates
   """
@@ -26222,6 +26504,26 @@ input UpdateAPITokenInput {
   clearScopes: Boolean
   lastUsedAt: Time
   clearLastUsedAt: Boolean
+  """
+  whether the token is active
+  """
+  isActive: Boolean
+  clearIsActive: Boolean
+  """
+  the reason the token was revoked
+  """
+  revokedReason: String
+  clearRevokedReason: Boolean
+  """
+  the user who revoked the token
+  """
+  revokedBy: String
+  clearRevokedBy: Boolean
+  """
+  when the token was revoked
+  """
+  revokedAt: Time
+  clearRevokedAt: Boolean
   ownerID: ID
   clearOwner: Boolean
 }
@@ -27503,6 +27805,26 @@ input UpdatePersonalAccessTokenInput {
   clearScopes: Boolean
   lastUsedAt: Time
   clearLastUsedAt: Boolean
+  """
+  whether the token is active
+  """
+  isActive: Boolean
+  clearIsActive: Boolean
+  """
+  the reason the token was revoked
+  """
+  revokedReason: String
+  clearRevokedReason: Boolean
+  """
+  the user who revoked the token
+  """
+  revokedBy: String
+  clearRevokedBy: Boolean
+  """
+  when the token was revoked
+  """
+  revokedAt: Time
+  clearRevokedAt: Boolean
   addOrganizationIDs: [ID!]
   removeOrganizationIDs: [ID!]
   clearOrganizations: Boolean

--- a/internal/graphapi/search.go
+++ b/internal/graphapi/search.go
@@ -79,6 +79,8 @@ func adminSearchAPITokens(ctx context.Context, query string) ([]*generated.APITo
 				likeQuery := "%" + query + "%"
 				s.Where(sql.ExprP("(scopes)::text LIKE $6", likeQuery)) // search by Scopes
 			},
+			apitoken.RevokedReasonContainsFold(query), // search by RevokedReason
+			apitoken.RevokedByContainsFold(query),     // search by RevokedBy
 		),
 	).All(ctx)
 }
@@ -638,13 +640,14 @@ func adminSearchOrgSubscriptions(ctx context.Context, query string) ([]*generate
 			orgsubscription.StripeProductTierIDContainsFold(query),      // search by StripeProductTierID
 			orgsubscription.StripeSubscriptionStatusContainsFold(query), // search by StripeSubscriptionStatus
 			orgsubscription.StripeCustomerIDContainsFold(query),         // search by StripeCustomerID
+			orgsubscription.DaysUntilDueContainsFold(query),             // search by DaysUntilDue
 			func(s *sql.Selector) {
 				likeQuery := "%" + query + "%"
-				s.Where(sql.ExprP("(features)::text LIKE $11", likeQuery)) // search by Features
+				s.Where(sql.ExprP("(features)::text LIKE $12", likeQuery)) // search by Features
 			},
 			func(s *sql.Selector) {
 				likeQuery := "%" + query + "%"
-				s.Where(sql.ExprP("(featurelookupkeys)::text LIKE $12", likeQuery)) // search by FeatureLookupKeys
+				s.Where(sql.ExprP("(featurelookupkeys)::text LIKE $13", likeQuery)) // search by FeatureLookupKeys
 			},
 		),
 	).All(ctx)
@@ -755,6 +758,8 @@ func adminSearchPersonalAccessTokens(ctx context.Context, query string) ([]*gene
 				likeQuery := "%" + query + "%"
 				s.Where(sql.ExprP("(scopes)::text LIKE $5", likeQuery)) // search by Scopes
 			},
+			personalaccesstoken.RevokedReasonContainsFold(query), // search by RevokedReason
+			personalaccesstoken.RevokedByContainsFold(query),     // search by RevokedBy
 		),
 	).All(ctx)
 }

--- a/pkg/openlaneclient/graphclient.go
+++ b/pkg/openlaneclient/graphclient.go
@@ -1389,12 +1389,14 @@ func (t *GetActionPlanHistories_ActionPlanHistories) GetEdges() []*GetActionPlan
 }
 
 type AdminSearch_AdminSearch_Nodes_APITokenSearchResult_APITokens struct {
-	DeletedBy *string  "json:\"deletedBy,omitempty\" graphql:\"deletedBy\""
-	ID        string   "json:\"id\" graphql:\"id\""
-	Name      string   "json:\"name\" graphql:\"name\""
-	OwnerID   *string  "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Scopes    []string "json:\"scopes,omitempty\" graphql:\"scopes\""
-	Tags      []string "json:\"tags,omitempty\" graphql:\"tags\""
+	DeletedBy     *string  "json:\"deletedBy,omitempty\" graphql:\"deletedBy\""
+	ID            string   "json:\"id\" graphql:\"id\""
+	Name          string   "json:\"name\" graphql:\"name\""
+	OwnerID       *string  "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	RevokedBy     *string  "json:\"revokedBy,omitempty\" graphql:\"revokedBy\""
+	RevokedReason *string  "json:\"revokedReason,omitempty\" graphql:\"revokedReason\""
+	Scopes        []string "json:\"scopes,omitempty\" graphql:\"scopes\""
+	Tags          []string "json:\"tags,omitempty\" graphql:\"tags\""
 }
 
 func (t *AdminSearch_AdminSearch_Nodes_APITokenSearchResult_APITokens) GetDeletedBy() *string {
@@ -1420,6 +1422,18 @@ func (t *AdminSearch_AdminSearch_Nodes_APITokenSearchResult_APITokens) GetOwnerI
 		t = &AdminSearch_AdminSearch_Nodes_APITokenSearchResult_APITokens{}
 	}
 	return t.OwnerID
+}
+func (t *AdminSearch_AdminSearch_Nodes_APITokenSearchResult_APITokens) GetRevokedBy() *string {
+	if t == nil {
+		t = &AdminSearch_AdminSearch_Nodes_APITokenSearchResult_APITokens{}
+	}
+	return t.RevokedBy
+}
+func (t *AdminSearch_AdminSearch_Nodes_APITokenSearchResult_APITokens) GetRevokedReason() *string {
+	if t == nil {
+		t = &AdminSearch_AdminSearch_Nodes_APITokenSearchResult_APITokens{}
+	}
+	return t.RevokedReason
 }
 func (t *AdminSearch_AdminSearch_Nodes_APITokenSearchResult_APITokens) GetScopes() []string {
 	if t == nil {
@@ -2636,6 +2650,7 @@ func (t *AdminSearch_AdminSearch_Nodes_NarrativeSearchResult) GetNarratives() []
 }
 
 type AdminSearch_AdminSearch_Nodes_OrgSubscriptionSearchResult_OrgSubscriptions struct {
+	DaysUntilDue             *string       "json:\"daysUntilDue,omitempty\" graphql:\"daysUntilDue\""
 	DeletedBy                *string       "json:\"deletedBy,omitempty\" graphql:\"deletedBy\""
 	FeatureLookupKeys        []string      "json:\"featureLookupKeys,omitempty\" graphql:\"featureLookupKeys\""
 	Features                 []string      "json:\"features,omitempty\" graphql:\"features\""
@@ -2650,6 +2665,12 @@ type AdminSearch_AdminSearch_Nodes_OrgSubscriptionSearchResult_OrgSubscriptions 
 	Tags                     []string      "json:\"tags,omitempty\" graphql:\"tags\""
 }
 
+func (t *AdminSearch_AdminSearch_Nodes_OrgSubscriptionSearchResult_OrgSubscriptions) GetDaysUntilDue() *string {
+	if t == nil {
+		t = &AdminSearch_AdminSearch_Nodes_OrgSubscriptionSearchResult_OrgSubscriptions{}
+	}
+	return t.DaysUntilDue
+}
 func (t *AdminSearch_AdminSearch_Nodes_OrgSubscriptionSearchResult_OrgSubscriptions) GetDeletedBy() *string {
 	if t == nil {
 		t = &AdminSearch_AdminSearch_Nodes_OrgSubscriptionSearchResult_OrgSubscriptions{}
@@ -2891,11 +2912,13 @@ func (t *AdminSearch_AdminSearch_Nodes_OrganizationSettingSearchResult) GetOrgan
 }
 
 type AdminSearch_AdminSearch_Nodes_PersonalAccessTokenSearchResult_PersonalAccessTokens struct {
-	DeletedBy *string  "json:\"deletedBy,omitempty\" graphql:\"deletedBy\""
-	ID        string   "json:\"id\" graphql:\"id\""
-	Name      string   "json:\"name\" graphql:\"name\""
-	Scopes    []string "json:\"scopes,omitempty\" graphql:\"scopes\""
-	Tags      []string "json:\"tags,omitempty\" graphql:\"tags\""
+	DeletedBy     *string  "json:\"deletedBy,omitempty\" graphql:\"deletedBy\""
+	ID            string   "json:\"id\" graphql:\"id\""
+	Name          string   "json:\"name\" graphql:\"name\""
+	RevokedBy     *string  "json:\"revokedBy,omitempty\" graphql:\"revokedBy\""
+	RevokedReason *string  "json:\"revokedReason,omitempty\" graphql:\"revokedReason\""
+	Scopes        []string "json:\"scopes,omitempty\" graphql:\"scopes\""
+	Tags          []string "json:\"tags,omitempty\" graphql:\"tags\""
 }
 
 func (t *AdminSearch_AdminSearch_Nodes_PersonalAccessTokenSearchResult_PersonalAccessTokens) GetDeletedBy() *string {
@@ -2915,6 +2938,18 @@ func (t *AdminSearch_AdminSearch_Nodes_PersonalAccessTokenSearchResult_PersonalA
 		t = &AdminSearch_AdminSearch_Nodes_PersonalAccessTokenSearchResult_PersonalAccessTokens{}
 	}
 	return t.Name
+}
+func (t *AdminSearch_AdminSearch_Nodes_PersonalAccessTokenSearchResult_PersonalAccessTokens) GetRevokedBy() *string {
+	if t == nil {
+		t = &AdminSearch_AdminSearch_Nodes_PersonalAccessTokenSearchResult_PersonalAccessTokens{}
+	}
+	return t.RevokedBy
+}
+func (t *AdminSearch_AdminSearch_Nodes_PersonalAccessTokenSearchResult_PersonalAccessTokens) GetRevokedReason() *string {
+	if t == nil {
+		t = &AdminSearch_AdminSearch_Nodes_PersonalAccessTokenSearchResult_PersonalAccessTokens{}
+	}
+	return t.RevokedReason
 }
 func (t *AdminSearch_AdminSearch_Nodes_PersonalAccessTokenSearchResult_PersonalAccessTokens) GetScopes() []string {
 	if t == nil {
@@ -54601,6 +54636,8 @@ const AdminSearchDocument = `query AdminSearch ($query: String!) {
 					ownerID
 					name
 					scopes
+					revokedReason
+					revokedBy
 				}
 			}
 			... on ActionPlanSearchResult {
@@ -54811,6 +54848,7 @@ const AdminSearchDocument = `query AdminSearch ($query: String!) {
 					stripeProductTierID
 					stripeSubscriptionStatus
 					stripeCustomerID
+					daysUntilDue
 					features
 					featureLookupKeys
 				}
@@ -54848,6 +54886,8 @@ const AdminSearchDocument = `query AdminSearch ($query: String!) {
 					tags
 					name
 					scopes
+					revokedReason
+					revokedBy
 				}
 			}
 			... on ProcedureSearchResult {

--- a/pkg/openlaneclient/models.go
+++ b/pkg/openlaneclient/models.go
@@ -36,10 +36,18 @@ type APIToken struct {
 	// when the token expires
 	ExpiresAt *time.Time `json:"expiresAt,omitempty"`
 	// a description of the token's purpose
-	Description *string       `json:"description,omitempty"`
-	Scopes      []string      `json:"scopes,omitempty"`
-	LastUsedAt  *time.Time    `json:"lastUsedAt,omitempty"`
-	Owner       *Organization `json:"owner,omitempty"`
+	Description *string    `json:"description,omitempty"`
+	Scopes      []string   `json:"scopes,omitempty"`
+	LastUsedAt  *time.Time `json:"lastUsedAt,omitempty"`
+	// whether the token is active
+	IsActive *bool `json:"isActive,omitempty"`
+	// the reason the token was revoked
+	RevokedReason *string `json:"revokedReason,omitempty"`
+	// the user who revoked the token
+	RevokedBy *string `json:"revokedBy,omitempty"`
+	// when the token was revoked
+	RevokedAt *time.Time    `json:"revokedAt,omitempty"`
+	Owner     *Organization `json:"owner,omitempty"`
 }
 
 func (APIToken) IsNode() {}
@@ -242,6 +250,54 @@ type APITokenWhereInput struct {
 	LastUsedAtLte    *time.Time   `json:"lastUsedAtLTE,omitempty"`
 	LastUsedAtIsNil  *bool        `json:"lastUsedAtIsNil,omitempty"`
 	LastUsedAtNotNil *bool        `json:"lastUsedAtNotNil,omitempty"`
+	// is_active field predicates
+	IsActive       *bool `json:"isActive,omitempty"`
+	IsActiveNeq    *bool `json:"isActiveNEQ,omitempty"`
+	IsActiveIsNil  *bool `json:"isActiveIsNil,omitempty"`
+	IsActiveNotNil *bool `json:"isActiveNotNil,omitempty"`
+	// revoked_reason field predicates
+	RevokedReason             *string  `json:"revokedReason,omitempty"`
+	RevokedReasonNeq          *string  `json:"revokedReasonNEQ,omitempty"`
+	RevokedReasonIn           []string `json:"revokedReasonIn,omitempty"`
+	RevokedReasonNotIn        []string `json:"revokedReasonNotIn,omitempty"`
+	RevokedReasonGt           *string  `json:"revokedReasonGT,omitempty"`
+	RevokedReasonGte          *string  `json:"revokedReasonGTE,omitempty"`
+	RevokedReasonLt           *string  `json:"revokedReasonLT,omitempty"`
+	RevokedReasonLte          *string  `json:"revokedReasonLTE,omitempty"`
+	RevokedReasonContains     *string  `json:"revokedReasonContains,omitempty"`
+	RevokedReasonHasPrefix    *string  `json:"revokedReasonHasPrefix,omitempty"`
+	RevokedReasonHasSuffix    *string  `json:"revokedReasonHasSuffix,omitempty"`
+	RevokedReasonIsNil        *bool    `json:"revokedReasonIsNil,omitempty"`
+	RevokedReasonNotNil       *bool    `json:"revokedReasonNotNil,omitempty"`
+	RevokedReasonEqualFold    *string  `json:"revokedReasonEqualFold,omitempty"`
+	RevokedReasonContainsFold *string  `json:"revokedReasonContainsFold,omitempty"`
+	// revoked_by field predicates
+	RevokedBy             *string  `json:"revokedBy,omitempty"`
+	RevokedByNeq          *string  `json:"revokedByNEQ,omitempty"`
+	RevokedByIn           []string `json:"revokedByIn,omitempty"`
+	RevokedByNotIn        []string `json:"revokedByNotIn,omitempty"`
+	RevokedByGt           *string  `json:"revokedByGT,omitempty"`
+	RevokedByGte          *string  `json:"revokedByGTE,omitempty"`
+	RevokedByLt           *string  `json:"revokedByLT,omitempty"`
+	RevokedByLte          *string  `json:"revokedByLTE,omitempty"`
+	RevokedByContains     *string  `json:"revokedByContains,omitempty"`
+	RevokedByHasPrefix    *string  `json:"revokedByHasPrefix,omitempty"`
+	RevokedByHasSuffix    *string  `json:"revokedByHasSuffix,omitempty"`
+	RevokedByIsNil        *bool    `json:"revokedByIsNil,omitempty"`
+	RevokedByNotNil       *bool    `json:"revokedByNotNil,omitempty"`
+	RevokedByEqualFold    *string  `json:"revokedByEqualFold,omitempty"`
+	RevokedByContainsFold *string  `json:"revokedByContainsFold,omitempty"`
+	// revoked_at field predicates
+	RevokedAt       *time.Time   `json:"revokedAt,omitempty"`
+	RevokedAtNeq    *time.Time   `json:"revokedAtNEQ,omitempty"`
+	RevokedAtIn     []*time.Time `json:"revokedAtIn,omitempty"`
+	RevokedAtNotIn  []*time.Time `json:"revokedAtNotIn,omitempty"`
+	RevokedAtGt     *time.Time   `json:"revokedAtGT,omitempty"`
+	RevokedAtGte    *time.Time   `json:"revokedAtGTE,omitempty"`
+	RevokedAtLt     *time.Time   `json:"revokedAtLT,omitempty"`
+	RevokedAtLte    *time.Time   `json:"revokedAtLTE,omitempty"`
+	RevokedAtIsNil  *bool        `json:"revokedAtIsNil,omitempty"`
+	RevokedAtNotNil *bool        `json:"revokedAtNotNil,omitempty"`
 	// owner edge predicates
 	HasOwner     *bool                     `json:"hasOwner,omitempty"`
 	HasOwnerWith []*OrganizationWhereInput `json:"hasOwnerWith,omitempty"`
@@ -3188,7 +3244,15 @@ type CreateAPITokenInput struct {
 	Description *string    `json:"description,omitempty"`
 	Scopes      []string   `json:"scopes,omitempty"`
 	LastUsedAt  *time.Time `json:"lastUsedAt,omitempty"`
-	OwnerID     *string    `json:"ownerID,omitempty"`
+	// whether the token is active
+	IsActive *bool `json:"isActive,omitempty"`
+	// the reason the token was revoked
+	RevokedReason *string `json:"revokedReason,omitempty"`
+	// the user who revoked the token
+	RevokedBy *string `json:"revokedBy,omitempty"`
+	// when the token was revoked
+	RevokedAt *time.Time `json:"revokedAt,omitempty"`
+	OwnerID   *string    `json:"ownerID,omitempty"`
 }
 
 // CreateActionPlanInput is used for create ActionPlan object.
@@ -3801,9 +3865,17 @@ type CreatePersonalAccessTokenInput struct {
 	// when the token expires
 	ExpiresAt *time.Time `json:"expiresAt,omitempty"`
 	// a description of the token's purpose
-	Description     *string    `json:"description,omitempty"`
-	Scopes          []string   `json:"scopes,omitempty"`
-	LastUsedAt      *time.Time `json:"lastUsedAt,omitempty"`
+	Description *string    `json:"description,omitempty"`
+	Scopes      []string   `json:"scopes,omitempty"`
+	LastUsedAt  *time.Time `json:"lastUsedAt,omitempty"`
+	// whether the token is active
+	IsActive *bool `json:"isActive,omitempty"`
+	// the reason the token was revoked
+	RevokedReason *string `json:"revokedReason,omitempty"`
+	// the user who revoked the token
+	RevokedBy *string `json:"revokedBy,omitempty"`
+	// when the token was revoked
+	RevokedAt       *time.Time `json:"revokedAt,omitempty"`
 	OwnerID         string     `json:"ownerID"`
 	OrganizationIDs []string   `json:"organizationIDs,omitempty"`
 	EventIDs        []string   `json:"eventIDs,omitempty"`
@@ -12144,11 +12216,18 @@ type OrgSubscription struct {
 	StripeCustomerID *string `json:"stripeCustomerID,omitempty"`
 	// the time the subscription is set to expire; only populated if subscription is cancelled
 	ExpiresAt *time.Time `json:"expiresAt,omitempty"`
+	// the time the trial is set to expire
+	TrialExpiresAt *time.Time `json:"trialExpiresAt,omitempty"`
+	// number of days until there is a due payment
+	DaysUntilDue *string `json:"daysUntilDue,omitempty"`
+	// whether or not a payment method has been added to the account
+	PaymentMethodAdded *bool `json:"paymentMethodAdded,omitempty"`
 	// the features associated with the subscription
 	Features []string `json:"features,omitempty"`
 	// the feature lookup keys associated with the subscription
 	FeatureLookupKeys []string      `json:"featureLookupKeys,omitempty"`
 	Owner             *Organization `json:"owner,omitempty"`
+	Events            []*Event      `json:"events,omitempty"`
 	SubscriptionURL   *string       `json:"subscriptionURL,omitempty"`
 }
 
@@ -12203,6 +12282,12 @@ type OrgSubscriptionHistory struct {
 	StripeCustomerID *string `json:"stripeCustomerID,omitempty"`
 	// the time the subscription is set to expire; only populated if subscription is cancelled
 	ExpiresAt *time.Time `json:"expiresAt,omitempty"`
+	// the time the trial is set to expire
+	TrialExpiresAt *time.Time `json:"trialExpiresAt,omitempty"`
+	// number of days until there is a due payment
+	DaysUntilDue *string `json:"daysUntilDue,omitempty"`
+	// whether or not a payment method has been added to the account
+	PaymentMethodAdded *bool `json:"paymentMethodAdded,omitempty"`
 	// the features associated with the subscription
 	Features []string `json:"features,omitempty"`
 	// the feature lookup keys associated with the subscription
@@ -12467,6 +12552,38 @@ type OrgSubscriptionHistoryWhereInput struct {
 	ExpiresAtLte    *time.Time   `json:"expiresAtLTE,omitempty"`
 	ExpiresAtIsNil  *bool        `json:"expiresAtIsNil,omitempty"`
 	ExpiresAtNotNil *bool        `json:"expiresAtNotNil,omitempty"`
+	// trial_expires_at field predicates
+	TrialExpiresAt       *time.Time   `json:"trialExpiresAt,omitempty"`
+	TrialExpiresAtNeq    *time.Time   `json:"trialExpiresAtNEQ,omitempty"`
+	TrialExpiresAtIn     []*time.Time `json:"trialExpiresAtIn,omitempty"`
+	TrialExpiresAtNotIn  []*time.Time `json:"trialExpiresAtNotIn,omitempty"`
+	TrialExpiresAtGt     *time.Time   `json:"trialExpiresAtGT,omitempty"`
+	TrialExpiresAtGte    *time.Time   `json:"trialExpiresAtGTE,omitempty"`
+	TrialExpiresAtLt     *time.Time   `json:"trialExpiresAtLT,omitempty"`
+	TrialExpiresAtLte    *time.Time   `json:"trialExpiresAtLTE,omitempty"`
+	TrialExpiresAtIsNil  *bool        `json:"trialExpiresAtIsNil,omitempty"`
+	TrialExpiresAtNotNil *bool        `json:"trialExpiresAtNotNil,omitempty"`
+	// days_until_due field predicates
+	DaysUntilDue             *string  `json:"daysUntilDue,omitempty"`
+	DaysUntilDueNeq          *string  `json:"daysUntilDueNEQ,omitempty"`
+	DaysUntilDueIn           []string `json:"daysUntilDueIn,omitempty"`
+	DaysUntilDueNotIn        []string `json:"daysUntilDueNotIn,omitempty"`
+	DaysUntilDueGt           *string  `json:"daysUntilDueGT,omitempty"`
+	DaysUntilDueGte          *string  `json:"daysUntilDueGTE,omitempty"`
+	DaysUntilDueLt           *string  `json:"daysUntilDueLT,omitempty"`
+	DaysUntilDueLte          *string  `json:"daysUntilDueLTE,omitempty"`
+	DaysUntilDueContains     *string  `json:"daysUntilDueContains,omitempty"`
+	DaysUntilDueHasPrefix    *string  `json:"daysUntilDueHasPrefix,omitempty"`
+	DaysUntilDueHasSuffix    *string  `json:"daysUntilDueHasSuffix,omitempty"`
+	DaysUntilDueIsNil        *bool    `json:"daysUntilDueIsNil,omitempty"`
+	DaysUntilDueNotNil       *bool    `json:"daysUntilDueNotNil,omitempty"`
+	DaysUntilDueEqualFold    *string  `json:"daysUntilDueEqualFold,omitempty"`
+	DaysUntilDueContainsFold *string  `json:"daysUntilDueContainsFold,omitempty"`
+	// payment_method_added field predicates
+	PaymentMethodAdded       *bool `json:"paymentMethodAdded,omitempty"`
+	PaymentMethodAddedNeq    *bool `json:"paymentMethodAddedNEQ,omitempty"`
+	PaymentMethodAddedIsNil  *bool `json:"paymentMethodAddedIsNil,omitempty"`
+	PaymentMethodAddedNotNil *bool `json:"paymentMethodAddedNotNil,omitempty"`
 }
 
 type OrgSubscriptionSearchResult struct {
@@ -12683,9 +12800,44 @@ type OrgSubscriptionWhereInput struct {
 	ExpiresAtLte    *time.Time   `json:"expiresAtLTE,omitempty"`
 	ExpiresAtIsNil  *bool        `json:"expiresAtIsNil,omitempty"`
 	ExpiresAtNotNil *bool        `json:"expiresAtNotNil,omitempty"`
+	// trial_expires_at field predicates
+	TrialExpiresAt       *time.Time   `json:"trialExpiresAt,omitempty"`
+	TrialExpiresAtNeq    *time.Time   `json:"trialExpiresAtNEQ,omitempty"`
+	TrialExpiresAtIn     []*time.Time `json:"trialExpiresAtIn,omitempty"`
+	TrialExpiresAtNotIn  []*time.Time `json:"trialExpiresAtNotIn,omitempty"`
+	TrialExpiresAtGt     *time.Time   `json:"trialExpiresAtGT,omitempty"`
+	TrialExpiresAtGte    *time.Time   `json:"trialExpiresAtGTE,omitempty"`
+	TrialExpiresAtLt     *time.Time   `json:"trialExpiresAtLT,omitempty"`
+	TrialExpiresAtLte    *time.Time   `json:"trialExpiresAtLTE,omitempty"`
+	TrialExpiresAtIsNil  *bool        `json:"trialExpiresAtIsNil,omitempty"`
+	TrialExpiresAtNotNil *bool        `json:"trialExpiresAtNotNil,omitempty"`
+	// days_until_due field predicates
+	DaysUntilDue             *string  `json:"daysUntilDue,omitempty"`
+	DaysUntilDueNeq          *string  `json:"daysUntilDueNEQ,omitempty"`
+	DaysUntilDueIn           []string `json:"daysUntilDueIn,omitempty"`
+	DaysUntilDueNotIn        []string `json:"daysUntilDueNotIn,omitempty"`
+	DaysUntilDueGt           *string  `json:"daysUntilDueGT,omitempty"`
+	DaysUntilDueGte          *string  `json:"daysUntilDueGTE,omitempty"`
+	DaysUntilDueLt           *string  `json:"daysUntilDueLT,omitempty"`
+	DaysUntilDueLte          *string  `json:"daysUntilDueLTE,omitempty"`
+	DaysUntilDueContains     *string  `json:"daysUntilDueContains,omitempty"`
+	DaysUntilDueHasPrefix    *string  `json:"daysUntilDueHasPrefix,omitempty"`
+	DaysUntilDueHasSuffix    *string  `json:"daysUntilDueHasSuffix,omitempty"`
+	DaysUntilDueIsNil        *bool    `json:"daysUntilDueIsNil,omitempty"`
+	DaysUntilDueNotNil       *bool    `json:"daysUntilDueNotNil,omitempty"`
+	DaysUntilDueEqualFold    *string  `json:"daysUntilDueEqualFold,omitempty"`
+	DaysUntilDueContainsFold *string  `json:"daysUntilDueContainsFold,omitempty"`
+	// payment_method_added field predicates
+	PaymentMethodAdded       *bool `json:"paymentMethodAdded,omitempty"`
+	PaymentMethodAddedNeq    *bool `json:"paymentMethodAddedNEQ,omitempty"`
+	PaymentMethodAddedIsNil  *bool `json:"paymentMethodAddedIsNil,omitempty"`
+	PaymentMethodAddedNotNil *bool `json:"paymentMethodAddedNotNil,omitempty"`
 	// owner edge predicates
 	HasOwner     *bool                     `json:"hasOwner,omitempty"`
 	HasOwnerWith []*OrganizationWhereInput `json:"hasOwnerWith,omitempty"`
+	// events edge predicates
+	HasEvents     *bool              `json:"hasEvents,omitempty"`
+	HasEventsWith []*EventWhereInput `json:"hasEventsWith,omitempty"`
 }
 
 type Organization struct {
@@ -13979,7 +14131,15 @@ type PersonalAccessToken struct {
 	Description *string    `json:"description,omitempty"`
 	Scopes      []string   `json:"scopes,omitempty"`
 	LastUsedAt  *time.Time `json:"lastUsedAt,omitempty"`
-	Owner       *User      `json:"owner"`
+	// whether the token is active
+	IsActive *bool `json:"isActive,omitempty"`
+	// the reason the token was revoked
+	RevokedReason *string `json:"revokedReason,omitempty"`
+	// the user who revoked the token
+	RevokedBy *string `json:"revokedBy,omitempty"`
+	// when the token was revoked
+	RevokedAt *time.Time `json:"revokedAt,omitempty"`
+	Owner     *User      `json:"owner"`
 	// the organization(s) the token is associated with
 	Organizations []*Organization `json:"organizations,omitempty"`
 	Events        []*Event        `json:"events,omitempty"`
@@ -14169,6 +14329,54 @@ type PersonalAccessTokenWhereInput struct {
 	LastUsedAtLte    *time.Time   `json:"lastUsedAtLTE,omitempty"`
 	LastUsedAtIsNil  *bool        `json:"lastUsedAtIsNil,omitempty"`
 	LastUsedAtNotNil *bool        `json:"lastUsedAtNotNil,omitempty"`
+	// is_active field predicates
+	IsActive       *bool `json:"isActive,omitempty"`
+	IsActiveNeq    *bool `json:"isActiveNEQ,omitempty"`
+	IsActiveIsNil  *bool `json:"isActiveIsNil,omitempty"`
+	IsActiveNotNil *bool `json:"isActiveNotNil,omitempty"`
+	// revoked_reason field predicates
+	RevokedReason             *string  `json:"revokedReason,omitempty"`
+	RevokedReasonNeq          *string  `json:"revokedReasonNEQ,omitempty"`
+	RevokedReasonIn           []string `json:"revokedReasonIn,omitempty"`
+	RevokedReasonNotIn        []string `json:"revokedReasonNotIn,omitempty"`
+	RevokedReasonGt           *string  `json:"revokedReasonGT,omitempty"`
+	RevokedReasonGte          *string  `json:"revokedReasonGTE,omitempty"`
+	RevokedReasonLt           *string  `json:"revokedReasonLT,omitempty"`
+	RevokedReasonLte          *string  `json:"revokedReasonLTE,omitempty"`
+	RevokedReasonContains     *string  `json:"revokedReasonContains,omitempty"`
+	RevokedReasonHasPrefix    *string  `json:"revokedReasonHasPrefix,omitempty"`
+	RevokedReasonHasSuffix    *string  `json:"revokedReasonHasSuffix,omitempty"`
+	RevokedReasonIsNil        *bool    `json:"revokedReasonIsNil,omitempty"`
+	RevokedReasonNotNil       *bool    `json:"revokedReasonNotNil,omitempty"`
+	RevokedReasonEqualFold    *string  `json:"revokedReasonEqualFold,omitempty"`
+	RevokedReasonContainsFold *string  `json:"revokedReasonContainsFold,omitempty"`
+	// revoked_by field predicates
+	RevokedBy             *string  `json:"revokedBy,omitempty"`
+	RevokedByNeq          *string  `json:"revokedByNEQ,omitempty"`
+	RevokedByIn           []string `json:"revokedByIn,omitempty"`
+	RevokedByNotIn        []string `json:"revokedByNotIn,omitempty"`
+	RevokedByGt           *string  `json:"revokedByGT,omitempty"`
+	RevokedByGte          *string  `json:"revokedByGTE,omitempty"`
+	RevokedByLt           *string  `json:"revokedByLT,omitempty"`
+	RevokedByLte          *string  `json:"revokedByLTE,omitempty"`
+	RevokedByContains     *string  `json:"revokedByContains,omitempty"`
+	RevokedByHasPrefix    *string  `json:"revokedByHasPrefix,omitempty"`
+	RevokedByHasSuffix    *string  `json:"revokedByHasSuffix,omitempty"`
+	RevokedByIsNil        *bool    `json:"revokedByIsNil,omitempty"`
+	RevokedByNotNil       *bool    `json:"revokedByNotNil,omitempty"`
+	RevokedByEqualFold    *string  `json:"revokedByEqualFold,omitempty"`
+	RevokedByContainsFold *string  `json:"revokedByContainsFold,omitempty"`
+	// revoked_at field predicates
+	RevokedAt       *time.Time   `json:"revokedAt,omitempty"`
+	RevokedAtNeq    *time.Time   `json:"revokedAtNEQ,omitempty"`
+	RevokedAtIn     []*time.Time `json:"revokedAtIn,omitempty"`
+	RevokedAtNotIn  []*time.Time `json:"revokedAtNotIn,omitempty"`
+	RevokedAtGt     *time.Time   `json:"revokedAtGT,omitempty"`
+	RevokedAtGte    *time.Time   `json:"revokedAtGTE,omitempty"`
+	RevokedAtLt     *time.Time   `json:"revokedAtLT,omitempty"`
+	RevokedAtLte    *time.Time   `json:"revokedAtLTE,omitempty"`
+	RevokedAtIsNil  *bool        `json:"revokedAtIsNil,omitempty"`
+	RevokedAtNotNil *bool        `json:"revokedAtNotNil,omitempty"`
 	// owner edge predicates
 	HasOwner     *bool             `json:"hasOwner,omitempty"`
 	HasOwnerWith []*UserWhereInput `json:"hasOwnerWith,omitempty"`
@@ -19923,8 +20131,20 @@ type UpdateAPITokenInput struct {
 	ClearScopes      *bool      `json:"clearScopes,omitempty"`
 	LastUsedAt       *time.Time `json:"lastUsedAt,omitempty"`
 	ClearLastUsedAt  *bool      `json:"clearLastUsedAt,omitempty"`
-	OwnerID          *string    `json:"ownerID,omitempty"`
-	ClearOwner       *bool      `json:"clearOwner,omitempty"`
+	// whether the token is active
+	IsActive      *bool `json:"isActive,omitempty"`
+	ClearIsActive *bool `json:"clearIsActive,omitempty"`
+	// the reason the token was revoked
+	RevokedReason      *string `json:"revokedReason,omitempty"`
+	ClearRevokedReason *bool   `json:"clearRevokedReason,omitempty"`
+	// the user who revoked the token
+	RevokedBy      *string `json:"revokedBy,omitempty"`
+	ClearRevokedBy *bool   `json:"clearRevokedBy,omitempty"`
+	// when the token was revoked
+	RevokedAt      *time.Time `json:"revokedAt,omitempty"`
+	ClearRevokedAt *bool      `json:"clearRevokedAt,omitempty"`
+	OwnerID        *string    `json:"ownerID,omitempty"`
+	ClearOwner     *bool      `json:"clearOwner,omitempty"`
 }
 
 // UpdateActionPlanInput is used for update ActionPlan object.
@@ -20924,13 +21144,25 @@ type UpdatePersonalAccessTokenInput struct {
 	// the name associated with the token
 	Name *string `json:"name,omitempty"`
 	// a description of the token's purpose
-	Description           *string    `json:"description,omitempty"`
-	ClearDescription      *bool      `json:"clearDescription,omitempty"`
-	Scopes                []string   `json:"scopes,omitempty"`
-	AppendScopes          []string   `json:"appendScopes,omitempty"`
-	ClearScopes           *bool      `json:"clearScopes,omitempty"`
-	LastUsedAt            *time.Time `json:"lastUsedAt,omitempty"`
-	ClearLastUsedAt       *bool      `json:"clearLastUsedAt,omitempty"`
+	Description      *string    `json:"description,omitempty"`
+	ClearDescription *bool      `json:"clearDescription,omitempty"`
+	Scopes           []string   `json:"scopes,omitempty"`
+	AppendScopes     []string   `json:"appendScopes,omitempty"`
+	ClearScopes      *bool      `json:"clearScopes,omitempty"`
+	LastUsedAt       *time.Time `json:"lastUsedAt,omitempty"`
+	ClearLastUsedAt  *bool      `json:"clearLastUsedAt,omitempty"`
+	// whether the token is active
+	IsActive      *bool `json:"isActive,omitempty"`
+	ClearIsActive *bool `json:"clearIsActive,omitempty"`
+	// the reason the token was revoked
+	RevokedReason      *string `json:"revokedReason,omitempty"`
+	ClearRevokedReason *bool   `json:"clearRevokedReason,omitempty"`
+	// the user who revoked the token
+	RevokedBy      *string `json:"revokedBy,omitempty"`
+	ClearRevokedBy *bool   `json:"clearRevokedBy,omitempty"`
+	// when the token was revoked
+	RevokedAt             *time.Time `json:"revokedAt,omitempty"`
+	ClearRevokedAt        *bool      `json:"clearRevokedAt,omitempty"`
 	AddOrganizationIDs    []string   `json:"addOrganizationIDs,omitempty"`
 	RemoveOrganizationIDs []string   `json:"removeOrganizationIDs,omitempty"`
 	ClearOrganizations    *bool      `json:"clearOrganizations,omitempty"`


### PR DESCRIPTION
- adds fields to api token and pat token tables to include revocation reason, date, bool flags for active so that tokens can be revoked under certain scenarios (e.g. org subscription has lapsed) and we keep a history of the revocation in the instance we want to allow restoration of the token when the event which caused it is reconciled (e.g. someone re-activates their org subscription or adds a payment method to bring the subscription back into an active status)
- adds additional fields to orgsubscription to better manage the difference between tiers and trials and changes some of the field names to be clearer around purpose