### PR TITLE
bug: object owned objects with org owners should filter on organzation

### DIFF
--- a/internal/ent/generated/control/control.go
+++ b/internal/ent/generated/control/control.go
@@ -319,7 +319,7 @@ func ValidColumn(column string) bool {
 //	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
 	Hooks        [10]ent.Hook
-	Interceptors [2]ent.Interceptor
+	Interceptors [3]ent.Interceptor
 	Policy       ent.Policy
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time

--- a/internal/ent/generated/controlobjective/controlobjective.go
+++ b/internal/ent/generated/controlobjective/controlobjective.go
@@ -224,7 +224,7 @@ func ValidColumn(column string) bool {
 //	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
 	Hooks        [11]ent.Hook
-	Interceptors [2]ent.Interceptor
+	Interceptors [3]ent.Interceptor
 	Policy       ent.Policy
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time

--- a/internal/ent/generated/documentdata/documentdata.go
+++ b/internal/ent/generated/documentdata/documentdata.go
@@ -112,7 +112,7 @@ func ValidColumn(column string) bool {
 //	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
 	Hooks        [6]ent.Hook
-	Interceptors [2]ent.Interceptor
+	Interceptors [3]ent.Interceptor
 	Policy       ent.Policy
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time

--- a/internal/ent/generated/evidence/evidence.go
+++ b/internal/ent/generated/evidence/evidence.go
@@ -170,7 +170,7 @@ func ValidColumn(column string) bool {
 //	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
 	Hooks        [8]ent.Hook
-	Interceptors [2]ent.Interceptor
+	Interceptors [3]ent.Interceptor
 	Policy       ent.Policy
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time

--- a/internal/ent/generated/narrative/narrative.go
+++ b/internal/ent/generated/narrative/narrative.go
@@ -153,7 +153,7 @@ func ValidColumn(column string) bool {
 //	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
 	Hooks        [10]ent.Hook
-	Interceptors [2]ent.Interceptor
+	Interceptors [3]ent.Interceptor
 	Policy       ent.Policy
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time

--- a/internal/ent/generated/note/note.go
+++ b/internal/ent/generated/note/note.go
@@ -99,7 +99,7 @@ func ValidColumn(column string) bool {
 //	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
 	Hooks        [7]ent.Hook
-	Interceptors [2]ent.Interceptor
+	Interceptors [3]ent.Interceptor
 	Policy       ent.Policy
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time

--- a/internal/ent/generated/risk/risk.go
+++ b/internal/ent/generated/risk/risk.go
@@ -215,7 +215,7 @@ func ValidColumn(column string) bool {
 //	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
 	Hooks        [10]ent.Hook
-	Interceptors [2]ent.Interceptor
+	Interceptors [3]ent.Interceptor
 	Policy       ent.Policy
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time

--- a/internal/ent/generated/runtime/runtime.go
+++ b/internal/ent/generated/runtime/runtime.go
@@ -432,6 +432,7 @@ func init() {
 	controlMixinInters4 := controlMixin[4].Interceptors()
 	control.Interceptors[0] = controlMixinInters1[0]
 	control.Interceptors[1] = controlMixinInters4[0]
+	control.Interceptors[2] = controlMixinInters4[1]
 	controlMixinFields0 := controlMixin[0].Fields()
 	_ = controlMixinFields0
 	controlMixinFields2 := controlMixin[2].Fields()
@@ -608,6 +609,7 @@ func init() {
 	controlobjectiveMixinInters5 := controlobjectiveMixin[5].Interceptors()
 	controlobjective.Interceptors[0] = controlobjectiveMixinInters1[0]
 	controlobjective.Interceptors[1] = controlobjectiveMixinInters5[0]
+	controlobjective.Interceptors[2] = controlobjectiveMixinInters5[1]
 	controlobjectiveMixinFields0 := controlobjectiveMixin[0].Fields()
 	_ = controlobjectiveMixinFields0
 	controlobjectiveMixinFields2 := controlobjectiveMixin[2].Fields()
@@ -713,6 +715,7 @@ func init() {
 	documentdataMixinInters4 := documentdataMixin[4].Interceptors()
 	documentdata.Interceptors[0] = documentdataMixinInters3[0]
 	documentdata.Interceptors[1] = documentdataMixinInters4[0]
+	documentdata.Interceptors[2] = documentdataMixinInters4[1]
 	documentdataMixinFields0 := documentdataMixin[0].Fields()
 	_ = documentdataMixinFields0
 	documentdataMixinFields1 := documentdataMixin[1].Fields()
@@ -1161,6 +1164,7 @@ func init() {
 	evidenceMixinInters4 := evidenceMixin[4].Interceptors()
 	evidence.Interceptors[0] = evidenceMixinInters2[0]
 	evidence.Interceptors[1] = evidenceMixinInters4[0]
+	evidence.Interceptors[2] = evidenceMixinInters4[1]
 	evidenceMixinFields0 := evidenceMixin[0].Fields()
 	_ = evidenceMixinFields0
 	evidenceMixinFields1 := evidenceMixin[1].Fields()
@@ -2095,6 +2099,7 @@ func init() {
 	narrativeMixinInters4 := narrativeMixin[4].Interceptors()
 	narrative.Interceptors[0] = narrativeMixinInters1[0]
 	narrative.Interceptors[1] = narrativeMixinInters4[0]
+	narrative.Interceptors[2] = narrativeMixinInters4[1]
 	narrativeMixinFields0 := narrativeMixin[0].Fields()
 	_ = narrativeMixinFields0
 	narrativeMixinFields2 := narrativeMixin[2].Fields()
@@ -2191,6 +2196,7 @@ func init() {
 	noteMixinInters3 := noteMixin[3].Interceptors()
 	note.Interceptors[0] = noteMixinInters2[0]
 	note.Interceptors[1] = noteMixinInters3[0]
+	note.Interceptors[2] = noteMixinInters3[1]
 	noteMixinFields0 := noteMixin[0].Fields()
 	_ = noteMixinFields0
 	noteMixinFields1 := noteMixin[1].Fields()
@@ -3205,6 +3211,7 @@ func init() {
 	riskMixinInters4 := riskMixin[4].Interceptors()
 	risk.Interceptors[0] = riskMixinInters1[0]
 	risk.Interceptors[1] = riskMixinInters4[0]
+	risk.Interceptors[2] = riskMixinInters4[1]
 	riskMixinFields0 := riskMixin[0].Fields()
 	_ = riskMixinFields0
 	riskMixinFields2 := riskMixin[2].Fields()
@@ -3445,6 +3452,7 @@ func init() {
 	subcontrolMixinInters4 := subcontrolMixin[4].Interceptors()
 	subcontrol.Interceptors[0] = subcontrolMixinInters1[0]
 	subcontrol.Interceptors[1] = subcontrolMixinInters4[0]
+	subcontrol.Interceptors[2] = subcontrolMixinInters4[1]
 	subcontrolMixinFields0 := subcontrolMixin[0].Fields()
 	_ = subcontrolMixinFields0
 	subcontrolMixinFields2 := subcontrolMixin[2].Fields()
@@ -3698,6 +3706,7 @@ func init() {
 	taskMixinInters4 := taskMixin[4].Interceptors()
 	task.Interceptors[0] = taskMixinInters2[0]
 	task.Interceptors[1] = taskMixinInters4[0]
+	task.Interceptors[2] = taskMixinInters4[1]
 	taskMixinFields0 := taskMixin[0].Fields()
 	_ = taskMixinFields0
 	taskMixinFields1 := taskMixin[1].Fields()

--- a/internal/ent/generated/subcontrol/subcontrol.go
+++ b/internal/ent/generated/subcontrol/subcontrol.go
@@ -257,7 +257,7 @@ func ValidColumn(column string) bool {
 //	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
 	Hooks        [8]ent.Hook
-	Interceptors [2]ent.Interceptor
+	Interceptors [3]ent.Interceptor
 	Policy       ent.Policy
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time

--- a/internal/ent/generated/task/task.go
+++ b/internal/ent/generated/task/task.go
@@ -217,7 +217,7 @@ func ValidColumn(column string) bool {
 //	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
 	Hooks        [9]ent.Hook
-	Interceptors [2]ent.Interceptor
+	Interceptors [3]ent.Interceptor
 	Policy       ent.Policy
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time

--- a/internal/ent/schema/entity.go
+++ b/internal/ent/schema/entity.go
@@ -100,7 +100,7 @@ func (Entity) Edges() []ent.Edge {
 func (Entity) Indexes() []ent.Index {
 	return []ent.Index{
 		// names should be unique, but ignore deleted names
-		index.Fields("name", "owner_id").
+		index.Fields("name", ownerFieldName).
 			Unique().Annotations(entsql.IndexWhere("deleted_at is NULL")),
 	}
 }

--- a/internal/ent/schema/entitytype.go
+++ b/internal/ent/schema/entitytype.go
@@ -68,7 +68,7 @@ func (EntityType) Edges() []ent.Edge {
 func (EntityType) Indexes() []ent.Index {
 	return []ent.Index{
 		// names should be unique by owner, but ignore deleted names
-		index.Fields("name", "owner_id").
+		index.Fields("name", ownerFieldName).
 			Unique().Annotations(entsql.IndexWhere("deleted_at is NULL")),
 	}
 }

--- a/internal/ent/schema/invite.go
+++ b/internal/ent/schema/invite.go
@@ -103,7 +103,7 @@ func (Invite) Mixin() []ent.Mixin {
 // Indexes of the Invite
 func (Invite) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("recipient", "owner_id").
+		index.Fields("recipient", ownerFieldName).
 			Unique().Annotations(entsql.IndexWhere("deleted_at is NULL")),
 	}
 }

--- a/internal/ent/schema/mixin_objectowned.go
+++ b/internal/ent/schema/mixin_objectowned.go
@@ -55,7 +55,7 @@ type ObjectOwnedMixin struct {
 	HookFuncs []HookFunc
 	// InterceptorFunc is the interceptor function for the object owned mixin
 	// that will be called on all queries
-	InterceptorFunc InterceptorFunc
+	InterceptorFuncs []InterceptorFunc
 }
 
 type HookFunc func(o ObjectOwnedMixin) ent.Hook
@@ -78,12 +78,13 @@ func NewObjectOwnedMixin(o ObjectOwnedMixin) ObjectOwnedMixin {
 		o.HookFuncs = []HookFunc{defaultObjectHookFunc, defaultTupleUpdateFunc}
 	}
 
-	if o.WithOrganizationOwner {
-		o.HookFuncs = append(o.HookFuncs, orgHookCreateFunc)
+	if o.InterceptorFuncs == nil {
+		o.InterceptorFuncs = []InterceptorFunc{defaultObjectInterceptorFunc}
 	}
 
-	if o.InterceptorFunc == nil {
-		o.InterceptorFunc = defaultObjectInterceptorFunc
+	if o.WithOrganizationOwner {
+		o.HookFuncs = append(o.HookFuncs, orgHookCreateFunc)
+		o.InterceptorFuncs = append(o.InterceptorFuncs, defaultOrgInterceptorFunc)
 	}
 
 	return o
@@ -96,7 +97,7 @@ func (o ObjectOwnedMixin) Fields() []ent.Field {
 	// add the organization owner field if the flag is set
 	if o.WithOrganizationOwner {
 		fields = append(fields,
-			field.String("owner_id").
+			field.String(ownerFieldName).
 				Comment("the ID of the organization owner of the object").
 				Immutable(). // Immutable because it is set on creation and never changes
 				Optional().  // Optional because it doesn't need to be provided as input
@@ -142,7 +143,7 @@ func (o ObjectOwnedMixin) Edges() []ent.Edge {
 	if o.WithOrganizationOwner {
 		edges = append(edges,
 			edge.From("owner", Organization.Type).
-				Field("owner_id").
+				Field(ownerFieldName).
 				Immutable().
 				Unique().
 				Ref(o.Ref))
@@ -181,16 +182,19 @@ func (o ObjectOwnedMixin) Hooks() []ent.Hook {
 
 // Interceptors of the ObjectOwnedMixin
 func (o ObjectOwnedMixin) Interceptors() []ent.Interceptor {
-	return []ent.Interceptor{
-		o.InterceptorFunc(o),
+	res := []ent.Interceptor{}
+	for _, interceptorFunc := range o.InterceptorFuncs {
+		res = append(res, interceptorFunc(o))
 	}
+
+	return res
 }
 
 // P adds a storage-level predicate to the queries and mutations.
-func (o ObjectOwnedMixin) P(w interface{ WhereP(...func(*sql.Selector)) }, objectIDs []string) {
+func (o ObjectOwnedMixin) PWithField(w interface{ WhereP(...func(*sql.Selector)) }, fieldName string, objectIDs []string) {
 	// if the field is only owned by one field, use that field
 	// this is used by the organization owned mixin
-	if len(o.FieldNames) == 1 && o.FieldNames[0] == "owner_id" {
+	if len(o.FieldNames) == 1 && o.FieldNames[0] == ownerFieldName {
 		selector := sql.FieldIn(o.FieldNames[0], objectIDs...)
 		if o.AllowEmptyForSystemAdmin {
 			// allow for empty values if the flag is set
@@ -210,9 +214,16 @@ func (o ObjectOwnedMixin) P(w interface{ WhereP(...func(*sql.Selector)) }, objec
 		return
 	}
 
-	// otherwise we are using getting all objects that the user has access to
-	// and should use the id field
-	w.WhereP(sql.FieldIn("id", objectIDs...))
+	// otherwise we are using getting all objects filtered by the field name
+	// usually "id" or "owner_id"
+	w.WhereP(sql.FieldIn(fieldName, objectIDs...))
+}
+
+// P adds the predicate to the queries, using the "id" field
+func (o ObjectOwnedMixin) P(w interface{ WhereP(...func(*sql.Selector)) }, objectIDs []string) {
+	o.PWithField(w, "id", objectIDs)
+
+	return
 }
 
 // defaultTupleUpdateFunc is the default hook function for the object owned mixin

--- a/internal/ent/schema/mixin_orgowned.go
+++ b/internal/ent/schema/mixin_orgowned.go
@@ -90,7 +90,7 @@ var defaultOrgHookFunc HookFunc = func(o ObjectOwnedMixin) ent.Hook {
 				return nil, ErrUnexpectedMutationType
 			}
 
-			o.P(mx, orgIDs)
+			o.PWithField(mx, ownerFieldName, orgIDs)
 
 			return next.Mutate(ctx, m)
 		})

--- a/internal/ent/schema/mixin_orgowned.go
+++ b/internal/ent/schema/mixin_orgowned.go
@@ -46,8 +46,8 @@ func NewOrgOwnedMixin(o ObjectOwnedMixin) ObjectOwnedMixin {
 		o.HookFuncs = []HookFunc{defaultOrgHookFunc}
 	}
 
-	if o.InterceptorFunc == nil {
-		o.InterceptorFunc = defaultOrgInterceptorFunc
+	if o.InterceptorFuncs == nil {
+		o.InterceptorFuncs = []InterceptorFunc{defaultOrgInterceptorFunc}
 	}
 
 	return o
@@ -222,7 +222,7 @@ var defaultOrgInterceptorFunc InterceptorFunc = func(o ObjectOwnedMixin) ent.Int
 		}
 
 		// sets the owner id on the query for the current organization
-		o.P(q, orgIDs)
+		o.PWithField(q, ownerFieldName, orgIDs)
 
 		return nil
 	})

--- a/internal/ent/schema/mixin_userowned.go
+++ b/internal/ent/schema/mixin_userowned.go
@@ -47,7 +47,7 @@ type UserOwnedMixin struct {
 
 // Fields of the UserOwnedMixin
 func (userOwned UserOwnedMixin) Fields() []ent.Field {
-	ownerIDField := field.String("owner_id").
+	ownerIDField := field.String(ownerFieldName).
 		Annotations(
 			entgql.Skip(),
 		).
@@ -70,7 +70,7 @@ func (userOwned UserOwnedMixin) Edges() []ent.Edge {
 
 	ownerEdge := edge.
 		From("owner", User.Type).
-		Field("owner_id").
+		Field(ownerFieldName).
 		Ref(userOwned.Ref).
 		Unique()
 
@@ -96,7 +96,7 @@ func (userOwned UserOwnedMixin) Indexes() []ent.Index {
 	}
 
 	return []ent.Index{
-		index.Fields("owner_id").
+		index.Fields(ownerFieldName).
 			Unique().Annotations(entsql.IndexWhere("deleted_at is NULL")),
 	}
 }

--- a/internal/ent/schema/subscriber.go
+++ b/internal/ent/schema/subscriber.go
@@ -115,7 +115,7 @@ func (Subscriber) Hooks() []ent.Hook {
 // Indexes of the Subscriber
 func (Subscriber) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("email", "owner_id").
+		index.Fields("email", ownerFieldName).
 			Unique().
 			Annotations(
 				entsql.IndexWhere("deleted_at is NULL"),

--- a/internal/ent/schema/template.go
+++ b/internal/ent/schema/template.go
@@ -78,7 +78,7 @@ func (Template) Edges() []ent.Edge {
 func (Template) Indexes() []ent.Index {
 	return []ent.Index{
 		// names should be unique, but ignore deleted names
-		index.Fields("name", "owner_id", "template_type").
+		index.Fields("name", ownerFieldName, "template_type").
 			Unique().Annotations(entsql.IndexWhere("deleted_at is NULL")),
 	}
 }

--- a/internal/graphapi/control_test.go
+++ b/internal/graphapi/control_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/models"
 	"github.com/theopenlane/core/pkg/openlaneclient"
+	"github.com/theopenlane/iam/auth"
 	"github.com/theopenlane/utils/ulids"
 )
 
@@ -114,6 +115,13 @@ func (suite *GraphTestSuite) TestQueryControls() {
 	// create multiple objects to be queried using testUser1
 	(&ControlBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	(&ControlBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+
+	org := (&OrganizationBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	userCtxAnotherOrg := auth.NewTestContextWithOrgID(testUser1.ID, org.ID)
+
+	// add a control for the user to another org; this should not be returned for JWT auth, since it's
+	// restricted to a single org. PAT auth would return it if both orgs are authorized on the token
+	(&ControlBuilder{client: suite.client}).MustNew(userCtxAnotherOrg, t)
 
 	testCases := []struct {
 		name            string

--- a/internal/graphapi/controlobjective_test.go
+++ b/internal/graphapi/controlobjective_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/models"
 	"github.com/theopenlane/core/pkg/openlaneclient"
+	"github.com/theopenlane/iam/auth"
 	"github.com/theopenlane/utils/ulids"
 )
 
@@ -111,6 +112,13 @@ func (suite *GraphTestSuite) TestQueryControlObjectives() {
 	// create multiple objects to be queried using testUser1
 	(&ControlObjectiveBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	(&ControlObjectiveBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+
+	org := (&OrganizationBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	userCtxAnotherOrg := auth.NewTestContextWithOrgID(testUser1.ID, org.ID)
+
+	// add control objective for the user to another org; this should not be returned for JWT auth, since it's
+	// restricted to a single org. PAT auth would return it if both orgs are authorized on the token
+	(&ControlObjectiveBuilder{client: suite.client}).MustNew(userCtxAnotherOrg, t)
 
 	testCases := []struct {
 		name            string

--- a/internal/graphapi/evidence_test.go
+++ b/internal/graphapi/evidence_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/theopenlane/core/pkg/objects"
 	"github.com/theopenlane/core/pkg/openlaneclient"
+	"github.com/theopenlane/iam/auth"
 	"github.com/theopenlane/utils/ulids"
 )
 
@@ -125,6 +126,13 @@ func (suite *GraphTestSuite) TestQueryEvidences() {
 	// create multiple objects by adminUser, org owner should have access to them as well
 	(&EvidenceBuilder{client: suite.client}).MustNew(adminUser.UserCtx, t)
 	(&EvidenceBuilder{client: suite.client}).MustNew(adminUser.UserCtx, t)
+
+	org := (&OrganizationBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	userCtxAnotherOrg := auth.NewTestContextWithOrgID(testUser1.ID, org.ID)
+
+	// add evidence for the user to another org; this should not be returned for JWT auth, since it's
+	// restricted to a single org. PAT auth would return it if both orgs are authorized on the token
+	(&EvidenceBuilder{client: suite.client}).MustNew(userCtxAnotherOrg, t)
 
 	testCases := []struct {
 		name            string

--- a/internal/graphapi/narrative_test.go
+++ b/internal/graphapi/narrative_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/openlaneclient"
+	"github.com/theopenlane/iam/auth"
 	"github.com/theopenlane/utils/ulids"
 )
 
@@ -113,6 +114,13 @@ func (suite *GraphTestSuite) TestQueryNarratives() {
 	// create multiple objects to be queried using testUser1
 	(&NarrativeBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	(&NarrativeBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+
+	org := (&OrganizationBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	userCtxAnotherOrg := auth.NewTestContextWithOrgID(testUser1.ID, org.ID)
+
+	// add narrative for the user to another org; this should not be returned for JWT auth, since it's
+	// restricted to a single org. PAT auth would return it if both orgs are authorized on the token
+	(&NarrativeBuilder{client: suite.client}).MustNew(userCtxAnotherOrg, t)
 
 	testCases := []struct {
 		name            string

--- a/internal/graphapi/procedure_test.go
+++ b/internal/graphapi/procedure_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/theopenlane/iam/auth"
 	"github.com/theopenlane/utils/ulids"
 
 	"github.com/theopenlane/core/pkg/enums"
@@ -91,6 +92,12 @@ func (suite *GraphTestSuite) TestQueryProcedures() {
 	// create multiple Procedures to be queried using testUser1
 	(&ProcedureBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	(&ProcedureBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+
+	org := (&OrganizationBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	userCtxAnotherOrg := auth.NewTestContextWithOrgID(testUser1.ID, org.ID)
+
+	// add procedure for another org; it should not be returned in the list
+	(&ProcedureBuilder{client: suite.client}).MustNew(userCtxAnotherOrg, t)
 
 	testCases := []struct {
 		name            string


### PR DESCRIPTION
Fixes a bug that would return all tasks for a user; instead of being filtered on the current organization ID. This was noticed on tasks, but was an issue for all object owned schemas. Adds tests to confirm behavior. 