### PR TITLE
Add OrderBy and RelayConnections on schemas + edges

### DIFF
--- a/cmd/cli/cmd/control/root.go
+++ b/cmd/cli/cmd/control/root.go
@@ -92,8 +92,8 @@ func tableOutput(out []openlaneclient.Control) {
 	for _, i := range out {
 		programs := []string{}
 
-		for _, p := range i.Programs {
-			programs = append(programs, p.Name)
+		for _, p := range i.Programs.Edges {
+			programs = append(programs, p.Node.Name)
 		}
 
 		stdName := ""

--- a/cmd/cli/cmd/controlobjective/root.go
+++ b/cmd/cli/cmd/controlobjective/root.go
@@ -93,13 +93,13 @@ func tableOutput(out []openlaneclient.ControlObjective) {
 	for _, i := range out {
 		programs := []string{}
 
-		for _, p := range i.Programs {
-			programs = append(programs, p.Name)
+		for _, p := range i.Programs.Edges {
+			programs = append(programs, p.Node.Name)
 		}
 
 		controls := []string{}
-		for _, c := range i.Controls {
-			controls = append(controls, c.RefCode)
+		for _, c := range i.Controls.Edges {
+			controls = append(controls, c.Node.RefCode)
 		}
 
 		writer.AddRow(i.ID, i.Name, *i.DesiredOutcome, *i.Source, *i.Revision, *i.Status, *i.ControlObjectiveType, strings.Join(controls, ", "), strings.Join(programs, ", "))

--- a/cmd/cli/cmd/evidence/root.go
+++ b/cmd/cli/cmd/evidence/root.go
@@ -90,20 +90,20 @@ func tableOutput(out []openlaneclient.Evidence) {
 	// create a table writer
 	writer := tables.NewTableWriter(command.OutOrStdout(), "ID", "DisplayID", "Name", "Description", "CollectionProcedure", "Source", "IsAutomated", "URL", "NumOfFiles", "Programs", "CreatedAt", "UpdatedAt")
 	for _, i := range out {
-		prgs := i.Programs
+		prgs := i.Programs.Edges
 
 		progNames := make([]string, 0, len(prgs))
 
 		// add programs with either no end date or end date before the current date
 		for _, p := range prgs {
-			if p.EndDate == nil {
-				progNames = append(progNames, p.Name)
-			} else if p.EndDate.Before(time.Now()) {
-				progNames = append(progNames, p.Name)
+			if p.Node.EndDate == nil {
+				progNames = append(progNames, p.Node.Name)
+			} else if p.Node.EndDate.Before(time.Now()) {
+				progNames = append(progNames, p.Node.Name)
 			}
 		}
 
-		writer.AddRow(i.ID, i.DisplayID, i.Name, *i.Description, *i.CollectionProcedure, *i.Source, *i.IsAutomated, *i.URL, len(i.Files), strings.Join(progNames, ","), i.CreatedAt, i.UpdatedAt)
+		writer.AddRow(i.ID, i.DisplayID, i.Name, *i.Description, *i.CollectionProcedure, *i.Source, *i.IsAutomated, *i.URL, len(i.Files.Edges), strings.Join(progNames, ","), i.CreatedAt, i.UpdatedAt)
 	}
 
 	writer.Render()

--- a/cmd/cli/cmd/narrative/root.go
+++ b/cmd/cli/cmd/narrative/root.go
@@ -93,8 +93,8 @@ func tableOutput(out []openlaneclient.Narrative) {
 	for _, i := range out {
 		programs := []string{}
 
-		for _, p := range i.Programs {
-			programs = append(programs, p.Name)
+		for _, p := range i.Programs.Edges {
+			programs = append(programs, p.Node.Name)
 		}
 
 		writer.AddRow(i.ID, i.Name, *i.Description, *i.Details, strings.Join(programs, ", "))

--- a/cmd/cli/cmd/personalaccesstokens/root.go
+++ b/cmd/cli/cmd/personalaccesstokens/root.go
@@ -93,8 +93,8 @@ func tableOutput(out []openlaneclient.PersonalAccessToken) {
 		}
 
 		orgs := []string{}
-		for _, o := range i.Organizations {
-			orgs = append(orgs, o.Name)
+		for _, o := range i.Organizations.Edges {
+			orgs = append(orgs, o.Node.Name)
 		}
 
 		authorizedOrgs := strings.Join(orgs, ", ")

--- a/cmd/cli/cmd/risk/root.go
+++ b/cmd/cli/cmd/risk/root.go
@@ -93,8 +93,8 @@ func tableOutput(out []openlaneclient.Risk) {
 	for _, i := range out {
 		programs := []string{}
 
-		for _, p := range i.Programs {
-			programs = append(programs, p.Name)
+		for _, p := range i.Programs.Edges {
+			programs = append(programs, p.Node.Name)
 		}
 
 		writer.AddRow(i.ID, i.DisplayID, i.Name, *i.Details, *i.Status, *i.RiskType, *i.BusinessCosts, *i.Impact, *i.Likelihood, *i.Score, *i.Mitigation, strings.Join(programs, ","))

--- a/cmd/cli/cmd/task/root.go
+++ b/cmd/cli/cmd/task/root.go
@@ -114,8 +114,8 @@ func tableOutput(out []openlaneclient.Task) {
 			writer.AddRow("----------------------------------------")
 			writer.AddRow("COMMENTS", "CREATEDBY", "CREATEDAT")
 			writer.AddRow("----------------------------------------")
-			for _, c := range i.Comments {
-				writer.AddRow(c.Text, *c.CreatedBy, *c.CreatedAt)
+			for _, c := range i.Comments.Edges {
+				writer.AddRow(c.Node.Text, *c.Node.CreatedBy, *c.Node.CreatedAt)
 			}
 		}
 

--- a/internal/ent/generated/gql_edge.go
+++ b/internal/ent/generated/gql_edge.go
@@ -40,52 +40,88 @@ func (ap *ActionPlan) Owner(ctx context.Context) (*Organization, error) {
 	return result, MaskNotFound(err)
 }
 
-func (ap *ActionPlan) Risk(ctx context.Context) (result []*Risk, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = ap.NamedRisk(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = ap.Edges.RiskOrErr()
+func (ap *ActionPlan) Risk(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*RiskOrder, where *RiskWhereInput,
+) (*RiskConnection, error) {
+	opts := []RiskPaginateOption{
+		WithRiskOrder(orderBy),
+		WithRiskFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = ap.QueryRisk().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := ap.Edges.totalCount[3][alias]
+	if nodes, err := ap.NamedRisk(alias); err == nil || hasTotalCount {
+		pager, err := newRiskPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &RiskConnection{Edges: []*RiskEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return ap.QueryRisk().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (ap *ActionPlan) Control(ctx context.Context) (result []*Control, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = ap.NamedControl(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = ap.Edges.ControlOrErr()
+func (ap *ActionPlan) Control(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ControlOrder, where *ControlWhereInput,
+) (*ControlConnection, error) {
+	opts := []ControlPaginateOption{
+		WithControlOrder(orderBy),
+		WithControlFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = ap.QueryControl().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := ap.Edges.totalCount[4][alias]
+	if nodes, err := ap.NamedControl(alias); err == nil || hasTotalCount {
+		pager, err := newControlPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ControlConnection{Edges: []*ControlEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return ap.QueryControl().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (ap *ActionPlan) User(ctx context.Context) (result []*User, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = ap.NamedUser(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = ap.Edges.UserOrErr()
+func (ap *ActionPlan) User(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*UserOrder, where *UserWhereInput,
+) (*UserConnection, error) {
+	opts := []UserPaginateOption{
+		WithUserOrder(orderBy),
+		WithUserFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = ap.QueryUser().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := ap.Edges.totalCount[5][alias]
+	if nodes, err := ap.NamedUser(alias); err == nil || hasTotalCount {
+		pager, err := newUserPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &UserConnection{Edges: []*UserEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return ap.QueryUser().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (ap *ActionPlan) Program(ctx context.Context) (result []*Program, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = ap.NamedProgram(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = ap.Edges.ProgramOrErr()
+func (ap *ActionPlan) Program(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ProgramOrder, where *ProgramWhereInput,
+) (*ProgramConnection, error) {
+	opts := []ProgramPaginateOption{
+		WithProgramOrder(orderBy),
+		WithProgramFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = ap.QueryProgram().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := ap.Edges.totalCount[6][alias]
+	if nodes, err := ap.NamedProgram(alias); err == nil || hasTotalCount {
+		pager, err := newProgramPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ProgramConnection{Edges: []*ProgramEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return ap.QueryProgram().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (c *Contact) Owner(ctx context.Context) (*Organization, error) {
@@ -96,28 +132,45 @@ func (c *Contact) Owner(ctx context.Context) (*Organization, error) {
 	return result, MaskNotFound(err)
 }
 
-func (c *Contact) Entities(ctx context.Context) (result []*Entity, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = c.NamedEntities(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = c.Edges.EntitiesOrErr()
+func (c *Contact) Entities(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*EntityOrder, where *EntityWhereInput,
+) (*EntityConnection, error) {
+	opts := []EntityPaginateOption{
+		WithEntityOrder(orderBy),
+		WithEntityFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = c.QueryEntities().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := c.Edges.totalCount[1][alias]
+	if nodes, err := c.NamedEntities(alias); err == nil || hasTotalCount {
+		pager, err := newEntityPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &EntityConnection{Edges: []*EntityEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return c.QueryEntities().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (c *Contact) Files(ctx context.Context) (result []*File, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = c.NamedFiles(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = c.Edges.FilesOrErr()
+func (c *Contact) Files(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *FileWhereInput,
+) (*FileConnection, error) {
+	opts := []FilePaginateOption{
+		WithFileFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = c.QueryFiles().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := c.Edges.totalCount[2][alias]
+	if nodes, err := c.NamedFiles(alias); err == nil || hasTotalCount {
+		pager, err := newFilePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &FileConnection{Edges: []*FileEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return c.QueryFiles().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (c *Control) Owner(ctx context.Context) (*Organization, error) {
@@ -172,52 +225,88 @@ func (c *Control) Standard(ctx context.Context) (*Standard, error) {
 	return result, MaskNotFound(err)
 }
 
-func (c *Control) Programs(ctx context.Context) (result []*Program, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = c.NamedPrograms(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = c.Edges.ProgramsOrErr()
+func (c *Control) Programs(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ProgramOrder, where *ProgramWhereInput,
+) (*ProgramConnection, error) {
+	opts := []ProgramPaginateOption{
+		WithProgramOrder(orderBy),
+		WithProgramFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = c.QueryPrograms().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := c.Edges.totalCount[5][alias]
+	if nodes, err := c.NamedPrograms(alias); err == nil || hasTotalCount {
+		pager, err := newProgramPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ProgramConnection{Edges: []*ProgramEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return c.QueryPrograms().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (c *Control) Evidence(ctx context.Context) (result []*Evidence, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = c.NamedEvidence(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = c.Edges.EvidenceOrErr()
+func (c *Control) Evidence(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*EvidenceOrder, where *EvidenceWhereInput,
+) (*EvidenceConnection, error) {
+	opts := []EvidencePaginateOption{
+		WithEvidenceOrder(orderBy),
+		WithEvidenceFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = c.QueryEvidence().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := c.Edges.totalCount[6][alias]
+	if nodes, err := c.NamedEvidence(alias); err == nil || hasTotalCount {
+		pager, err := newEvidencePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &EvidenceConnection{Edges: []*EvidenceEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return c.QueryEvidence().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (c *Control) ControlImplementations(ctx context.Context) (result []*ControlImplementation, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = c.NamedControlImplementations(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = c.Edges.ControlImplementationsOrErr()
+func (c *Control) ControlImplementations(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ControlImplementationOrder, where *ControlImplementationWhereInput,
+) (*ControlImplementationConnection, error) {
+	opts := []ControlImplementationPaginateOption{
+		WithControlImplementationOrder(orderBy),
+		WithControlImplementationFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = c.QueryControlImplementations().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := c.Edges.totalCount[7][alias]
+	if nodes, err := c.NamedControlImplementations(alias); err == nil || hasTotalCount {
+		pager, err := newControlImplementationPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ControlImplementationConnection{Edges: []*ControlImplementationEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return c.QueryControlImplementations().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (c *Control) MappedControls(ctx context.Context) (result []*MappedControl, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = c.NamedMappedControls(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = c.Edges.MappedControlsOrErr()
+func (c *Control) MappedControls(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy *MappedControlOrder, where *MappedControlWhereInput,
+) (*MappedControlConnection, error) {
+	opts := []MappedControlPaginateOption{
+		WithMappedControlOrder(orderBy),
+		WithMappedControlFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = c.QueryMappedControls().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := c.Edges.totalCount[8][alias]
+	if nodes, err := c.NamedMappedControls(alias); err == nil || hasTotalCount {
+		pager, err := newMappedControlPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &MappedControlConnection{Edges: []*MappedControlEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return c.QueryMappedControls().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (c *Control) ControlObjectives(ctx context.Context) (result []*ControlObjective, err error) {
@@ -232,88 +321,149 @@ func (c *Control) ControlObjectives(ctx context.Context) (result []*ControlObjec
 	return result, err
 }
 
-func (c *Control) Subcontrols(ctx context.Context) (result []*Subcontrol, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = c.NamedSubcontrols(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = c.Edges.SubcontrolsOrErr()
+func (c *Control) Subcontrols(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*SubcontrolOrder, where *SubcontrolWhereInput,
+) (*SubcontrolConnection, error) {
+	opts := []SubcontrolPaginateOption{
+		WithSubcontrolOrder(orderBy),
+		WithSubcontrolFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = c.QuerySubcontrols().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := c.Edges.totalCount[10][alias]
+	if nodes, err := c.NamedSubcontrols(alias); err == nil || hasTotalCount {
+		pager, err := newSubcontrolPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &SubcontrolConnection{Edges: []*SubcontrolEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return c.QuerySubcontrols().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (c *Control) Tasks(ctx context.Context) (result []*Task, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = c.NamedTasks(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = c.Edges.TasksOrErr()
+func (c *Control) Tasks(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*TaskOrder, where *TaskWhereInput,
+) (*TaskConnection, error) {
+	opts := []TaskPaginateOption{
+		WithTaskOrder(orderBy),
+		WithTaskFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = c.QueryTasks().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := c.Edges.totalCount[11][alias]
+	if nodes, err := c.NamedTasks(alias); err == nil || hasTotalCount {
+		pager, err := newTaskPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &TaskConnection{Edges: []*TaskEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return c.QueryTasks().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (c *Control) Narratives(ctx context.Context) (result []*Narrative, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = c.NamedNarratives(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = c.Edges.NarrativesOrErr()
+func (c *Control) Narratives(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy *NarrativeOrder, where *NarrativeWhereInput,
+) (*NarrativeConnection, error) {
+	opts := []NarrativePaginateOption{
+		WithNarrativeOrder(orderBy),
+		WithNarrativeFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = c.QueryNarratives().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := c.Edges.totalCount[12][alias]
+	if nodes, err := c.NamedNarratives(alias); err == nil || hasTotalCount {
+		pager, err := newNarrativePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &NarrativeConnection{Edges: []*NarrativeEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return c.QueryNarratives().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (c *Control) Risks(ctx context.Context) (result []*Risk, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = c.NamedRisks(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = c.Edges.RisksOrErr()
+func (c *Control) Risks(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*RiskOrder, where *RiskWhereInput,
+) (*RiskConnection, error) {
+	opts := []RiskPaginateOption{
+		WithRiskOrder(orderBy),
+		WithRiskFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = c.QueryRisks().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := c.Edges.totalCount[13][alias]
+	if nodes, err := c.NamedRisks(alias); err == nil || hasTotalCount {
+		pager, err := newRiskPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &RiskConnection{Edges: []*RiskEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return c.QueryRisks().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (c *Control) ActionPlans(ctx context.Context) (result []*ActionPlan, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = c.NamedActionPlans(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = c.Edges.ActionPlansOrErr()
+func (c *Control) ActionPlans(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ActionPlanOrder, where *ActionPlanWhereInput,
+) (*ActionPlanConnection, error) {
+	opts := []ActionPlanPaginateOption{
+		WithActionPlanOrder(orderBy),
+		WithActionPlanFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = c.QueryActionPlans().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := c.Edges.totalCount[14][alias]
+	if nodes, err := c.NamedActionPlans(alias); err == nil || hasTotalCount {
+		pager, err := newActionPlanPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ActionPlanConnection{Edges: []*ActionPlanEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return c.QueryActionPlans().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (c *Control) Procedures(ctx context.Context) (result []*Procedure, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = c.NamedProcedures(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = c.Edges.ProceduresOrErr()
+func (c *Control) Procedures(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *ProcedureWhereInput,
+) (*ProcedureConnection, error) {
+	opts := []ProcedurePaginateOption{
+		WithProcedureFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = c.QueryProcedures().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := c.Edges.totalCount[15][alias]
+	if nodes, err := c.NamedProcedures(alias); err == nil || hasTotalCount {
+		pager, err := newProcedurePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ProcedureConnection{Edges: []*ProcedureEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return c.QueryProcedures().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (c *Control) InternalPolicies(ctx context.Context) (result []*InternalPolicy, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = c.NamedInternalPolicies(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = c.Edges.InternalPoliciesOrErr()
+func (c *Control) InternalPolicies(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *InternalPolicyWhereInput,
+) (*InternalPolicyConnection, error) {
+	opts := []InternalPolicyPaginateOption{
+		WithInternalPolicyFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = c.QueryInternalPolicies().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := c.Edges.totalCount[16][alias]
+	if nodes, err := c.NamedInternalPolicies(alias); err == nil || hasTotalCount {
+		pager, err := newInternalPolicyPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &InternalPolicyConnection{Edges: []*InternalPolicyEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return c.QueryInternalPolicies().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (c *Control) ControlOwner(ctx context.Context) (*Group, error) {
@@ -332,16 +482,25 @@ func (c *Control) Delegate(ctx context.Context) (*Group, error) {
 	return result, MaskNotFound(err)
 }
 
-func (ci *ControlImplementation) Controls(ctx context.Context) (result []*Control, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = ci.NamedControls(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = ci.Edges.ControlsOrErr()
+func (ci *ControlImplementation) Controls(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ControlOrder, where *ControlWhereInput,
+) (*ControlConnection, error) {
+	opts := []ControlPaginateOption{
+		WithControlOrder(orderBy),
+		WithControlFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = ci.QueryControls().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := ci.Edges.totalCount[0][alias]
+	if nodes, err := ci.NamedControls(alias); err == nil || hasTotalCount {
+		pager, err := newControlPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ControlConnection{Edges: []*ControlEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return ci.QueryControls().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (co *ControlObjective) Owner(ctx context.Context) (*Organization, error) {
@@ -388,112 +547,191 @@ func (co *ControlObjective) Viewers(ctx context.Context) (result []*Group, err e
 	return result, err
 }
 
-func (co *ControlObjective) Programs(ctx context.Context) (result []*Program, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = co.NamedPrograms(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = co.Edges.ProgramsOrErr()
+func (co *ControlObjective) Programs(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ProgramOrder, where *ProgramWhereInput,
+) (*ProgramConnection, error) {
+	opts := []ProgramPaginateOption{
+		WithProgramOrder(orderBy),
+		WithProgramFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = co.QueryPrograms().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := co.Edges.totalCount[4][alias]
+	if nodes, err := co.NamedPrograms(alias); err == nil || hasTotalCount {
+		pager, err := newProgramPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ProgramConnection{Edges: []*ProgramEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return co.QueryPrograms().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (co *ControlObjective) Evidence(ctx context.Context) (result []*Evidence, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = co.NamedEvidence(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = co.Edges.EvidenceOrErr()
+func (co *ControlObjective) Evidence(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*EvidenceOrder, where *EvidenceWhereInput,
+) (*EvidenceConnection, error) {
+	opts := []EvidencePaginateOption{
+		WithEvidenceOrder(orderBy),
+		WithEvidenceFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = co.QueryEvidence().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := co.Edges.totalCount[5][alias]
+	if nodes, err := co.NamedEvidence(alias); err == nil || hasTotalCount {
+		pager, err := newEvidencePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &EvidenceConnection{Edges: []*EvidenceEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return co.QueryEvidence().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (co *ControlObjective) Controls(ctx context.Context) (result []*Control, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = co.NamedControls(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = co.Edges.ControlsOrErr()
+func (co *ControlObjective) Controls(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ControlOrder, where *ControlWhereInput,
+) (*ControlConnection, error) {
+	opts := []ControlPaginateOption{
+		WithControlOrder(orderBy),
+		WithControlFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = co.QueryControls().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := co.Edges.totalCount[6][alias]
+	if nodes, err := co.NamedControls(alias); err == nil || hasTotalCount {
+		pager, err := newControlPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ControlConnection{Edges: []*ControlEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return co.QueryControls().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (co *ControlObjective) Subcontrols(ctx context.Context) (result []*Subcontrol, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = co.NamedSubcontrols(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = co.Edges.SubcontrolsOrErr()
+func (co *ControlObjective) Subcontrols(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*SubcontrolOrder, where *SubcontrolWhereInput,
+) (*SubcontrolConnection, error) {
+	opts := []SubcontrolPaginateOption{
+		WithSubcontrolOrder(orderBy),
+		WithSubcontrolFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = co.QuerySubcontrols().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := co.Edges.totalCount[7][alias]
+	if nodes, err := co.NamedSubcontrols(alias); err == nil || hasTotalCount {
+		pager, err := newSubcontrolPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &SubcontrolConnection{Edges: []*SubcontrolEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return co.QuerySubcontrols().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (co *ControlObjective) InternalPolicies(ctx context.Context) (result []*InternalPolicy, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = co.NamedInternalPolicies(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = co.Edges.InternalPoliciesOrErr()
+func (co *ControlObjective) InternalPolicies(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *InternalPolicyWhereInput,
+) (*InternalPolicyConnection, error) {
+	opts := []InternalPolicyPaginateOption{
+		WithInternalPolicyFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = co.QueryInternalPolicies().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := co.Edges.totalCount[8][alias]
+	if nodes, err := co.NamedInternalPolicies(alias); err == nil || hasTotalCount {
+		pager, err := newInternalPolicyPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &InternalPolicyConnection{Edges: []*InternalPolicyEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return co.QueryInternalPolicies().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (co *ControlObjective) Procedures(ctx context.Context) (result []*Procedure, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = co.NamedProcedures(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = co.Edges.ProceduresOrErr()
+func (co *ControlObjective) Procedures(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *ProcedureWhereInput,
+) (*ProcedureConnection, error) {
+	opts := []ProcedurePaginateOption{
+		WithProcedureFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = co.QueryProcedures().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := co.Edges.totalCount[9][alias]
+	if nodes, err := co.NamedProcedures(alias); err == nil || hasTotalCount {
+		pager, err := newProcedurePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ProcedureConnection{Edges: []*ProcedureEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return co.QueryProcedures().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (co *ControlObjective) Risks(ctx context.Context) (result []*Risk, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = co.NamedRisks(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = co.Edges.RisksOrErr()
+func (co *ControlObjective) Risks(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*RiskOrder, where *RiskWhereInput,
+) (*RiskConnection, error) {
+	opts := []RiskPaginateOption{
+		WithRiskOrder(orderBy),
+		WithRiskFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = co.QueryRisks().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := co.Edges.totalCount[10][alias]
+	if nodes, err := co.NamedRisks(alias); err == nil || hasTotalCount {
+		pager, err := newRiskPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &RiskConnection{Edges: []*RiskEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return co.QueryRisks().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (co *ControlObjective) Narratives(ctx context.Context) (result []*Narrative, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = co.NamedNarratives(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = co.Edges.NarrativesOrErr()
+func (co *ControlObjective) Narratives(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy *NarrativeOrder, where *NarrativeWhereInput,
+) (*NarrativeConnection, error) {
+	opts := []NarrativePaginateOption{
+		WithNarrativeOrder(orderBy),
+		WithNarrativeFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = co.QueryNarratives().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := co.Edges.totalCount[11][alias]
+	if nodes, err := co.NamedNarratives(alias); err == nil || hasTotalCount {
+		pager, err := newNarrativePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &NarrativeConnection{Edges: []*NarrativeEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return co.QueryNarratives().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (co *ControlObjective) Tasks(ctx context.Context) (result []*Task, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = co.NamedTasks(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = co.Edges.TasksOrErr()
+func (co *ControlObjective) Tasks(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*TaskOrder, where *TaskWhereInput,
+) (*TaskConnection, error) {
+	opts := []TaskPaginateOption{
+		WithTaskOrder(orderBy),
+		WithTaskFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = co.QueryTasks().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := co.Edges.totalCount[12][alias]
+	if nodes, err := co.NamedTasks(alias); err == nil || hasTotalCount {
+		pager, err := newTaskPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &TaskConnection{Edges: []*TaskEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return co.QueryTasks().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (dd *DocumentData) Owner(ctx context.Context) (*Organization, error) {
@@ -512,28 +750,45 @@ func (dd *DocumentData) Template(ctx context.Context) (*Template, error) {
 	return result, err
 }
 
-func (dd *DocumentData) Entity(ctx context.Context) (result []*Entity, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = dd.NamedEntity(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = dd.Edges.EntityOrErr()
+func (dd *DocumentData) Entity(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*EntityOrder, where *EntityWhereInput,
+) (*EntityConnection, error) {
+	opts := []EntityPaginateOption{
+		WithEntityOrder(orderBy),
+		WithEntityFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = dd.QueryEntity().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := dd.Edges.totalCount[2][alias]
+	if nodes, err := dd.NamedEntity(alias); err == nil || hasTotalCount {
+		pager, err := newEntityPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &EntityConnection{Edges: []*EntityEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return dd.QueryEntity().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (dd *DocumentData) Files(ctx context.Context) (result []*File, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = dd.NamedFiles(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = dd.Edges.FilesOrErr()
+func (dd *DocumentData) Files(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *FileWhereInput,
+) (*FileConnection, error) {
+	opts := []FilePaginateOption{
+		WithFileFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = dd.QueryFiles().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := dd.Edges.totalCount[3][alias]
+	if nodes, err := dd.NamedFiles(alias); err == nil || hasTotalCount {
+		pager, err := newFilePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &FileConnection{Edges: []*FileEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return dd.QueryFiles().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (e *Entity) Owner(ctx context.Context) (*Organization, error) {
@@ -544,52 +799,85 @@ func (e *Entity) Owner(ctx context.Context) (*Organization, error) {
 	return result, MaskNotFound(err)
 }
 
-func (e *Entity) Contacts(ctx context.Context) (result []*Contact, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = e.NamedContacts(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = e.Edges.ContactsOrErr()
+func (e *Entity) Contacts(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ContactOrder, where *ContactWhereInput,
+) (*ContactConnection, error) {
+	opts := []ContactPaginateOption{
+		WithContactOrder(orderBy),
+		WithContactFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = e.QueryContacts().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := e.Edges.totalCount[1][alias]
+	if nodes, err := e.NamedContacts(alias); err == nil || hasTotalCount {
+		pager, err := newContactPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ContactConnection{Edges: []*ContactEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return e.QueryContacts().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (e *Entity) Documents(ctx context.Context) (result []*DocumentData, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = e.NamedDocuments(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = e.Edges.DocumentsOrErr()
+func (e *Entity) Documents(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *DocumentDataWhereInput,
+) (*DocumentDataConnection, error) {
+	opts := []DocumentDataPaginateOption{
+		WithDocumentDataFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = e.QueryDocuments().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := e.Edges.totalCount[2][alias]
+	if nodes, err := e.NamedDocuments(alias); err == nil || hasTotalCount {
+		pager, err := newDocumentDataPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &DocumentDataConnection{Edges: []*DocumentDataEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return e.QueryDocuments().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (e *Entity) Notes(ctx context.Context) (result []*Note, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = e.NamedNotes(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = e.Edges.NotesOrErr()
+func (e *Entity) Notes(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *NoteWhereInput,
+) (*NoteConnection, error) {
+	opts := []NotePaginateOption{
+		WithNoteFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = e.QueryNotes().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := e.Edges.totalCount[3][alias]
+	if nodes, err := e.NamedNotes(alias); err == nil || hasTotalCount {
+		pager, err := newNotePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &NoteConnection{Edges: []*NoteEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return e.QueryNotes().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (e *Entity) Files(ctx context.Context) (result []*File, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = e.NamedFiles(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = e.Edges.FilesOrErr()
+func (e *Entity) Files(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *FileWhereInput,
+) (*FileConnection, error) {
+	opts := []FilePaginateOption{
+		WithFileFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = e.QueryFiles().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := e.Edges.totalCount[4][alias]
+	if nodes, err := e.NamedFiles(alias); err == nil || hasTotalCount {
+		pager, err := newFilePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &FileConnection{Edges: []*FileEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return e.QueryFiles().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (e *Entity) EntityType(ctx context.Context) (*EntityType, error) {
@@ -608,160 +896,275 @@ func (et *EntityType) Owner(ctx context.Context) (*Organization, error) {
 	return result, MaskNotFound(err)
 }
 
-func (et *EntityType) Entities(ctx context.Context) (result []*Entity, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = et.NamedEntities(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = et.Edges.EntitiesOrErr()
+func (et *EntityType) Entities(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*EntityOrder, where *EntityWhereInput,
+) (*EntityConnection, error) {
+	opts := []EntityPaginateOption{
+		WithEntityOrder(orderBy),
+		WithEntityFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = et.QueryEntities().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := et.Edges.totalCount[1][alias]
+	if nodes, err := et.NamedEntities(alias); err == nil || hasTotalCount {
+		pager, err := newEntityPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &EntityConnection{Edges: []*EntityEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return et.QueryEntities().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (e *Event) User(ctx context.Context) (result []*User, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = e.NamedUser(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = e.Edges.UserOrErr()
+func (e *Event) User(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*UserOrder, where *UserWhereInput,
+) (*UserConnection, error) {
+	opts := []UserPaginateOption{
+		WithUserOrder(orderBy),
+		WithUserFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = e.QueryUser().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := e.Edges.totalCount[0][alias]
+	if nodes, err := e.NamedUser(alias); err == nil || hasTotalCount {
+		pager, err := newUserPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &UserConnection{Edges: []*UserEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return e.QueryUser().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (e *Event) Group(ctx context.Context) (result []*Group, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = e.NamedGroup(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = e.Edges.GroupOrErr()
+func (e *Event) Group(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*GroupOrder, where *GroupWhereInput,
+) (*GroupConnection, error) {
+	opts := []GroupPaginateOption{
+		WithGroupOrder(orderBy),
+		WithGroupFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = e.QueryGroup().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := e.Edges.totalCount[1][alias]
+	if nodes, err := e.NamedGroup(alias); err == nil || hasTotalCount {
+		pager, err := newGroupPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &GroupConnection{Edges: []*GroupEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return e.QueryGroup().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (e *Event) Integration(ctx context.Context) (result []*Integration, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = e.NamedIntegration(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = e.Edges.IntegrationOrErr()
+func (e *Event) Integration(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*IntegrationOrder, where *IntegrationWhereInput,
+) (*IntegrationConnection, error) {
+	opts := []IntegrationPaginateOption{
+		WithIntegrationOrder(orderBy),
+		WithIntegrationFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = e.QueryIntegration().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := e.Edges.totalCount[2][alias]
+	if nodes, err := e.NamedIntegration(alias); err == nil || hasTotalCount {
+		pager, err := newIntegrationPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &IntegrationConnection{Edges: []*IntegrationEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return e.QueryIntegration().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (e *Event) Organization(ctx context.Context) (result []*Organization, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = e.NamedOrganization(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = e.Edges.OrganizationOrErr()
+func (e *Event) Organization(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*OrganizationOrder, where *OrganizationWhereInput,
+) (*OrganizationConnection, error) {
+	opts := []OrganizationPaginateOption{
+		WithOrganizationOrder(orderBy),
+		WithOrganizationFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = e.QueryOrganization().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := e.Edges.totalCount[3][alias]
+	if nodes, err := e.NamedOrganization(alias); err == nil || hasTotalCount {
+		pager, err := newOrganizationPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &OrganizationConnection{Edges: []*OrganizationEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return e.QueryOrganization().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (e *Event) Invite(ctx context.Context) (result []*Invite, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = e.NamedInvite(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = e.Edges.InviteOrErr()
+func (e *Event) Invite(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*InviteOrder, where *InviteWhereInput,
+) (*InviteConnection, error) {
+	opts := []InvitePaginateOption{
+		WithInviteOrder(orderBy),
+		WithInviteFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = e.QueryInvite().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := e.Edges.totalCount[4][alias]
+	if nodes, err := e.NamedInvite(alias); err == nil || hasTotalCount {
+		pager, err := newInvitePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &InviteConnection{Edges: []*InviteEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return e.QueryInvite().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (e *Event) PersonalAccessToken(ctx context.Context) (result []*PersonalAccessToken, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = e.NamedPersonalAccessToken(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = e.Edges.PersonalAccessTokenOrErr()
+func (e *Event) PersonalAccessToken(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *PersonalAccessTokenWhereInput,
+) (*PersonalAccessTokenConnection, error) {
+	opts := []PersonalAccessTokenPaginateOption{
+		WithPersonalAccessTokenFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = e.QueryPersonalAccessToken().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := e.Edges.totalCount[5][alias]
+	if nodes, err := e.NamedPersonalAccessToken(alias); err == nil || hasTotalCount {
+		pager, err := newPersonalAccessTokenPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &PersonalAccessTokenConnection{Edges: []*PersonalAccessTokenEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return e.QueryPersonalAccessToken().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (e *Event) Hush(ctx context.Context) (result []*Hush, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = e.NamedHush(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = e.Edges.HushOrErr()
+func (e *Event) Hush(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*HushOrder, where *HushWhereInput,
+) (*HushConnection, error) {
+	opts := []HushPaginateOption{
+		WithHushOrder(orderBy),
+		WithHushFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = e.QueryHush().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := e.Edges.totalCount[6][alias]
+	if nodes, err := e.NamedHush(alias); err == nil || hasTotalCount {
+		pager, err := newHushPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &HushConnection{Edges: []*HushEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return e.QueryHush().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (e *Event) Orgmembership(ctx context.Context) (result []*OrgMembership, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = e.NamedOrgmembership(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = e.Edges.OrgmembershipOrErr()
+func (e *Event) Orgmembership(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy *OrgMembershipOrder, where *OrgMembershipWhereInput,
+) (*OrgMembershipConnection, error) {
+	opts := []OrgMembershipPaginateOption{
+		WithOrgMembershipOrder(orderBy),
+		WithOrgMembershipFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = e.QueryOrgmembership().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := e.Edges.totalCount[7][alias]
+	if nodes, err := e.NamedOrgmembership(alias); err == nil || hasTotalCount {
+		pager, err := newOrgMembershipPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &OrgMembershipConnection{Edges: []*OrgMembershipEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return e.QueryOrgmembership().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (e *Event) Groupmembership(ctx context.Context) (result []*GroupMembership, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = e.NamedGroupmembership(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = e.Edges.GroupmembershipOrErr()
+func (e *Event) Groupmembership(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy *GroupMembershipOrder, where *GroupMembershipWhereInput,
+) (*GroupMembershipConnection, error) {
+	opts := []GroupMembershipPaginateOption{
+		WithGroupMembershipOrder(orderBy),
+		WithGroupMembershipFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = e.QueryGroupmembership().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := e.Edges.totalCount[8][alias]
+	if nodes, err := e.NamedGroupmembership(alias); err == nil || hasTotalCount {
+		pager, err := newGroupMembershipPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &GroupMembershipConnection{Edges: []*GroupMembershipEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return e.QueryGroupmembership().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (e *Event) Subscriber(ctx context.Context) (result []*Subscriber, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = e.NamedSubscriber(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = e.Edges.SubscriberOrErr()
+func (e *Event) Subscriber(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*SubscriberOrder, where *SubscriberWhereInput,
+) (*SubscriberConnection, error) {
+	opts := []SubscriberPaginateOption{
+		WithSubscriberOrder(orderBy),
+		WithSubscriberFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = e.QuerySubscriber().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := e.Edges.totalCount[9][alias]
+	if nodes, err := e.NamedSubscriber(alias); err == nil || hasTotalCount {
+		pager, err := newSubscriberPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &SubscriberConnection{Edges: []*SubscriberEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return e.QuerySubscriber().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (e *Event) File(ctx context.Context) (result []*File, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = e.NamedFile(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = e.Edges.FileOrErr()
+func (e *Event) File(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *FileWhereInput,
+) (*FileConnection, error) {
+	opts := []FilePaginateOption{
+		WithFileFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = e.QueryFile().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := e.Edges.totalCount[10][alias]
+	if nodes, err := e.NamedFile(alias); err == nil || hasTotalCount {
+		pager, err := newFilePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &FileConnection{Edges: []*FileEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return e.QueryFile().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (e *Event) Orgsubscription(ctx context.Context) (result []*OrgSubscription, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = e.NamedOrgsubscription(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = e.Edges.OrgsubscriptionOrErr()
+func (e *Event) Orgsubscription(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy *OrgSubscriptionOrder, where *OrgSubscriptionWhereInput,
+) (*OrgSubscriptionConnection, error) {
+	opts := []OrgSubscriptionPaginateOption{
+		WithOrgSubscriptionOrder(orderBy),
+		WithOrgSubscriptionFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = e.QueryOrgsubscription().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := e.Edges.totalCount[11][alias]
+	if nodes, err := e.NamedOrgsubscription(alias); err == nil || hasTotalCount {
+		pager, err := newOrgSubscriptionPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &OrgSubscriptionConnection{Edges: []*OrgSubscriptionEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return e.QueryOrgsubscription().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (e *Evidence) Owner(ctx context.Context) (*Organization, error) {
@@ -772,220 +1175,377 @@ func (e *Evidence) Owner(ctx context.Context) (*Organization, error) {
 	return result, MaskNotFound(err)
 }
 
-func (e *Evidence) ControlObjectives(ctx context.Context) (result []*ControlObjective, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = e.NamedControlObjectives(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = e.Edges.ControlObjectivesOrErr()
+func (e *Evidence) ControlObjectives(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ControlObjectiveOrder, where *ControlObjectiveWhereInput,
+) (*ControlObjectiveConnection, error) {
+	opts := []ControlObjectivePaginateOption{
+		WithControlObjectiveOrder(orderBy),
+		WithControlObjectiveFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = e.QueryControlObjectives().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := e.Edges.totalCount[1][alias]
+	if nodes, err := e.NamedControlObjectives(alias); err == nil || hasTotalCount {
+		pager, err := newControlObjectivePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ControlObjectiveConnection{Edges: []*ControlObjectiveEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return e.QueryControlObjectives().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (e *Evidence) Controls(ctx context.Context) (result []*Control, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = e.NamedControls(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = e.Edges.ControlsOrErr()
+func (e *Evidence) Controls(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ControlOrder, where *ControlWhereInput,
+) (*ControlConnection, error) {
+	opts := []ControlPaginateOption{
+		WithControlOrder(orderBy),
+		WithControlFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = e.QueryControls().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := e.Edges.totalCount[2][alias]
+	if nodes, err := e.NamedControls(alias); err == nil || hasTotalCount {
+		pager, err := newControlPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ControlConnection{Edges: []*ControlEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return e.QueryControls().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (e *Evidence) Subcontrols(ctx context.Context) (result []*Subcontrol, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = e.NamedSubcontrols(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = e.Edges.SubcontrolsOrErr()
+func (e *Evidence) Subcontrols(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*SubcontrolOrder, where *SubcontrolWhereInput,
+) (*SubcontrolConnection, error) {
+	opts := []SubcontrolPaginateOption{
+		WithSubcontrolOrder(orderBy),
+		WithSubcontrolFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = e.QuerySubcontrols().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := e.Edges.totalCount[3][alias]
+	if nodes, err := e.NamedSubcontrols(alias); err == nil || hasTotalCount {
+		pager, err := newSubcontrolPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &SubcontrolConnection{Edges: []*SubcontrolEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return e.QuerySubcontrols().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (e *Evidence) Files(ctx context.Context) (result []*File, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = e.NamedFiles(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = e.Edges.FilesOrErr()
+func (e *Evidence) Files(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *FileWhereInput,
+) (*FileConnection, error) {
+	opts := []FilePaginateOption{
+		WithFileFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = e.QueryFiles().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := e.Edges.totalCount[4][alias]
+	if nodes, err := e.NamedFiles(alias); err == nil || hasTotalCount {
+		pager, err := newFilePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &FileConnection{Edges: []*FileEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return e.QueryFiles().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (e *Evidence) Programs(ctx context.Context) (result []*Program, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = e.NamedPrograms(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = e.Edges.ProgramsOrErr()
+func (e *Evidence) Programs(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ProgramOrder, where *ProgramWhereInput,
+) (*ProgramConnection, error) {
+	opts := []ProgramPaginateOption{
+		WithProgramOrder(orderBy),
+		WithProgramFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = e.QueryPrograms().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := e.Edges.totalCount[5][alias]
+	if nodes, err := e.NamedPrograms(alias); err == nil || hasTotalCount {
+		pager, err := newProgramPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ProgramConnection{Edges: []*ProgramEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return e.QueryPrograms().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (e *Evidence) Tasks(ctx context.Context) (result []*Task, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = e.NamedTasks(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = e.Edges.TasksOrErr()
+func (e *Evidence) Tasks(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*TaskOrder, where *TaskWhereInput,
+) (*TaskConnection, error) {
+	opts := []TaskPaginateOption{
+		WithTaskOrder(orderBy),
+		WithTaskFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = e.QueryTasks().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := e.Edges.totalCount[6][alias]
+	if nodes, err := e.NamedTasks(alias); err == nil || hasTotalCount {
+		pager, err := newTaskPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &TaskConnection{Edges: []*TaskEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return e.QueryTasks().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (f *File) User(ctx context.Context) (result []*User, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = f.NamedUser(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = f.Edges.UserOrErr()
+func (f *File) User(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*UserOrder, where *UserWhereInput,
+) (*UserConnection, error) {
+	opts := []UserPaginateOption{
+		WithUserOrder(orderBy),
+		WithUserFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = f.QueryUser().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := f.Edges.totalCount[0][alias]
+	if nodes, err := f.NamedUser(alias); err == nil || hasTotalCount {
+		pager, err := newUserPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &UserConnection{Edges: []*UserEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return f.QueryUser().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (f *File) Organization(ctx context.Context) (result []*Organization, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = f.NamedOrganization(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = f.Edges.OrganizationOrErr()
+func (f *File) Organization(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*OrganizationOrder, where *OrganizationWhereInput,
+) (*OrganizationConnection, error) {
+	opts := []OrganizationPaginateOption{
+		WithOrganizationOrder(orderBy),
+		WithOrganizationFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = f.QueryOrganization().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := f.Edges.totalCount[1][alias]
+	if nodes, err := f.NamedOrganization(alias); err == nil || hasTotalCount {
+		pager, err := newOrganizationPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &OrganizationConnection{Edges: []*OrganizationEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return f.QueryOrganization().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (f *File) Group(ctx context.Context) (result []*Group, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = f.NamedGroup(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = f.Edges.GroupOrErr()
+func (f *File) Group(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*GroupOrder, where *GroupWhereInput,
+) (*GroupConnection, error) {
+	opts := []GroupPaginateOption{
+		WithGroupOrder(orderBy),
+		WithGroupFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = f.QueryGroup().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := f.Edges.totalCount[2][alias]
+	if nodes, err := f.NamedGroup(alias); err == nil || hasTotalCount {
+		pager, err := newGroupPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &GroupConnection{Edges: []*GroupEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return f.QueryGroup().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (f *File) Contact(ctx context.Context) (result []*Contact, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = f.NamedContact(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = f.Edges.ContactOrErr()
+func (f *File) Contact(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ContactOrder, where *ContactWhereInput,
+) (*ContactConnection, error) {
+	opts := []ContactPaginateOption{
+		WithContactOrder(orderBy),
+		WithContactFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = f.QueryContact().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := f.Edges.totalCount[3][alias]
+	if nodes, err := f.NamedContact(alias); err == nil || hasTotalCount {
+		pager, err := newContactPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ContactConnection{Edges: []*ContactEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return f.QueryContact().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (f *File) Entity(ctx context.Context) (result []*Entity, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = f.NamedEntity(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = f.Edges.EntityOrErr()
+func (f *File) Entity(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*EntityOrder, where *EntityWhereInput,
+) (*EntityConnection, error) {
+	opts := []EntityPaginateOption{
+		WithEntityOrder(orderBy),
+		WithEntityFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = f.QueryEntity().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := f.Edges.totalCount[4][alias]
+	if nodes, err := f.NamedEntity(alias); err == nil || hasTotalCount {
+		pager, err := newEntityPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &EntityConnection{Edges: []*EntityEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return f.QueryEntity().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (f *File) UserSetting(ctx context.Context) (result []*UserSetting, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = f.NamedUserSetting(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = f.Edges.UserSettingOrErr()
+func (f *File) UserSetting(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *UserSettingWhereInput,
+) (*UserSettingConnection, error) {
+	opts := []UserSettingPaginateOption{
+		WithUserSettingFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = f.QueryUserSetting().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := f.Edges.totalCount[5][alias]
+	if nodes, err := f.NamedUserSetting(alias); err == nil || hasTotalCount {
+		pager, err := newUserSettingPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &UserSettingConnection{Edges: []*UserSettingEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return f.QueryUserSetting().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (f *File) OrganizationSetting(ctx context.Context) (result []*OrganizationSetting, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = f.NamedOrganizationSetting(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = f.Edges.OrganizationSettingOrErr()
+func (f *File) OrganizationSetting(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *OrganizationSettingWhereInput,
+) (*OrganizationSettingConnection, error) {
+	opts := []OrganizationSettingPaginateOption{
+		WithOrganizationSettingFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = f.QueryOrganizationSetting().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := f.Edges.totalCount[6][alias]
+	if nodes, err := f.NamedOrganizationSetting(alias); err == nil || hasTotalCount {
+		pager, err := newOrganizationSettingPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &OrganizationSettingConnection{Edges: []*OrganizationSettingEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return f.QueryOrganizationSetting().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (f *File) Template(ctx context.Context) (result []*Template, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = f.NamedTemplate(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = f.Edges.TemplateOrErr()
+func (f *File) Template(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*TemplateOrder, where *TemplateWhereInput,
+) (*TemplateConnection, error) {
+	opts := []TemplatePaginateOption{
+		WithTemplateOrder(orderBy),
+		WithTemplateFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = f.QueryTemplate().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := f.Edges.totalCount[7][alias]
+	if nodes, err := f.NamedTemplate(alias); err == nil || hasTotalCount {
+		pager, err := newTemplatePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &TemplateConnection{Edges: []*TemplateEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return f.QueryTemplate().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (f *File) DocumentData(ctx context.Context) (result []*DocumentData, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = f.NamedDocumentData(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = f.Edges.DocumentDataOrErr()
+func (f *File) DocumentData(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *DocumentDataWhereInput,
+) (*DocumentDataConnection, error) {
+	opts := []DocumentDataPaginateOption{
+		WithDocumentDataFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = f.QueryDocumentData().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := f.Edges.totalCount[8][alias]
+	if nodes, err := f.NamedDocumentData(alias); err == nil || hasTotalCount {
+		pager, err := newDocumentDataPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &DocumentDataConnection{Edges: []*DocumentDataEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return f.QueryDocumentData().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (f *File) Events(ctx context.Context) (result []*Event, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = f.NamedEvents(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = f.Edges.EventsOrErr()
+func (f *File) Events(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *EventWhereInput,
+) (*EventConnection, error) {
+	opts := []EventPaginateOption{
+		WithEventFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = f.QueryEvents().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := f.Edges.totalCount[9][alias]
+	if nodes, err := f.NamedEvents(alias); err == nil || hasTotalCount {
+		pager, err := newEventPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &EventConnection{Edges: []*EventEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return f.QueryEvents().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (f *File) Program(ctx context.Context) (result []*Program, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = f.NamedProgram(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = f.Edges.ProgramOrErr()
+func (f *File) Program(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ProgramOrder, where *ProgramWhereInput,
+) (*ProgramConnection, error) {
+	opts := []ProgramPaginateOption{
+		WithProgramOrder(orderBy),
+		WithProgramFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = f.QueryProgram().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := f.Edges.totalCount[10][alias]
+	if nodes, err := f.NamedProgram(alias); err == nil || hasTotalCount {
+		pager, err := newProgramPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ProgramConnection{Edges: []*ProgramEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return f.QueryProgram().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (f *File) Evidence(ctx context.Context) (result []*Evidence, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = f.NamedEvidence(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = f.Edges.EvidenceOrErr()
+func (f *File) Evidence(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*EvidenceOrder, where *EvidenceWhereInput,
+) (*EvidenceConnection, error) {
+	opts := []EvidencePaginateOption{
+		WithEvidenceOrder(orderBy),
+		WithEvidenceFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = f.QueryEvidence().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := f.Edges.totalCount[11][alias]
+	if nodes, err := f.NamedEvidence(alias); err == nil || hasTotalCount {
+		pager, err := newEvidencePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &EvidenceConnection{Edges: []*EvidenceEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return f.QueryEvidence().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (gr *Group) Owner(ctx context.Context) (*Organization, error) {
@@ -1244,52 +1804,86 @@ func (gr *Group) Users(ctx context.Context) (result []*User, err error) {
 	return result, err
 }
 
-func (gr *Group) Events(ctx context.Context) (result []*Event, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = gr.NamedEvents(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = gr.Edges.EventsOrErr()
+func (gr *Group) Events(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *EventWhereInput,
+) (*EventConnection, error) {
+	opts := []EventPaginateOption{
+		WithEventFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = gr.QueryEvents().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := gr.Edges.totalCount[22][alias]
+	if nodes, err := gr.NamedEvents(alias); err == nil || hasTotalCount {
+		pager, err := newEventPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &EventConnection{Edges: []*EventEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return gr.QueryEvents().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (gr *Group) Integrations(ctx context.Context) (result []*Integration, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = gr.NamedIntegrations(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = gr.Edges.IntegrationsOrErr()
+func (gr *Group) Integrations(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*IntegrationOrder, where *IntegrationWhereInput,
+) (*IntegrationConnection, error) {
+	opts := []IntegrationPaginateOption{
+		WithIntegrationOrder(orderBy),
+		WithIntegrationFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = gr.QueryIntegrations().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := gr.Edges.totalCount[23][alias]
+	if nodes, err := gr.NamedIntegrations(alias); err == nil || hasTotalCount {
+		pager, err := newIntegrationPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &IntegrationConnection{Edges: []*IntegrationEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return gr.QueryIntegrations().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (gr *Group) Files(ctx context.Context) (result []*File, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = gr.NamedFiles(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = gr.Edges.FilesOrErr()
+func (gr *Group) Files(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *FileWhereInput,
+) (*FileConnection, error) {
+	opts := []FilePaginateOption{
+		WithFileFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = gr.QueryFiles().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := gr.Edges.totalCount[24][alias]
+	if nodes, err := gr.NamedFiles(alias); err == nil || hasTotalCount {
+		pager, err := newFilePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &FileConnection{Edges: []*FileEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return gr.QueryFiles().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (gr *Group) Tasks(ctx context.Context) (result []*Task, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = gr.NamedTasks(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = gr.Edges.TasksOrErr()
+func (gr *Group) Tasks(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*TaskOrder, where *TaskWhereInput,
+) (*TaskConnection, error) {
+	opts := []TaskPaginateOption{
+		WithTaskOrder(orderBy),
+		WithTaskFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = gr.QueryTasks().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := gr.Edges.totalCount[25][alias]
+	if nodes, err := gr.NamedTasks(alias); err == nil || hasTotalCount {
+		pager, err := newTaskPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &TaskConnection{Edges: []*TaskEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return gr.QueryTasks().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (gr *Group) Members(ctx context.Context) (result []*GroupMembership, err error) {
@@ -1340,40 +1934,66 @@ func (gs *GroupSetting) Group(ctx context.Context) (*Group, error) {
 	return result, MaskNotFound(err)
 }
 
-func (h *Hush) Integrations(ctx context.Context) (result []*Integration, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = h.NamedIntegrations(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = h.Edges.IntegrationsOrErr()
+func (h *Hush) Integrations(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*IntegrationOrder, where *IntegrationWhereInput,
+) (*IntegrationConnection, error) {
+	opts := []IntegrationPaginateOption{
+		WithIntegrationOrder(orderBy),
+		WithIntegrationFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = h.QueryIntegrations().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := h.Edges.totalCount[0][alias]
+	if nodes, err := h.NamedIntegrations(alias); err == nil || hasTotalCount {
+		pager, err := newIntegrationPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &IntegrationConnection{Edges: []*IntegrationEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return h.QueryIntegrations().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (h *Hush) Organization(ctx context.Context) (result []*Organization, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = h.NamedOrganization(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = h.Edges.OrganizationOrErr()
+func (h *Hush) Organization(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*OrganizationOrder, where *OrganizationWhereInput,
+) (*OrganizationConnection, error) {
+	opts := []OrganizationPaginateOption{
+		WithOrganizationOrder(orderBy),
+		WithOrganizationFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = h.QueryOrganization().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := h.Edges.totalCount[1][alias]
+	if nodes, err := h.NamedOrganization(alias); err == nil || hasTotalCount {
+		pager, err := newOrganizationPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &OrganizationConnection{Edges: []*OrganizationEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return h.QueryOrganization().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (h *Hush) Events(ctx context.Context) (result []*Event, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = h.NamedEvents(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = h.Edges.EventsOrErr()
+func (h *Hush) Events(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *EventWhereInput,
+) (*EventConnection, error) {
+	opts := []EventPaginateOption{
+		WithEventFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = h.QueryEvents().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := h.Edges.totalCount[2][alias]
+	if nodes, err := h.NamedEvents(alias); err == nil || hasTotalCount {
+		pager, err := newEventPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &EventConnection{Edges: []*EventEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return h.QueryEvents().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (i *Integration) Owner(ctx context.Context) (*Organization, error) {
@@ -1384,28 +2004,45 @@ func (i *Integration) Owner(ctx context.Context) (*Organization, error) {
 	return result, MaskNotFound(err)
 }
 
-func (i *Integration) Secrets(ctx context.Context) (result []*Hush, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = i.NamedSecrets(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = i.Edges.SecretsOrErr()
+func (i *Integration) Secrets(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*HushOrder, where *HushWhereInput,
+) (*HushConnection, error) {
+	opts := []HushPaginateOption{
+		WithHushOrder(orderBy),
+		WithHushFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = i.QuerySecrets().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := i.Edges.totalCount[1][alias]
+	if nodes, err := i.NamedSecrets(alias); err == nil || hasTotalCount {
+		pager, err := newHushPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &HushConnection{Edges: []*HushEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return i.QuerySecrets().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (i *Integration) Events(ctx context.Context) (result []*Event, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = i.NamedEvents(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = i.Edges.EventsOrErr()
+func (i *Integration) Events(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *EventWhereInput,
+) (*EventConnection, error) {
+	opts := []EventPaginateOption{
+		WithEventFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = i.QueryEvents().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := i.Edges.totalCount[2][alias]
+	if nodes, err := i.NamedEvents(alias); err == nil || hasTotalCount {
+		pager, err := newEventPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &EventConnection{Edges: []*EventEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return i.QueryEvents().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (ip *InternalPolicy) Owner(ctx context.Context) (*Organization, error) {
@@ -1456,76 +2093,129 @@ func (ip *InternalPolicy) Delegate(ctx context.Context) (*Group, error) {
 	return result, MaskNotFound(err)
 }
 
-func (ip *InternalPolicy) ControlObjectives(ctx context.Context) (result []*ControlObjective, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = ip.NamedControlObjectives(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = ip.Edges.ControlObjectivesOrErr()
+func (ip *InternalPolicy) ControlObjectives(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ControlObjectiveOrder, where *ControlObjectiveWhereInput,
+) (*ControlObjectiveConnection, error) {
+	opts := []ControlObjectivePaginateOption{
+		WithControlObjectiveOrder(orderBy),
+		WithControlObjectiveFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = ip.QueryControlObjectives().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := ip.Edges.totalCount[5][alias]
+	if nodes, err := ip.NamedControlObjectives(alias); err == nil || hasTotalCount {
+		pager, err := newControlObjectivePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ControlObjectiveConnection{Edges: []*ControlObjectiveEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return ip.QueryControlObjectives().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (ip *InternalPolicy) Controls(ctx context.Context) (result []*Control, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = ip.NamedControls(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = ip.Edges.ControlsOrErr()
+func (ip *InternalPolicy) Controls(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ControlOrder, where *ControlWhereInput,
+) (*ControlConnection, error) {
+	opts := []ControlPaginateOption{
+		WithControlOrder(orderBy),
+		WithControlFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = ip.QueryControls().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := ip.Edges.totalCount[6][alias]
+	if nodes, err := ip.NamedControls(alias); err == nil || hasTotalCount {
+		pager, err := newControlPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ControlConnection{Edges: []*ControlEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return ip.QueryControls().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (ip *InternalPolicy) Procedures(ctx context.Context) (result []*Procedure, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = ip.NamedProcedures(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = ip.Edges.ProceduresOrErr()
+func (ip *InternalPolicy) Procedures(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *ProcedureWhereInput,
+) (*ProcedureConnection, error) {
+	opts := []ProcedurePaginateOption{
+		WithProcedureFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = ip.QueryProcedures().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := ip.Edges.totalCount[7][alias]
+	if nodes, err := ip.NamedProcedures(alias); err == nil || hasTotalCount {
+		pager, err := newProcedurePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ProcedureConnection{Edges: []*ProcedureEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return ip.QueryProcedures().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (ip *InternalPolicy) Narratives(ctx context.Context) (result []*Narrative, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = ip.NamedNarratives(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = ip.Edges.NarrativesOrErr()
+func (ip *InternalPolicy) Narratives(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy *NarrativeOrder, where *NarrativeWhereInput,
+) (*NarrativeConnection, error) {
+	opts := []NarrativePaginateOption{
+		WithNarrativeOrder(orderBy),
+		WithNarrativeFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = ip.QueryNarratives().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := ip.Edges.totalCount[8][alias]
+	if nodes, err := ip.NamedNarratives(alias); err == nil || hasTotalCount {
+		pager, err := newNarrativePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &NarrativeConnection{Edges: []*NarrativeEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return ip.QueryNarratives().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (ip *InternalPolicy) Tasks(ctx context.Context) (result []*Task, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = ip.NamedTasks(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = ip.Edges.TasksOrErr()
+func (ip *InternalPolicy) Tasks(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*TaskOrder, where *TaskWhereInput,
+) (*TaskConnection, error) {
+	opts := []TaskPaginateOption{
+		WithTaskOrder(orderBy),
+		WithTaskFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = ip.QueryTasks().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := ip.Edges.totalCount[9][alias]
+	if nodes, err := ip.NamedTasks(alias); err == nil || hasTotalCount {
+		pager, err := newTaskPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &TaskConnection{Edges: []*TaskEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return ip.QueryTasks().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (ip *InternalPolicy) Programs(ctx context.Context) (result []*Program, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = ip.NamedPrograms(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = ip.Edges.ProgramsOrErr()
+func (ip *InternalPolicy) Programs(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ProgramOrder, where *ProgramWhereInput,
+) (*ProgramConnection, error) {
+	opts := []ProgramPaginateOption{
+		WithProgramOrder(orderBy),
+		WithProgramFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = ip.QueryPrograms().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := ip.Edges.totalCount[10][alias]
+	if nodes, err := ip.NamedPrograms(alias); err == nil || hasTotalCount {
+		pager, err := newProgramPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ProgramConnection{Edges: []*ProgramEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return ip.QueryPrograms().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (i *Invite) Owner(ctx context.Context) (*Organization, error) {
@@ -1536,40 +2226,66 @@ func (i *Invite) Owner(ctx context.Context) (*Organization, error) {
 	return result, MaskNotFound(err)
 }
 
-func (i *Invite) Events(ctx context.Context) (result []*Event, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = i.NamedEvents(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = i.Edges.EventsOrErr()
+func (i *Invite) Events(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *EventWhereInput,
+) (*EventConnection, error) {
+	opts := []EventPaginateOption{
+		WithEventFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = i.QueryEvents().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := i.Edges.totalCount[1][alias]
+	if nodes, err := i.NamedEvents(alias); err == nil || hasTotalCount {
+		pager, err := newEventPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &EventConnection{Edges: []*EventEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return i.QueryEvents().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (mc *MappedControl) Controls(ctx context.Context) (result []*Control, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = mc.NamedControls(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = mc.Edges.ControlsOrErr()
+func (mc *MappedControl) Controls(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ControlOrder, where *ControlWhereInput,
+) (*ControlConnection, error) {
+	opts := []ControlPaginateOption{
+		WithControlOrder(orderBy),
+		WithControlFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = mc.QueryControls().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := mc.Edges.totalCount[0][alias]
+	if nodes, err := mc.NamedControls(alias); err == nil || hasTotalCount {
+		pager, err := newControlPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ControlConnection{Edges: []*ControlEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return mc.QueryControls().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (mc *MappedControl) Subcontrols(ctx context.Context) (result []*Subcontrol, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = mc.NamedSubcontrols(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = mc.Edges.SubcontrolsOrErr()
+func (mc *MappedControl) Subcontrols(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*SubcontrolOrder, where *SubcontrolWhereInput,
+) (*SubcontrolConnection, error) {
+	opts := []SubcontrolPaginateOption{
+		WithSubcontrolOrder(orderBy),
+		WithSubcontrolFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = mc.QuerySubcontrols().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := mc.Edges.totalCount[1][alias]
+	if nodes, err := mc.NamedSubcontrols(alias); err == nil || hasTotalCount {
+		pager, err := newSubcontrolPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &SubcontrolConnection{Edges: []*SubcontrolEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return mc.QuerySubcontrols().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (n *Narrative) Owner(ctx context.Context) (*Organization, error) {
@@ -1616,28 +2332,46 @@ func (n *Narrative) Viewers(ctx context.Context) (result []*Group, err error) {
 	return result, err
 }
 
-func (n *Narrative) Satisfies(ctx context.Context) (result []*Control, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = n.NamedSatisfies(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = n.Edges.SatisfiesOrErr()
+func (n *Narrative) Satisfies(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ControlOrder, where *ControlWhereInput,
+) (*ControlConnection, error) {
+	opts := []ControlPaginateOption{
+		WithControlOrder(orderBy),
+		WithControlFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = n.QuerySatisfies().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := n.Edges.totalCount[4][alias]
+	if nodes, err := n.NamedSatisfies(alias); err == nil || hasTotalCount {
+		pager, err := newControlPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ControlConnection{Edges: []*ControlEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return n.QuerySatisfies().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (n *Narrative) Programs(ctx context.Context) (result []*Program, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = n.NamedPrograms(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = n.Edges.ProgramsOrErr()
+func (n *Narrative) Programs(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ProgramOrder, where *ProgramWhereInput,
+) (*ProgramConnection, error) {
+	opts := []ProgramPaginateOption{
+		WithProgramOrder(orderBy),
+		WithProgramFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = n.QueryPrograms().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := n.Edges.totalCount[5][alias]
+	if nodes, err := n.NamedPrograms(alias); err == nil || hasTotalCount {
+		pager, err := newProgramPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ProgramConnection{Edges: []*ProgramEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return n.QueryPrograms().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (n *Note) Owner(ctx context.Context) (*Organization, error) {
@@ -1680,16 +2414,24 @@ func (om *OrgMembership) User(ctx context.Context) (*User, error) {
 	return result, err
 }
 
-func (om *OrgMembership) Events(ctx context.Context) (result []*Event, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = om.NamedEvents(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = om.Edges.EventsOrErr()
+func (om *OrgMembership) Events(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *EventWhereInput,
+) (*EventConnection, error) {
+	opts := []EventPaginateOption{
+		WithEventFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = om.QueryEvents().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := om.Edges.totalCount[2][alias]
+	if nodes, err := om.NamedEvents(alias); err == nil || hasTotalCount {
+		pager, err := newEventPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &EventConnection{Edges: []*EventEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return om.QueryEvents().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (os *OrgSubscription) Owner(ctx context.Context) (*Organization, error) {
@@ -1829,7 +2571,7 @@ func (o *Organization) Parent(ctx context.Context) (*Organization, error) {
 }
 
 func (o *Organization) Children(
-	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy *OrganizationOrder, where *OrganizationWhereInput,
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*OrganizationOrder, where *OrganizationWhereInput,
 ) (*OrganizationConnection, error) {
 	opts := []OrganizationPaginateOption{
 		WithOrganizationOrder(orderBy),
@@ -1857,28 +2599,44 @@ func (o *Organization) Setting(ctx context.Context) (*OrganizationSetting, error
 	return result, MaskNotFound(err)
 }
 
-func (o *Organization) PersonalAccessTokens(ctx context.Context) (result []*PersonalAccessToken, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedPersonalAccessTokens(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.PersonalAccessTokensOrErr()
+func (o *Organization) PersonalAccessTokens(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *PersonalAccessTokenWhereInput,
+) (*PersonalAccessTokenConnection, error) {
+	opts := []PersonalAccessTokenPaginateOption{
+		WithPersonalAccessTokenFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QueryPersonalAccessTokens().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[12][alias]
+	if nodes, err := o.NamedPersonalAccessTokens(alias); err == nil || hasTotalCount {
+		pager, err := newPersonalAccessTokenPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &PersonalAccessTokenConnection{Edges: []*PersonalAccessTokenEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QueryPersonalAccessTokens().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (o *Organization) APITokens(ctx context.Context) (result []*APIToken, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedAPITokens(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.APITokensOrErr()
+func (o *Organization) APITokens(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *APITokenWhereInput,
+) (*APITokenConnection, error) {
+	opts := []APITokenPaginateOption{
+		WithAPITokenFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QueryAPITokens().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[13][alias]
+	if nodes, err := o.NamedAPITokens(alias); err == nil || hasTotalCount {
+		pager, err := newAPITokenPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &APITokenConnection{Edges: []*APITokenEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QueryAPITokens().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (o *Organization) Users(ctx context.Context) (result []*User, err error) {
@@ -1893,40 +2651,65 @@ func (o *Organization) Users(ctx context.Context) (result []*User, err error) {
 	return result, err
 }
 
-func (o *Organization) Files(ctx context.Context) (result []*File, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedFiles(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.FilesOrErr()
+func (o *Organization) Files(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *FileWhereInput,
+) (*FileConnection, error) {
+	opts := []FilePaginateOption{
+		WithFileFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QueryFiles().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[15][alias]
+	if nodes, err := o.NamedFiles(alias); err == nil || hasTotalCount {
+		pager, err := newFilePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &FileConnection{Edges: []*FileEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QueryFiles().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (o *Organization) Events(ctx context.Context) (result []*Event, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedEvents(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.EventsOrErr()
+func (o *Organization) Events(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *EventWhereInput,
+) (*EventConnection, error) {
+	opts := []EventPaginateOption{
+		WithEventFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QueryEvents().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[16][alias]
+	if nodes, err := o.NamedEvents(alias); err == nil || hasTotalCount {
+		pager, err := newEventPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &EventConnection{Edges: []*EventEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QueryEvents().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (o *Organization) Secrets(ctx context.Context) (result []*Hush, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedSecrets(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.SecretsOrErr()
+func (o *Organization) Secrets(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*HushOrder, where *HushWhereInput,
+) (*HushConnection, error) {
+	opts := []HushPaginateOption{
+		WithHushOrder(orderBy),
+		WithHushFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QuerySecrets().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[17][alias]
+	if nodes, err := o.NamedSecrets(alias); err == nil || hasTotalCount {
+		pager, err := newHushPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &HushConnection{Edges: []*HushEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QuerySecrets().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (o *Organization) AvatarFile(ctx context.Context) (*File, error) {
@@ -1937,52 +2720,87 @@ func (o *Organization) AvatarFile(ctx context.Context) (*File, error) {
 	return result, MaskNotFound(err)
 }
 
-func (o *Organization) Groups(ctx context.Context) (result []*Group, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedGroups(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.GroupsOrErr()
+func (o *Organization) Groups(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*GroupOrder, where *GroupWhereInput,
+) (*GroupConnection, error) {
+	opts := []GroupPaginateOption{
+		WithGroupOrder(orderBy),
+		WithGroupFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QueryGroups().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[19][alias]
+	if nodes, err := o.NamedGroups(alias); err == nil || hasTotalCount {
+		pager, err := newGroupPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &GroupConnection{Edges: []*GroupEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QueryGroups().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (o *Organization) Templates(ctx context.Context) (result []*Template, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedTemplates(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.TemplatesOrErr()
+func (o *Organization) Templates(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*TemplateOrder, where *TemplateWhereInput,
+) (*TemplateConnection, error) {
+	opts := []TemplatePaginateOption{
+		WithTemplateOrder(orderBy),
+		WithTemplateFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QueryTemplates().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[20][alias]
+	if nodes, err := o.NamedTemplates(alias); err == nil || hasTotalCount {
+		pager, err := newTemplatePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &TemplateConnection{Edges: []*TemplateEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QueryTemplates().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (o *Organization) Integrations(ctx context.Context) (result []*Integration, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedIntegrations(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.IntegrationsOrErr()
+func (o *Organization) Integrations(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*IntegrationOrder, where *IntegrationWhereInput,
+) (*IntegrationConnection, error) {
+	opts := []IntegrationPaginateOption{
+		WithIntegrationOrder(orderBy),
+		WithIntegrationFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QueryIntegrations().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[21][alias]
+	if nodes, err := o.NamedIntegrations(alias); err == nil || hasTotalCount {
+		pager, err := newIntegrationPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &IntegrationConnection{Edges: []*IntegrationEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QueryIntegrations().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (o *Organization) DocumentData(ctx context.Context) (result []*DocumentData, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedDocumentData(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.DocumentDataOrErr()
+func (o *Organization) DocumentData(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *DocumentDataWhereInput,
+) (*DocumentDataConnection, error) {
+	opts := []DocumentDataPaginateOption{
+		WithDocumentDataFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QueryDocumentData().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[22][alias]
+	if nodes, err := o.NamedDocumentData(alias); err == nil || hasTotalCount {
+		pager, err := newDocumentDataPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &DocumentDataConnection{Edges: []*DocumentDataEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QueryDocumentData().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (o *Organization) OrgSubscriptions(ctx context.Context) (result []*OrgSubscription, err error) {
@@ -1997,220 +2815,379 @@ func (o *Organization) OrgSubscriptions(ctx context.Context) (result []*OrgSubsc
 	return result, err
 }
 
-func (o *Organization) Invites(ctx context.Context) (result []*Invite, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedInvites(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.InvitesOrErr()
+func (o *Organization) Invites(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*InviteOrder, where *InviteWhereInput,
+) (*InviteConnection, error) {
+	opts := []InvitePaginateOption{
+		WithInviteOrder(orderBy),
+		WithInviteFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QueryInvites().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[24][alias]
+	if nodes, err := o.NamedInvites(alias); err == nil || hasTotalCount {
+		pager, err := newInvitePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &InviteConnection{Edges: []*InviteEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QueryInvites().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (o *Organization) Subscribers(ctx context.Context) (result []*Subscriber, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedSubscribers(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.SubscribersOrErr()
+func (o *Organization) Subscribers(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*SubscriberOrder, where *SubscriberWhereInput,
+) (*SubscriberConnection, error) {
+	opts := []SubscriberPaginateOption{
+		WithSubscriberOrder(orderBy),
+		WithSubscriberFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QuerySubscribers().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[25][alias]
+	if nodes, err := o.NamedSubscribers(alias); err == nil || hasTotalCount {
+		pager, err := newSubscriberPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &SubscriberConnection{Edges: []*SubscriberEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QuerySubscribers().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (o *Organization) Entities(ctx context.Context) (result []*Entity, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedEntities(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.EntitiesOrErr()
+func (o *Organization) Entities(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*EntityOrder, where *EntityWhereInput,
+) (*EntityConnection, error) {
+	opts := []EntityPaginateOption{
+		WithEntityOrder(orderBy),
+		WithEntityFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QueryEntities().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[26][alias]
+	if nodes, err := o.NamedEntities(alias); err == nil || hasTotalCount {
+		pager, err := newEntityPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &EntityConnection{Edges: []*EntityEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QueryEntities().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (o *Organization) EntityTypes(ctx context.Context) (result []*EntityType, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedEntityTypes(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.EntityTypesOrErr()
+func (o *Organization) EntityTypes(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy *EntityTypeOrder, where *EntityTypeWhereInput,
+) (*EntityTypeConnection, error) {
+	opts := []EntityTypePaginateOption{
+		WithEntityTypeOrder(orderBy),
+		WithEntityTypeFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QueryEntityTypes().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[27][alias]
+	if nodes, err := o.NamedEntityTypes(alias); err == nil || hasTotalCount {
+		pager, err := newEntityTypePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &EntityTypeConnection{Edges: []*EntityTypeEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QueryEntityTypes().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (o *Organization) Contacts(ctx context.Context) (result []*Contact, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedContacts(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.ContactsOrErr()
+func (o *Organization) Contacts(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ContactOrder, where *ContactWhereInput,
+) (*ContactConnection, error) {
+	opts := []ContactPaginateOption{
+		WithContactOrder(orderBy),
+		WithContactFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QueryContacts().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[28][alias]
+	if nodes, err := o.NamedContacts(alias); err == nil || hasTotalCount {
+		pager, err := newContactPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ContactConnection{Edges: []*ContactEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QueryContacts().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (o *Organization) Notes(ctx context.Context) (result []*Note, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedNotes(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.NotesOrErr()
+func (o *Organization) Notes(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *NoteWhereInput,
+) (*NoteConnection, error) {
+	opts := []NotePaginateOption{
+		WithNoteFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QueryNotes().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[29][alias]
+	if nodes, err := o.NamedNotes(alias); err == nil || hasTotalCount {
+		pager, err := newNotePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &NoteConnection{Edges: []*NoteEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QueryNotes().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (o *Organization) Tasks(ctx context.Context) (result []*Task, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedTasks(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.TasksOrErr()
+func (o *Organization) Tasks(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*TaskOrder, where *TaskWhereInput,
+) (*TaskConnection, error) {
+	opts := []TaskPaginateOption{
+		WithTaskOrder(orderBy),
+		WithTaskFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QueryTasks().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[30][alias]
+	if nodes, err := o.NamedTasks(alias); err == nil || hasTotalCount {
+		pager, err := newTaskPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &TaskConnection{Edges: []*TaskEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QueryTasks().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (o *Organization) Programs(ctx context.Context) (result []*Program, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedPrograms(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.ProgramsOrErr()
+func (o *Organization) Programs(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ProgramOrder, where *ProgramWhereInput,
+) (*ProgramConnection, error) {
+	opts := []ProgramPaginateOption{
+		WithProgramOrder(orderBy),
+		WithProgramFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QueryPrograms().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[31][alias]
+	if nodes, err := o.NamedPrograms(alias); err == nil || hasTotalCount {
+		pager, err := newProgramPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ProgramConnection{Edges: []*ProgramEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QueryPrograms().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (o *Organization) Procedures(ctx context.Context) (result []*Procedure, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedProcedures(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.ProceduresOrErr()
+func (o *Organization) Procedures(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *ProcedureWhereInput,
+) (*ProcedureConnection, error) {
+	opts := []ProcedurePaginateOption{
+		WithProcedureFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QueryProcedures().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[32][alias]
+	if nodes, err := o.NamedProcedures(alias); err == nil || hasTotalCount {
+		pager, err := newProcedurePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ProcedureConnection{Edges: []*ProcedureEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QueryProcedures().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (o *Organization) InternalPolicies(ctx context.Context) (result []*InternalPolicy, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedInternalPolicies(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.InternalPoliciesOrErr()
+func (o *Organization) InternalPolicies(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *InternalPolicyWhereInput,
+) (*InternalPolicyConnection, error) {
+	opts := []InternalPolicyPaginateOption{
+		WithInternalPolicyFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QueryInternalPolicies().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[33][alias]
+	if nodes, err := o.NamedInternalPolicies(alias); err == nil || hasTotalCount {
+		pager, err := newInternalPolicyPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &InternalPolicyConnection{Edges: []*InternalPolicyEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QueryInternalPolicies().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (o *Organization) Risks(ctx context.Context) (result []*Risk, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedRisks(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.RisksOrErr()
+func (o *Organization) Risks(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*RiskOrder, where *RiskWhereInput,
+) (*RiskConnection, error) {
+	opts := []RiskPaginateOption{
+		WithRiskOrder(orderBy),
+		WithRiskFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QueryRisks().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[34][alias]
+	if nodes, err := o.NamedRisks(alias); err == nil || hasTotalCount {
+		pager, err := newRiskPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &RiskConnection{Edges: []*RiskEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QueryRisks().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (o *Organization) ControlObjectives(ctx context.Context) (result []*ControlObjective, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedControlObjectives(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.ControlObjectivesOrErr()
+func (o *Organization) ControlObjectives(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ControlObjectiveOrder, where *ControlObjectiveWhereInput,
+) (*ControlObjectiveConnection, error) {
+	opts := []ControlObjectivePaginateOption{
+		WithControlObjectiveOrder(orderBy),
+		WithControlObjectiveFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QueryControlObjectives().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[35][alias]
+	if nodes, err := o.NamedControlObjectives(alias); err == nil || hasTotalCount {
+		pager, err := newControlObjectivePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ControlObjectiveConnection{Edges: []*ControlObjectiveEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QueryControlObjectives().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (o *Organization) Narratives(ctx context.Context) (result []*Narrative, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedNarratives(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.NarrativesOrErr()
+func (o *Organization) Narratives(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy *NarrativeOrder, where *NarrativeWhereInput,
+) (*NarrativeConnection, error) {
+	opts := []NarrativePaginateOption{
+		WithNarrativeOrder(orderBy),
+		WithNarrativeFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QueryNarratives().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[36][alias]
+	if nodes, err := o.NamedNarratives(alias); err == nil || hasTotalCount {
+		pager, err := newNarrativePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &NarrativeConnection{Edges: []*NarrativeEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QueryNarratives().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (o *Organization) Controls(ctx context.Context) (result []*Control, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedControls(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.ControlsOrErr()
+func (o *Organization) Controls(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ControlOrder, where *ControlWhereInput,
+) (*ControlConnection, error) {
+	opts := []ControlPaginateOption{
+		WithControlOrder(orderBy),
+		WithControlFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QueryControls().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[37][alias]
+	if nodes, err := o.NamedControls(alias); err == nil || hasTotalCount {
+		pager, err := newControlPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ControlConnection{Edges: []*ControlEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QueryControls().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (o *Organization) Subcontrols(ctx context.Context) (result []*Subcontrol, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedSubcontrols(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.SubcontrolsOrErr()
+func (o *Organization) Subcontrols(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*SubcontrolOrder, where *SubcontrolWhereInput,
+) (*SubcontrolConnection, error) {
+	opts := []SubcontrolPaginateOption{
+		WithSubcontrolOrder(orderBy),
+		WithSubcontrolFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QuerySubcontrols().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[38][alias]
+	if nodes, err := o.NamedSubcontrols(alias); err == nil || hasTotalCount {
+		pager, err := newSubcontrolPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &SubcontrolConnection{Edges: []*SubcontrolEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QuerySubcontrols().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (o *Organization) Evidence(ctx context.Context) (result []*Evidence, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedEvidence(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.EvidenceOrErr()
+func (o *Organization) Evidence(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*EvidenceOrder, where *EvidenceWhereInput,
+) (*EvidenceConnection, error) {
+	opts := []EvidencePaginateOption{
+		WithEvidenceOrder(orderBy),
+		WithEvidenceFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QueryEvidence().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[39][alias]
+	if nodes, err := o.NamedEvidence(alias); err == nil || hasTotalCount {
+		pager, err := newEvidencePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &EvidenceConnection{Edges: []*EvidenceEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QueryEvidence().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (o *Organization) Standards(ctx context.Context) (result []*Standard, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedStandards(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.StandardsOrErr()
+func (o *Organization) Standards(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*StandardOrder, where *StandardWhereInput,
+) (*StandardConnection, error) {
+	opts := []StandardPaginateOption{
+		WithStandardOrder(orderBy),
+		WithStandardFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QueryStandards().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[40][alias]
+	if nodes, err := o.NamedStandards(alias); err == nil || hasTotalCount {
+		pager, err := newStandardPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &StandardConnection{Edges: []*StandardEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QueryStandards().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (o *Organization) ActionPlans(ctx context.Context) (result []*ActionPlan, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedActionPlans(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.ActionPlansOrErr()
+func (o *Organization) ActionPlans(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ActionPlanOrder, where *ActionPlanWhereInput,
+) (*ActionPlanConnection, error) {
+	opts := []ActionPlanPaginateOption{
+		WithActionPlanOrder(orderBy),
+		WithActionPlanFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QueryActionPlans().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[41][alias]
+	if nodes, err := o.NamedActionPlans(alias); err == nil || hasTotalCount {
+		pager, err := newActionPlanPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ActionPlanConnection{Edges: []*ActionPlanEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QueryActionPlans().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (o *Organization) Members(ctx context.Context) (result []*OrgMembership, err error) {
@@ -2233,16 +3210,24 @@ func (os *OrganizationSetting) Organization(ctx context.Context) (*Organization,
 	return result, MaskNotFound(err)
 }
 
-func (os *OrganizationSetting) Files(ctx context.Context) (result []*File, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = os.NamedFiles(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = os.Edges.FilesOrErr()
+func (os *OrganizationSetting) Files(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *FileWhereInput,
+) (*FileConnection, error) {
+	opts := []FilePaginateOption{
+		WithFileFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = os.QueryFiles().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := os.Edges.totalCount[1][alias]
+	if nodes, err := os.NamedFiles(alias); err == nil || hasTotalCount {
+		pager, err := newFilePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &FileConnection{Edges: []*FileEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return os.QueryFiles().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (pat *PersonalAccessToken) Owner(ctx context.Context) (*User, error) {
@@ -2253,28 +3238,45 @@ func (pat *PersonalAccessToken) Owner(ctx context.Context) (*User, error) {
 	return result, err
 }
 
-func (pat *PersonalAccessToken) Organizations(ctx context.Context) (result []*Organization, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = pat.NamedOrganizations(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = pat.Edges.OrganizationsOrErr()
+func (pat *PersonalAccessToken) Organizations(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*OrganizationOrder, where *OrganizationWhereInput,
+) (*OrganizationConnection, error) {
+	opts := []OrganizationPaginateOption{
+		WithOrganizationOrder(orderBy),
+		WithOrganizationFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = pat.QueryOrganizations().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := pat.Edges.totalCount[1][alias]
+	if nodes, err := pat.NamedOrganizations(alias); err == nil || hasTotalCount {
+		pager, err := newOrganizationPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &OrganizationConnection{Edges: []*OrganizationEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return pat.QueryOrganizations().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (pat *PersonalAccessToken) Events(ctx context.Context) (result []*Event, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = pat.NamedEvents(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = pat.Edges.EventsOrErr()
+func (pat *PersonalAccessToken) Events(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *EventWhereInput,
+) (*EventConnection, error) {
+	opts := []EventPaginateOption{
+		WithEventFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = pat.QueryEvents().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := pat.Edges.totalCount[2][alias]
+	if nodes, err := pat.NamedEvents(alias); err == nil || hasTotalCount {
+		pager, err := newEventPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &EventConnection{Edges: []*EventEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return pat.QueryEvents().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (pr *Procedure) Owner(ctx context.Context) (*Organization, error) {
@@ -2325,76 +3327,129 @@ func (pr *Procedure) Delegate(ctx context.Context) (*Group, error) {
 	return result, MaskNotFound(err)
 }
 
-func (pr *Procedure) Controls(ctx context.Context) (result []*Control, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = pr.NamedControls(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = pr.Edges.ControlsOrErr()
+func (pr *Procedure) Controls(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ControlOrder, where *ControlWhereInput,
+) (*ControlConnection, error) {
+	opts := []ControlPaginateOption{
+		WithControlOrder(orderBy),
+		WithControlFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = pr.QueryControls().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := pr.Edges.totalCount[5][alias]
+	if nodes, err := pr.NamedControls(alias); err == nil || hasTotalCount {
+		pager, err := newControlPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ControlConnection{Edges: []*ControlEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return pr.QueryControls().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (pr *Procedure) InternalPolicies(ctx context.Context) (result []*InternalPolicy, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = pr.NamedInternalPolicies(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = pr.Edges.InternalPoliciesOrErr()
+func (pr *Procedure) InternalPolicies(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *InternalPolicyWhereInput,
+) (*InternalPolicyConnection, error) {
+	opts := []InternalPolicyPaginateOption{
+		WithInternalPolicyFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = pr.QueryInternalPolicies().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := pr.Edges.totalCount[6][alias]
+	if nodes, err := pr.NamedInternalPolicies(alias); err == nil || hasTotalCount {
+		pager, err := newInternalPolicyPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &InternalPolicyConnection{Edges: []*InternalPolicyEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return pr.QueryInternalPolicies().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (pr *Procedure) Narratives(ctx context.Context) (result []*Narrative, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = pr.NamedNarratives(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = pr.Edges.NarrativesOrErr()
+func (pr *Procedure) Narratives(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy *NarrativeOrder, where *NarrativeWhereInput,
+) (*NarrativeConnection, error) {
+	opts := []NarrativePaginateOption{
+		WithNarrativeOrder(orderBy),
+		WithNarrativeFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = pr.QueryNarratives().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := pr.Edges.totalCount[7][alias]
+	if nodes, err := pr.NamedNarratives(alias); err == nil || hasTotalCount {
+		pager, err := newNarrativePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &NarrativeConnection{Edges: []*NarrativeEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return pr.QueryNarratives().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (pr *Procedure) Risks(ctx context.Context) (result []*Risk, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = pr.NamedRisks(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = pr.Edges.RisksOrErr()
+func (pr *Procedure) Risks(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*RiskOrder, where *RiskWhereInput,
+) (*RiskConnection, error) {
+	opts := []RiskPaginateOption{
+		WithRiskOrder(orderBy),
+		WithRiskFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = pr.QueryRisks().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := pr.Edges.totalCount[8][alias]
+	if nodes, err := pr.NamedRisks(alias); err == nil || hasTotalCount {
+		pager, err := newRiskPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &RiskConnection{Edges: []*RiskEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return pr.QueryRisks().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (pr *Procedure) Tasks(ctx context.Context) (result []*Task, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = pr.NamedTasks(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = pr.Edges.TasksOrErr()
+func (pr *Procedure) Tasks(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*TaskOrder, where *TaskWhereInput,
+) (*TaskConnection, error) {
+	opts := []TaskPaginateOption{
+		WithTaskOrder(orderBy),
+		WithTaskFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = pr.QueryTasks().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := pr.Edges.totalCount[9][alias]
+	if nodes, err := pr.NamedTasks(alias); err == nil || hasTotalCount {
+		pager, err := newTaskPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &TaskConnection{Edges: []*TaskEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return pr.QueryTasks().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (pr *Procedure) Programs(ctx context.Context) (result []*Program, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = pr.NamedPrograms(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = pr.Edges.ProgramsOrErr()
+func (pr *Procedure) Programs(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ProgramOrder, where *ProgramWhereInput,
+) (*ProgramConnection, error) {
+	opts := []ProgramPaginateOption{
+		WithProgramOrder(orderBy),
+		WithProgramFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = pr.QueryPrograms().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := pr.Edges.totalCount[10][alias]
+	if nodes, err := pr.NamedPrograms(alias); err == nil || hasTotalCount {
+		pager, err := newProgramPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ProgramConnection{Edges: []*ProgramEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return pr.QueryPrograms().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (pr *Program) Owner(ctx context.Context) (*Organization, error) {
@@ -2441,136 +3496,231 @@ func (pr *Program) Viewers(ctx context.Context) (result []*Group, err error) {
 	return result, err
 }
 
-func (pr *Program) Controls(ctx context.Context) (result []*Control, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = pr.NamedControls(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = pr.Edges.ControlsOrErr()
+func (pr *Program) Controls(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ControlOrder, where *ControlWhereInput,
+) (*ControlConnection, error) {
+	opts := []ControlPaginateOption{
+		WithControlOrder(orderBy),
+		WithControlFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = pr.QueryControls().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := pr.Edges.totalCount[4][alias]
+	if nodes, err := pr.NamedControls(alias); err == nil || hasTotalCount {
+		pager, err := newControlPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ControlConnection{Edges: []*ControlEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return pr.QueryControls().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (pr *Program) Subcontrols(ctx context.Context) (result []*Subcontrol, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = pr.NamedSubcontrols(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = pr.Edges.SubcontrolsOrErr()
+func (pr *Program) Subcontrols(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*SubcontrolOrder, where *SubcontrolWhereInput,
+) (*SubcontrolConnection, error) {
+	opts := []SubcontrolPaginateOption{
+		WithSubcontrolOrder(orderBy),
+		WithSubcontrolFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = pr.QuerySubcontrols().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := pr.Edges.totalCount[5][alias]
+	if nodes, err := pr.NamedSubcontrols(alias); err == nil || hasTotalCount {
+		pager, err := newSubcontrolPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &SubcontrolConnection{Edges: []*SubcontrolEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return pr.QuerySubcontrols().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (pr *Program) ControlObjectives(ctx context.Context) (result []*ControlObjective, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = pr.NamedControlObjectives(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = pr.Edges.ControlObjectivesOrErr()
+func (pr *Program) ControlObjectives(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ControlObjectiveOrder, where *ControlObjectiveWhereInput,
+) (*ControlObjectiveConnection, error) {
+	opts := []ControlObjectivePaginateOption{
+		WithControlObjectiveOrder(orderBy),
+		WithControlObjectiveFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = pr.QueryControlObjectives().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := pr.Edges.totalCount[6][alias]
+	if nodes, err := pr.NamedControlObjectives(alias); err == nil || hasTotalCount {
+		pager, err := newControlObjectivePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ControlObjectiveConnection{Edges: []*ControlObjectiveEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return pr.QueryControlObjectives().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (pr *Program) InternalPolicies(ctx context.Context) (result []*InternalPolicy, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = pr.NamedInternalPolicies(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = pr.Edges.InternalPoliciesOrErr()
+func (pr *Program) InternalPolicies(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *InternalPolicyWhereInput,
+) (*InternalPolicyConnection, error) {
+	opts := []InternalPolicyPaginateOption{
+		WithInternalPolicyFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = pr.QueryInternalPolicies().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := pr.Edges.totalCount[7][alias]
+	if nodes, err := pr.NamedInternalPolicies(alias); err == nil || hasTotalCount {
+		pager, err := newInternalPolicyPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &InternalPolicyConnection{Edges: []*InternalPolicyEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return pr.QueryInternalPolicies().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (pr *Program) Procedures(ctx context.Context) (result []*Procedure, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = pr.NamedProcedures(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = pr.Edges.ProceduresOrErr()
+func (pr *Program) Procedures(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *ProcedureWhereInput,
+) (*ProcedureConnection, error) {
+	opts := []ProcedurePaginateOption{
+		WithProcedureFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = pr.QueryProcedures().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := pr.Edges.totalCount[8][alias]
+	if nodes, err := pr.NamedProcedures(alias); err == nil || hasTotalCount {
+		pager, err := newProcedurePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ProcedureConnection{Edges: []*ProcedureEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return pr.QueryProcedures().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (pr *Program) Risks(ctx context.Context) (result []*Risk, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = pr.NamedRisks(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = pr.Edges.RisksOrErr()
+func (pr *Program) Risks(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*RiskOrder, where *RiskWhereInput,
+) (*RiskConnection, error) {
+	opts := []RiskPaginateOption{
+		WithRiskOrder(orderBy),
+		WithRiskFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = pr.QueryRisks().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := pr.Edges.totalCount[9][alias]
+	if nodes, err := pr.NamedRisks(alias); err == nil || hasTotalCount {
+		pager, err := newRiskPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &RiskConnection{Edges: []*RiskEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return pr.QueryRisks().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (pr *Program) Tasks(ctx context.Context) (result []*Task, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = pr.NamedTasks(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = pr.Edges.TasksOrErr()
+func (pr *Program) Tasks(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*TaskOrder, where *TaskWhereInput,
+) (*TaskConnection, error) {
+	opts := []TaskPaginateOption{
+		WithTaskOrder(orderBy),
+		WithTaskFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = pr.QueryTasks().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := pr.Edges.totalCount[10][alias]
+	if nodes, err := pr.NamedTasks(alias); err == nil || hasTotalCount {
+		pager, err := newTaskPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &TaskConnection{Edges: []*TaskEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return pr.QueryTasks().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (pr *Program) Notes(ctx context.Context) (result []*Note, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = pr.NamedNotes(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = pr.Edges.NotesOrErr()
+func (pr *Program) Notes(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *NoteWhereInput,
+) (*NoteConnection, error) {
+	opts := []NotePaginateOption{
+		WithNoteFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = pr.QueryNotes().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := pr.Edges.totalCount[11][alias]
+	if nodes, err := pr.NamedNotes(alias); err == nil || hasTotalCount {
+		pager, err := newNotePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &NoteConnection{Edges: []*NoteEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return pr.QueryNotes().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (pr *Program) Files(ctx context.Context) (result []*File, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = pr.NamedFiles(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = pr.Edges.FilesOrErr()
+func (pr *Program) Files(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *FileWhereInput,
+) (*FileConnection, error) {
+	opts := []FilePaginateOption{
+		WithFileFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = pr.QueryFiles().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := pr.Edges.totalCount[12][alias]
+	if nodes, err := pr.NamedFiles(alias); err == nil || hasTotalCount {
+		pager, err := newFilePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &FileConnection{Edges: []*FileEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return pr.QueryFiles().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (pr *Program) Evidence(ctx context.Context) (result []*Evidence, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = pr.NamedEvidence(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = pr.Edges.EvidenceOrErr()
+func (pr *Program) Evidence(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*EvidenceOrder, where *EvidenceWhereInput,
+) (*EvidenceConnection, error) {
+	opts := []EvidencePaginateOption{
+		WithEvidenceOrder(orderBy),
+		WithEvidenceFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = pr.QueryEvidence().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := pr.Edges.totalCount[13][alias]
+	if nodes, err := pr.NamedEvidence(alias); err == nil || hasTotalCount {
+		pager, err := newEvidencePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &EvidenceConnection{Edges: []*EvidenceEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return pr.QueryEvidence().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (pr *Program) Narratives(ctx context.Context) (result []*Narrative, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = pr.NamedNarratives(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = pr.Edges.NarrativesOrErr()
+func (pr *Program) Narratives(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy *NarrativeOrder, where *NarrativeWhereInput,
+) (*NarrativeConnection, error) {
+	opts := []NarrativePaginateOption{
+		WithNarrativeOrder(orderBy),
+		WithNarrativeFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = pr.QueryNarratives().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := pr.Edges.totalCount[14][alias]
+	if nodes, err := pr.NamedNarratives(alias); err == nil || hasTotalCount {
+		pager, err := newNarrativePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &NarrativeConnection{Edges: []*NarrativeEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return pr.QueryNarratives().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (pr *Program) ActionPlans(ctx context.Context) (result []*ActionPlan, err error) {
@@ -2585,28 +3735,46 @@ func (pr *Program) ActionPlans(ctx context.Context) (result []*ActionPlan, err e
 	return result, err
 }
 
-func (pr *Program) Users(ctx context.Context) (result []*User, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = pr.NamedUsers(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = pr.Edges.UsersOrErr()
+func (pr *Program) Users(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*UserOrder, where *UserWhereInput,
+) (*UserConnection, error) {
+	opts := []UserPaginateOption{
+		WithUserOrder(orderBy),
+		WithUserFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = pr.QueryUsers().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := pr.Edges.totalCount[16][alias]
+	if nodes, err := pr.NamedUsers(alias); err == nil || hasTotalCount {
+		pager, err := newUserPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &UserConnection{Edges: []*UserEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return pr.QueryUsers().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (pr *Program) Members(ctx context.Context) (result []*ProgramMembership, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = pr.NamedMembers(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = pr.Edges.MembersOrErr()
+func (pr *Program) Members(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy *ProgramMembershipOrder, where *ProgramMembershipWhereInput,
+) (*ProgramMembershipConnection, error) {
+	opts := []ProgramMembershipPaginateOption{
+		WithProgramMembershipOrder(orderBy),
+		WithProgramMembershipFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = pr.QueryMembers().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := pr.Edges.totalCount[17][alias]
+	if nodes, err := pr.NamedMembers(alias); err == nil || hasTotalCount {
+		pager, err := newProgramMembershipPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ProgramMembershipConnection{Edges: []*ProgramMembershipEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return pr.QueryMembers().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (pm *ProgramMembership) Program(ctx context.Context) (*Program, error) {
@@ -2669,52 +3837,87 @@ func (r *Risk) Viewers(ctx context.Context) (result []*Group, err error) {
 	return result, err
 }
 
-func (r *Risk) Control(ctx context.Context) (result []*Control, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = r.NamedControl(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = r.Edges.ControlOrErr()
+func (r *Risk) Control(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ControlOrder, where *ControlWhereInput,
+) (*ControlConnection, error) {
+	opts := []ControlPaginateOption{
+		WithControlOrder(orderBy),
+		WithControlFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = r.QueryControl().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := r.Edges.totalCount[4][alias]
+	if nodes, err := r.NamedControl(alias); err == nil || hasTotalCount {
+		pager, err := newControlPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ControlConnection{Edges: []*ControlEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return r.QueryControl().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (r *Risk) Procedure(ctx context.Context) (result []*Procedure, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = r.NamedProcedure(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = r.Edges.ProcedureOrErr()
+func (r *Risk) Procedure(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *ProcedureWhereInput,
+) (*ProcedureConnection, error) {
+	opts := []ProcedurePaginateOption{
+		WithProcedureFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = r.QueryProcedure().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := r.Edges.totalCount[5][alias]
+	if nodes, err := r.NamedProcedure(alias); err == nil || hasTotalCount {
+		pager, err := newProcedurePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ProcedureConnection{Edges: []*ProcedureEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return r.QueryProcedure().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (r *Risk) ActionPlans(ctx context.Context) (result []*ActionPlan, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = r.NamedActionPlans(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = r.Edges.ActionPlansOrErr()
+func (r *Risk) ActionPlans(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ActionPlanOrder, where *ActionPlanWhereInput,
+) (*ActionPlanConnection, error) {
+	opts := []ActionPlanPaginateOption{
+		WithActionPlanOrder(orderBy),
+		WithActionPlanFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = r.QueryActionPlans().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := r.Edges.totalCount[6][alias]
+	if nodes, err := r.NamedActionPlans(alias); err == nil || hasTotalCount {
+		pager, err := newActionPlanPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ActionPlanConnection{Edges: []*ActionPlanEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return r.QueryActionPlans().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (r *Risk) Programs(ctx context.Context) (result []*Program, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = r.NamedPrograms(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = r.Edges.ProgramsOrErr()
+func (r *Risk) Programs(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ProgramOrder, where *ProgramWhereInput,
+) (*ProgramConnection, error) {
+	opts := []ProgramPaginateOption{
+		WithProgramOrder(orderBy),
+		WithProgramFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = r.QueryPrograms().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := r.Edges.totalCount[7][alias]
+	if nodes, err := r.NamedPrograms(alias); err == nil || hasTotalCount {
+		pager, err := newProgramPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ProgramConnection{Edges: []*ProgramEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return r.QueryPrograms().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (r *Risk) Stakeholder(ctx context.Context) (*Group, error) {
@@ -2741,16 +3944,25 @@ func (s *Standard) Owner(ctx context.Context) (*Organization, error) {
 	return result, MaskNotFound(err)
 }
 
-func (s *Standard) Controls(ctx context.Context) (result []*Control, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = s.NamedControls(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = s.Edges.ControlsOrErr()
+func (s *Standard) Controls(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ControlOrder, where *ControlWhereInput,
+) (*ControlConnection, error) {
+	opts := []ControlPaginateOption{
+		WithControlOrder(orderBy),
+		WithControlFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = s.QueryControls().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := s.Edges.totalCount[1][alias]
+	if nodes, err := s.NamedControls(alias); err == nil || hasTotalCount {
+		pager, err := newControlPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ControlConnection{Edges: []*ControlEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return s.QueryControls().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (s *Subcontrol) Owner(ctx context.Context) (*Organization, error) {
@@ -2781,100 +3993,170 @@ func (s *Subcontrol) MappedControls(ctx context.Context) (result []*MappedContro
 	return result, err
 }
 
-func (s *Subcontrol) Evidence(ctx context.Context) (result []*Evidence, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = s.NamedEvidence(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = s.Edges.EvidenceOrErr()
+func (s *Subcontrol) Evidence(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*EvidenceOrder, where *EvidenceWhereInput,
+) (*EvidenceConnection, error) {
+	opts := []EvidencePaginateOption{
+		WithEvidenceOrder(orderBy),
+		WithEvidenceFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = s.QueryEvidence().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := s.Edges.totalCount[3][alias]
+	if nodes, err := s.NamedEvidence(alias); err == nil || hasTotalCount {
+		pager, err := newEvidencePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &EvidenceConnection{Edges: []*EvidenceEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return s.QueryEvidence().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (s *Subcontrol) ControlObjectives(ctx context.Context) (result []*ControlObjective, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = s.NamedControlObjectives(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = s.Edges.ControlObjectivesOrErr()
+func (s *Subcontrol) ControlObjectives(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ControlObjectiveOrder, where *ControlObjectiveWhereInput,
+) (*ControlObjectiveConnection, error) {
+	opts := []ControlObjectivePaginateOption{
+		WithControlObjectiveOrder(orderBy),
+		WithControlObjectiveFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = s.QueryControlObjectives().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := s.Edges.totalCount[4][alias]
+	if nodes, err := s.NamedControlObjectives(alias); err == nil || hasTotalCount {
+		pager, err := newControlObjectivePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ControlObjectiveConnection{Edges: []*ControlObjectiveEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return s.QueryControlObjectives().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (s *Subcontrol) Tasks(ctx context.Context) (result []*Task, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = s.NamedTasks(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = s.Edges.TasksOrErr()
+func (s *Subcontrol) Tasks(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*TaskOrder, where *TaskWhereInput,
+) (*TaskConnection, error) {
+	opts := []TaskPaginateOption{
+		WithTaskOrder(orderBy),
+		WithTaskFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = s.QueryTasks().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := s.Edges.totalCount[5][alias]
+	if nodes, err := s.NamedTasks(alias); err == nil || hasTotalCount {
+		pager, err := newTaskPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &TaskConnection{Edges: []*TaskEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return s.QueryTasks().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (s *Subcontrol) Narratives(ctx context.Context) (result []*Narrative, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = s.NamedNarratives(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = s.Edges.NarrativesOrErr()
+func (s *Subcontrol) Narratives(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy *NarrativeOrder, where *NarrativeWhereInput,
+) (*NarrativeConnection, error) {
+	opts := []NarrativePaginateOption{
+		WithNarrativeOrder(orderBy),
+		WithNarrativeFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = s.QueryNarratives().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := s.Edges.totalCount[6][alias]
+	if nodes, err := s.NamedNarratives(alias); err == nil || hasTotalCount {
+		pager, err := newNarrativePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &NarrativeConnection{Edges: []*NarrativeEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return s.QueryNarratives().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (s *Subcontrol) Risks(ctx context.Context) (result []*Risk, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = s.NamedRisks(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = s.Edges.RisksOrErr()
+func (s *Subcontrol) Risks(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*RiskOrder, where *RiskWhereInput,
+) (*RiskConnection, error) {
+	opts := []RiskPaginateOption{
+		WithRiskOrder(orderBy),
+		WithRiskFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = s.QueryRisks().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := s.Edges.totalCount[7][alias]
+	if nodes, err := s.NamedRisks(alias); err == nil || hasTotalCount {
+		pager, err := newRiskPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &RiskConnection{Edges: []*RiskEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return s.QueryRisks().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (s *Subcontrol) ActionPlans(ctx context.Context) (result []*ActionPlan, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = s.NamedActionPlans(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = s.Edges.ActionPlansOrErr()
+func (s *Subcontrol) ActionPlans(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ActionPlanOrder, where *ActionPlanWhereInput,
+) (*ActionPlanConnection, error) {
+	opts := []ActionPlanPaginateOption{
+		WithActionPlanOrder(orderBy),
+		WithActionPlanFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = s.QueryActionPlans().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := s.Edges.totalCount[8][alias]
+	if nodes, err := s.NamedActionPlans(alias); err == nil || hasTotalCount {
+		pager, err := newActionPlanPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ActionPlanConnection{Edges: []*ActionPlanEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return s.QueryActionPlans().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (s *Subcontrol) Procedures(ctx context.Context) (result []*Procedure, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = s.NamedProcedures(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = s.Edges.ProceduresOrErr()
+func (s *Subcontrol) Procedures(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *ProcedureWhereInput,
+) (*ProcedureConnection, error) {
+	opts := []ProcedurePaginateOption{
+		WithProcedureFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = s.QueryProcedures().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := s.Edges.totalCount[9][alias]
+	if nodes, err := s.NamedProcedures(alias); err == nil || hasTotalCount {
+		pager, err := newProcedurePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ProcedureConnection{Edges: []*ProcedureEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return s.QueryProcedures().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (s *Subcontrol) InternalPolicies(ctx context.Context) (result []*InternalPolicy, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = s.NamedInternalPolicies(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = s.Edges.InternalPoliciesOrErr()
+func (s *Subcontrol) InternalPolicies(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *InternalPolicyWhereInput,
+) (*InternalPolicyConnection, error) {
+	opts := []InternalPolicyPaginateOption{
+		WithInternalPolicyFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = s.QueryInternalPolicies().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := s.Edges.totalCount[10][alias]
+	if nodes, err := s.NamedInternalPolicies(alias); err == nil || hasTotalCount {
+		pager, err := newInternalPolicyPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &InternalPolicyConnection{Edges: []*InternalPolicyEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return s.QueryInternalPolicies().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (s *Subcontrol) ControlOwner(ctx context.Context) (*Group, error) {
@@ -2901,16 +4183,24 @@ func (s *Subscriber) Owner(ctx context.Context) (*Organization, error) {
 	return result, MaskNotFound(err)
 }
 
-func (s *Subscriber) Events(ctx context.Context) (result []*Event, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = s.NamedEvents(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = s.Edges.EventsOrErr()
+func (s *Subscriber) Events(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *EventWhereInput,
+) (*EventConnection, error) {
+	opts := []EventPaginateOption{
+		WithEventFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = s.QueryEvents().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := s.Edges.totalCount[1][alias]
+	if nodes, err := s.NamedEvents(alias); err == nil || hasTotalCount {
+		pager, err := newEventPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &EventConnection{Edges: []*EventEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return s.QueryEvents().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (ts *TFASetting) Owner(ctx context.Context) (*User, error) {
@@ -2945,112 +4235,190 @@ func (t *Task) Assignee(ctx context.Context) (*User, error) {
 	return result, MaskNotFound(err)
 }
 
-func (t *Task) Comments(ctx context.Context) (result []*Note, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = t.NamedComments(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = t.Edges.CommentsOrErr()
+func (t *Task) Comments(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *NoteWhereInput,
+) (*NoteConnection, error) {
+	opts := []NotePaginateOption{
+		WithNoteFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = t.QueryComments().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := t.Edges.totalCount[3][alias]
+	if nodes, err := t.NamedComments(alias); err == nil || hasTotalCount {
+		pager, err := newNotePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &NoteConnection{Edges: []*NoteEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return t.QueryComments().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (t *Task) Group(ctx context.Context) (result []*Group, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = t.NamedGroup(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = t.Edges.GroupOrErr()
+func (t *Task) Group(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*GroupOrder, where *GroupWhereInput,
+) (*GroupConnection, error) {
+	opts := []GroupPaginateOption{
+		WithGroupOrder(orderBy),
+		WithGroupFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = t.QueryGroup().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := t.Edges.totalCount[4][alias]
+	if nodes, err := t.NamedGroup(alias); err == nil || hasTotalCount {
+		pager, err := newGroupPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &GroupConnection{Edges: []*GroupEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return t.QueryGroup().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (t *Task) InternalPolicy(ctx context.Context) (result []*InternalPolicy, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = t.NamedInternalPolicy(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = t.Edges.InternalPolicyOrErr()
+func (t *Task) InternalPolicy(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *InternalPolicyWhereInput,
+) (*InternalPolicyConnection, error) {
+	opts := []InternalPolicyPaginateOption{
+		WithInternalPolicyFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = t.QueryInternalPolicy().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := t.Edges.totalCount[5][alias]
+	if nodes, err := t.NamedInternalPolicy(alias); err == nil || hasTotalCount {
+		pager, err := newInternalPolicyPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &InternalPolicyConnection{Edges: []*InternalPolicyEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return t.QueryInternalPolicy().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (t *Task) Procedure(ctx context.Context) (result []*Procedure, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = t.NamedProcedure(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = t.Edges.ProcedureOrErr()
+func (t *Task) Procedure(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *ProcedureWhereInput,
+) (*ProcedureConnection, error) {
+	opts := []ProcedurePaginateOption{
+		WithProcedureFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = t.QueryProcedure().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := t.Edges.totalCount[6][alias]
+	if nodes, err := t.NamedProcedure(alias); err == nil || hasTotalCount {
+		pager, err := newProcedurePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ProcedureConnection{Edges: []*ProcedureEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return t.QueryProcedure().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (t *Task) Control(ctx context.Context) (result []*Control, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = t.NamedControl(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = t.Edges.ControlOrErr()
+func (t *Task) Control(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ControlOrder, where *ControlWhereInput,
+) (*ControlConnection, error) {
+	opts := []ControlPaginateOption{
+		WithControlOrder(orderBy),
+		WithControlFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = t.QueryControl().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := t.Edges.totalCount[7][alias]
+	if nodes, err := t.NamedControl(alias); err == nil || hasTotalCount {
+		pager, err := newControlPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ControlConnection{Edges: []*ControlEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return t.QueryControl().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (t *Task) ControlObjective(ctx context.Context) (result []*ControlObjective, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = t.NamedControlObjective(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = t.Edges.ControlObjectiveOrErr()
+func (t *Task) ControlObjective(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ControlObjectiveOrder, where *ControlObjectiveWhereInput,
+) (*ControlObjectiveConnection, error) {
+	opts := []ControlObjectivePaginateOption{
+		WithControlObjectiveOrder(orderBy),
+		WithControlObjectiveFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = t.QueryControlObjective().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := t.Edges.totalCount[8][alias]
+	if nodes, err := t.NamedControlObjective(alias); err == nil || hasTotalCount {
+		pager, err := newControlObjectivePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ControlObjectiveConnection{Edges: []*ControlObjectiveEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return t.QueryControlObjective().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (t *Task) Subcontrol(ctx context.Context) (result []*Subcontrol, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = t.NamedSubcontrol(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = t.Edges.SubcontrolOrErr()
+func (t *Task) Subcontrol(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*SubcontrolOrder, where *SubcontrolWhereInput,
+) (*SubcontrolConnection, error) {
+	opts := []SubcontrolPaginateOption{
+		WithSubcontrolOrder(orderBy),
+		WithSubcontrolFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = t.QuerySubcontrol().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := t.Edges.totalCount[9][alias]
+	if nodes, err := t.NamedSubcontrol(alias); err == nil || hasTotalCount {
+		pager, err := newSubcontrolPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &SubcontrolConnection{Edges: []*SubcontrolEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return t.QuerySubcontrol().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (t *Task) Program(ctx context.Context) (result []*Program, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = t.NamedProgram(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = t.Edges.ProgramOrErr()
+func (t *Task) Program(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ProgramOrder, where *ProgramWhereInput,
+) (*ProgramConnection, error) {
+	opts := []ProgramPaginateOption{
+		WithProgramOrder(orderBy),
+		WithProgramFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = t.QueryProgram().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := t.Edges.totalCount[10][alias]
+	if nodes, err := t.NamedProgram(alias); err == nil || hasTotalCount {
+		pager, err := newProgramPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ProgramConnection{Edges: []*ProgramEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return t.QueryProgram().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (t *Task) Evidence(ctx context.Context) (result []*Evidence, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = t.NamedEvidence(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = t.Edges.EvidenceOrErr()
+func (t *Task) Evidence(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*EvidenceOrder, where *EvidenceWhereInput,
+) (*EvidenceConnection, error) {
+	opts := []EvidencePaginateOption{
+		WithEvidenceOrder(orderBy),
+		WithEvidenceFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = t.QueryEvidence().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := t.Edges.totalCount[11][alias]
+	if nodes, err := t.NamedEvidence(alias); err == nil || hasTotalCount {
+		pager, err := newEvidencePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &EvidenceConnection{Edges: []*EvidenceEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return t.QueryEvidence().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (t *Template) Owner(ctx context.Context) (*Organization, error) {
@@ -3061,52 +4429,84 @@ func (t *Template) Owner(ctx context.Context) (*Organization, error) {
 	return result, MaskNotFound(err)
 }
 
-func (t *Template) Documents(ctx context.Context) (result []*DocumentData, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = t.NamedDocuments(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = t.Edges.DocumentsOrErr()
+func (t *Template) Documents(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *DocumentDataWhereInput,
+) (*DocumentDataConnection, error) {
+	opts := []DocumentDataPaginateOption{
+		WithDocumentDataFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = t.QueryDocuments().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := t.Edges.totalCount[1][alias]
+	if nodes, err := t.NamedDocuments(alias); err == nil || hasTotalCount {
+		pager, err := newDocumentDataPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &DocumentDataConnection{Edges: []*DocumentDataEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return t.QueryDocuments().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (t *Template) Files(ctx context.Context) (result []*File, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = t.NamedFiles(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = t.Edges.FilesOrErr()
+func (t *Template) Files(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *FileWhereInput,
+) (*FileConnection, error) {
+	opts := []FilePaginateOption{
+		WithFileFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = t.QueryFiles().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := t.Edges.totalCount[2][alias]
+	if nodes, err := t.NamedFiles(alias); err == nil || hasTotalCount {
+		pager, err := newFilePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &FileConnection{Edges: []*FileEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return t.QueryFiles().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (u *User) PersonalAccessTokens(ctx context.Context) (result []*PersonalAccessToken, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = u.NamedPersonalAccessTokens(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = u.Edges.PersonalAccessTokensOrErr()
+func (u *User) PersonalAccessTokens(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *PersonalAccessTokenWhereInput,
+) (*PersonalAccessTokenConnection, error) {
+	opts := []PersonalAccessTokenPaginateOption{
+		WithPersonalAccessTokenFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = u.QueryPersonalAccessTokens().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := u.Edges.totalCount[0][alias]
+	if nodes, err := u.NamedPersonalAccessTokens(alias); err == nil || hasTotalCount {
+		pager, err := newPersonalAccessTokenPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &PersonalAccessTokenConnection{Edges: []*PersonalAccessTokenEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return u.QueryPersonalAccessTokens().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (u *User) TfaSettings(ctx context.Context) (result []*TFASetting, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = u.NamedTfaSettings(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = u.Edges.TfaSettingsOrErr()
+func (u *User) TfaSettings(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *TFASettingWhereInput,
+) (*TFASettingConnection, error) {
+	opts := []TFASettingPaginateOption{
+		WithTFASettingFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = u.QueryTfaSettings().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := u.Edges.totalCount[1][alias]
+	if nodes, err := u.NamedTfaSettings(alias); err == nil || hasTotalCount {
+		pager, err := newTFASettingPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &TFASettingConnection{Edges: []*TFASettingEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return u.QueryTfaSettings().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (u *User) Setting(ctx context.Context) (*UserSetting, error) {
@@ -3141,16 +4541,24 @@ func (u *User) Organizations(ctx context.Context) (result []*Organization, err e
 	return result, err
 }
 
-func (u *User) Files(ctx context.Context) (result []*File, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = u.NamedFiles(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = u.Edges.FilesOrErr()
+func (u *User) Files(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *FileWhereInput,
+) (*FileConnection, error) {
+	opts := []FilePaginateOption{
+		WithFileFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = u.QueryFiles().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := u.Edges.totalCount[5][alias]
+	if nodes, err := u.NamedFiles(alias); err == nil || hasTotalCount {
+		pager, err := newFilePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &FileConnection{Edges: []*FileEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return u.QueryFiles().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (u *User) AvatarFile(ctx context.Context) (*File, error) {
@@ -3161,64 +4569,108 @@ func (u *User) AvatarFile(ctx context.Context) (*File, error) {
 	return result, MaskNotFound(err)
 }
 
-func (u *User) Events(ctx context.Context) (result []*Event, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = u.NamedEvents(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = u.Edges.EventsOrErr()
+func (u *User) Events(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *EventWhereInput,
+) (*EventConnection, error) {
+	opts := []EventPaginateOption{
+		WithEventFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = u.QueryEvents().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := u.Edges.totalCount[7][alias]
+	if nodes, err := u.NamedEvents(alias); err == nil || hasTotalCount {
+		pager, err := newEventPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &EventConnection{Edges: []*EventEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return u.QueryEvents().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (u *User) ActionPlans(ctx context.Context) (result []*ActionPlan, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = u.NamedActionPlans(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = u.Edges.ActionPlansOrErr()
+func (u *User) ActionPlans(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*ActionPlanOrder, where *ActionPlanWhereInput,
+) (*ActionPlanConnection, error) {
+	opts := []ActionPlanPaginateOption{
+		WithActionPlanOrder(orderBy),
+		WithActionPlanFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = u.QueryActionPlans().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := u.Edges.totalCount[8][alias]
+	if nodes, err := u.NamedActionPlans(alias); err == nil || hasTotalCount {
+		pager, err := newActionPlanPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &ActionPlanConnection{Edges: []*ActionPlanEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return u.QueryActionPlans().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (u *User) Subcontrols(ctx context.Context) (result []*Subcontrol, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = u.NamedSubcontrols(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = u.Edges.SubcontrolsOrErr()
+func (u *User) Subcontrols(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*SubcontrolOrder, where *SubcontrolWhereInput,
+) (*SubcontrolConnection, error) {
+	opts := []SubcontrolPaginateOption{
+		WithSubcontrolOrder(orderBy),
+		WithSubcontrolFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = u.QuerySubcontrols().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := u.Edges.totalCount[9][alias]
+	if nodes, err := u.NamedSubcontrols(alias); err == nil || hasTotalCount {
+		pager, err := newSubcontrolPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &SubcontrolConnection{Edges: []*SubcontrolEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return u.QuerySubcontrols().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (u *User) AssignerTasks(ctx context.Context) (result []*Task, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = u.NamedAssignerTasks(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = u.Edges.AssignerTasksOrErr()
+func (u *User) AssignerTasks(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*TaskOrder, where *TaskWhereInput,
+) (*TaskConnection, error) {
+	opts := []TaskPaginateOption{
+		WithTaskOrder(orderBy),
+		WithTaskFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = u.QueryAssignerTasks().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := u.Edges.totalCount[10][alias]
+	if nodes, err := u.NamedAssignerTasks(alias); err == nil || hasTotalCount {
+		pager, err := newTaskPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &TaskConnection{Edges: []*TaskEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return u.QueryAssignerTasks().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (u *User) AssigneeTasks(ctx context.Context) (result []*Task, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = u.NamedAssigneeTasks(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = u.Edges.AssigneeTasksOrErr()
+func (u *User) AssigneeTasks(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*TaskOrder, where *TaskWhereInput,
+) (*TaskConnection, error) {
+	opts := []TaskPaginateOption{
+		WithTaskOrder(orderBy),
+		WithTaskFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = u.QueryAssigneeTasks().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := u.Edges.totalCount[11][alias]
+	if nodes, err := u.NamedAssigneeTasks(alias); err == nil || hasTotalCount {
+		pager, err := newTaskPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &TaskConnection{Edges: []*TaskEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return u.QueryAssigneeTasks().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (u *User) Programs(ctx context.Context) (result []*Program, err error) {
@@ -3285,14 +4737,22 @@ func (us *UserSetting) DefaultOrg(ctx context.Context) (*Organization, error) {
 	return result, MaskNotFound(err)
 }
 
-func (us *UserSetting) Files(ctx context.Context) (result []*File, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = us.NamedFiles(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = us.Edges.FilesOrErr()
+func (us *UserSetting) Files(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, where *FileWhereInput,
+) (*FileConnection, error) {
+	opts := []FilePaginateOption{
+		WithFileFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = us.QueryFiles().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := us.Edges.totalCount[2][alias]
+	if nodes, err := us.NamedFiles(alias); err == nil || hasTotalCount {
+		pager, err := newFilePager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &FileConnection{Edges: []*FileEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return us.QueryFiles().Paginate(ctx, after, first, before, last, opts...)
 }

--- a/internal/ent/schema/actionplan.go
+++ b/internal/ent/schema/actionplan.go
@@ -26,12 +26,21 @@ func (ActionPlan) Fields() []ent.Field {
 	return []ent.Field{
 		field.Time("due_date").
 			Optional().
+			Annotations(
+				entgql.OrderField("due_date"),
+			).
 			Comment("due date of the action plan"),
 		field.Enum("priority").
 			GoType(enums.Priority("")).
+			Annotations(
+				entgql.OrderField("PRIORITY"),
+			).
 			Optional().
 			Comment("priority of the action plan"),
 		field.String("source").
+			Annotations(
+				entgql.OrderField("source"),
+			).
 			Optional().
 			Comment("source of the action plan"),
 	}
@@ -41,12 +50,16 @@ func (ActionPlan) Fields() []ent.Field {
 func (ActionPlan) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("risk", Risk.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("action_plans"),
 		edge.From("control", Control.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("action_plans"),
 		edge.From("user", User.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("action_plans"),
 		edge.From("program", Program.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("action_plans"),
 	}
 }
@@ -71,6 +84,7 @@ func (ActionPlan) Annotations() []schema.Annotation {
 	return []schema.Annotation{
 		entgql.RelayConnection(),
 		entgql.QueryField(),
+		entgql.MultiOrder(),
 		entgql.Mutations(entgql.MutationCreate(), (entgql.MutationUpdate())),
 		entfga.SelfAccessChecks(),
 	}

--- a/internal/ent/schema/contact.go
+++ b/internal/ent/schema/contact.go
@@ -36,17 +36,28 @@ func (Contact) Fields() []ent.Field {
 			MaxLen(nameMaxLen).
 			Annotations(
 				entx.FieldSearchable(),
+				entgql.OrderField("full_name"),
 			).
 			NotEmpty(),
 		field.String("title").
 			Comment("the title of the contact").
+			Annotations(
+				entgql.OrderField("title"),
+			).
 			Optional(),
 		field.String("company").
 			Comment("the company of the contact").
+			Annotations(
+				entgql.OrderField("company"),
+			).
 			Optional(),
 		field.String("email").
 			Comment("the email of the contact").
 			Optional().
+			Annotations(
+				entx.FieldSearchable(),
+				entgql.OrderField("email"),
+			).
 			Validate(func(email string) error {
 				_, err := mail.ParseAddress(email)
 				return err
@@ -67,6 +78,9 @@ func (Contact) Fields() []ent.Field {
 			Optional(),
 		field.Enum("status").
 			Comment("status of the contact").
+			Annotations(
+				entgql.OrderField("STATUS"),
+			).
 			GoType(enums.UserStatus("")).
 			Default(enums.UserStatusActive.String()),
 	}
@@ -87,8 +101,9 @@ func (Contact) Mixin() []ent.Mixin {
 func (Contact) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("entities", Entity.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("contacts"),
-		edge.To("files", File.Type),
+		edge.To("files", File.Type).Annotations(entgql.RelayConnection()),
 	}
 }
 
@@ -97,6 +112,7 @@ func (Contact) Annotations() []schema.Annotation {
 	return []schema.Annotation{
 		entgql.QueryField(),
 		entgql.RelayConnection(),
+		entgql.MultiOrder(),
 		entgql.Mutations(entgql.MutationCreate(), (entgql.MutationUpdate())),
 		entfga.OrganizationInheritedChecks(),
 	}

--- a/internal/ent/schema/control.go
+++ b/internal/ent/schema/control.go
@@ -51,17 +51,20 @@ func (Control) Edges() []ent.Edge {
 			Unique().
 			Ref("controls"),
 		edge.From("programs", Program.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("controls"),
 
 		// evidence can be associated with the control
 		edge.From("evidence", Evidence.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("controls"),
 
 		edge.To("control_implementations", ControlImplementation.Type).
-			Annotations(entx.CascadeAnnotationField("Controls")). // cascade delete the implementation when the control is deleted
+			Annotations(entx.CascadeAnnotationField("Controls"), entgql.RelayConnection()). // cascade delete the implementation when the control is deleted
 			Comment("the implementation(s) of the control"),
 
 		edge.From("mapped_controls", MappedControl.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("controls").
 			Comment("mapped subcontrols that have a relation to another control or subcontrol"),
 
@@ -69,17 +72,17 @@ func (Control) Edges() []ent.Edge {
 		edge.To("control_objectives", ControlObjective.Type),
 
 		edge.To("subcontrols", Subcontrol.Type).
-			Annotations(entx.CascadeAnnotationField("Control")), // cascade delete the subcontrol when the control is deleted
+			Annotations(entx.CascadeAnnotationField("Control"), entgql.RelayConnection()), // cascade delete the subcontrol when the control is deleted
 
 		// controls can have associated task, narratives, risks, and action plans
-		edge.To("tasks", Task.Type),
-		edge.To("narratives", Narrative.Type),
-		edge.To("risks", Risk.Type),
-		edge.To("action_plans", ActionPlan.Type),
+		edge.To("tasks", Task.Type).Annotations(entgql.RelayConnection()),
+		edge.To("narratives", Narrative.Type).Annotations(entgql.RelayConnection()),
+		edge.To("risks", Risk.Type).Annotations(entgql.RelayConnection()),
+		edge.To("action_plans", ActionPlan.Type).Annotations(entgql.RelayConnection()),
 
 		// policies and procedures are used to implement the control
-		edge.To("procedures", Procedure.Type),
-		edge.To("internal_policies", InternalPolicy.Type),
+		edge.To("procedures", Procedure.Type).Annotations(entgql.RelayConnection()),
+		edge.To("internal_policies", InternalPolicy.Type).Annotations(entgql.RelayConnection()),
 
 		// owner is the user who is responsible for the control
 		edge.To("control_owner", Group.Type).
@@ -126,6 +129,7 @@ func (Control) Annotations() []schema.Annotation {
 	return []schema.Annotation{
 		entgql.RelayConnection(),
 		entgql.QueryField(),
+		entgql.MultiOrder(),
 		entgql.Mutations(entgql.MutationCreate(), (entgql.MutationUpdate())),
 		entfga.SelfAccessChecks(),
 	}

--- a/internal/ent/schema/controlfields.go
+++ b/internal/ent/schema/controlfields.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"entgo.io/contrib/entgql"
 	"entgo.io/ent"
 	"entgo.io/ent/schema/field"
 	"github.com/theopenlane/core/pkg/enums"
@@ -18,21 +19,31 @@ var controlFields = []ent.Field{
 		Comment("description of what the control is supposed to accomplish"),
 	field.String("status").
 		Optional().
+		Annotations(
+			entgql.OrderField("status"),
+		).
 		Comment("status of the control"),
 	field.Enum("source").
 		GoType(enums.ControlSource("")).
 		Optional().
+		Annotations(
+			entgql.OrderField("SOURCE"),
+		).
 		Default(enums.ControlSourceUserDefined.String()).
 		Comment("source of the control, e.g. framework, template, custom, etc."),
 	field.Enum("control_type").
 		GoType(enums.ControlType("")).
 		Default(enums.ControlTypePreventative.String()).
+		Annotations(
+			entgql.OrderField("CONTROL_TYPE"),
+		).
 		Optional().
 		Comment("type of the control e.g. preventive, detective, corrective, or deterrent."),
 	field.String("category").
 		Optional().
 		Annotations(
 			entx.FieldSearchable(),
+			entgql.OrderField("category"),
 		).
 		Comment("category of the control"),
 	field.String("category_id").
@@ -42,6 +53,7 @@ var controlFields = []ent.Field{
 		Optional().
 		Annotations(
 			entx.FieldSearchable(),
+			entgql.OrderField("subcategory"),
 		).
 		Comment("subcategory of the control"),
 	field.Strings("mapped_categories").

--- a/internal/ent/schema/controlimplementation.go
+++ b/internal/ent/schema/controlimplementation.go
@@ -26,15 +26,27 @@ func (ControlImplementation) Fields() []ent.Field {
 			GoType(enums.DocumentStatus("")).
 			Default(enums.DocumentDraft.String()).
 			Optional().
+			Annotations(
+				entgql.OrderField("STATUS"),
+			).
 			Comment("status of the %s, e.g. draft, published, archived, etc."),
 		field.Time("implementation_date").
 			Optional().
+			Annotations(
+				entgql.OrderField("implementation_date"),
+			).
 			Comment("date the control was implemented"),
 		field.Bool("verified").
 			Optional().
+			Annotations(
+				entgql.OrderField("verified"),
+			).
 			Comment("set to true if the control implementation has been verified"),
 		field.Time("verification_date").
 			Optional().
+			Annotations(
+				entgql.OrderField("verification_date"),
+			).
 			Comment("date the control implementation was verified"),
 		field.Text("details").
 			Optional().
@@ -56,6 +68,7 @@ func (ControlImplementation) Mixin() []ent.Mixin {
 func (ControlImplementation) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("controls", Control.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("control_implementations"),
 	}
 }
@@ -65,6 +78,7 @@ func (ControlImplementation) Annotations() []schema.Annotation {
 	return []schema.Annotation{
 		entgql.QueryField(),
 		entgql.RelayConnection(),
+		entgql.MultiOrder(),
 		entgql.Mutations(entgql.MutationCreate(), entgql.MutationUpdate()),
 	}
 }

--- a/internal/ent/schema/controlobjective.go
+++ b/internal/ent/schema/controlobjective.go
@@ -30,6 +30,7 @@ func (ControlObjective) Fields() []ent.Field {
 			NotEmpty().
 			Annotations(
 				entx.FieldSearchable(),
+				entgql.OrderField("name"),
 			).
 			Comment("the name of the control objective"),
 		field.Text("desired_outcome").
@@ -37,25 +38,36 @@ func (ControlObjective) Fields() []ent.Field {
 			Comment("the desired outcome or target of the control objective"),
 		field.String("status").
 			Optional().
+			Annotations(
+				entgql.OrderField("status"),
+			).
 			Comment("status of the control objective"),
 		field.Enum("source").
 			GoType(enums.ControlSource("")).
 			Optional().
+			Annotations(
+				entgql.OrderField("SOURCE"),
+			).
 			Default(enums.ControlSourceUserDefined.String()).
 			Comment("source of the control, e.g. framework, template, custom, etc."),
 		field.String("control_objective_type").
 			Optional().
+			Annotations(
+				entgql.OrderField("control_objective_type"),
+			).
 			Comment("type of the control objective e.g. compliance, financial, operational, etc."),
 		field.String("category").
 			Optional().
 			Annotations(
 				entx.FieldSearchable(),
+				entgql.OrderField("category"),
 			).
 			Comment("category of the control"),
 		field.String("subcategory").
 			Optional().
 			Annotations(
 				entx.FieldSearchable(),
+				entgql.OrderField("subcategory"),
 			).
 			Comment("subcategory of the control"),
 	}
@@ -65,25 +77,30 @@ func (ControlObjective) Fields() []ent.Field {
 func (ControlObjective) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("programs", Program.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("control_objectives"),
 		edge.From("evidence", Evidence.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("control_objectives"),
 
 		// control objectives can map to multiple controls and subcontrols
 		edge.From("controls", Control.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("control_objectives"),
 		edge.From("subcontrols", Subcontrol.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("control_objectives"),
 
 		edge.From("internal_policies", InternalPolicy.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("control_objectives"),
 
-		edge.To("procedures", Procedure.Type),
+		edge.To("procedures", Procedure.Type).Annotations(entgql.RelayConnection()),
 
-		edge.To("risks", Risk.Type),
-		edge.To("narratives", Narrative.Type),
+		edge.To("risks", Risk.Type).Annotations(entgql.RelayConnection()),
+		edge.To("narratives", Narrative.Type).Annotations(entgql.RelayConnection()),
 
-		edge.To("tasks", Task.Type),
+		edge.To("tasks", Task.Type).Annotations(entgql.RelayConnection()),
 	}
 }
 
@@ -114,6 +131,7 @@ func (ControlObjective) Annotations() []schema.Annotation {
 	return []schema.Annotation{
 		entgql.RelayConnection(),
 		entgql.QueryField(),
+		entgql.MultiOrder(),
 		entgql.Mutations(entgql.MutationCreate(), (entgql.MutationUpdate())),
 		entfga.SelfAccessChecks(),
 	}

--- a/internal/ent/schema/documentdata.go
+++ b/internal/ent/schema/documentdata.go
@@ -54,8 +54,9 @@ func (DocumentData) Edges() []ent.Edge {
 			Required().
 			Field("template_id"),
 		edge.From("entity", Entity.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("documents"),
-		edge.To("files", File.Type),
+		edge.To("files", File.Type).Annotations(entgql.RelayConnection()),
 	}
 }
 

--- a/internal/ent/schema/entity.go
+++ b/internal/ent/schema/entity.go
@@ -68,6 +68,9 @@ func (Entity) Fields() []ent.Field {
 		field.String("status").
 			Comment("status of the entity").
 			Default("active").
+			Annotations(
+				entgql.OrderField("status"),
+			).
 			Optional(),
 	}
 }
@@ -86,10 +89,10 @@ func (Entity) Mixin() []ent.Mixin {
 // Edges of the Entity
 func (Entity) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.To("contacts", Contact.Type),
-		edge.To("documents", DocumentData.Type),
-		edge.To("notes", Note.Type),
-		edge.To("files", File.Type),
+		edge.To("contacts", Contact.Type).Annotations(entgql.RelayConnection()),
+		edge.To("documents", DocumentData.Type).Annotations(entgql.RelayConnection()),
+		edge.To("notes", Note.Type).Annotations(entgql.RelayConnection()),
+		edge.To("files", File.Type).Annotations(entgql.RelayConnection()),
 		edge.To("entity_type", EntityType.Type).
 			Field("entity_type_id").
 			Unique(),
@@ -110,6 +113,7 @@ func (Entity) Annotations() []schema.Annotation {
 	return []schema.Annotation{
 		entgql.QueryField(),
 		entgql.RelayConnection(),
+		entgql.MultiOrder(),
 		entgql.Mutations(entgql.MutationCreate(), entgql.MutationUpdate()),
 		entfga.OrganizationInheritedChecks(),
 	}

--- a/internal/ent/schema/entitytype.go
+++ b/internal/ent/schema/entitytype.go
@@ -60,7 +60,7 @@ func (EntityType) Mixin() []ent.Mixin {
 // Edges of the EntityType
 func (EntityType) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.To("entities", Entity.Type),
+		edge.To("entities", Entity.Type).Annotations(entgql.RelayConnection()),
 	}
 }
 

--- a/internal/ent/schema/event.go
+++ b/internal/ent/schema/event.go
@@ -29,18 +29,18 @@ func (Event) Fields() []ent.Field {
 // Edges of the Event
 func (Event) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.From("user", User.Type).Ref("events"),
-		edge.From("group", Group.Type).Ref("events"),
-		edge.From("integration", Integration.Type).Ref("events"),
-		edge.From("organization", Organization.Type).Ref("events"),
-		edge.From("invite", Invite.Type).Ref("events"),
-		edge.From("personal_access_token", PersonalAccessToken.Type).Ref("events"),
-		edge.From("hush", Hush.Type).Ref("events"),
-		edge.From("orgmembership", OrgMembership.Type).Ref("events"),
-		edge.From("groupmembership", GroupMembership.Type).Ref("events"),
-		edge.From("subscriber", Subscriber.Type).Ref("events"),
-		edge.From("file", File.Type).Ref("events"),
-		edge.From("orgsubscription", OrgSubscription.Type).Ref("events"),
+		edge.From("user", User.Type).Ref("events").Annotations(entgql.RelayConnection()),
+		edge.From("group", Group.Type).Ref("events").Annotations(entgql.RelayConnection()),
+		edge.From("integration", Integration.Type).Ref("events").Annotations(entgql.RelayConnection()),
+		edge.From("organization", Organization.Type).Ref("events").Annotations(entgql.RelayConnection()),
+		edge.From("invite", Invite.Type).Ref("events").Annotations(entgql.RelayConnection()),
+		edge.From("personal_access_token", PersonalAccessToken.Type).Ref("events").Annotations(entgql.RelayConnection()),
+		edge.From("hush", Hush.Type).Ref("events").Annotations(entgql.RelayConnection()),
+		edge.From("orgmembership", OrgMembership.Type).Ref("events").Annotations(entgql.RelayConnection()),
+		edge.From("groupmembership", GroupMembership.Type).Ref("events").Annotations(entgql.RelayConnection()),
+		edge.From("subscriber", Subscriber.Type).Ref("events").Annotations(entgql.RelayConnection()),
+		edge.From("file", File.Type).Ref("events").Annotations(entgql.RelayConnection()),
+		edge.From("orgsubscription", OrgSubscription.Type).Ref("events").Annotations(entgql.RelayConnection()),
 	}
 }
 

--- a/internal/ent/schema/file.go
+++ b/internal/ent/schema/file.go
@@ -74,27 +74,38 @@ func (File) Fields() []ent.Field {
 func (File) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("user", User.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("files"),
 		edge.From("organization", Organization.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("files"),
 		edge.From("group", Group.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("files"),
 		edge.From("contact", Contact.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("files"),
 		edge.From("entity", Entity.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("files"),
 		edge.From("user_setting", UserSetting.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("files"),
 		edge.From("organization_setting", OrganizationSetting.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("files"),
 		edge.From("template", Template.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("files"),
 		edge.From("document_data", DocumentData.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("files"),
-		edge.To("events", Event.Type),
+		edge.To("events", Event.Type).Annotations(entgql.RelayConnection()),
 		edge.From("program", Program.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("files"),
 		edge.From("evidence", Evidence.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("files"),
 	}
 }

--- a/internal/ent/schema/group.go
+++ b/internal/ent/schema/group.go
@@ -93,10 +93,10 @@ func (Group) Edges() []ent.Edge {
 			// this should be done via the members edge
 			Annotations(entgql.Skip(entgql.SkipMutationCreateInput, entgql.SkipMutationUpdateInput)).
 			Through("members", GroupMembership.Type),
-		edge.To("events", Event.Type),
-		edge.To("integrations", Integration.Type),
-		edge.To("files", File.Type),
-		edge.To("tasks", Task.Type),
+		edge.To("events", Event.Type).Annotations(entgql.RelayConnection()),
+		edge.To("integrations", Integration.Type).Annotations(entgql.RelayConnection()),
+		edge.To("files", File.Type).Annotations(entgql.RelayConnection()),
+		edge.To("tasks", Task.Type).Annotations(entgql.RelayConnection()),
 	}
 }
 
@@ -167,6 +167,7 @@ func (Group) Annotations() []schema.Annotation {
 	return []schema.Annotation{
 		entgql.RelayConnection(),
 		entgql.QueryField(),
+		entgql.MultiOrder(),
 		entgql.Mutations(entgql.MutationCreate(), (entgql.MutationUpdate())),
 		// Delete groups members when groups are deleted
 		entx.CascadeThroughAnnotationField(

--- a/internal/ent/schema/groupmembership.go
+++ b/internal/ent/schema/groupmembership.go
@@ -31,6 +31,9 @@ func (GroupMembership) Fields() []ent.Field {
 	return []ent.Field{
 		field.Enum("role").
 			GoType(enums.Role("")).
+			Annotations(
+				entgql.OrderField("ROLE"),
+			).
 			Default(string(enums.RoleMember)),
 		field.String("group_id").Immutable(),
 		field.String("user_id").Immutable(),

--- a/internal/ent/schema/hush.go
+++ b/internal/ent/schema/hush.go
@@ -60,10 +60,12 @@ func (Hush) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("integrations", Integration.Type).
 			Comment("the integration associated with the secret").
+			Annotations(entgql.RelayConnection()).
 			Ref("secrets"),
 		edge.From("organization", Organization.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("secrets"),
-		edge.To("events", Event.Type),
+		edge.To("events", Event.Type).Annotations(entgql.RelayConnection()),
 	}
 }
 
@@ -72,6 +74,7 @@ func (Hush) Annotations() []schema.Annotation {
 	return []schema.Annotation{
 		entgql.QueryField(),
 		entgql.RelayConnection(),
+		entgql.MultiOrder(),
 		entgql.Mutations(entgql.MutationCreate(), (entgql.MutationUpdate())),
 	}
 }

--- a/internal/ent/schema/integration.go
+++ b/internal/ent/schema/integration.go
@@ -48,8 +48,9 @@ func (Integration) Fields() []ent.Field {
 func (Integration) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.To("secrets", Hush.Type).
+			Annotations(entgql.RelayConnection()).
 			Comment("the secrets associated with the integration"),
-		edge.To("events", Event.Type),
+		edge.To("events", Event.Type).Annotations(entgql.RelayConnection()),
 	}
 }
 
@@ -58,6 +59,7 @@ func (Integration) Annotations() []schema.Annotation {
 	return []schema.Annotation{
 		entgql.QueryField(),
 		entgql.RelayConnection(),
+		entgql.MultiOrder(),
 		entgql.Mutations(entgql.MutationCreate(), (entgql.MutationUpdate())),
 		entfga.OrganizationInheritedChecks(),
 	}

--- a/internal/ent/schema/internalpolicy.go
+++ b/internal/ent/schema/internalpolicy.go
@@ -31,12 +31,13 @@ func (InternalPolicy) Fields() []ent.Field {
 // Edges of the InternalPolicy
 func (InternalPolicy) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.To("control_objectives", ControlObjective.Type),
-		edge.To("controls", Control.Type),
-		edge.To("procedures", Procedure.Type),
-		edge.To("narratives", Narrative.Type),
-		edge.To("tasks", Task.Type),
+		edge.To("control_objectives", ControlObjective.Type).Annotations(entgql.RelayConnection()),
+		edge.To("controls", Control.Type).Annotations(entgql.RelayConnection()),
+		edge.To("procedures", Procedure.Type).Annotations(entgql.RelayConnection()),
+		edge.To("narratives", Narrative.Type).Annotations(entgql.RelayConnection()),
+		edge.To("tasks", Task.Type).Annotations(entgql.RelayConnection()),
 		edge.From("programs", Program.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("internal_policies"),
 	}
 }

--- a/internal/ent/schema/invite.go
+++ b/internal/ent/schema/invite.go
@@ -51,6 +51,9 @@ func (Invite) Fields() []ent.Field {
 			Default(func() time.Time {
 				return time.Now().AddDate(0, 0, defaultInviteExpiresDays)
 			}).
+			Annotations(
+				entgql.OrderField("expires"),
+			).
 			Optional(),
 		field.String("recipient").
 			Comment("the email used as input to generate the invitation token and is the destination person the invitation is sent to who is required to accept to join the organization").
@@ -63,12 +66,18 @@ func (Invite) Fields() []ent.Field {
 		field.Enum("status").
 			Comment("the status of the invitation").
 			GoType(enums.InviteStatus("")).
+			Annotations(
+				entgql.OrderField("STATUS"),
+			).
 			Default(string(enums.InvitationSent)),
 		field.Enum("role").
 			GoType(enums.Role("")).
 			Default(string(enums.RoleMember)),
 		field.Int("send_attempts").
 			Comment("the number of attempts made to perform email send of the invitation, maximum of 5").
+			Annotations(
+				entgql.OrderField("send_attempts"),
+			).
 			Default(0),
 		field.String("requestor_id").
 			Comment("the user who initiated the invitation").
@@ -111,7 +120,7 @@ func (Invite) Indexes() []ent.Index {
 // Edges of the Invite
 func (Invite) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.To("events", Event.Type),
+		edge.To("events", Event.Type).Annotations(entgql.RelayConnection()),
 	}
 }
 
@@ -120,6 +129,7 @@ func (Invite) Annotations() []schema.Annotation {
 	return []schema.Annotation{
 		entgql.QueryField(),
 		entgql.RelayConnection(),
+		entgql.MultiOrder(),
 		entgql.Mutations(entgql.MutationCreate(), (entgql.MutationUpdate())),
 		entfga.OrganizationInheritedChecks(),
 		history.Annotations{

--- a/internal/ent/schema/mappedcontrol.go
+++ b/internal/ent/schema/mappedcontrol.go
@@ -23,6 +23,9 @@ func (MappedControl) Fields() []ent.Field {
 	return []ent.Field{
 		field.String("mapping_type").
 			Comment("the type of mapping between the two controls, e.g. subset, intersect, equal, superset").
+			Annotations(
+				entgql.OrderField("mapping_type"),
+			).
 			Optional(),
 		field.String("relation").
 			Comment("description of how the two controls are related").
@@ -34,8 +37,10 @@ func (MappedControl) Fields() []ent.Field {
 func (MappedControl) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.To("controls", Control.Type).
+			Annotations(entgql.RelayConnection()).
 			Comment("mapped controls that have a relation to each other"),
 		edge.To("subcontrols", Subcontrol.Type).
+			Annotations(entgql.RelayConnection()).
 			Comment("mapped subcontrols that have a relation to each other"),
 	}
 }

--- a/internal/ent/schema/narrative.go
+++ b/internal/ent/schema/narrative.go
@@ -29,6 +29,7 @@ func (Narrative) Fields() []ent.Field {
 			NotEmpty().
 			Annotations(
 				entx.FieldSearchable(),
+				entgql.OrderField("name"),
 			).
 			Comment("the name of the narrative"),
 		field.Text("description").
@@ -48,8 +49,10 @@ func (Narrative) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("satisfies", Control.Type).
 			Comment("which controls are satisfied by the narrative").
+			Annotations(entgql.RelayConnection()).
 			Ref("narratives"),
 		edge.From("programs", Program.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("narratives"),
 	}
 }

--- a/internal/ent/schema/organization.go
+++ b/internal/ent/schema/organization.go
@@ -136,8 +136,8 @@ func (Organization) Edges() []ent.Edge {
 				entx.CascadeAnnotationField("Organization"),
 			),
 
-		edge.To("personal_access_tokens", PersonalAccessToken.Type),
-		edge.To("api_tokens", APIToken.Type),
+		edge.To("personal_access_tokens", PersonalAccessToken.Type).Annotations(entgql.RelayConnection()),
+		edge.To("api_tokens", APIToken.Type).Annotations(entgql.RelayConnection()),
 		edge.From("users", User.Type).
 			Ref("organizations").
 			// Skip the mutation input for the users edge
@@ -148,59 +148,128 @@ func (Organization) Edges() []ent.Edge {
 		// files can be owned by an organization, but don't have to be
 		// only those with the organization id set should be cascade deleted
 		edge.To("files", File.Type).
-			Annotations(entx.CascadeAnnotationField("Organization")),
-		edge.To("events", Event.Type),
-		edge.To("secrets", Hush.Type),
+			Annotations(entx.CascadeAnnotationField("Organization"),
+				entgql.RelayConnection()),
+		edge.To("events", Event.Type).Annotations(entgql.RelayConnection()),
+		edge.To("secrets", Hush.Type).Annotations(entgql.RelayConnection()),
 		edge.To("avatar_file", File.Type).
 			Field("avatar_local_file_id").Unique(),
 
 		// Organization owns the following entities
 		edge.To("groups", Group.Type).
-			Annotations(entx.CascadeAnnotationField("Owner")),
+			Annotations(
+				entx.CascadeAnnotationField("Owner"),
+				entgql.RelayConnection(),
+			),
 		edge.To("templates", Template.Type).
-			Annotations(entx.CascadeAnnotationField("Owner")),
+			Annotations(
+				entx.CascadeAnnotationField("Owner"),
+				entgql.RelayConnection(),
+			),
 		edge.To("integrations", Integration.Type).
-			Annotations(entx.CascadeAnnotationField("Owner")),
+			Annotations(
+				entx.CascadeAnnotationField("Owner"),
+				entgql.RelayConnection(),
+			),
 		edge.To("document_data", DocumentData.Type).
-			Annotations(entx.CascadeAnnotationField("Owner")),
+			Annotations(
+				entx.CascadeAnnotationField("Owner"),
+				entgql.RelayConnection(),
+			),
 		edge.To("org_subscriptions", OrgSubscription.Type).
-			Annotations(entx.CascadeAnnotationField("Owner")),
+			Annotations(
+				entx.CascadeAnnotationField("Owner"),
+			),
 		edge.To("invites", Invite.Type).
-			Annotations(entx.CascadeAnnotationField("Owner")),
+			Annotations(
+				entx.CascadeAnnotationField("Owner"),
+				entgql.RelayConnection(),
+			),
 		edge.To("subscribers", Subscriber.Type).
-			Annotations(entx.CascadeAnnotationField("Owner")),
+			Annotations(
+				entx.CascadeAnnotationField("Owner"),
+				entgql.RelayConnection(),
+			),
 		edge.To("entities", Entity.Type).
-			Annotations(entx.CascadeAnnotationField("Owner")),
+			Annotations(
+				entx.CascadeAnnotationField("Owner"),
+				entgql.RelayConnection(),
+			),
 		edge.To("entity_types", EntityType.Type).
-			Annotations(entx.CascadeAnnotationField("Owner")),
+			Annotations(
+				entx.CascadeAnnotationField("Owner"),
+				entgql.RelayConnection(),
+			),
 		edge.To("contacts", Contact.Type).
-			Annotations(entx.CascadeAnnotationField("Owner")),
+			Annotations(
+				entx.CascadeAnnotationField("Owner"),
+				entgql.RelayConnection(),
+			),
 		edge.To("notes", Note.Type).
-			Annotations(entx.CascadeAnnotationField("Owner")),
+			Annotations(
+				entx.CascadeAnnotationField("Owner"),
+				entgql.RelayConnection(),
+			),
 		edge.To("tasks", Task.Type).
-			Annotations(entx.CascadeAnnotationField("Owner")),
+			Annotations(
+				entx.CascadeAnnotationField("Owner"),
+				entgql.RelayConnection(),
+			),
 		edge.To("programs", Program.Type).
-			Annotations(entx.CascadeAnnotationField("Owner")),
+			Annotations(
+				entx.CascadeAnnotationField("Owner"),
+				entgql.RelayConnection(),
+			),
 		edge.To("procedures", Procedure.Type).
-			Annotations(entx.CascadeAnnotationField("Owner")),
+			Annotations(
+				entx.CascadeAnnotationField("Owner"),
+				entgql.RelayConnection(),
+			),
 		edge.To("internal_policies", InternalPolicy.Type).
-			Annotations(entx.CascadeAnnotationField("Owner")),
+			Annotations(
+				entx.CascadeAnnotationField("Owner"),
+				entgql.RelayConnection(),
+			),
 		edge.To("risks", Risk.Type).
-			Annotations(entx.CascadeAnnotationField("Owner")),
+			Annotations(
+				entx.CascadeAnnotationField("Owner"),
+				entgql.RelayConnection(),
+			),
 		edge.To("control_objectives", ControlObjective.Type).
-			Annotations(entx.CascadeAnnotationField("Owner")),
+			Annotations(
+				entx.CascadeAnnotationField("Owner"),
+				entgql.RelayConnection(),
+			),
 		edge.To("narratives", Narrative.Type).
-			Annotations(entx.CascadeAnnotationField("Owner")),
+			Annotations(
+				entx.CascadeAnnotationField("Owner"),
+				entgql.RelayConnection(),
+			),
 		edge.To("controls", Control.Type).
-			Annotations(entx.CascadeAnnotationField("Owner")),
+			Annotations(
+				entx.CascadeAnnotationField("Owner"),
+				entgql.RelayConnection(),
+			),
 		edge.To("subcontrols", Subcontrol.Type).
-			Annotations(entx.CascadeAnnotationField("Owner")),
+			Annotations(
+				entx.CascadeAnnotationField("Owner"),
+				entgql.RelayConnection(),
+			),
 		edge.To("evidence", Evidence.Type).
-			Annotations(entx.CascadeAnnotationField("Owner")),
+			Annotations(
+				entx.CascadeAnnotationField("Owner"),
+				entgql.RelayConnection(),
+			),
 		edge.To("standards", Standard.Type).
-			Annotations(entx.CascadeAnnotationField("Owner")),
+			Annotations(
+				entx.CascadeAnnotationField("Owner"),
+				entgql.RelayConnection(),
+			),
 		edge.To("action_plans", ActionPlan.Type).
-			Annotations(entx.CascadeAnnotationField("Owner")),
+			Annotations(
+				entx.CascadeAnnotationField("Owner"),
+				entgql.RelayConnection(),
+			),
 	}
 }
 
@@ -219,6 +288,7 @@ func (Organization) Annotations() []schema.Annotation {
 	return []schema.Annotation{
 		entgql.QueryField(),
 		entgql.RelayConnection(),
+		entgql.MultiOrder(),
 		entgql.Mutations(entgql.MutationCreate(), (entgql.MutationUpdate())),
 		// Delete org members when orgs are deleted
 		entx.CascadeThroughAnnotationField(

--- a/internal/ent/schema/organizationsetting.go
+++ b/internal/ent/schema/organizationsetting.go
@@ -81,7 +81,7 @@ func (OrganizationSetting) Fields() []ent.Field {
 func (OrganizationSetting) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("organization", Organization.Type).Ref("setting").Field("organization_id").Unique(),
-		edge.To("files", File.Type),
+		edge.To("files", File.Type).Annotations(entgql.RelayConnection()),
 	}
 }
 

--- a/internal/ent/schema/orgmembership.go
+++ b/internal/ent/schema/orgmembership.go
@@ -34,6 +34,9 @@ func (OrgMembership) Fields() []ent.Field {
 	return []ent.Field{
 		field.Enum("role").
 			GoType(enums.Role("")).
+			Annotations(
+				entgql.OrderField("ROLE"),
+			).
 			Values(string(enums.RoleOwner)). // adds owner to the allowed values
 			Default(string(enums.RoleMember)),
 		field.String("organization_id").Immutable(),
@@ -54,7 +57,7 @@ func (OrgMembership) Edges() []ent.Edge {
 			Required().
 			Unique().
 			Immutable(),
-		edge.To("events", Event.Type),
+		edge.To("events", Event.Type).Annotations(entgql.RelayConnection()),
 	}
 }
 

--- a/internal/ent/schema/orgsubscription.go
+++ b/internal/ent/schema/orgsubscription.go
@@ -28,6 +28,9 @@ func (OrgSubscription) Fields() []ent.Field {
 			Optional(),
 		field.String("product_tier").
 			Comment("the common name of the product tier the subscription is associated with, e.g. starter tier").
+			Annotations(
+				entgql.OrderField("product_tier"),
+			).
 			Optional(),
 		field.JSON("product_price", models.Price{}).
 			Comment("the price of the product tier").
@@ -37,9 +40,15 @@ func (OrgSubscription) Fields() []ent.Field {
 			Optional(),
 		field.String("stripe_subscription_status").
 			Comment("the status of the subscription in stripe -- see https://docs.stripe.com/api/subscriptions/object#subscription_object-status").
+			Annotations(
+				entgql.OrderField("stripe_subscription_status"),
+			).
 			Optional(),
 		field.Bool("active").
 			Comment("indicates if the subscription is active").
+			Annotations(
+				entgql.OrderField("active"),
+			).
 			Default(true),
 		field.String("stripe_customer_id").
 			Comment("the customer ID the subscription is associated to").
@@ -47,14 +56,23 @@ func (OrgSubscription) Fields() []ent.Field {
 			Optional(),
 		field.Time("expires_at").
 			Comment("the time the subscription is set to expire; only populated if subscription is cancelled").
+			Annotations(
+				entgql.OrderField("expires_at"),
+			).
 			Nillable().
 			Optional(),
 		field.Time("trial_expires_at").
 			Comment("the time the trial is set to expire").
+			Annotations(
+				entgql.OrderField("trial_expires_at"),
+			).
 			Nillable().
 			Optional(),
 		field.String("days_until_due").
 			Comment("number of days until there is a due payment").
+			Annotations(
+				entgql.OrderField("days_until_due"),
+			).
 			Nillable().
 			Optional(),
 		field.Bool("payment_method_added").

--- a/internal/ent/schema/personalaccesstoken.go
+++ b/internal/ent/schema/personalaccesstoken.go
@@ -84,8 +84,9 @@ func (PersonalAccessToken) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("organizations", Organization.Type).
 			Ref("personal_access_tokens").
+			Annotations(entgql.RelayConnection()).
 			Comment("the organization(s) the token is associated with"),
-		edge.To("events", Event.Type),
+		edge.To("events", Event.Type).Annotations(entgql.RelayConnection()),
 	}
 }
 

--- a/internal/ent/schema/procedure.go
+++ b/internal/ent/schema/procedure.go
@@ -32,13 +32,16 @@ func (Procedure) Fields() []ent.Field {
 func (Procedure) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("controls", Control.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("procedures"),
 		edge.From("internal_policies", InternalPolicy.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("procedures"),
-		edge.To("narratives", Narrative.Type),
-		edge.To("risks", Risk.Type),
-		edge.To("tasks", Task.Type),
+		edge.To("narratives", Narrative.Type).Annotations(entgql.RelayConnection()),
+		edge.To("risks", Risk.Type).Annotations(entgql.RelayConnection()),
+		edge.To("tasks", Task.Type).Annotations(entgql.RelayConnection()),
 		edge.From("programs", Program.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("procedures"),
 	}
 }

--- a/internal/ent/schema/program.go
+++ b/internal/ent/schema/program.go
@@ -30,7 +30,10 @@ func (Program) Fields() []ent.Field {
 		field.String("name").
 			Comment("the name of the program").
 			NotEmpty().
-			Annotations(entx.FieldSearchable()),
+			Annotations(
+				entx.FieldSearchable(),
+				entgql.OrderField("name"),
+			),
 		field.String("description").
 			Comment("the description of the program").
 			Annotations(
@@ -40,12 +43,21 @@ func (Program) Fields() []ent.Field {
 		field.Enum("status").
 			Comment("the status of the program").
 			GoType(enums.ProgramStatus("")).
+			Annotations(
+				entgql.OrderField("STATUS"),
+			).
 			Default(enums.ProgramStatusNotStarted.String()),
 		field.Time("start_date").
 			Comment("the start date of the period").
+			Annotations(
+				entgql.OrderField("start_date"),
+			).
 			Optional(),
 		field.Time("end_date").
 			Comment("the end date of the period").
+			Annotations(
+				entgql.OrderField("end_date"),
+			).
 			Optional(),
 		field.Bool("auditor_ready").
 			Comment("is the program ready for the auditor").
@@ -77,34 +89,34 @@ func (Program) Mixin() []ent.Mixin {
 func (Program) Edges() []ent.Edge {
 	return []ent.Edge{
 		// programs can have 1:many controls
-		edge.To("controls", Control.Type),
+		edge.To("controls", Control.Type).Annotations(entgql.RelayConnection()),
 		// programs can have 1:many subcontrols
-		edge.To("subcontrols", Subcontrol.Type),
+		edge.To("subcontrols", Subcontrol.Type).Annotations(entgql.RelayConnection()),
 		// programs can have 1:many control objectives
-		edge.To("control_objectives", ControlObjective.Type),
+		edge.To("control_objectives", ControlObjective.Type).Annotations(entgql.RelayConnection()),
 		// programs can have 1:many associated policies
-		edge.To("internal_policies", InternalPolicy.Type),
+		edge.To("internal_policies", InternalPolicy.Type).Annotations(entgql.RelayConnection()),
 		// programs can have 1:many associated procedures
-		edge.To("procedures", Procedure.Type),
+		edge.To("procedures", Procedure.Type).Annotations(entgql.RelayConnection()),
 		// programs can have 1:many associated risks
-		edge.To("risks", Risk.Type),
+		edge.To("risks", Risk.Type).Annotations(entgql.RelayConnection()),
 		// programs can have 1:many associated tasks
-		edge.To("tasks", Task.Type),
+		edge.To("tasks", Task.Type).Annotations(entgql.RelayConnection()),
 		// programs can have 1:many associated notes (comments)
-		edge.To("notes", Note.Type),
+		edge.To("notes", Note.Type).Annotations(entgql.RelayConnection()),
 		// programs can have 1:many associated files
-		edge.To("files", File.Type),
+		edge.To("files", File.Type).Annotations(entgql.RelayConnection()),
 		// programs can be many:many with evidence
-		edge.To("evidence", Evidence.Type),
+		edge.To("evidence", Evidence.Type).Annotations(entgql.RelayConnection()),
 		// programs can have 1:many associated narratives
-		edge.To("narratives", Narrative.Type),
+		edge.To("narratives", Narrative.Type).Annotations(entgql.RelayConnection()),
 		// programs can have 1:many associated action plans
 		edge.To("action_plans", ActionPlan.Type),
 		edge.From("users", User.Type).
 			Ref("programs").
 			// Skip the mutation input for the users edge
 			// this should be done via the members edge
-			Annotations(entgql.Skip(entgql.SkipMutationCreateInput, entgql.SkipMutationUpdateInput)).
+			Annotations(entgql.Skip(entgql.SkipMutationCreateInput, entgql.SkipMutationUpdateInput), entgql.RelayConnection()).
 			Through("members", ProgramMembership.Type),
 	}
 }
@@ -114,6 +126,7 @@ func (Program) Annotations() []schema.Annotation {
 	return []schema.Annotation{
 		entgql.QueryField(),
 		entgql.RelayConnection(),
+		entgql.MultiOrder(),
 		entgql.Mutations(entgql.MutationCreate(), (entgql.MutationUpdate())),
 		// Delete groups members when groups are deleted
 		entx.CascadeThroughAnnotationField(

--- a/internal/ent/schema/programmembership.go
+++ b/internal/ent/schema/programmembership.go
@@ -31,7 +31,10 @@ func (ProgramMembership) Fields() []ent.Field {
 	return []ent.Field{
 		field.Enum("role").
 			GoType(enums.Role("")).
-			Default(string(enums.RoleMember)),
+			Default(string(enums.RoleMember)).
+			Annotations(
+				entgql.OrderField("ROLE"),
+			),
 		field.String("program_id").Immutable(),
 		field.String("user_id").Immutable(),
 	}

--- a/internal/ent/schema/risk.go
+++ b/internal/ent/schema/risk.go
@@ -30,31 +30,51 @@ func (Risk) Fields() []ent.Field {
 			NotEmpty().
 			Annotations(
 				entx.FieldSearchable(),
+				entgql.OrderField("name"),
 			).
 			Comment("the name of the risk"),
 		field.Enum("status").
 			GoType(enums.RiskStatus("")).
 			Default(enums.RiskOpen.String()).
+			Annotations(
+				entgql.OrderField("STATUS"),
+			).
 			Optional().
 			Comment("status of the risk - open, mitigated, ongoing, in-progress, and archived."),
 		field.String("risk_type").
+			Annotations(
+				entgql.OrderField("risk_type"),
+			).
 			Optional().
 			Comment("type of the risk, e.g. strategic, operational, financial, external, etc."),
 		field.String("category").
 			Optional().
+			Annotations(
+				entgql.OrderField("category"),
+			).
 			Comment("category of the risk, e.g. human resources, operations, IT, etc."),
 		field.Enum("impact").
 			GoType(enums.RiskImpact("")).
 			Default(enums.RiskImpactModerate.String()).
+			Annotations(
+				entgql.OrderField("IMPACT"),
+			).
 			Optional().
 			Comment("impact of the risk -critical, high, medium, low"),
 		field.Enum("likelihood").
 			GoType(enums.RiskLikelihood("")).
 			Default(enums.RiskLikelihoodMid.String()).
 			Optional().
+			Annotations(
+				entgql.OrderField("LIKELIHOOD"),
+			).
 			Comment("likelihood of the risk occurring; unlikely, likely, highly likely"),
 		field.Int("score").
 			Optional().
+			Annotations(
+				entgql.OrderField("score"),
+				entx.FieldSearchable(),
+			).
 			Comment("score of the risk based on impact and likelihood (1-4 unlikely, 5-9 likely, 10-16 highly likely, 17-20 critical)"),
 		field.Text("mitigation").
 			Optional().
@@ -63,6 +83,9 @@ func (Risk) Fields() []ent.Field {
 			Optional().
 			Comment("details of the risk"),
 		field.Text("business_costs").
+			Annotations(
+				entgql.OrderField("business_costs"),
+			).
 			Optional().
 			Comment("business costs associated with the risk"),
 	}
@@ -72,11 +95,14 @@ func (Risk) Fields() []ent.Field {
 func (Risk) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("control", Control.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("risks"),
 		edge.From("procedure", Procedure.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("risks"),
-		edge.To("action_plans", ActionPlan.Type),
+		edge.To("action_plans", ActionPlan.Type).Annotations(entgql.RelayConnection()),
 		edge.From("programs", Program.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("risks"), // risk can be associated to 1:m programs, this allow permission inheritance from the program(s)
 
 		edge.To("stakeholder", Group.Type).
@@ -113,6 +139,7 @@ func (Risk) Annotations() []schema.Annotation {
 	return []schema.Annotation{
 		entgql.RelayConnection(),
 		entgql.QueryField(),
+		entgql.MultiOrder(),
 		entgql.Mutations(entgql.MutationCreate(), (entgql.MutationUpdate())),
 		entfga.SelfAccessChecks(),
 	}

--- a/internal/ent/schema/standard.go
+++ b/internal/ent/schema/standard.go
@@ -32,6 +32,7 @@ func (Standard) Fields() []ent.Field {
 			NotEmpty().
 			Annotations(
 				entx.FieldSearchable(),
+				entgql.OrderField("name"),
 			).
 			Comment("the long name of the standard body").
 			Annotations(entx.FieldSearchable()),
@@ -39,10 +40,15 @@ func (Standard) Fields() []ent.Field {
 			Optional().
 			Annotations(
 				entx.FieldSearchable(),
+				entgql.OrderField("short_name"),
 			).
 			Comment("short name of the standard, e.g. SOC 2, ISO 27001, etc."),
 		field.Text("framework").
 			Optional().
+			Annotations(
+				entx.FieldSearchable(),
+				entgql.OrderField("framework"),
+			).
 			Comment("unique identifier of the standard with version"),
 		field.String("description").
 			Optional().
@@ -57,8 +63,15 @@ func (Standard) Fields() []ent.Field {
 			Optional(),
 		field.String("governing_body").
 			Optional().
+			Annotations(
+				entx.FieldSearchable(),
+				entgql.OrderField("governing_body"),
+			).
 			Comment("governing body of the standard, e.g. AICPA, etc."),
 		field.Strings("domains").
+			Annotations(
+				entx.FieldSearchable(),
+			).
 			Optional().
 			Comment("domains the standard covers, e.g. availability, confidentiality, etc."),
 		field.String("link").
@@ -68,6 +81,9 @@ func (Standard) Fields() []ent.Field {
 			GoType(enums.StandardStatus("")).
 			Default(enums.StandardActive.String()).
 			Optional().
+			Annotations(
+				entgql.OrderField("STATUS"),
+			).
 			Comment("status of the standard - active, draft, and archived"),
 		field.Bool("is_public").
 			Optional().
@@ -82,6 +98,9 @@ func (Standard) Fields() []ent.Field {
 			Default(false).
 			Comment("indicates if the standard is owned by the the openlane system"),
 		field.String("standard_type").
+			Annotations(
+				entgql.OrderField("standard_type"),
+			).
 			Optional().
 			Comment("type of the standard - cybersecurity, healthcare , financial, etc."),
 		field.String("version").
@@ -93,7 +112,7 @@ func (Standard) Fields() []ent.Field {
 // Edges of the Standard
 func (Standard) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.To("controls", Control.Type),
+		edge.To("controls", Control.Type).Annotations(entgql.RelayConnection()),
 	}
 }
 
@@ -131,6 +150,7 @@ func (Standard) Annotations() []schema.Annotation {
 	return []schema.Annotation{
 		entgql.RelayConnection(),
 		entgql.QueryField(),
+		entgql.MultiOrder(),
 		entgql.Mutations(entgql.MutationCreate(), (entgql.MutationUpdate())),
 	}
 }

--- a/internal/ent/schema/subcontrol.go
+++ b/internal/ent/schema/subcontrol.go
@@ -32,6 +32,7 @@ func (Subcontrol) Fields() []ent.Field {
 		field.String("ref_code").
 			Annotations(
 				entx.FieldSearchable(),
+				entgql.OrderField("ref_code"),
 			).
 			NotEmpty().
 			Comment("the unique reference code for the control"),
@@ -61,19 +62,20 @@ func (Subcontrol) Edges() []ent.Edge {
 
 		// evidence can be associated with the control
 		edge.From("evidence", Evidence.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("subcontrols"),
 
-		edge.To("control_objectives", ControlObjective.Type),
+		edge.To("control_objectives", ControlObjective.Type).Annotations(entgql.RelayConnection()),
 
 		// sub controls can have associated task, narratives, risks, and action plans
-		edge.To("tasks", Task.Type),
-		edge.To("narratives", Narrative.Type),
-		edge.To("risks", Risk.Type),
-		edge.To("action_plans", ActionPlan.Type),
+		edge.To("tasks", Task.Type).Annotations(entgql.RelayConnection()),
+		edge.To("narratives", Narrative.Type).Annotations(entgql.RelayConnection()),
+		edge.To("risks", Risk.Type).Annotations(entgql.RelayConnection()),
+		edge.To("action_plans", ActionPlan.Type).Annotations(entgql.RelayConnection()),
 
 		// policies and procedures are used to implement the subcontrol
-		edge.To("procedures", Procedure.Type),
-		edge.To("internal_policies", InternalPolicy.Type),
+		edge.To("procedures", Procedure.Type).Annotations(entgql.RelayConnection()),
+		edge.To("internal_policies", InternalPolicy.Type).Annotations(entgql.RelayConnection()),
 
 		// owner is the user who is responsible for the subcontrol
 		edge.To("control_owner", Group.Type).
@@ -117,6 +119,7 @@ func (Subcontrol) Annotations() []schema.Annotation {
 	return []schema.Annotation{
 		entgql.RelayConnection(),
 		entgql.QueryField(),
+		entgql.MultiOrder(),
 		entgql.Mutations(entgql.MutationCreate(), (entgql.MutationUpdate())),
 		entfga.SelfAccessChecks(),
 	}

--- a/internal/ent/schema/subscriber.go
+++ b/internal/ent/schema/subscriber.go
@@ -38,6 +38,7 @@ func (Subscriber) Fields() []ent.Field {
 			Comment("email address of the subscriber").
 			Annotations(
 				entx.FieldSearchable(),
+				entgql.OrderField("email"),
 			).
 			Validate(func(email string) error {
 				_, err := mail.ParseAddress(email)
@@ -62,7 +63,7 @@ func (Subscriber) Fields() []ent.Field {
 		field.Bool("active").
 			Comment("indicates if the subscriber is active or not, active users will have at least one verified contact method").
 			Default(false).
-			Annotations(entgql.Skip(entgql.SkipMutationCreateInput, entgql.SkipMutationUpdateInput)),
+			Annotations(entgql.Skip(entgql.SkipMutationCreateInput, entgql.SkipMutationUpdateInput), entgql.OrderField("active")),
 		field.String("token").
 			Comment("the verification token sent to the user via email which should only be provided to the /subscribe endpoint + handler").
 			Unique().
@@ -102,7 +103,7 @@ func (Subscriber) Mixin() []ent.Mixin {
 // Edges of the Subscriber
 func (Subscriber) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.To("events", Event.Type),
+		edge.To("events", Event.Type).Annotations(entgql.RelayConnection()),
 	}
 }
 
@@ -128,6 +129,7 @@ func (Subscriber) Annotations() []schema.Annotation {
 	return []schema.Annotation{
 		entgql.QueryField(),
 		entgql.RelayConnection(),
+		entgql.MultiOrder(),
 		entgql.Mutations(entgql.MutationCreate(), (entgql.MutationUpdate())),
 		entfga.OrganizationInheritedChecks(),
 		history.Annotations{

--- a/internal/ent/schema/task.go
+++ b/internal/ent/schema/task.go
@@ -30,6 +30,7 @@ func (Task) Fields() []ent.Field {
 			Comment("the title of the task").
 			Annotations(
 				entx.FieldSearchable(),
+				entgql.OrderField("title"),
 			).
 			NotEmpty(),
 		field.String("description").
@@ -44,15 +45,27 @@ func (Task) Fields() []ent.Field {
 		field.Enum("status").
 			GoType(enums.TaskStatus("")).
 			Comment("the status of the task").
+			Annotations(
+				entgql.OrderField("STATUS"),
+			).
 			Default(enums.TaskStatusOpen.String()),
 		field.String("category").
 			Comment("the category of the task, e.g. evidence upload, risk review, policy review, etc.").
+			Annotations(
+				entgql.OrderField("category"),
+			).
 			Optional(),
 		field.Time("due").
 			Comment("the due date of the task").
+			Annotations(
+				entgql.OrderField("due"),
+			).
 			Optional(),
 		field.Time("completed").
 			Comment("the completion date of the task").
+			Annotations(
+				entgql.OrderField("completed"),
+			).
 			Optional(),
 		field.String("assignee_id").
 			Comment("the id of the user who was assigned the task").
@@ -90,22 +103,30 @@ func (Task) Edges() []ent.Edge {
 			Field("assignee_id").
 			Unique(),
 		edge.To("comments", Note.Type).
+			Annotations(entgql.RelayConnection()).
 			Comment("conversations related to the task"),
 		edge.From("group", Group.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("tasks"),
 		edge.From("internal_policy", InternalPolicy.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("tasks"),
 		edge.From("procedure", Procedure.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("tasks"),
 		edge.From("control", Control.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("tasks"),
 		edge.From("control_objective", ControlObjective.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("tasks"),
 		edge.From("subcontrol", Subcontrol.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("tasks"),
 		edge.From("program", Program.Type).
+			Annotations(entgql.RelayConnection()).
 			Ref("tasks"),
-		edge.To("evidence", Evidence.Type),
+		edge.To("evidence", Evidence.Type).Annotations(entgql.RelayConnection()),
 	}
 }
 
@@ -114,6 +135,7 @@ func (Task) Annotations() []schema.Annotation {
 	return []schema.Annotation{
 		entgql.QueryField(),
 		entgql.RelayConnection(),
+		entgql.MultiOrder(),
 		entgql.Mutations(entgql.MutationCreate(), (entgql.MutationUpdate())),
 		entfga.SelfAccessChecks(),
 	}

--- a/internal/ent/schema/template.go
+++ b/internal/ent/schema/template.go
@@ -48,6 +48,9 @@ func (Template) Fields() []ent.Field {
 		field.Enum("template_type").
 			Comment("the type of the template, either a provided template or an implementation (document)").
 			GoType(enums.DocumentType("")).
+			Annotations(
+				entgql.OrderField("TEMPLATE_TYPE"),
+			).
 			Default(string(enums.Document)),
 		field.String("description").
 			Comment("the description of the template").
@@ -69,8 +72,9 @@ func (Template) Edges() []ent.Edge {
 		edge.To("documents", DocumentData.Type).
 			Annotations(
 				entx.CascadeAnnotationField("Template"),
+				entgql.RelayConnection(),
 			),
-		edge.To("files", File.Type),
+		edge.To("files", File.Type).Annotations(entgql.RelayConnection()),
 	}
 }
 
@@ -88,6 +92,7 @@ func (Template) Annotations() []schema.Annotation {
 	return []schema.Annotation{
 		entgql.RelayConnection(),
 		entgql.QueryField(),
+		entgql.MultiOrder(),
 		entgql.Mutations(entgql.MutationCreate(), (entgql.MutationUpdate())),
 		entfga.OrganizationInheritedChecks(),
 	}

--- a/internal/ent/schema/user.go
+++ b/internal/ent/schema/user.go
@@ -150,9 +150,13 @@ func (User) Indexes() []ent.Index {
 func (User) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.To("personal_access_tokens", PersonalAccessToken.Type).
-			Annotations(entx.CascadeAnnotationField("Owner")),
+			Annotations(
+				entx.CascadeAnnotationField("Owner"),
+				entgql.RelayConnection()),
 		edge.To("tfa_settings", TFASetting.Type).
-			Annotations(entx.CascadeAnnotationField("Owner")),
+			Annotations(
+				entx.CascadeAnnotationField("Owner"),
+				entgql.RelayConnection()),
 		edge.To("setting", UserSetting.Type).
 			Required().
 			Unique().
@@ -162,25 +166,27 @@ func (User) Edges() []ent.Edge {
 		edge.To("email_verification_tokens", EmailVerificationToken.Type).
 			Annotations(
 				entx.CascadeAnnotationField("Owner"),
-			),
+				entgql.RelayConnection()),
 		edge.To("password_reset_tokens", PasswordResetToken.Type).
 			Annotations(
 				entx.CascadeAnnotationField("Owner"),
-			),
+				entgql.RelayConnection()),
 		edge.To("groups", Group.Type).
 			Through("group_memberships", GroupMembership.Type),
 		edge.To("organizations", Organization.Type).
 			Through("org_memberships", OrgMembership.Type),
 		edge.To("webauthn", Webauthn.Type).
-			Annotations(entx.CascadeAnnotationField("Owner")),
-		edge.To("files", File.Type),
+			Annotations(
+				entx.CascadeAnnotationField("Owner"),
+				entgql.RelayConnection()),
+		edge.To("files", File.Type).Annotations(entgql.RelayConnection()),
 		edge.To("avatar_file", File.Type).
 			Field("avatar_local_file_id").Unique(),
-		edge.To("events", Event.Type),
-		edge.To("action_plans", ActionPlan.Type),
-		edge.To("subcontrols", Subcontrol.Type),
-		edge.To("assigner_tasks", Task.Type),
-		edge.To("assignee_tasks", Task.Type),
+		edge.To("events", Event.Type).Annotations(entgql.RelayConnection()),
+		edge.To("action_plans", ActionPlan.Type).Annotations(entgql.RelayConnection()),
+		edge.To("subcontrols", Subcontrol.Type).Annotations(entgql.RelayConnection()),
+		edge.To("assigner_tasks", Task.Type).Annotations(entgql.RelayConnection()),
+		edge.To("assignee_tasks", Task.Type).Annotations(entgql.RelayConnection()),
 		edge.To("programs", Program.Type).
 			Through("program_memberships", ProgramMembership.Type),
 	}
@@ -191,6 +197,7 @@ func (User) Annotations() []schema.Annotation {
 	return []schema.Annotation{
 		entgql.QueryField(),
 		entgql.RelayConnection(),
+		entgql.MultiOrder(),
 		entgql.Mutations(entgql.MutationCreate(), (entgql.MutationUpdate())),
 		// Delete users from groups and orgs when the user is deleted
 		entx.CascadeThroughAnnotationField(

--- a/internal/ent/schema/usersetting.go
+++ b/internal/ent/schema/usersetting.go
@@ -77,11 +77,15 @@ func (UserSetting) Fields() []ent.Field {
 // Edges of the UserSetting
 func (UserSetting) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.From("user", User.Type).Ref("setting").Unique().Field("user_id"),
+		edge.From("user", User.Type).
+			Ref("setting").
+			Unique().
+			Field("user_id"),
 		edge.To("default_org", Organization.Type).
 			Unique().
 			Comment("organization to load on user login"),
-		edge.To("files", File.Type),
+		edge.To("files", File.Type).
+			Annotations(entgql.RelayConnection()),
 	}
 }
 

--- a/internal/graphapi/clientschema/schema.graphql
+++ b/internal/graphapi/clientschema/schema.graphql
@@ -424,10 +424,130 @@ type ActionPlan implements Node {
 	"""
 	delegate: Group
 	owner: Organization
-	risk: [Risk!]
-	control: [Control!]
-	user: [User!]
-	program: [Program!]
+	risk(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Risks returned from the connection.
+		"""
+		orderBy: [RiskOrder!]
+
+		"""
+		Filtering options for Risks returned from the connection.
+		"""
+		where: RiskWhereInput
+	): RiskConnection!
+	control(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Controls returned from the connection.
+		"""
+		orderBy: [ControlOrder!]
+
+		"""
+		Filtering options for Controls returned from the connection.
+		"""
+		where: ControlWhereInput
+	): ControlConnection!
+	user(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Users returned from the connection.
+		"""
+		orderBy: [UserOrder!]
+
+		"""
+		Filtering options for Users returned from the connection.
+		"""
+		where: UserWhereInput
+	): UserConnection!
+	program(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Programs returned from the connection.
+		"""
+		orderBy: [ProgramOrder!]
+
+		"""
+		Filtering options for Programs returned from the connection.
+		"""
+		where: ProgramWhereInput
+	): ProgramConnection!
 }
 """
 Return response for createBulkActionPlan mutation
@@ -625,6 +745,27 @@ enum ActionPlanHistoryOpType @goModel(model: "github.com/theopenlane/entx/histor
 	INSERT
 	UPDATE
 	DELETE
+}
+"""
+Ordering options for ActionPlanHistory connections
+"""
+input ActionPlanHistoryOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order ActionPlanHistories.
+	"""
+	field: ActionPlanHistoryOrderField!
+}
+"""
+Properties by which ActionPlanHistory connections can be ordered.
+"""
+enum ActionPlanHistoryOrderField {
+	due_date
+	PRIORITY
+	source
 }
 """
 ActionPlanHistoryPriority is enum for the field priority
@@ -951,6 +1092,27 @@ input ActionPlanHistoryWhereInput {
 	sourceNotNil: Boolean
 	sourceEqualFold: String
 	sourceContainsFold: String
+}
+"""
+Ordering options for ActionPlan connections
+"""
+input ActionPlanOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order ActionPlans.
+	"""
+	field: ActionPlanOrderField!
+}
+"""
+Properties by which ActionPlan connections can be ordered.
+"""
+enum ActionPlanOrderField {
+	due_date
+	PRIORITY
+	source
 }
 """
 ActionPlanPriority is enum for the field priority
@@ -1394,8 +1556,63 @@ type Contact implements Node {
 	"""
 	status: ContactUserStatus!
 	owner: Organization
-	entities: [Entity!]
-	files: [File!]
+	entities(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Entities returned from the connection.
+		"""
+		orderBy: [EntityOrder!]
+
+		"""
+		Filtering options for Entities returned from the connection.
+		"""
+		where: EntityWhereInput
+	): EntityConnection!
+	files(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Files returned from the connection.
+		"""
+		where: FileWhereInput
+	): FileConnection!
 }
 """
 Return response for createBulkContact mutation
@@ -1539,6 +1756,29 @@ enum ContactHistoryOpType @goModel(model: "github.com/theopenlane/entx/history.O
 	INSERT
 	UPDATE
 	DELETE
+}
+"""
+Ordering options for ContactHistory connections
+"""
+input ContactHistoryOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order ContactHistories.
+	"""
+	field: ContactHistoryOrderField!
+}
+"""
+Properties by which ContactHistory connections can be ordered.
+"""
+enum ContactHistoryOrderField {
+	full_name
+	title
+	company
+	email
+	STATUS
 }
 """
 ContactHistoryUserStatus is enum for the field status
@@ -1831,6 +2071,29 @@ input ContactHistoryWhereInput {
 	statusNEQ: ContactHistoryUserStatus
 	statusIn: [ContactHistoryUserStatus!]
 	statusNotIn: [ContactHistoryUserStatus!]
+}
+"""
+Ordering options for Contact connections
+"""
+input ContactOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order Contacts.
+	"""
+	field: ContactOrderField!
+}
+"""
+Properties by which Contact connections can be ordered.
+"""
+enum ContactOrderField {
+	full_name
+	title
+	company
+	email
+	STATUS
 }
 type ContactSearchResult {
 	contacts: [Contact!]
@@ -2213,24 +2476,338 @@ type Control implements Node {
 	"""
 	viewers: [Group!]
 	standard: Standard
-	programs: [Program!]
-	evidence: [Evidence!]
-	"""
-	the implementation(s) of the control
-	"""
-	controlImplementations: [ControlImplementation!]
-	"""
-	mapped subcontrols that have a relation to another control or subcontrol
-	"""
-	mappedControls: [MappedControl!]
+	programs(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Programs returned from the connection.
+		"""
+		orderBy: [ProgramOrder!]
+
+		"""
+		Filtering options for Programs returned from the connection.
+		"""
+		where: ProgramWhereInput
+	): ProgramConnection!
+	evidence(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Evidences returned from the connection.
+		"""
+		orderBy: [EvidenceOrder!]
+
+		"""
+		Filtering options for Evidences returned from the connection.
+		"""
+		where: EvidenceWhereInput
+	): EvidenceConnection!
+	controlImplementations(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for ControlImplementations returned from the connection.
+		"""
+		orderBy: [ControlImplementationOrder!]
+
+		"""
+		Filtering options for ControlImplementations returned from the connection.
+		"""
+		where: ControlImplementationWhereInput
+	): ControlImplementationConnection!
+	mappedControls(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for MappedControls returned from the connection.
+		"""
+		orderBy: MappedControlOrder
+
+		"""
+		Filtering options for MappedControls returned from the connection.
+		"""
+		where: MappedControlWhereInput
+	): MappedControlConnection!
 	controlObjectives: [ControlObjective!]
-	subcontrols: [Subcontrol!]
-	tasks: [Task!]
-	narratives: [Narrative!]
-	risks: [Risk!]
-	actionPlans: [ActionPlan!]
-	procedures: [Procedure!]
-	internalPolicies: [InternalPolicy!]
+	subcontrols(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Subcontrols returned from the connection.
+		"""
+		orderBy: [SubcontrolOrder!]
+
+		"""
+		Filtering options for Subcontrols returned from the connection.
+		"""
+		where: SubcontrolWhereInput
+	): SubcontrolConnection!
+	tasks(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Tasks returned from the connection.
+		"""
+		orderBy: [TaskOrder!]
+
+		"""
+		Filtering options for Tasks returned from the connection.
+		"""
+		where: TaskWhereInput
+	): TaskConnection!
+	narratives(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Narratives returned from the connection.
+		"""
+		orderBy: NarrativeOrder
+
+		"""
+		Filtering options for Narratives returned from the connection.
+		"""
+		where: NarrativeWhereInput
+	): NarrativeConnection!
+	risks(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Risks returned from the connection.
+		"""
+		orderBy: [RiskOrder!]
+
+		"""
+		Filtering options for Risks returned from the connection.
+		"""
+		where: RiskWhereInput
+	): RiskConnection!
+	actionPlans(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for ActionPlans returned from the connection.
+		"""
+		orderBy: [ActionPlanOrder!]
+
+		"""
+		Filtering options for ActionPlans returned from the connection.
+		"""
+		where: ActionPlanWhereInput
+	): ActionPlanConnection!
+	procedures(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Procedures returned from the connection.
+		"""
+		where: ProcedureWhereInput
+	): ProcedureConnection!
+	internalPolicies(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for InternalPolicies returned from the connection.
+		"""
+		where: InternalPolicyWhereInput
+	): InternalPolicyConnection!
 	"""
 	the group of users who are responsible for the control, will be assigned tasks, approval, etc.
 	"""
@@ -2458,6 +3035,29 @@ enum ControlHistoryOpType @goModel(model: "github.com/theopenlane/entx/history.O
 	INSERT
 	UPDATE
 	DELETE
+}
+"""
+Ordering options for ControlHistory connections
+"""
+input ControlHistoryOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order ControlHistories.
+	"""
+	field: ControlHistoryOrderField!
+}
+"""
+Properties by which ControlHistory connections can be ordered.
+"""
+enum ControlHistoryOrderField {
+	status
+	SOURCE
+	CONTROL_TYPE
+	category
+	subcategory
 }
 """
 ControlHistoryWhereInput is used for filtering ControlHistory objects.
@@ -2818,7 +3418,37 @@ type ControlImplementation implements Node {
 	details of the control implementation
 	"""
 	details: String
-	controls: [Control!]
+	controls(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Controls returned from the connection.
+		"""
+		orderBy: [ControlOrder!]
+
+		"""
+		Filtering options for Controls returned from the connection.
+		"""
+		where: ControlWhereInput
+	): ControlConnection!
 }
 """
 Return response for createBulkControlImplementation mutation
@@ -2970,6 +3600,28 @@ enum ControlImplementationHistoryOpType @goModel(model: "github.com/theopenlane/
 	INSERT
 	UPDATE
 	DELETE
+}
+"""
+Ordering options for ControlImplementationHistory connections
+"""
+input ControlImplementationHistoryOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order ControlImplementationHistories.
+	"""
+	field: ControlImplementationHistoryOrderField!
+}
+"""
+Properties by which ControlImplementationHistory connections can be ordered.
+"""
+enum ControlImplementationHistoryOrderField {
+	STATUS
+	implementation_date
+	verified
+	verification_date
 }
 """
 ControlImplementationHistoryWhereInput is used for filtering ControlImplementationHistory objects.
@@ -3181,6 +3833,28 @@ input ControlImplementationHistoryWhereInput {
 	detailsNotNil: Boolean
 	detailsEqualFold: String
 	detailsContainsFold: String
+}
+"""
+Ordering options for ControlImplementation connections
+"""
+input ControlImplementationOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order ControlImplementations.
+	"""
+	field: ControlImplementationOrderField!
+}
+"""
+Properties by which ControlImplementation connections can be ordered.
+"""
+enum ControlImplementationOrderField {
+	STATUS
+	implementation_date
+	verified
+	verification_date
 }
 type ControlImplementationSearchResult {
 	controlImplementations: [ControlImplementation!]
@@ -3439,15 +4113,275 @@ type ControlObjective implements Node {
 	provides view access to the risk to members of the group
 	"""
 	viewers: [Group!]
-	programs: [Program!]
-	evidence: [Evidence!]
-	controls: [Control!]
-	subcontrols: [Subcontrol!]
-	internalPolicies: [InternalPolicy!]
-	procedures: [Procedure!]
-	risks: [Risk!]
-	narratives: [Narrative!]
-	tasks: [Task!]
+	programs(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Programs returned from the connection.
+		"""
+		orderBy: [ProgramOrder!]
+
+		"""
+		Filtering options for Programs returned from the connection.
+		"""
+		where: ProgramWhereInput
+	): ProgramConnection!
+	evidence(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Evidences returned from the connection.
+		"""
+		orderBy: [EvidenceOrder!]
+
+		"""
+		Filtering options for Evidences returned from the connection.
+		"""
+		where: EvidenceWhereInput
+	): EvidenceConnection!
+	controls(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Controls returned from the connection.
+		"""
+		orderBy: [ControlOrder!]
+
+		"""
+		Filtering options for Controls returned from the connection.
+		"""
+		where: ControlWhereInput
+	): ControlConnection!
+	subcontrols(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Subcontrols returned from the connection.
+		"""
+		orderBy: [SubcontrolOrder!]
+
+		"""
+		Filtering options for Subcontrols returned from the connection.
+		"""
+		where: SubcontrolWhereInput
+	): SubcontrolConnection!
+	internalPolicies(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for InternalPolicies returned from the connection.
+		"""
+		where: InternalPolicyWhereInput
+	): InternalPolicyConnection!
+	procedures(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Procedures returned from the connection.
+		"""
+		where: ProcedureWhereInput
+	): ProcedureConnection!
+	risks(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Risks returned from the connection.
+		"""
+		orderBy: [RiskOrder!]
+
+		"""
+		Filtering options for Risks returned from the connection.
+		"""
+		where: RiskWhereInput
+	): RiskConnection!
+	narratives(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Narratives returned from the connection.
+		"""
+		orderBy: NarrativeOrder
+
+		"""
+		Filtering options for Narratives returned from the connection.
+		"""
+		where: NarrativeWhereInput
+	): NarrativeConnection!
+	tasks(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Tasks returned from the connection.
+		"""
+		orderBy: [TaskOrder!]
+
+		"""
+		Filtering options for Tasks returned from the connection.
+		"""
+		where: TaskWhereInput
+	): TaskConnection!
 }
 """
 Return response for createBulkControlObjective mutation
@@ -3617,6 +4551,30 @@ enum ControlObjectiveHistoryOpType @goModel(model: "github.com/theopenlane/entx/
 	INSERT
 	UPDATE
 	DELETE
+}
+"""
+Ordering options for ControlObjectiveHistory connections
+"""
+input ControlObjectiveHistoryOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order ControlObjectiveHistories.
+	"""
+	field: ControlObjectiveHistoryOrderField!
+}
+"""
+Properties by which ControlObjectiveHistory connections can be ordered.
+"""
+enum ControlObjectiveHistoryOrderField {
+	name
+	status
+	SOURCE
+	control_objective_type
+	category
+	subcategory
 }
 """
 ControlObjectiveHistoryWhereInput is used for filtering ControlObjectiveHistory objects.
@@ -3935,6 +4893,30 @@ input ControlObjectiveHistoryWhereInput {
 	subcategoryNotNil: Boolean
 	subcategoryEqualFold: String
 	subcategoryContainsFold: String
+}
+"""
+Ordering options for ControlObjective connections
+"""
+input ControlObjectiveOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order ControlObjectives.
+	"""
+	field: ControlObjectiveOrderField!
+}
+"""
+Properties by which ControlObjective connections can be ordered.
+"""
+enum ControlObjectiveOrderField {
+	name
+	status
+	SOURCE
+	control_objective_type
+	category
+	subcategory
 }
 type ControlObjectiveSearchResult {
 	controlObjectives: [ControlObjective!]
@@ -4294,6 +5276,29 @@ input ControlObjectiveWhereInput {
 	"""
 	hasTasks: Boolean
 	hasTasksWith: [TaskWhereInput!]
+}
+"""
+Ordering options for Control connections
+"""
+input ControlOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order Controls.
+	"""
+	field: ControlOrderField!
+}
+"""
+Properties by which Control connections can be ordered.
+"""
+enum ControlOrderField {
+	status
+	SOURCE
+	CONTROL_TYPE
+	category
+	subcategory
 }
 type ControlSearchResult {
 	controls: [Control!]
@@ -6321,8 +7326,63 @@ type DocumentData implements Node {
 	data: Map!
 	owner: Organization
 	template: Template!
-	entity: [Entity!]
-	files: [File!]
+	entity(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Entities returned from the connection.
+		"""
+		orderBy: [EntityOrder!]
+
+		"""
+		Filtering options for Entities returned from the connection.
+		"""
+		where: EntityWhereInput
+	): EntityConnection!
+	files(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Files returned from the connection.
+		"""
+		where: FileWhereInput
+	): FileConnection!
 }
 """
 Return response for createBulkDocumentData mutation
@@ -6854,10 +7914,115 @@ type Entity implements Node {
 	"""
 	status: String
 	owner: Organization
-	contacts: [Contact!]
-	documents: [DocumentData!]
-	notes: [Note!]
-	files: [File!]
+	contacts(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Contacts returned from the connection.
+		"""
+		orderBy: [ContactOrder!]
+
+		"""
+		Filtering options for Contacts returned from the connection.
+		"""
+		where: ContactWhereInput
+	): ContactConnection!
+	documents(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for DocumentDataSlice returned from the connection.
+		"""
+		where: DocumentDataWhereInput
+	): DocumentDataConnection!
+	notes(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Notes returned from the connection.
+		"""
+		where: NoteWhereInput
+	): NoteConnection!
+	files(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Files returned from the connection.
+		"""
+		where: FileWhereInput
+	): FileConnection!
 	entityType: EntityType
 }
 """
@@ -7018,6 +8183,7 @@ Properties by which EntityHistory connections can be ordered.
 enum EntityHistoryOrderField {
 	name
 	display_name
+	status
 }
 """
 EntityHistoryWhereInput is used for filtering EntityHistory objects.
@@ -7279,6 +8445,7 @@ Properties by which Entity connections can be ordered.
 enum EntityOrderField {
 	name
 	display_name
+	status
 }
 type EntitySearchResult {
 	entities: [Entity!]
@@ -7304,7 +8471,37 @@ type EntityType implements Node {
 	"""
 	name: String!
 	owner: Organization
-	entities: [Entity!]
+	entities(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Entities returned from the connection.
+		"""
+		orderBy: [EntityOrder!]
+
+		"""
+		Filtering options for Entities returned from the connection.
+		"""
+		where: EntityWhereInput
+	): EntityConnection!
 }
 """
 Return response for createBulkEntityType mutation
@@ -8077,18 +9274,368 @@ type Event implements Node {
 	correlationID: String
 	eventType: String!
 	metadata: Map
-	user: [User!]
-	group: [Group!]
-	integration: [Integration!]
-	organization: [Organization!]
-	invite: [Invite!]
-	personalAccessToken: [PersonalAccessToken!]
-	hush: [Hush!]
-	orgmembership: [OrgMembership!]
-	groupmembership: [GroupMembership!]
-	subscriber: [Subscriber!]
-	file: [File!]
-	orgsubscription: [OrgSubscription!]
+	user(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Users returned from the connection.
+		"""
+		orderBy: [UserOrder!]
+
+		"""
+		Filtering options for Users returned from the connection.
+		"""
+		where: UserWhereInput
+	): UserConnection!
+	group(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Groups returned from the connection.
+		"""
+		orderBy: [GroupOrder!]
+
+		"""
+		Filtering options for Groups returned from the connection.
+		"""
+		where: GroupWhereInput
+	): GroupConnection!
+	integration(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Integrations returned from the connection.
+		"""
+		orderBy: [IntegrationOrder!]
+
+		"""
+		Filtering options for Integrations returned from the connection.
+		"""
+		where: IntegrationWhereInput
+	): IntegrationConnection!
+	organization(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Organizations returned from the connection.
+		"""
+		orderBy: [OrganizationOrder!]
+
+		"""
+		Filtering options for Organizations returned from the connection.
+		"""
+		where: OrganizationWhereInput
+	): OrganizationConnection!
+	invite(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Invites returned from the connection.
+		"""
+		orderBy: [InviteOrder!]
+
+		"""
+		Filtering options for Invites returned from the connection.
+		"""
+		where: InviteWhereInput
+	): InviteConnection!
+	personalAccessToken(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for PersonalAccessTokens returned from the connection.
+		"""
+		where: PersonalAccessTokenWhereInput
+	): PersonalAccessTokenConnection!
+	hush(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Hushes returned from the connection.
+		"""
+		orderBy: [HushOrder!]
+
+		"""
+		Filtering options for Hushes returned from the connection.
+		"""
+		where: HushWhereInput
+	): HushConnection!
+	orgmembership(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for OrgMemberships returned from the connection.
+		"""
+		orderBy: OrgMembershipOrder
+
+		"""
+		Filtering options for OrgMemberships returned from the connection.
+		"""
+		where: OrgMembershipWhereInput
+	): OrgMembershipConnection!
+	groupmembership(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for GroupMemberships returned from the connection.
+		"""
+		orderBy: GroupMembershipOrder
+
+		"""
+		Filtering options for GroupMemberships returned from the connection.
+		"""
+		where: GroupMembershipWhereInput
+	): GroupMembershipConnection!
+	subscriber(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Subscribers returned from the connection.
+		"""
+		orderBy: [SubscriberOrder!]
+
+		"""
+		Filtering options for Subscribers returned from the connection.
+		"""
+		where: SubscriberWhereInput
+	): SubscriberConnection!
+	file(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Files returned from the connection.
+		"""
+		where: FileWhereInput
+	): FileConnection!
+	orgsubscription(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for OrgSubscriptions returned from the connection.
+		"""
+		orderBy: OrgSubscriptionOrder
+
+		"""
+		Filtering options for OrgSubscriptions returned from the connection.
+		"""
+		where: OrgSubscriptionWhereInput
+	): OrgSubscriptionConnection!
 }
 """
 Return response for createBulkEvent mutation
@@ -8640,12 +10187,187 @@ type Evidence implements Node {
 	"""
 	status: EvidenceEvidenceStatus
 	owner: Organization
-	controlObjectives: [ControlObjective!]
-	controls: [Control!]
-	subcontrols: [Subcontrol!]
-	files: [File!]
-	programs: [Program!]
-	tasks: [Task!]
+	controlObjectives(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for ControlObjectives returned from the connection.
+		"""
+		orderBy: [ControlObjectiveOrder!]
+
+		"""
+		Filtering options for ControlObjectives returned from the connection.
+		"""
+		where: ControlObjectiveWhereInput
+	): ControlObjectiveConnection!
+	controls(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Controls returned from the connection.
+		"""
+		orderBy: [ControlOrder!]
+
+		"""
+		Filtering options for Controls returned from the connection.
+		"""
+		where: ControlWhereInput
+	): ControlConnection!
+	subcontrols(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Subcontrols returned from the connection.
+		"""
+		orderBy: [SubcontrolOrder!]
+
+		"""
+		Filtering options for Subcontrols returned from the connection.
+		"""
+		where: SubcontrolWhereInput
+	): SubcontrolConnection!
+	files(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Files returned from the connection.
+		"""
+		where: FileWhereInput
+	): FileConnection!
+	programs(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Programs returned from the connection.
+		"""
+		orderBy: [ProgramOrder!]
+
+		"""
+		Filtering options for Programs returned from the connection.
+		"""
+		where: ProgramWhereInput
+	): ProgramConnection!
+	tasks(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Tasks returned from the connection.
+		"""
+		orderBy: [TaskOrder!]
+
+		"""
+		Filtering options for Tasks returned from the connection.
+		"""
+		where: TaskWhereInput
+	): TaskConnection!
 }
 """
 Return response for createBulkEvidence mutation
@@ -8821,6 +10543,28 @@ enum EvidenceHistoryOpType @goModel(model: "github.com/theopenlane/entx/history.
 	INSERT
 	UPDATE
 	DELETE
+}
+"""
+Ordering options for EvidenceHistory connections
+"""
+input EvidenceHistoryOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order EvidenceHistories.
+	"""
+	field: EvidenceHistoryOrderField!
+}
+"""
+Properties by which EvidenceHistory connections can be ordered.
+"""
+enum EvidenceHistoryOrderField {
+	name
+	creation_date
+	renewal_date
+	STATUS
 }
 """
 EvidenceHistoryWhereInput is used for filtering EvidenceHistory objects.
@@ -9134,6 +10878,28 @@ input EvidenceHistoryWhereInput {
 	statusNotIn: [EvidenceHistoryEvidenceStatus!]
 	statusIsNil: Boolean
 	statusNotNil: Boolean
+}
+"""
+Ordering options for Evidence connections
+"""
+input EvidenceOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order Evidences.
+	"""
+	field: EvidenceOrderField!
+}
+"""
+Properties by which Evidence connections can be ordered.
+"""
+enum EvidenceOrderField {
+	name
+	creation_date
+	renewal_date
+	STATUS
 }
 type EvidenceSearchResult {
 	evidences: [Evidence!]
@@ -9524,18 +11290,358 @@ type File implements Node {
 	the storage path is the second-level directory of the file path, typically the correlating logical object ID the file is associated with; files can be stand alone objects and not always correlated to a logical one, so this path of the tree may be empty
 	"""
 	storagePath: String
-	user: [User!]
-	organization: [Organization!]
-	group: [Group!]
-	contact: [Contact!]
-	entity: [Entity!]
-	userSetting: [UserSetting!]
-	organizationSetting: [OrganizationSetting!]
-	template: [Template!]
-	documentData: [DocumentData!]
-	events: [Event!]
-	program: [Program!]
-	evidence: [Evidence!]
+	user(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Users returned from the connection.
+		"""
+		orderBy: [UserOrder!]
+
+		"""
+		Filtering options for Users returned from the connection.
+		"""
+		where: UserWhereInput
+	): UserConnection!
+	organization(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Organizations returned from the connection.
+		"""
+		orderBy: [OrganizationOrder!]
+
+		"""
+		Filtering options for Organizations returned from the connection.
+		"""
+		where: OrganizationWhereInput
+	): OrganizationConnection!
+	group(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Groups returned from the connection.
+		"""
+		orderBy: [GroupOrder!]
+
+		"""
+		Filtering options for Groups returned from the connection.
+		"""
+		where: GroupWhereInput
+	): GroupConnection!
+	contact(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Contacts returned from the connection.
+		"""
+		orderBy: [ContactOrder!]
+
+		"""
+		Filtering options for Contacts returned from the connection.
+		"""
+		where: ContactWhereInput
+	): ContactConnection!
+	entity(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Entities returned from the connection.
+		"""
+		orderBy: [EntityOrder!]
+
+		"""
+		Filtering options for Entities returned from the connection.
+		"""
+		where: EntityWhereInput
+	): EntityConnection!
+	userSetting(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for UserSettings returned from the connection.
+		"""
+		where: UserSettingWhereInput
+	): UserSettingConnection!
+	organizationSetting(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for OrganizationSettings returned from the connection.
+		"""
+		where: OrganizationSettingWhereInput
+	): OrganizationSettingConnection!
+	template(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Templates returned from the connection.
+		"""
+		orderBy: [TemplateOrder!]
+
+		"""
+		Filtering options for Templates returned from the connection.
+		"""
+		where: TemplateWhereInput
+	): TemplateConnection!
+	documentData(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for DocumentDataSlice returned from the connection.
+		"""
+		where: DocumentDataWhereInput
+	): DocumentDataConnection!
+	events(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Events returned from the connection.
+		"""
+		where: EventWhereInput
+	): EventConnection!
+	program(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Programs returned from the connection.
+		"""
+		orderBy: [ProgramOrder!]
+
+		"""
+		Filtering options for Programs returned from the connection.
+		"""
+		where: ProgramWhereInput
+	): ProgramConnection!
+	evidence(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Evidences returned from the connection.
+		"""
+		orderBy: [EvidenceOrder!]
+
+		"""
+		Filtering options for Evidences returned from the connection.
+		"""
+		where: EvidenceWhereInput
+	): EvidenceConnection!
 	presignedURL: String
 }
 """
@@ -10511,10 +12617,120 @@ type Group implements Node {
 	narrativeViewers: [Narrative!]
 	setting: GroupSetting
 	users: [User!]
-	events: [Event!]
-	integrations: [Integration!]
-	files: [File!]
-	tasks: [Task!]
+	events(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Events returned from the connection.
+		"""
+		where: EventWhereInput
+	): EventConnection!
+	integrations(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Integrations returned from the connection.
+		"""
+		orderBy: [IntegrationOrder!]
+
+		"""
+		Filtering options for Integrations returned from the connection.
+		"""
+		where: IntegrationWhereInput
+	): IntegrationConnection!
+	files(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Files returned from the connection.
+		"""
+		where: FileWhereInput
+	): FileConnection!
+	tasks(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Tasks returned from the connection.
+		"""
+		orderBy: [TaskOrder!]
+
+		"""
+		Filtering options for Tasks returned from the connection.
+		"""
+		where: TaskWhereInput
+	): TaskConnection!
 	members: [GroupMembership!]
 	"""
 	permissions the group provides
@@ -11042,6 +13258,25 @@ enum GroupMembershipHistoryOpType @goModel(model: "github.com/theopenlane/entx/h
 	DELETE
 }
 """
+Ordering options for GroupMembershipHistory connections
+"""
+input GroupMembershipHistoryOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order GroupMembershipHistories.
+	"""
+	field: GroupMembershipHistoryOrderField!
+}
+"""
+Properties by which GroupMembershipHistory connections can be ordered.
+"""
+enum GroupMembershipHistoryOrderField {
+	ROLE
+}
+"""
 GroupMembershipHistoryRole is enum for the field role
 """
 enum GroupMembershipHistoryRole @goModel(model: "github.com/theopenlane/core/pkg/enums.Role") {
@@ -11237,6 +13472,25 @@ input GroupMembershipHistoryWhereInput {
 	userIDHasSuffix: String
 	userIDEqualFold: String
 	userIDContainsFold: String
+}
+"""
+Ordering options for GroupMembership connections
+"""
+input GroupMembershipOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order GroupMemberships.
+	"""
+	field: GroupMembershipOrderField!
+}
+"""
+Properties by which GroupMembership connections can be ordered.
+"""
+enum GroupMembershipOrderField {
+	ROLE
 }
 """
 GroupMembershipRole is enum for the field role
@@ -12330,12 +14584,94 @@ type Hush implements Node {
 	the generic name of a secret associated with the organization
 	"""
 	secretName: String
-	"""
-	the integration associated with the secret
-	"""
-	integrations: [Integration!]
-	organization: [Organization!]
-	events: [Event!]
+	integrations(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Integrations returned from the connection.
+		"""
+		orderBy: [IntegrationOrder!]
+
+		"""
+		Filtering options for Integrations returned from the connection.
+		"""
+		where: IntegrationWhereInput
+	): IntegrationConnection!
+	organization(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Organizations returned from the connection.
+		"""
+		orderBy: [OrganizationOrder!]
+
+		"""
+		Filtering options for Organizations returned from the connection.
+		"""
+		where: OrganizationWhereInput
+	): OrganizationConnection!
+	events(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Events returned from the connection.
+		"""
+		where: EventWhereInput
+	): EventConnection!
 }
 """
 Return response for createBulkHush mutation
@@ -12924,11 +15260,63 @@ type Integration implements Node {
 	description: String
 	kind: String
 	owner: Organization
-	"""
-	the secrets associated with the integration
-	"""
-	secrets: [Hush!]
-	events: [Event!]
+	secrets(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Hushes returned from the connection.
+		"""
+		orderBy: [HushOrder!]
+
+		"""
+		Filtering options for Hushes returned from the connection.
+		"""
+		where: HushWhereInput
+	): HushConnection!
+	events(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Events returned from the connection.
+		"""
+		where: EventWhereInput
+	): EventConnection!
 }
 """
 Return response for createBulkIntegration mutation
@@ -13560,12 +15948,187 @@ type InternalPolicy implements Node {
 	temporary delegates for the policy, used for temporary approval
 	"""
 	delegate: Group
-	controlObjectives: [ControlObjective!]
-	controls: [Control!]
-	procedures: [Procedure!]
-	narratives: [Narrative!]
-	tasks: [Task!]
-	programs: [Program!]
+	controlObjectives(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for ControlObjectives returned from the connection.
+		"""
+		orderBy: [ControlObjectiveOrder!]
+
+		"""
+		Filtering options for ControlObjectives returned from the connection.
+		"""
+		where: ControlObjectiveWhereInput
+	): ControlObjectiveConnection!
+	controls(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Controls returned from the connection.
+		"""
+		orderBy: [ControlOrder!]
+
+		"""
+		Filtering options for Controls returned from the connection.
+		"""
+		where: ControlWhereInput
+	): ControlConnection!
+	procedures(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Procedures returned from the connection.
+		"""
+		where: ProcedureWhereInput
+	): ProcedureConnection!
+	narratives(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Narratives returned from the connection.
+		"""
+		orderBy: NarrativeOrder
+
+		"""
+		Filtering options for Narratives returned from the connection.
+		"""
+		where: NarrativeWhereInput
+	): NarrativeConnection!
+	tasks(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Tasks returned from the connection.
+		"""
+		orderBy: [TaskOrder!]
+
+		"""
+		Filtering options for Tasks returned from the connection.
+		"""
+		where: TaskWhereInput
+	): TaskConnection!
+	programs(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Programs returned from the connection.
+		"""
+		orderBy: [ProgramOrder!]
+
+		"""
+		Filtering options for Programs returned from the connection.
+		"""
+		where: ProgramWhereInput
+	): ProgramConnection!
 }
 """
 Return response for createBulkInternalPolicy mutation
@@ -14407,7 +16970,32 @@ type Invite implements Node {
 	"""
 	requestorID: String
 	owner: Organization
-	events: [Event!]
+	events(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Events returned from the connection.
+		"""
+		where: EventWhereInput
+	): EventConnection!
 }
 """
 Return response for createBulkInvite mutation
@@ -14474,6 +17062,27 @@ enum InviteInviteStatus @goModel(model: "github.com/theopenlane/core/pkg/enums.I
 	APPROVAL_REQUIRED
 	INVITATION_ACCEPTED
 	INVITATION_EXPIRED
+}
+"""
+Ordering options for Invite connections
+"""
+input InviteOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order Invites.
+	"""
+	field: InviteOrderField!
+}
+"""
+Properties by which Invite connections can be ordered.
+"""
+enum InviteOrderField {
+	expires
+	STATUS
+	send_attempts
 }
 """
 InviteRole is enum for the field role
@@ -14734,14 +17343,68 @@ type MappedControl implements Node {
 	description of how the two controls are related
 	"""
 	relation: String
-	"""
-	mapped controls that have a relation to each other
-	"""
-	controls: [Control!]
-	"""
-	mapped subcontrols that have a relation to each other
-	"""
-	subcontrols: [Subcontrol!]
+	controls(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Controls returned from the connection.
+		"""
+		orderBy: [ControlOrder!]
+
+		"""
+		Filtering options for Controls returned from the connection.
+		"""
+		where: ControlWhereInput
+	): ControlConnection!
+	subcontrols(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Subcontrols returned from the connection.
+		"""
+		orderBy: [SubcontrolOrder!]
+
+		"""
+		Filtering options for Subcontrols returned from the connection.
+		"""
+		where: SubcontrolWhereInput
+	): SubcontrolConnection!
 }
 """
 Return response for createBulkMappedControl mutation
@@ -14861,6 +17524,25 @@ enum MappedControlHistoryOpType @goModel(model: "github.com/theopenlane/entx/his
 	INSERT
 	UPDATE
 	DELETE
+}
+"""
+Ordering options for MappedControlHistory connections
+"""
+input MappedControlHistoryOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order MappedControlHistories.
+	"""
+	field: MappedControlHistoryOrderField!
+}
+"""
+Properties by which MappedControlHistory connections can be ordered.
+"""
+enum MappedControlHistoryOrderField {
+	mapping_type
 }
 """
 MappedControlHistoryWhereInput is used for filtering MappedControlHistory objects.
@@ -15048,6 +17730,25 @@ input MappedControlHistoryWhereInput {
 	relationNotNil: Boolean
 	relationEqualFold: String
 	relationContainsFold: String
+}
+"""
+Ordering options for MappedControl connections
+"""
+input MappedControlOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order MappedControls.
+	"""
+	field: MappedControlOrderField!
+}
+"""
+Properties by which MappedControl connections can be ordered.
+"""
+enum MappedControlOrderField {
+	mapping_type
 }
 type MappedControlSearchResult {
 	mappedControls: [MappedControl!]
@@ -17061,11 +19762,68 @@ type Narrative implements Node {
 	provides view access to the risk to members of the group
 	"""
 	viewers: [Group!]
-	"""
-	which controls are satisfied by the narrative
-	"""
-	satisfies: [Control!]
-	programs: [Program!]
+	satisfies(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Controls returned from the connection.
+		"""
+		orderBy: [ControlOrder!]
+
+		"""
+		Filtering options for Controls returned from the connection.
+		"""
+		where: ControlWhereInput
+	): ControlConnection!
+	programs(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Programs returned from the connection.
+		"""
+		orderBy: [ProgramOrder!]
+
+		"""
+		Filtering options for Programs returned from the connection.
+		"""
+		where: ProgramWhereInput
+	): ProgramConnection!
 }
 """
 Return response for createBulkNarrative mutation
@@ -17197,6 +19955,25 @@ enum NarrativeHistoryOpType @goModel(model: "github.com/theopenlane/entx/history
 	INSERT
 	UPDATE
 	DELETE
+}
+"""
+Ordering options for NarrativeHistory connections
+"""
+input NarrativeHistoryOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order NarrativeHistories.
+	"""
+	field: NarrativeHistoryOrderField!
+}
+"""
+Properties by which NarrativeHistory connections can be ordered.
+"""
+enum NarrativeHistoryOrderField {
+	name
 }
 """
 NarrativeHistoryWhereInput is used for filtering NarrativeHistory objects.
@@ -17434,6 +20211,25 @@ input NarrativeHistoryWhereInput {
 	detailsNotNil: Boolean
 	detailsEqualFold: String
 	detailsContainsFold: String
+}
+"""
+Ordering options for Narrative connections
+"""
+input NarrativeOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order Narratives.
+	"""
+	field: NarrativeOrderField!
+}
+"""
+Properties by which Narrative connections can be ordered.
+"""
+enum NarrativeOrderField {
+	name
 }
 type NarrativeSearchResult {
 	narratives: [Narrative!]
@@ -18341,7 +21137,32 @@ type OrgMembership implements Node {
 	userID: ID!
 	organization: Organization!
 	user: User!
-	events: [Event!]
+	events(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Events returned from the connection.
+		"""
+		where: EventWhereInput
+	): EventConnection!
 }
 """
 Return response for createBulkOrgMembership mutation
@@ -18452,6 +21273,25 @@ enum OrgMembershipHistoryOpType @goModel(model: "github.com/theopenlane/entx/his
 	INSERT
 	UPDATE
 	DELETE
+}
+"""
+Ordering options for OrgMembershipHistory connections
+"""
+input OrgMembershipHistoryOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order OrgMembershipHistories.
+	"""
+	field: OrgMembershipHistoryOrderField!
+}
+"""
+Properties by which OrgMembershipHistory connections can be ordered.
+"""
+enum OrgMembershipHistoryOrderField {
+	ROLE
 }
 """
 OrgMembershipHistoryRole is enum for the field role
@@ -18650,6 +21490,25 @@ input OrgMembershipHistoryWhereInput {
 	userIDHasSuffix: String
 	userIDEqualFold: String
 	userIDContainsFold: String
+}
+"""
+Ordering options for OrgMembership connections
+"""
+input OrgMembershipOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order OrgMemberships.
+	"""
+	field: OrgMembershipOrderField!
+}
+"""
+Properties by which OrgMembership connections can be ordered.
+"""
+enum OrgMembershipOrderField {
+	ROLE
 }
 """
 OrgMembershipRole is enum for the field role
@@ -19007,6 +21866,30 @@ enum OrgSubscriptionHistoryOpType @goModel(model: "github.com/theopenlane/entx/h
 	DELETE
 }
 """
+Ordering options for OrgSubscriptionHistory connections
+"""
+input OrgSubscriptionHistoryOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order OrgSubscriptionHistories.
+	"""
+	field: OrgSubscriptionHistoryOrderField!
+}
+"""
+Properties by which OrgSubscriptionHistory connections can be ordered.
+"""
+enum OrgSubscriptionHistoryOrderField {
+	product_tier
+	stripe_subscription_status
+	active
+	expires_at
+	trial_expires_at
+	days_until_due
+}
+"""
 OrgSubscriptionHistoryWhereInput is used for filtering OrgSubscriptionHistory objects.
 Input was generated by ent.
 """
@@ -19320,6 +22203,30 @@ input OrgSubscriptionHistoryWhereInput {
 	paymentMethodAddedNEQ: Boolean
 	paymentMethodAddedIsNil: Boolean
 	paymentMethodAddedNotNil: Boolean
+}
+"""
+Ordering options for OrgSubscription connections
+"""
+input OrgSubscriptionOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order OrgSubscriptions.
+	"""
+	field: OrgSubscriptionOrderField!
+}
+"""
+Properties by which OrgSubscription connections can be ordered.
+"""
+enum OrgSubscriptionOrderField {
+	product_tier
+	stripe_subscription_status
+	active
+	expires_at
+	trial_expires_at
+	days_until_due
 }
 type OrgSubscriptionSearchResult {
 	orgSubscriptions: [OrgSubscription!]
@@ -19718,7 +22625,7 @@ type Organization implements Node {
 		"""
 		Ordering options for Organizations returned from the connection.
 		"""
-		orderBy: OrganizationOrder
+		orderBy: [OrganizationOrder!]
 
 		"""
 		Filtering options for Organizations returned from the connection.
@@ -19726,36 +22633,806 @@ type Organization implements Node {
 		where: OrganizationWhereInput
 	): OrganizationConnection!
 	setting: OrganizationSetting
-	personalAccessTokens: [PersonalAccessToken!]
-	apiTokens: [APIToken!]
+	personalAccessTokens(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for PersonalAccessTokens returned from the connection.
+		"""
+		where: PersonalAccessTokenWhereInput
+	): PersonalAccessTokenConnection!
+	apiTokens(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for APITokens returned from the connection.
+		"""
+		where: APITokenWhereInput
+	): APITokenConnection!
 	users: [User!]
-	files: [File!]
-	events: [Event!]
-	secrets: [Hush!]
+	files(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Files returned from the connection.
+		"""
+		where: FileWhereInput
+	): FileConnection!
+	events(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Events returned from the connection.
+		"""
+		where: EventWhereInput
+	): EventConnection!
+	secrets(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Hushes returned from the connection.
+		"""
+		orderBy: [HushOrder!]
+
+		"""
+		Filtering options for Hushes returned from the connection.
+		"""
+		where: HushWhereInput
+	): HushConnection!
 	avatarFile: File
-	groups: [Group!]
-	templates: [Template!]
-	integrations: [Integration!]
-	documentData: [DocumentData!]
+	groups(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Groups returned from the connection.
+		"""
+		orderBy: [GroupOrder!]
+
+		"""
+		Filtering options for Groups returned from the connection.
+		"""
+		where: GroupWhereInput
+	): GroupConnection!
+	templates(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Templates returned from the connection.
+		"""
+		orderBy: [TemplateOrder!]
+
+		"""
+		Filtering options for Templates returned from the connection.
+		"""
+		where: TemplateWhereInput
+	): TemplateConnection!
+	integrations(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Integrations returned from the connection.
+		"""
+		orderBy: [IntegrationOrder!]
+
+		"""
+		Filtering options for Integrations returned from the connection.
+		"""
+		where: IntegrationWhereInput
+	): IntegrationConnection!
+	documentData(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for DocumentDataSlice returned from the connection.
+		"""
+		where: DocumentDataWhereInput
+	): DocumentDataConnection!
 	orgSubscriptions: [OrgSubscription!]
-	invites: [Invite!]
-	subscribers: [Subscriber!]
-	entities: [Entity!]
-	entityTypes: [EntityType!]
-	contacts: [Contact!]
-	notes: [Note!]
-	tasks: [Task!]
-	programs: [Program!]
-	procedures: [Procedure!]
-	internalPolicies: [InternalPolicy!]
-	risks: [Risk!]
-	controlObjectives: [ControlObjective!]
-	narratives: [Narrative!]
-	controls: [Control!]
-	subcontrols: [Subcontrol!]
-	evidence: [Evidence!]
-	standards: [Standard!]
-	actionPlans: [ActionPlan!]
+	invites(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Invites returned from the connection.
+		"""
+		orderBy: [InviteOrder!]
+
+		"""
+		Filtering options for Invites returned from the connection.
+		"""
+		where: InviteWhereInput
+	): InviteConnection!
+	subscribers(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Subscribers returned from the connection.
+		"""
+		orderBy: [SubscriberOrder!]
+
+		"""
+		Filtering options for Subscribers returned from the connection.
+		"""
+		where: SubscriberWhereInput
+	): SubscriberConnection!
+	entities(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Entities returned from the connection.
+		"""
+		orderBy: [EntityOrder!]
+
+		"""
+		Filtering options for Entities returned from the connection.
+		"""
+		where: EntityWhereInput
+	): EntityConnection!
+	entityTypes(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for EntityTypes returned from the connection.
+		"""
+		orderBy: EntityTypeOrder
+
+		"""
+		Filtering options for EntityTypes returned from the connection.
+		"""
+		where: EntityTypeWhereInput
+	): EntityTypeConnection!
+	contacts(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Contacts returned from the connection.
+		"""
+		orderBy: [ContactOrder!]
+
+		"""
+		Filtering options for Contacts returned from the connection.
+		"""
+		where: ContactWhereInput
+	): ContactConnection!
+	notes(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Notes returned from the connection.
+		"""
+		where: NoteWhereInput
+	): NoteConnection!
+	tasks(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Tasks returned from the connection.
+		"""
+		orderBy: [TaskOrder!]
+
+		"""
+		Filtering options for Tasks returned from the connection.
+		"""
+		where: TaskWhereInput
+	): TaskConnection!
+	programs(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Programs returned from the connection.
+		"""
+		orderBy: [ProgramOrder!]
+
+		"""
+		Filtering options for Programs returned from the connection.
+		"""
+		where: ProgramWhereInput
+	): ProgramConnection!
+	procedures(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Procedures returned from the connection.
+		"""
+		where: ProcedureWhereInput
+	): ProcedureConnection!
+	internalPolicies(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for InternalPolicies returned from the connection.
+		"""
+		where: InternalPolicyWhereInput
+	): InternalPolicyConnection!
+	risks(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Risks returned from the connection.
+		"""
+		orderBy: [RiskOrder!]
+
+		"""
+		Filtering options for Risks returned from the connection.
+		"""
+		where: RiskWhereInput
+	): RiskConnection!
+	controlObjectives(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for ControlObjectives returned from the connection.
+		"""
+		orderBy: [ControlObjectiveOrder!]
+
+		"""
+		Filtering options for ControlObjectives returned from the connection.
+		"""
+		where: ControlObjectiveWhereInput
+	): ControlObjectiveConnection!
+	narratives(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Narratives returned from the connection.
+		"""
+		orderBy: NarrativeOrder
+
+		"""
+		Filtering options for Narratives returned from the connection.
+		"""
+		where: NarrativeWhereInput
+	): NarrativeConnection!
+	controls(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Controls returned from the connection.
+		"""
+		orderBy: [ControlOrder!]
+
+		"""
+		Filtering options for Controls returned from the connection.
+		"""
+		where: ControlWhereInput
+	): ControlConnection!
+	subcontrols(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Subcontrols returned from the connection.
+		"""
+		orderBy: [SubcontrolOrder!]
+
+		"""
+		Filtering options for Subcontrols returned from the connection.
+		"""
+		where: SubcontrolWhereInput
+	): SubcontrolConnection!
+	evidence(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Evidences returned from the connection.
+		"""
+		orderBy: [EvidenceOrder!]
+
+		"""
+		Filtering options for Evidences returned from the connection.
+		"""
+		where: EvidenceWhereInput
+	): EvidenceConnection!
+	standards(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Standards returned from the connection.
+		"""
+		orderBy: [StandardOrder!]
+
+		"""
+		Filtering options for Standards returned from the connection.
+		"""
+		where: StandardWhereInput
+	): StandardConnection!
+	actionPlans(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for ActionPlans returned from the connection.
+		"""
+		orderBy: [ActionPlanOrder!]
+
+		"""
+		Filtering options for ActionPlans returned from the connection.
+		"""
+		where: ActionPlanWhereInput
+	): ActionPlanConnection!
 	members: [OrgMembership!]
 }
 """
@@ -20238,7 +23915,32 @@ type OrganizationSetting implements Node {
 	"""
 	allowedEmailDomains: [String!]
 	organization: Organization
-	files: [File!]
+	files(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Files returned from the connection.
+		"""
+		where: FileWhereInput
+	): FileConnection!
 }
 """
 Return response for createBulkOrganizationSetting mutation
@@ -21407,11 +25109,63 @@ type PersonalAccessToken implements Node {
 	"""
 	revokedAt: Time
 	owner: User!
-	"""
-	the organization(s) the token is associated with
-	"""
-	organizations: [Organization!]
-	events: [Event!]
+	organizations(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Organizations returned from the connection.
+		"""
+		orderBy: [OrganizationOrder!]
+
+		"""
+		Filtering options for Organizations returned from the connection.
+		"""
+		where: OrganizationWhereInput
+	): OrganizationConnection!
+	events(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Events returned from the connection.
+		"""
+		where: EventWhereInput
+	): EventConnection!
 }
 """
 Return response for createBulkPersonalAccessToken mutation
@@ -21783,12 +25537,187 @@ type Procedure implements Node {
 	temporary delegates for the procedure, used for temporary approval
 	"""
 	delegate: Group
-	controls: [Control!]
-	internalPolicies: [InternalPolicy!]
-	narratives: [Narrative!]
-	risks: [Risk!]
-	tasks: [Task!]
-	programs: [Program!]
+	controls(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Controls returned from the connection.
+		"""
+		orderBy: [ControlOrder!]
+
+		"""
+		Filtering options for Controls returned from the connection.
+		"""
+		where: ControlWhereInput
+	): ControlConnection!
+	internalPolicies(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for InternalPolicies returned from the connection.
+		"""
+		where: InternalPolicyWhereInput
+	): InternalPolicyConnection!
+	narratives(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Narratives returned from the connection.
+		"""
+		orderBy: NarrativeOrder
+
+		"""
+		Filtering options for Narratives returned from the connection.
+		"""
+		where: NarrativeWhereInput
+	): NarrativeConnection!
+	risks(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Risks returned from the connection.
+		"""
+		orderBy: [RiskOrder!]
+
+		"""
+		Filtering options for Risks returned from the connection.
+		"""
+		where: RiskWhereInput
+	): RiskConnection!
+	tasks(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Tasks returned from the connection.
+		"""
+		orderBy: [TaskOrder!]
+
+		"""
+		Filtering options for Tasks returned from the connection.
+		"""
+		where: TaskWhereInput
+	): TaskConnection!
+	programs(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Programs returned from the connection.
+		"""
+		orderBy: [ProgramOrder!]
+
+		"""
+		Filtering options for Programs returned from the connection.
+		"""
+		where: ProgramWhereInput
+	): ProgramConnection!
 }
 """
 Return response for createBulkProcedure mutation
@@ -22661,20 +26590,390 @@ type Program implements Node {
 	provides view access to the risk to members of the group
 	"""
 	viewers: [Group!]
-	controls: [Control!]
-	subcontrols: [Subcontrol!]
-	controlObjectives: [ControlObjective!]
-	internalPolicies: [InternalPolicy!]
-	procedures: [Procedure!]
-	risks: [Risk!]
-	tasks: [Task!]
-	notes: [Note!]
-	files: [File!]
-	evidence: [Evidence!]
-	narratives: [Narrative!]
+	controls(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Controls returned from the connection.
+		"""
+		orderBy: [ControlOrder!]
+
+		"""
+		Filtering options for Controls returned from the connection.
+		"""
+		where: ControlWhereInput
+	): ControlConnection!
+	subcontrols(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Subcontrols returned from the connection.
+		"""
+		orderBy: [SubcontrolOrder!]
+
+		"""
+		Filtering options for Subcontrols returned from the connection.
+		"""
+		where: SubcontrolWhereInput
+	): SubcontrolConnection!
+	controlObjectives(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for ControlObjectives returned from the connection.
+		"""
+		orderBy: [ControlObjectiveOrder!]
+
+		"""
+		Filtering options for ControlObjectives returned from the connection.
+		"""
+		where: ControlObjectiveWhereInput
+	): ControlObjectiveConnection!
+	internalPolicies(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for InternalPolicies returned from the connection.
+		"""
+		where: InternalPolicyWhereInput
+	): InternalPolicyConnection!
+	procedures(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Procedures returned from the connection.
+		"""
+		where: ProcedureWhereInput
+	): ProcedureConnection!
+	risks(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Risks returned from the connection.
+		"""
+		orderBy: [RiskOrder!]
+
+		"""
+		Filtering options for Risks returned from the connection.
+		"""
+		where: RiskWhereInput
+	): RiskConnection!
+	tasks(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Tasks returned from the connection.
+		"""
+		orderBy: [TaskOrder!]
+
+		"""
+		Filtering options for Tasks returned from the connection.
+		"""
+		where: TaskWhereInput
+	): TaskConnection!
+	notes(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Notes returned from the connection.
+		"""
+		where: NoteWhereInput
+	): NoteConnection!
+	files(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Files returned from the connection.
+		"""
+		where: FileWhereInput
+	): FileConnection!
+	evidence(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Evidences returned from the connection.
+		"""
+		orderBy: [EvidenceOrder!]
+
+		"""
+		Filtering options for Evidences returned from the connection.
+		"""
+		where: EvidenceWhereInput
+	): EvidenceConnection!
+	narratives(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Narratives returned from the connection.
+		"""
+		orderBy: NarrativeOrder
+
+		"""
+		Filtering options for Narratives returned from the connection.
+		"""
+		where: NarrativeWhereInput
+	): NarrativeConnection!
 	actionPlans: [ActionPlan!]
-	users: [User!]
-	members: [ProgramMembership!]
+	users(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Users returned from the connection.
+		"""
+		orderBy: [UserOrder!]
+
+		"""
+		Filtering options for Users returned from the connection.
+		"""
+		where: UserWhereInput
+	): UserConnection!
+	members(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for ProgramMemberships returned from the connection.
+		"""
+		orderBy: ProgramMembershipOrder
+
+		"""
+		Filtering options for ProgramMemberships returned from the connection.
+		"""
+		where: ProgramMembershipWhereInput
+	): ProgramMembershipConnection!
 }
 """
 Return response for createBulkProgram mutation
@@ -22826,6 +27125,28 @@ enum ProgramHistoryOpType @goModel(model: "github.com/theopenlane/entx/history.O
 	INSERT
 	UPDATE
 	DELETE
+}
+"""
+Ordering options for ProgramHistory connections
+"""
+input ProgramHistoryOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order ProgramHistories.
+	"""
+	field: ProgramHistoryOrderField!
+}
+"""
+Properties by which ProgramHistory connections can be ordered.
+"""
+enum ProgramHistoryOrderField {
+	name
+	STATUS
+	start_date
+	end_date
 }
 """
 ProgramHistoryProgramStatus is enum for the field status
@@ -23229,6 +27550,25 @@ enum ProgramMembershipHistoryOpType @goModel(model: "github.com/theopenlane/entx
 	DELETE
 }
 """
+Ordering options for ProgramMembershipHistory connections
+"""
+input ProgramMembershipHistoryOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order ProgramMembershipHistories.
+	"""
+	field: ProgramMembershipHistoryOrderField!
+}
+"""
+Properties by which ProgramMembershipHistory connections can be ordered.
+"""
+enum ProgramMembershipHistoryOrderField {
+	ROLE
+}
+"""
 ProgramMembershipHistoryRole is enum for the field role
 """
 enum ProgramMembershipHistoryRole @goModel(model: "github.com/theopenlane/core/pkg/enums.Role") {
@@ -23426,6 +27766,25 @@ input ProgramMembershipHistoryWhereInput {
 	userIDContainsFold: String
 }
 """
+Ordering options for ProgramMembership connections
+"""
+input ProgramMembershipOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order ProgramMemberships.
+	"""
+	field: ProgramMembershipOrderField!
+}
+"""
+Properties by which ProgramMembership connections can be ordered.
+"""
+enum ProgramMembershipOrderField {
+	ROLE
+}
+"""
 ProgramMembershipRole is enum for the field role
 """
 enum ProgramMembershipRole @goModel(model: "github.com/theopenlane/core/pkg/enums.Role") {
@@ -23564,6 +27923,28 @@ input ProgramMembershipWhereInput {
 	roleNotIn: [ProgramMembershipRole!]
 	programID: String
 	userID: String
+}
+"""
+Ordering options for Program connections
+"""
+input ProgramOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order Programs.
+	"""
+	field: ProgramOrderField!
+}
+"""
+Properties by which Program connections can be ordered.
+"""
+enum ProgramOrderField {
+	name
+	STATUS
+	start_date
+	end_date
 }
 """
 ProgramProgramStatus is enum for the field status
@@ -23975,6 +28356,11 @@ type Query {
 		last: Int
 
 		"""
+		Ordering options for ActionPlans returned from the connection.
+		"""
+		orderBy: [ActionPlanOrder!]
+
+		"""
 		Filtering options for ActionPlans returned from the connection.
 		"""
 		where: ActionPlanWhereInput
@@ -23999,6 +28385,11 @@ type Query {
 		Returns the last _n_ elements from the list.
 		"""
 		last: Int
+
+		"""
+		Ordering options for ActionPlanHistories returned from the connection.
+		"""
+		orderBy: ActionPlanHistoryOrder
 
 		"""
 		Filtering options for ActionPlanHistories returned from the connection.
@@ -24027,6 +28418,11 @@ type Query {
 		last: Int
 
 		"""
+		Ordering options for Contacts returned from the connection.
+		"""
+		orderBy: [ContactOrder!]
+
+		"""
 		Filtering options for Contacts returned from the connection.
 		"""
 		where: ContactWhereInput
@@ -24051,6 +28447,11 @@ type Query {
 		Returns the last _n_ elements from the list.
 		"""
 		last: Int
+
+		"""
+		Ordering options for ContactHistories returned from the connection.
+		"""
+		orderBy: ContactHistoryOrder
 
 		"""
 		Filtering options for ContactHistories returned from the connection.
@@ -24079,6 +28480,11 @@ type Query {
 		last: Int
 
 		"""
+		Ordering options for Controls returned from the connection.
+		"""
+		orderBy: [ControlOrder!]
+
+		"""
 		Filtering options for Controls returned from the connection.
 		"""
 		where: ControlWhereInput
@@ -24103,6 +28509,11 @@ type Query {
 		Returns the last _n_ elements from the list.
 		"""
 		last: Int
+
+		"""
+		Ordering options for ControlHistories returned from the connection.
+		"""
+		orderBy: ControlHistoryOrder
 
 		"""
 		Filtering options for ControlHistories returned from the connection.
@@ -24131,6 +28542,11 @@ type Query {
 		last: Int
 
 		"""
+		Ordering options for ControlImplementations returned from the connection.
+		"""
+		orderBy: [ControlImplementationOrder!]
+
+		"""
 		Filtering options for ControlImplementations returned from the connection.
 		"""
 		where: ControlImplementationWhereInput
@@ -24155,6 +28571,11 @@ type Query {
 		Returns the last _n_ elements from the list.
 		"""
 		last: Int
+
+		"""
+		Ordering options for ControlImplementationHistories returned from the connection.
+		"""
+		orderBy: ControlImplementationHistoryOrder
 
 		"""
 		Filtering options for ControlImplementationHistories returned from the connection.
@@ -24183,6 +28604,11 @@ type Query {
 		last: Int
 
 		"""
+		Ordering options for ControlObjectives returned from the connection.
+		"""
+		orderBy: [ControlObjectiveOrder!]
+
+		"""
 		Filtering options for ControlObjectives returned from the connection.
 		"""
 		where: ControlObjectiveWhereInput
@@ -24207,6 +28633,11 @@ type Query {
 		Returns the last _n_ elements from the list.
 		"""
 		last: Int
+
+		"""
+		Ordering options for ControlObjectiveHistories returned from the connection.
+		"""
+		orderBy: ControlObjectiveHistoryOrder
 
 		"""
 		Filtering options for ControlObjectiveHistories returned from the connection.
@@ -24289,7 +28720,7 @@ type Query {
 		"""
 		Ordering options for Entities returned from the connection.
 		"""
-		orderBy: EntityOrder
+		orderBy: [EntityOrder!]
 
 		"""
 		Filtering options for Entities returned from the connection.
@@ -24463,6 +28894,11 @@ type Query {
 		last: Int
 
 		"""
+		Ordering options for Evidences returned from the connection.
+		"""
+		orderBy: [EvidenceOrder!]
+
+		"""
 		Filtering options for Evidences returned from the connection.
 		"""
 		where: EvidenceWhereInput
@@ -24487,6 +28923,11 @@ type Query {
 		Returns the last _n_ elements from the list.
 		"""
 		last: Int
+
+		"""
+		Ordering options for EvidenceHistories returned from the connection.
+		"""
+		orderBy: EvidenceHistoryOrder
 
 		"""
 		Filtering options for EvidenceHistories returned from the connection.
@@ -24569,7 +29010,7 @@ type Query {
 		"""
 		Ordering options for Groups returned from the connection.
 		"""
-		orderBy: GroupOrder
+		orderBy: [GroupOrder!]
 
 		"""
 		Filtering options for Groups returned from the connection.
@@ -24629,6 +29070,11 @@ type Query {
 		last: Int
 
 		"""
+		Ordering options for GroupMemberships returned from the connection.
+		"""
+		orderBy: GroupMembershipOrder
+
+		"""
 		Filtering options for GroupMemberships returned from the connection.
 		"""
 		where: GroupMembershipWhereInput
@@ -24653,6 +29099,11 @@ type Query {
 		Returns the last _n_ elements from the list.
 		"""
 		last: Int
+
+		"""
+		Ordering options for GroupMembershipHistories returned from the connection.
+		"""
+		orderBy: GroupMembershipHistoryOrder
 
 		"""
 		Filtering options for GroupMembershipHistories returned from the connection.
@@ -24735,7 +29186,7 @@ type Query {
 		"""
 		Ordering options for Hushes returned from the connection.
 		"""
-		orderBy: HushOrder
+		orderBy: [HushOrder!]
 
 		"""
 		Filtering options for Hushes returned from the connection.
@@ -24797,7 +29248,7 @@ type Query {
 		"""
 		Ordering options for Integrations returned from the connection.
 		"""
-		orderBy: IntegrationOrder
+		orderBy: [IntegrationOrder!]
 
 		"""
 		Filtering options for Integrations returned from the connection.
@@ -24909,6 +29360,11 @@ type Query {
 		last: Int
 
 		"""
+		Ordering options for Invites returned from the connection.
+		"""
+		orderBy: [InviteOrder!]
+
+		"""
 		Filtering options for Invites returned from the connection.
 		"""
 		where: InviteWhereInput
@@ -24933,6 +29389,11 @@ type Query {
 		Returns the last _n_ elements from the list.
 		"""
 		last: Int
+
+		"""
+		Ordering options for MappedControls returned from the connection.
+		"""
+		orderBy: MappedControlOrder
 
 		"""
 		Filtering options for MappedControls returned from the connection.
@@ -24961,6 +29422,11 @@ type Query {
 		last: Int
 
 		"""
+		Ordering options for MappedControlHistories returned from the connection.
+		"""
+		orderBy: MappedControlHistoryOrder
+
+		"""
 		Filtering options for MappedControlHistories returned from the connection.
 		"""
 		where: MappedControlHistoryWhereInput
@@ -24987,6 +29453,11 @@ type Query {
 		last: Int
 
 		"""
+		Ordering options for Narratives returned from the connection.
+		"""
+		orderBy: NarrativeOrder
+
+		"""
 		Filtering options for Narratives returned from the connection.
 		"""
 		where: NarrativeWhereInput
@@ -25011,6 +29482,11 @@ type Query {
 		Returns the last _n_ elements from the list.
 		"""
 		last: Int
+
+		"""
+		Ordering options for NarrativeHistories returned from the connection.
+		"""
+		orderBy: NarrativeHistoryOrder
 
 		"""
 		Filtering options for NarrativeHistories returned from the connection.
@@ -25091,6 +29567,11 @@ type Query {
 		last: Int
 
 		"""
+		Ordering options for OrgMemberships returned from the connection.
+		"""
+		orderBy: OrgMembershipOrder
+
+		"""
 		Filtering options for OrgMemberships returned from the connection.
 		"""
 		where: OrgMembershipWhereInput
@@ -25115,6 +29596,11 @@ type Query {
 		Returns the last _n_ elements from the list.
 		"""
 		last: Int
+
+		"""
+		Ordering options for OrgMembershipHistories returned from the connection.
+		"""
+		orderBy: OrgMembershipHistoryOrder
 
 		"""
 		Filtering options for OrgMembershipHistories returned from the connection.
@@ -25143,6 +29629,11 @@ type Query {
 		last: Int
 
 		"""
+		Ordering options for OrgSubscriptions returned from the connection.
+		"""
+		orderBy: OrgSubscriptionOrder
+
+		"""
 		Filtering options for OrgSubscriptions returned from the connection.
 		"""
 		where: OrgSubscriptionWhereInput
@@ -25167,6 +29658,11 @@ type Query {
 		Returns the last _n_ elements from the list.
 		"""
 		last: Int
+
+		"""
+		Ordering options for OrgSubscriptionHistories returned from the connection.
+		"""
+		orderBy: OrgSubscriptionHistoryOrder
 
 		"""
 		Filtering options for OrgSubscriptionHistories returned from the connection.
@@ -25197,7 +29693,7 @@ type Query {
 		"""
 		Ordering options for Organizations returned from the connection.
 		"""
-		orderBy: OrganizationOrder
+		orderBy: [OrganizationOrder!]
 
 		"""
 		Filtering options for Organizations returned from the connection.
@@ -25387,6 +29883,11 @@ type Query {
 		last: Int
 
 		"""
+		Ordering options for Programs returned from the connection.
+		"""
+		orderBy: [ProgramOrder!]
+
+		"""
 		Filtering options for Programs returned from the connection.
 		"""
 		where: ProgramWhereInput
@@ -25411,6 +29912,11 @@ type Query {
 		Returns the last _n_ elements from the list.
 		"""
 		last: Int
+
+		"""
+		Ordering options for ProgramHistories returned from the connection.
+		"""
+		orderBy: ProgramHistoryOrder
 
 		"""
 		Filtering options for ProgramHistories returned from the connection.
@@ -25439,6 +29945,11 @@ type Query {
 		last: Int
 
 		"""
+		Ordering options for ProgramMemberships returned from the connection.
+		"""
+		orderBy: ProgramMembershipOrder
+
+		"""
 		Filtering options for ProgramMemberships returned from the connection.
 		"""
 		where: ProgramMembershipWhereInput
@@ -25463,6 +29974,11 @@ type Query {
 		Returns the last _n_ elements from the list.
 		"""
 		last: Int
+
+		"""
+		Ordering options for ProgramMembershipHistories returned from the connection.
+		"""
+		orderBy: ProgramMembershipHistoryOrder
 
 		"""
 		Filtering options for ProgramMembershipHistories returned from the connection.
@@ -25491,6 +30007,11 @@ type Query {
 		last: Int
 
 		"""
+		Ordering options for Risks returned from the connection.
+		"""
+		orderBy: [RiskOrder!]
+
+		"""
 		Filtering options for Risks returned from the connection.
 		"""
 		where: RiskWhereInput
@@ -25515,6 +30036,11 @@ type Query {
 		Returns the last _n_ elements from the list.
 		"""
 		last: Int
+
+		"""
+		Ordering options for RiskHistories returned from the connection.
+		"""
+		orderBy: RiskHistoryOrder
 
 		"""
 		Filtering options for RiskHistories returned from the connection.
@@ -25543,6 +30069,11 @@ type Query {
 		last: Int
 
 		"""
+		Ordering options for Standards returned from the connection.
+		"""
+		orderBy: [StandardOrder!]
+
+		"""
 		Filtering options for Standards returned from the connection.
 		"""
 		where: StandardWhereInput
@@ -25567,6 +30098,11 @@ type Query {
 		Returns the last _n_ elements from the list.
 		"""
 		last: Int
+
+		"""
+		Ordering options for StandardHistories returned from the connection.
+		"""
+		orderBy: StandardHistoryOrder
 
 		"""
 		Filtering options for StandardHistories returned from the connection.
@@ -25595,6 +30131,11 @@ type Query {
 		last: Int
 
 		"""
+		Ordering options for Subcontrols returned from the connection.
+		"""
+		orderBy: [SubcontrolOrder!]
+
+		"""
 		Filtering options for Subcontrols returned from the connection.
 		"""
 		where: SubcontrolWhereInput
@@ -25621,6 +30162,11 @@ type Query {
 		last: Int
 
 		"""
+		Ordering options for SubcontrolHistories returned from the connection.
+		"""
+		orderBy: SubcontrolHistoryOrder
+
+		"""
 		Filtering options for SubcontrolHistories returned from the connection.
 		"""
 		where: SubcontrolHistoryWhereInput
@@ -25645,6 +30191,11 @@ type Query {
 		Returns the last _n_ elements from the list.
 		"""
 		last: Int
+
+		"""
+		Ordering options for Subscribers returned from the connection.
+		"""
+		orderBy: [SubscriberOrder!]
 
 		"""
 		Filtering options for Subscribers returned from the connection.
@@ -25699,6 +30250,11 @@ type Query {
 		last: Int
 
 		"""
+		Ordering options for Tasks returned from the connection.
+		"""
+		orderBy: [TaskOrder!]
+
+		"""
 		Filtering options for Tasks returned from the connection.
 		"""
 		where: TaskWhereInput
@@ -25723,6 +30279,11 @@ type Query {
 		Returns the last _n_ elements from the list.
 		"""
 		last: Int
+
+		"""
+		Ordering options for TaskHistories returned from the connection.
+		"""
+		orderBy: TaskHistoryOrder
 
 		"""
 		Filtering options for TaskHistories returned from the connection.
@@ -25753,7 +30314,7 @@ type Query {
 		"""
 		Ordering options for Templates returned from the connection.
 		"""
-		orderBy: TemplateOrder
+		orderBy: [TemplateOrder!]
 
 		"""
 		Filtering options for Templates returned from the connection.
@@ -25815,7 +30376,7 @@ type Query {
 		"""
 		Ordering options for Users returned from the connection.
 		"""
-		orderBy: UserOrder
+		orderBy: [UserOrder!]
 
 		"""
 		Filtering options for Users returned from the connection.
@@ -26940,10 +31501,125 @@ type Risk implements Node {
 	provides view access to the risk to members of the group
 	"""
 	viewers: [Group!]
-	control: [Control!]
-	procedure: [Procedure!]
-	actionPlans: [ActionPlan!]
-	programs: [Program!]
+	control(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Controls returned from the connection.
+		"""
+		orderBy: [ControlOrder!]
+
+		"""
+		Filtering options for Controls returned from the connection.
+		"""
+		where: ControlWhereInput
+	): ControlConnection!
+	procedure(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Procedures returned from the connection.
+		"""
+		where: ProcedureWhereInput
+	): ProcedureConnection!
+	actionPlans(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for ActionPlans returned from the connection.
+		"""
+		orderBy: [ActionPlanOrder!]
+
+		"""
+		Filtering options for ActionPlans returned from the connection.
+		"""
+		where: ActionPlanWhereInput
+	): ActionPlanConnection!
+	programs(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Programs returned from the connection.
+		"""
+		orderBy: [ProgramOrder!]
+
+		"""
+		Filtering options for Programs returned from the connection.
+		"""
+		where: ProgramWhereInput
+	): ProgramConnection!
 	"""
 	the group of users who are responsible for risk oversight
 	"""
@@ -27111,6 +31787,32 @@ enum RiskHistoryOpType @goModel(model: "github.com/theopenlane/entx/history.OpTy
 	INSERT
 	UPDATE
 	DELETE
+}
+"""
+Ordering options for RiskHistory connections
+"""
+input RiskHistoryOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order RiskHistories.
+	"""
+	field: RiskHistoryOrderField!
+}
+"""
+Properties by which RiskHistory connections can be ordered.
+"""
+enum RiskHistoryOrderField {
+	name
+	STATUS
+	risk_type
+	category
+	IMPACT
+	LIKELIHOOD
+	score
+	business_costs
 }
 """
 RiskHistoryRiskImpact is enum for the field impact
@@ -27469,6 +32171,32 @@ input RiskHistoryWhereInput {
 	businessCostsNotNil: Boolean
 	businessCostsEqualFold: String
 	businessCostsContainsFold: String
+}
+"""
+Ordering options for Risk connections
+"""
+input RiskOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order Risks.
+	"""
+	field: RiskOrderField!
+}
+"""
+Properties by which Risk connections can be ordered.
+"""
+enum RiskOrderField {
+	name
+	STATUS
+	risk_type
+	category
+	IMPACT
+	LIKELIHOOD
+	score
+	business_costs
 }
 """
 RiskRiskImpact is enum for the field impact
@@ -27946,7 +32674,37 @@ type Standard implements Node {
 	"""
 	version: String
 	owner: Organization
-	controls: [Control!]
+	controls(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Controls returned from the connection.
+		"""
+		orderBy: [ControlOrder!]
+
+		"""
+		Filtering options for Controls returned from the connection.
+		"""
+		where: ControlWhereInput
+	): ControlConnection!
 }
 """
 Return response for createBulkStandard mutation
@@ -28122,6 +32880,30 @@ enum StandardHistoryOpType @goModel(model: "github.com/theopenlane/entx/history.
 	INSERT
 	UPDATE
 	DELETE
+}
+"""
+Ordering options for StandardHistory connections
+"""
+input StandardHistoryOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order StandardHistories.
+	"""
+	field: StandardHistoryOrderField!
+}
+"""
+Properties by which StandardHistory connections can be ordered.
+"""
+enum StandardHistoryOrderField {
+	name
+	short_name
+	framework
+	governing_body
+	STATUS
+	standard_type
 }
 """
 StandardHistoryStandardStatus is enum for the field status
@@ -28507,6 +33289,30 @@ input StandardHistoryWhereInput {
 	versionNotNil: Boolean
 	versionEqualFold: String
 	versionContainsFold: String
+}
+"""
+Ordering options for Standard connections
+"""
+input StandardOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order Standards.
+	"""
+	field: StandardOrderField!
+}
+"""
+Properties by which Standard connections can be ordered.
+"""
+enum StandardOrderField {
+	name
+	short_name
+	framework
+	governing_body
+	STATUS
+	standard_type
 }
 type StandardSearchResult {
 	standards: [Standard!]
@@ -28969,14 +33775,244 @@ type Subcontrol implements Node {
 	mapped subcontrols that have a relation to another control or subcontrol
 	"""
 	mappedControls: [MappedControl!]
-	evidence: [Evidence!]
-	controlObjectives: [ControlObjective!]
-	tasks: [Task!]
-	narratives: [Narrative!]
-	risks: [Risk!]
-	actionPlans: [ActionPlan!]
-	procedures: [Procedure!]
-	internalPolicies: [InternalPolicy!]
+	evidence(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Evidences returned from the connection.
+		"""
+		orderBy: [EvidenceOrder!]
+
+		"""
+		Filtering options for Evidences returned from the connection.
+		"""
+		where: EvidenceWhereInput
+	): EvidenceConnection!
+	controlObjectives(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for ControlObjectives returned from the connection.
+		"""
+		orderBy: [ControlObjectiveOrder!]
+
+		"""
+		Filtering options for ControlObjectives returned from the connection.
+		"""
+		where: ControlObjectiveWhereInput
+	): ControlObjectiveConnection!
+	tasks(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Tasks returned from the connection.
+		"""
+		orderBy: [TaskOrder!]
+
+		"""
+		Filtering options for Tasks returned from the connection.
+		"""
+		where: TaskWhereInput
+	): TaskConnection!
+	narratives(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Narratives returned from the connection.
+		"""
+		orderBy: NarrativeOrder
+
+		"""
+		Filtering options for Narratives returned from the connection.
+		"""
+		where: NarrativeWhereInput
+	): NarrativeConnection!
+	risks(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Risks returned from the connection.
+		"""
+		orderBy: [RiskOrder!]
+
+		"""
+		Filtering options for Risks returned from the connection.
+		"""
+		where: RiskWhereInput
+	): RiskConnection!
+	actionPlans(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for ActionPlans returned from the connection.
+		"""
+		orderBy: [ActionPlanOrder!]
+
+		"""
+		Filtering options for ActionPlans returned from the connection.
+		"""
+		where: ActionPlanWhereInput
+	): ActionPlanConnection!
+	procedures(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Procedures returned from the connection.
+		"""
+		where: ProcedureWhereInput
+	): ProcedureConnection!
+	internalPolicies(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for InternalPolicies returned from the connection.
+		"""
+		where: InternalPolicyWhereInput
+	): InternalPolicyConnection!
 	"""
 	the user who is responsible for the subcontrol, defaults to the parent control owner if not set
 	"""
@@ -29204,6 +34240,30 @@ enum SubcontrolHistoryOpType @goModel(model: "github.com/theopenlane/entx/histor
 	INSERT
 	UPDATE
 	DELETE
+}
+"""
+Ordering options for SubcontrolHistory connections
+"""
+input SubcontrolHistoryOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order SubcontrolHistories.
+	"""
+	field: SubcontrolHistoryOrderField!
+}
+"""
+Properties by which SubcontrolHistory connections can be ordered.
+"""
+enum SubcontrolHistoryOrderField {
+	status
+	SOURCE
+	CONTROL_TYPE
+	category
+	subcategory
+	ref_code
 }
 """
 SubcontrolHistoryWhereInput is used for filtering SubcontrolHistory objects.
@@ -29529,6 +34589,30 @@ input SubcontrolHistoryWhereInput {
 	controlIDHasSuffix: String
 	controlIDEqualFold: String
 	controlIDContainsFold: String
+}
+"""
+Ordering options for Subcontrol connections
+"""
+input SubcontrolOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order Subcontrols.
+	"""
+	field: SubcontrolOrderField!
+}
+"""
+Properties by which Subcontrol connections can be ordered.
+"""
+enum SubcontrolOrderField {
+	status
+	SOURCE
+	CONTROL_TYPE
+	category
+	subcategory
+	ref_code
 }
 type SubcontrolSearchResult {
 	subcontrols: [Subcontrol!]
@@ -29933,7 +35017,32 @@ type Subscriber implements Node {
 	"""
 	active: Boolean!
 	owner: Organization
-	events: [Event!]
+	events(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Events returned from the connection.
+		"""
+		where: EventWhereInput
+	): EventConnection!
 }
 """
 Return response for createBulkSubscriber mutation
@@ -29991,6 +35100,26 @@ type SubscriberEdge {
 	A cursor for use in pagination.
 	"""
 	cursor: Cursor!
+}
+"""
+Ordering options for Subscriber connections
+"""
+input SubscriberOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order Subscribers.
+	"""
+	field: SubscriberOrderField!
+}
+"""
+Properties by which Subscriber connections can be ordered.
+"""
+enum SubscriberOrderField {
+	email
+	active
 }
 type SubscriberSearchResult {
 	subscribers: [Subscriber!]
@@ -30458,18 +35587,270 @@ type Task implements Node {
 	owner: Organization
 	assigner: User
 	assignee: User
-	"""
-	conversations related to the task
-	"""
-	comments: [Note!]
-	group: [Group!]
-	internalPolicy: [InternalPolicy!]
-	procedure: [Procedure!]
-	control: [Control!]
-	controlObjective: [ControlObjective!]
-	subcontrol: [Subcontrol!]
-	program: [Program!]
-	evidence: [Evidence!]
+	comments(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Notes returned from the connection.
+		"""
+		where: NoteWhereInput
+	): NoteConnection!
+	group(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Groups returned from the connection.
+		"""
+		orderBy: [GroupOrder!]
+
+		"""
+		Filtering options for Groups returned from the connection.
+		"""
+		where: GroupWhereInput
+	): GroupConnection!
+	internalPolicy(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for InternalPolicies returned from the connection.
+		"""
+		where: InternalPolicyWhereInput
+	): InternalPolicyConnection!
+	procedure(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Procedures returned from the connection.
+		"""
+		where: ProcedureWhereInput
+	): ProcedureConnection!
+	control(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Controls returned from the connection.
+		"""
+		orderBy: [ControlOrder!]
+
+		"""
+		Filtering options for Controls returned from the connection.
+		"""
+		where: ControlWhereInput
+	): ControlConnection!
+	controlObjective(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for ControlObjectives returned from the connection.
+		"""
+		orderBy: [ControlObjectiveOrder!]
+
+		"""
+		Filtering options for ControlObjectives returned from the connection.
+		"""
+		where: ControlObjectiveWhereInput
+	): ControlObjectiveConnection!
+	subcontrol(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Subcontrols returned from the connection.
+		"""
+		orderBy: [SubcontrolOrder!]
+
+		"""
+		Filtering options for Subcontrols returned from the connection.
+		"""
+		where: SubcontrolWhereInput
+	): SubcontrolConnection!
+	program(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Programs returned from the connection.
+		"""
+		orderBy: [ProgramOrder!]
+
+		"""
+		Filtering options for Programs returned from the connection.
+		"""
+		where: ProgramWhereInput
+	): ProgramConnection!
+	evidence(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Evidences returned from the connection.
+		"""
+		orderBy: [EvidenceOrder!]
+
+		"""
+		Filtering options for Evidences returned from the connection.
+		"""
+		where: EvidenceWhereInput
+	): EvidenceConnection!
 }
 """
 Return response for createBulkTask mutation
@@ -30625,6 +36006,29 @@ enum TaskHistoryOpType @goModel(model: "github.com/theopenlane/entx/history.OpTy
 	INSERT
 	UPDATE
 	DELETE
+}
+"""
+Ordering options for TaskHistory connections
+"""
+input TaskHistoryOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order TaskHistories.
+	"""
+	field: TaskHistoryOrderField!
+}
+"""
+Properties by which TaskHistory connections can be ordered.
+"""
+enum TaskHistoryOrderField {
+	title
+	STATUS
+	category
+	due
+	completed
 }
 """
 TaskHistoryTaskStatus is enum for the field status
@@ -30959,6 +36363,29 @@ input TaskHistoryWhereInput {
 	assignerIDNotNil: Boolean
 	assignerIDEqualFold: String
 	assignerIDContainsFold: String
+}
+"""
+Ordering options for Task connections
+"""
+input TaskOrder {
+	"""
+	The ordering direction.
+	"""
+	direction: OrderDirection! = ASC
+	"""
+	The field by which to order Tasks.
+	"""
+	field: TaskOrderField!
+}
+"""
+Properties by which Task connections can be ordered.
+"""
+enum TaskOrderField {
+	title
+	STATUS
+	category
+	due
+	completed
 }
 type TaskSearchResult {
 	tasks: [Task!]
@@ -31367,8 +36794,58 @@ type Template implements Node {
 	"""
 	uischema: Map
 	owner: Organization
-	documents: [DocumentData!]
-	files: [File!]
+	documents(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for DocumentDataSlice returned from the connection.
+		"""
+		where: DocumentDataWhereInput
+	): DocumentDataConnection!
+	files(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Files returned from the connection.
+		"""
+		where: FileWhereInput
+	): FileConnection!
 }
 """
 Return response for createBulkTemplate mutation
@@ -31537,6 +37014,7 @@ Properties by which TemplateHistory connections can be ordered.
 """
 enum TemplateHistoryOrderField {
 	name
+	TEMPLATE_TYPE
 }
 """
 TemplateHistoryWhereInput is used for filtering TemplateHistory objects.
@@ -31766,6 +37244,7 @@ Properties by which Template connections can be ordered.
 """
 enum TemplateOrderField {
 	name
+	TEMPLATE_TYPE
 }
 type TemplateSearchResult {
 	templates: [Template!]
@@ -34297,18 +39776,238 @@ type User implements Node {
 	the user's role
 	"""
 	role: UserRole
-	personalAccessTokens: [PersonalAccessToken!]
-	tfaSettings: [TFASetting!]
+	personalAccessTokens(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for PersonalAccessTokens returned from the connection.
+		"""
+		where: PersonalAccessTokenWhereInput
+	): PersonalAccessTokenConnection!
+	tfaSettings(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for TFASettings returned from the connection.
+		"""
+		where: TFASettingWhereInput
+	): TFASettingConnection!
 	setting: UserSetting!
 	groups: [Group!]
 	organizations: [Organization!]
-	files: [File!]
+	files(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Files returned from the connection.
+		"""
+		where: FileWhereInput
+	): FileConnection!
 	avatarFile: File
-	events: [Event!]
-	actionPlans: [ActionPlan!]
-	subcontrols: [Subcontrol!]
-	assignerTasks: [Task!]
-	assigneeTasks: [Task!]
+	events(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Events returned from the connection.
+		"""
+		where: EventWhereInput
+	): EventConnection!
+	actionPlans(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for ActionPlans returned from the connection.
+		"""
+		orderBy: [ActionPlanOrder!]
+
+		"""
+		Filtering options for ActionPlans returned from the connection.
+		"""
+		where: ActionPlanWhereInput
+	): ActionPlanConnection!
+	subcontrols(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Subcontrols returned from the connection.
+		"""
+		orderBy: [SubcontrolOrder!]
+
+		"""
+		Filtering options for Subcontrols returned from the connection.
+		"""
+		where: SubcontrolWhereInput
+	): SubcontrolConnection!
+	assignerTasks(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Tasks returned from the connection.
+		"""
+		orderBy: [TaskOrder!]
+
+		"""
+		Filtering options for Tasks returned from the connection.
+		"""
+		where: TaskWhereInput
+	): TaskConnection!
+	assigneeTasks(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Tasks returned from the connection.
+		"""
+		orderBy: [TaskOrder!]
+
+		"""
+		Filtering options for Tasks returned from the connection.
+		"""
+		where: TaskWhereInput
+	): TaskConnection!
 	programs: [Program!]
 	groupMemberships: [GroupMembership!]
 	orgMemberships: [OrgMembership!]
@@ -34920,7 +40619,32 @@ type UserSetting implements Node {
 	organization to load on user login
 	"""
 	defaultOrg: Organization
-	files: [File!]
+	files(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Filtering options for Files returned from the connection.
+		"""
+		where: FileWhereInput
+	): FileConnection!
 }
 """
 Return response for createBulkUserSetting mutation

--- a/internal/graphapi/control_test.go
+++ b/internal/graphapi/control_test.go
@@ -103,7 +103,7 @@ func (suite *GraphTestSuite) TestQueryControl() {
 			assert.Equal(t, tc.queryID, resp.Control.ID)
 			assert.NotEmpty(t, resp.Control.RefCode)
 
-			require.Len(t, resp.Control.Programs, 1)
+			require.Len(t, resp.Control.Programs.Edges, 1)
 			assert.NotEmpty(t, resp.Control.Programs.Edges[0].Node.ID)
 		})
 	}
@@ -375,13 +375,13 @@ func (suite *GraphTestSuite) TestMutationCreateControl() {
 			// ensure the program is set
 			if len(tc.request.ProgramIDs) > 0 {
 				require.NotEmpty(t, resp.CreateControl.Control.Programs)
-				require.Len(t, resp.CreateControl.Control.Programs, len(tc.request.ProgramIDs))
+				require.Len(t, resp.CreateControl.Control.Programs.Edges, len(tc.request.ProgramIDs))
 
 				for i, p := range resp.CreateControl.Control.Programs.Edges {
 					assert.Equal(t, tc.request.ProgramIDs[i], p.Node.ID)
 				}
 			} else {
-				assert.Empty(t, resp.CreateControl.Control.Programs)
+				assert.Empty(t, resp.CreateControl.Control.Programs.Edges)
 			}
 
 			if tc.request.Description != nil {
@@ -755,7 +755,7 @@ func (suite *GraphTestSuite) TestMutationUpdateControl() {
 			// ensure the program is set
 			if len(tc.request.AddProgramIDs) > 0 {
 				require.NotEmpty(t, resp.UpdateControl.Control.Programs)
-				require.Len(t, resp.UpdateControl.Control.Programs, len(tc.request.AddProgramIDs))
+				require.Len(t, resp.UpdateControl.Control.Programs.Edges, len(tc.request.AddProgramIDs))
 			}
 
 			if len(tc.request.AddViewerIDs) > 0 {

--- a/internal/graphapi/control_test.go
+++ b/internal/graphapi/control_test.go
@@ -104,7 +104,7 @@ func (suite *GraphTestSuite) TestQueryControl() {
 			assert.NotEmpty(t, resp.Control.RefCode)
 
 			require.Len(t, resp.Control.Programs, 1)
-			assert.NotEmpty(t, resp.Control.Programs[0].ID)
+			assert.NotEmpty(t, resp.Control.Programs.Edges[0].Node.ID)
 		})
 	}
 }
@@ -377,8 +377,8 @@ func (suite *GraphTestSuite) TestMutationCreateControl() {
 				require.NotEmpty(t, resp.CreateControl.Control.Programs)
 				require.Len(t, resp.CreateControl.Control.Programs, len(tc.request.ProgramIDs))
 
-				for i, p := range resp.CreateControl.Control.Programs {
-					assert.Equal(t, tc.request.ProgramIDs[i], p.ID)
+				for i, p := range resp.CreateControl.Control.Programs.Edges {
+					assert.Equal(t, tc.request.ProgramIDs[i], p.Node.ID)
 				}
 			} else {
 				assert.Empty(t, resp.CreateControl.Control.Programs)

--- a/internal/graphapi/ent.resolvers.go
+++ b/internal/graphapi/ent.resolvers.go
@@ -50,7 +50,7 @@ func (r *queryResolver) APITokens(ctx context.Context, after *entgql.Cursor[stri
 }
 
 // ActionPlans is the resolver for the actionPlans field.
-func (r *queryResolver) ActionPlans(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ActionPlanWhereInput) (*generated.ActionPlanConnection, error) {
+func (r *queryResolver) ActionPlans(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ActionPlanOrder, where *generated.ActionPlanWhereInput) (*generated.ActionPlanConnection, error) {
 	res, err := withTransactionalMutation(ctx).ActionPlan.Query().Paginate(
 		ctx,
 		after,
@@ -66,7 +66,7 @@ func (r *queryResolver) ActionPlans(ctx context.Context, after *entgql.Cursor[st
 }
 
 // ActionPlanHistories is the resolver for the actionPlanHistories field.
-func (r *queryResolver) ActionPlanHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ActionPlanHistoryWhereInput) (*generated.ActionPlanHistoryConnection, error) {
+func (r *queryResolver) ActionPlanHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ActionPlanHistoryOrder, where *generated.ActionPlanHistoryWhereInput) (*generated.ActionPlanHistoryConnection, error) {
 	res, err := withTransactionalMutation(ctx).ActionPlanHistory.Query().Paginate(
 		ctx,
 		after,
@@ -82,7 +82,7 @@ func (r *queryResolver) ActionPlanHistories(ctx context.Context, after *entgql.C
 }
 
 // Contacts is the resolver for the contacts field.
-func (r *queryResolver) Contacts(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ContactWhereInput) (*generated.ContactConnection, error) {
+func (r *queryResolver) Contacts(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ContactOrder, where *generated.ContactWhereInput) (*generated.ContactConnection, error) {
 	res, err := withTransactionalMutation(ctx).Contact.Query().Paginate(
 		ctx,
 		after,
@@ -98,7 +98,7 @@ func (r *queryResolver) Contacts(ctx context.Context, after *entgql.Cursor[strin
 }
 
 // ContactHistories is the resolver for the contactHistories field.
-func (r *queryResolver) ContactHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ContactHistoryWhereInput) (*generated.ContactHistoryConnection, error) {
+func (r *queryResolver) ContactHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ContactHistoryOrder, where *generated.ContactHistoryWhereInput) (*generated.ContactHistoryConnection, error) {
 	res, err := withTransactionalMutation(ctx).ContactHistory.Query().Paginate(
 		ctx,
 		after,
@@ -114,7 +114,7 @@ func (r *queryResolver) ContactHistories(ctx context.Context, after *entgql.Curs
 }
 
 // Controls is the resolver for the controls field.
-func (r *queryResolver) Controls(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ControlWhereInput) (*generated.ControlConnection, error) {
+func (r *queryResolver) Controls(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlOrder, where *generated.ControlWhereInput) (*generated.ControlConnection, error) {
 	query := withTransactionalMutation(ctx).Control.Query()
 
 	if graphutils.CheckForRequestedField(ctx, generated.TypeSubcontrol) {
@@ -210,7 +210,7 @@ func (r *queryResolver) Controls(ctx context.Context, after *entgql.Cursor[strin
 }
 
 // ControlHistories is the resolver for the controlHistories field.
-func (r *queryResolver) ControlHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ControlHistoryWhereInput) (*generated.ControlHistoryConnection, error) {
+func (r *queryResolver) ControlHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ControlHistoryOrder, where *generated.ControlHistoryWhereInput) (*generated.ControlHistoryConnection, error) {
 	res, err := withTransactionalMutation(ctx).ControlHistory.Query().Paginate(
 		ctx,
 		after,
@@ -226,7 +226,7 @@ func (r *queryResolver) ControlHistories(ctx context.Context, after *entgql.Curs
 }
 
 // ControlImplementations is the resolver for the controlImplementations field.
-func (r *queryResolver) ControlImplementations(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ControlImplementationWhereInput) (*generated.ControlImplementationConnection, error) {
+func (r *queryResolver) ControlImplementations(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlImplementationOrder, where *generated.ControlImplementationWhereInput) (*generated.ControlImplementationConnection, error) {
 	res, err := withTransactionalMutation(ctx).ControlImplementation.Query().Paginate(
 		ctx,
 		after,
@@ -242,7 +242,7 @@ func (r *queryResolver) ControlImplementations(ctx context.Context, after *entgq
 }
 
 // ControlImplementationHistories is the resolver for the controlImplementationHistories field.
-func (r *queryResolver) ControlImplementationHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ControlImplementationHistoryWhereInput) (*generated.ControlImplementationHistoryConnection, error) {
+func (r *queryResolver) ControlImplementationHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ControlImplementationHistoryOrder, where *generated.ControlImplementationHistoryWhereInput) (*generated.ControlImplementationHistoryConnection, error) {
 	res, err := withTransactionalMutation(ctx).ControlImplementationHistory.Query().Paginate(
 		ctx,
 		after,
@@ -258,7 +258,7 @@ func (r *queryResolver) ControlImplementationHistories(ctx context.Context, afte
 }
 
 // ControlObjectives is the resolver for the controlObjectives field.
-func (r *queryResolver) ControlObjectives(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ControlObjectiveWhereInput) (*generated.ControlObjectiveConnection, error) {
+func (r *queryResolver) ControlObjectives(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlObjectiveOrder, where *generated.ControlObjectiveWhereInput) (*generated.ControlObjectiveConnection, error) {
 	res, err := withTransactionalMutation(ctx).ControlObjective.Query().Paginate(
 		ctx,
 		after,
@@ -274,7 +274,7 @@ func (r *queryResolver) ControlObjectives(ctx context.Context, after *entgql.Cur
 }
 
 // ControlObjectiveHistories is the resolver for the controlObjectiveHistories field.
-func (r *queryResolver) ControlObjectiveHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ControlObjectiveHistoryWhereInput) (*generated.ControlObjectiveHistoryConnection, error) {
+func (r *queryResolver) ControlObjectiveHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ControlObjectiveHistoryOrder, where *generated.ControlObjectiveHistoryWhereInput) (*generated.ControlObjectiveHistoryConnection, error) {
 	res, err := withTransactionalMutation(ctx).ControlObjectiveHistory.Query().Paginate(
 		ctx,
 		after,
@@ -322,7 +322,7 @@ func (r *queryResolver) DocumentDataHistories(ctx context.Context, after *entgql
 }
 
 // Entities is the resolver for the entities field.
-func (r *queryResolver) Entities(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.EntityOrder, where *generated.EntityWhereInput) (*generated.EntityConnection, error) {
+func (r *queryResolver) Entities(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.EntityOrder, where *generated.EntityWhereInput) (*generated.EntityConnection, error) {
 	res, err := withTransactionalMutation(ctx).Entity.Query().Paginate(
 		ctx,
 		after,
@@ -422,7 +422,7 @@ func (r *queryResolver) EventHistories(ctx context.Context, after *entgql.Cursor
 }
 
 // Evidences is the resolver for the evidences field.
-func (r *queryResolver) Evidences(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.EvidenceWhereInput) (*generated.EvidenceConnection, error) {
+func (r *queryResolver) Evidences(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.EvidenceOrder, where *generated.EvidenceWhereInput) (*generated.EvidenceConnection, error) {
 	res, err := withTransactionalMutation(ctx).Evidence.Query().Paginate(
 		ctx,
 		after,
@@ -438,7 +438,7 @@ func (r *queryResolver) Evidences(ctx context.Context, after *entgql.Cursor[stri
 }
 
 // EvidenceHistories is the resolver for the evidenceHistories field.
-func (r *queryResolver) EvidenceHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.EvidenceHistoryWhereInput) (*generated.EvidenceHistoryConnection, error) {
+func (r *queryResolver) EvidenceHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.EvidenceHistoryOrder, where *generated.EvidenceHistoryWhereInput) (*generated.EvidenceHistoryConnection, error) {
 	res, err := withTransactionalMutation(ctx).EvidenceHistory.Query().Paginate(
 		ctx,
 		after,
@@ -486,7 +486,7 @@ func (r *queryResolver) FileHistories(ctx context.Context, after *entgql.Cursor[
 }
 
 // Groups is the resolver for the groups field.
-func (r *queryResolver) Groups(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.GroupOrder, where *generated.GroupWhereInput) (*generated.GroupConnection, error) {
+func (r *queryResolver) Groups(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.GroupOrder, where *generated.GroupWhereInput) (*generated.GroupConnection, error) {
 	res, err := withTransactionalMutation(ctx).Group.Query().Paginate(
 		ctx,
 		after,
@@ -520,7 +520,7 @@ func (r *queryResolver) GroupHistories(ctx context.Context, after *entgql.Cursor
 }
 
 // GroupMemberships is the resolver for the groupMemberships field.
-func (r *queryResolver) GroupMemberships(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.GroupMembershipWhereInput) (*generated.GroupMembershipConnection, error) {
+func (r *queryResolver) GroupMemberships(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.GroupMembershipOrder, where *generated.GroupMembershipWhereInput) (*generated.GroupMembershipConnection, error) {
 	res, err := withTransactionalMutation(ctx).GroupMembership.Query().Paginate(
 		ctx,
 		after,
@@ -536,7 +536,7 @@ func (r *queryResolver) GroupMemberships(ctx context.Context, after *entgql.Curs
 }
 
 // GroupMembershipHistories is the resolver for the groupMembershipHistories field.
-func (r *queryResolver) GroupMembershipHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.GroupMembershipHistoryWhereInput) (*generated.GroupMembershipHistoryConnection, error) {
+func (r *queryResolver) GroupMembershipHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.GroupMembershipHistoryOrder, where *generated.GroupMembershipHistoryWhereInput) (*generated.GroupMembershipHistoryConnection, error) {
 	res, err := withTransactionalMutation(ctx).GroupMembershipHistory.Query().Paginate(
 		ctx,
 		after,
@@ -584,7 +584,7 @@ func (r *queryResolver) GroupSettingHistories(ctx context.Context, after *entgql
 }
 
 // Hushes is the resolver for the hushes field.
-func (r *queryResolver) Hushes(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.HushOrder, where *generated.HushWhereInput) (*generated.HushConnection, error) {
+func (r *queryResolver) Hushes(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.HushOrder, where *generated.HushWhereInput) (*generated.HushConnection, error) {
 	res, err := withTransactionalMutation(ctx).Hush.Query().Paginate(
 		ctx,
 		after,
@@ -618,7 +618,7 @@ func (r *queryResolver) HushHistories(ctx context.Context, after *entgql.Cursor[
 }
 
 // Integrations is the resolver for the integrations field.
-func (r *queryResolver) Integrations(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.IntegrationOrder, where *generated.IntegrationWhereInput) (*generated.IntegrationConnection, error) {
+func (r *queryResolver) Integrations(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.IntegrationOrder, where *generated.IntegrationWhereInput) (*generated.IntegrationConnection, error) {
 	res, err := withTransactionalMutation(ctx).Integration.Query().Paginate(
 		ctx,
 		after,
@@ -684,7 +684,7 @@ func (r *queryResolver) InternalPolicyHistories(ctx context.Context, after *entg
 }
 
 // Invites is the resolver for the invites field.
-func (r *queryResolver) Invites(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.InviteWhereInput) (*generated.InviteConnection, error) {
+func (r *queryResolver) Invites(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.InviteOrder, where *generated.InviteWhereInput) (*generated.InviteConnection, error) {
 	res, err := withTransactionalMutation(ctx).Invite.Query().Paginate(
 		ctx,
 		after,
@@ -700,7 +700,7 @@ func (r *queryResolver) Invites(ctx context.Context, after *entgql.Cursor[string
 }
 
 // MappedControls is the resolver for the mappedControls field.
-func (r *queryResolver) MappedControls(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.MappedControlWhereInput) (*generated.MappedControlConnection, error) {
+func (r *queryResolver) MappedControls(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.MappedControlOrder, where *generated.MappedControlWhereInput) (*generated.MappedControlConnection, error) {
 	res, err := withTransactionalMutation(ctx).MappedControl.Query().Paginate(
 		ctx,
 		after,
@@ -716,7 +716,7 @@ func (r *queryResolver) MappedControls(ctx context.Context, after *entgql.Cursor
 }
 
 // MappedControlHistories is the resolver for the mappedControlHistories field.
-func (r *queryResolver) MappedControlHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.MappedControlHistoryWhereInput) (*generated.MappedControlHistoryConnection, error) {
+func (r *queryResolver) MappedControlHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.MappedControlHistoryOrder, where *generated.MappedControlHistoryWhereInput) (*generated.MappedControlHistoryConnection, error) {
 	res, err := withTransactionalMutation(ctx).MappedControlHistory.Query().Paginate(
 		ctx,
 		after,
@@ -732,7 +732,7 @@ func (r *queryResolver) MappedControlHistories(ctx context.Context, after *entgq
 }
 
 // Narratives is the resolver for the narratives field.
-func (r *queryResolver) Narratives(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.NarrativeWhereInput) (*generated.NarrativeConnection, error) {
+func (r *queryResolver) Narratives(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.NarrativeOrder, where *generated.NarrativeWhereInput) (*generated.NarrativeConnection, error) {
 	res, err := withTransactionalMutation(ctx).Narrative.Query().Paginate(
 		ctx,
 		after,
@@ -748,7 +748,7 @@ func (r *queryResolver) Narratives(ctx context.Context, after *entgql.Cursor[str
 }
 
 // NarrativeHistories is the resolver for the narrativeHistories field.
-func (r *queryResolver) NarrativeHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.NarrativeHistoryWhereInput) (*generated.NarrativeHistoryConnection, error) {
+func (r *queryResolver) NarrativeHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.NarrativeHistoryOrder, where *generated.NarrativeHistoryWhereInput) (*generated.NarrativeHistoryConnection, error) {
 	res, err := withTransactionalMutation(ctx).NarrativeHistory.Query().Paginate(
 		ctx,
 		after,
@@ -796,7 +796,7 @@ func (r *queryResolver) NoteHistories(ctx context.Context, after *entgql.Cursor[
 }
 
 // OrgMemberships is the resolver for the orgMemberships field.
-func (r *queryResolver) OrgMemberships(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.OrgMembershipWhereInput) (*generated.OrgMembershipConnection, error) {
+func (r *queryResolver) OrgMemberships(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.OrgMembershipOrder, where *generated.OrgMembershipWhereInput) (*generated.OrgMembershipConnection, error) {
 	res, err := withTransactionalMutation(ctx).OrgMembership.Query().Paginate(
 		ctx,
 		after,
@@ -812,7 +812,7 @@ func (r *queryResolver) OrgMemberships(ctx context.Context, after *entgql.Cursor
 }
 
 // OrgMembershipHistories is the resolver for the orgMembershipHistories field.
-func (r *queryResolver) OrgMembershipHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.OrgMembershipHistoryWhereInput) (*generated.OrgMembershipHistoryConnection, error) {
+func (r *queryResolver) OrgMembershipHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.OrgMembershipHistoryOrder, where *generated.OrgMembershipHistoryWhereInput) (*generated.OrgMembershipHistoryConnection, error) {
 	res, err := withTransactionalMutation(ctx).OrgMembershipHistory.Query().Paginate(
 		ctx,
 		after,
@@ -828,7 +828,7 @@ func (r *queryResolver) OrgMembershipHistories(ctx context.Context, after *entgq
 }
 
 // OrgSubscriptions is the resolver for the orgSubscriptions field.
-func (r *queryResolver) OrgSubscriptions(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.OrgSubscriptionWhereInput) (*generated.OrgSubscriptionConnection, error) {
+func (r *queryResolver) OrgSubscriptions(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.OrgSubscriptionOrder, where *generated.OrgSubscriptionWhereInput) (*generated.OrgSubscriptionConnection, error) {
 	res, err := withTransactionalMutation(ctx).OrgSubscription.Query().Paginate(
 		ctx,
 		after,
@@ -844,7 +844,7 @@ func (r *queryResolver) OrgSubscriptions(ctx context.Context, after *entgql.Curs
 }
 
 // OrgSubscriptionHistories is the resolver for the orgSubscriptionHistories field.
-func (r *queryResolver) OrgSubscriptionHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.OrgSubscriptionHistoryWhereInput) (*generated.OrgSubscriptionHistoryConnection, error) {
+func (r *queryResolver) OrgSubscriptionHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.OrgSubscriptionHistoryOrder, where *generated.OrgSubscriptionHistoryWhereInput) (*generated.OrgSubscriptionHistoryConnection, error) {
 	res, err := withTransactionalMutation(ctx).OrgSubscriptionHistory.Query().Paginate(
 		ctx,
 		after,
@@ -860,7 +860,7 @@ func (r *queryResolver) OrgSubscriptionHistories(ctx context.Context, after *ent
 }
 
 // Organizations is the resolver for the organizations field.
-func (r *queryResolver) Organizations(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.OrganizationOrder, where *generated.OrganizationWhereInput) (*generated.OrganizationConnection, error) {
+func (r *queryResolver) Organizations(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.OrganizationOrder, where *generated.OrganizationWhereInput) (*generated.OrganizationConnection, error) {
 	res, err := withTransactionalMutation(ctx).Organization.Query().Paginate(
 		ctx,
 		after,
@@ -974,7 +974,7 @@ func (r *queryResolver) ProcedureHistories(ctx context.Context, after *entgql.Cu
 }
 
 // Programs is the resolver for the programs field.
-func (r *queryResolver) Programs(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ProgramWhereInput) (*generated.ProgramConnection, error) {
+func (r *queryResolver) Programs(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ProgramOrder, where *generated.ProgramWhereInput) (*generated.ProgramConnection, error) {
 	res, err := withTransactionalMutation(ctx).Program.Query().Paginate(
 		ctx,
 		after,
@@ -990,7 +990,7 @@ func (r *queryResolver) Programs(ctx context.Context, after *entgql.Cursor[strin
 }
 
 // ProgramHistories is the resolver for the programHistories field.
-func (r *queryResolver) ProgramHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ProgramHistoryWhereInput) (*generated.ProgramHistoryConnection, error) {
+func (r *queryResolver) ProgramHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ProgramHistoryOrder, where *generated.ProgramHistoryWhereInput) (*generated.ProgramHistoryConnection, error) {
 	res, err := withTransactionalMutation(ctx).ProgramHistory.Query().Paginate(
 		ctx,
 		after,
@@ -1006,7 +1006,7 @@ func (r *queryResolver) ProgramHistories(ctx context.Context, after *entgql.Curs
 }
 
 // ProgramMemberships is the resolver for the programMemberships field.
-func (r *queryResolver) ProgramMemberships(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ProgramMembershipWhereInput) (*generated.ProgramMembershipConnection, error) {
+func (r *queryResolver) ProgramMemberships(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ProgramMembershipOrder, where *generated.ProgramMembershipWhereInput) (*generated.ProgramMembershipConnection, error) {
 	res, err := withTransactionalMutation(ctx).ProgramMembership.Query().Paginate(
 		ctx,
 		after,
@@ -1022,7 +1022,7 @@ func (r *queryResolver) ProgramMemberships(ctx context.Context, after *entgql.Cu
 }
 
 // ProgramMembershipHistories is the resolver for the programMembershipHistories field.
-func (r *queryResolver) ProgramMembershipHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ProgramMembershipHistoryWhereInput) (*generated.ProgramMembershipHistoryConnection, error) {
+func (r *queryResolver) ProgramMembershipHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ProgramMembershipHistoryOrder, where *generated.ProgramMembershipHistoryWhereInput) (*generated.ProgramMembershipHistoryConnection, error) {
 	res, err := withTransactionalMutation(ctx).ProgramMembershipHistory.Query().Paginate(
 		ctx,
 		after,
@@ -1038,7 +1038,7 @@ func (r *queryResolver) ProgramMembershipHistories(ctx context.Context, after *e
 }
 
 // Risks is the resolver for the risks field.
-func (r *queryResolver) Risks(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.RiskWhereInput) (*generated.RiskConnection, error) {
+func (r *queryResolver) Risks(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.RiskOrder, where *generated.RiskWhereInput) (*generated.RiskConnection, error) {
 	res, err := withTransactionalMutation(ctx).Risk.Query().Paginate(
 		ctx,
 		after,
@@ -1054,7 +1054,7 @@ func (r *queryResolver) Risks(ctx context.Context, after *entgql.Cursor[string],
 }
 
 // RiskHistories is the resolver for the riskHistories field.
-func (r *queryResolver) RiskHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.RiskHistoryWhereInput) (*generated.RiskHistoryConnection, error) {
+func (r *queryResolver) RiskHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.RiskHistoryOrder, where *generated.RiskHistoryWhereInput) (*generated.RiskHistoryConnection, error) {
 	res, err := withTransactionalMutation(ctx).RiskHistory.Query().Paginate(
 		ctx,
 		after,
@@ -1070,7 +1070,7 @@ func (r *queryResolver) RiskHistories(ctx context.Context, after *entgql.Cursor[
 }
 
 // Standards is the resolver for the standards field.
-func (r *queryResolver) Standards(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.StandardWhereInput) (*generated.StandardConnection, error) {
+func (r *queryResolver) Standards(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.StandardOrder, where *generated.StandardWhereInput) (*generated.StandardConnection, error) {
 	query := withTransactionalMutation(ctx).Standard.Query()
 
 	if graphutils.CheckForRequestedField(ctx, generated.TypeControl) {
@@ -1172,7 +1172,7 @@ func (r *queryResolver) Standards(ctx context.Context, after *entgql.Cursor[stri
 }
 
 // StandardHistories is the resolver for the standardHistories field.
-func (r *queryResolver) StandardHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.StandardHistoryWhereInput) (*generated.StandardHistoryConnection, error) {
+func (r *queryResolver) StandardHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.StandardHistoryOrder, where *generated.StandardHistoryWhereInput) (*generated.StandardHistoryConnection, error) {
 	res, err := withTransactionalMutation(ctx).StandardHistory.Query().Paginate(
 		ctx,
 		after,
@@ -1188,7 +1188,7 @@ func (r *queryResolver) StandardHistories(ctx context.Context, after *entgql.Cur
 }
 
 // Subcontrols is the resolver for the subcontrols field.
-func (r *queryResolver) Subcontrols(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.SubcontrolWhereInput) (*generated.SubcontrolConnection, error) {
+func (r *queryResolver) Subcontrols(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.SubcontrolOrder, where *generated.SubcontrolWhereInput) (*generated.SubcontrolConnection, error) {
 	query := withTransactionalMutation(ctx).Subcontrol.Query()
 
 	if graphutils.CheckForRequestedField(ctx, generated.TypeControlObjective) {
@@ -1260,7 +1260,7 @@ func (r *queryResolver) Subcontrols(ctx context.Context, after *entgql.Cursor[st
 }
 
 // SubcontrolHistories is the resolver for the subcontrolHistories field.
-func (r *queryResolver) SubcontrolHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.SubcontrolHistoryWhereInput) (*generated.SubcontrolHistoryConnection, error) {
+func (r *queryResolver) SubcontrolHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.SubcontrolHistoryOrder, where *generated.SubcontrolHistoryWhereInput) (*generated.SubcontrolHistoryConnection, error) {
 	res, err := withTransactionalMutation(ctx).SubcontrolHistory.Query().Paginate(
 		ctx,
 		after,
@@ -1276,7 +1276,7 @@ func (r *queryResolver) SubcontrolHistories(ctx context.Context, after *entgql.C
 }
 
 // Subscribers is the resolver for the subscribers field.
-func (r *queryResolver) Subscribers(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.SubscriberWhereInput) (*generated.SubscriberConnection, error) {
+func (r *queryResolver) Subscribers(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.SubscriberOrder, where *generated.SubscriberWhereInput) (*generated.SubscriberConnection, error) {
 	res, err := withTransactionalMutation(ctx).Subscriber.Query().Paginate(
 		ctx,
 		after,
@@ -1308,7 +1308,7 @@ func (r *queryResolver) TfaSettings(ctx context.Context, after *entgql.Cursor[st
 }
 
 // Tasks is the resolver for the tasks field.
-func (r *queryResolver) Tasks(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.TaskWhereInput) (*generated.TaskConnection, error) {
+func (r *queryResolver) Tasks(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.TaskOrder, where *generated.TaskWhereInput) (*generated.TaskConnection, error) {
 	res, err := withTransactionalMutation(ctx).Task.Query().Paginate(
 		ctx,
 		after,
@@ -1324,7 +1324,7 @@ func (r *queryResolver) Tasks(ctx context.Context, after *entgql.Cursor[string],
 }
 
 // TaskHistories is the resolver for the taskHistories field.
-func (r *queryResolver) TaskHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.TaskHistoryWhereInput) (*generated.TaskHistoryConnection, error) {
+func (r *queryResolver) TaskHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.TaskHistoryOrder, where *generated.TaskHistoryWhereInput) (*generated.TaskHistoryConnection, error) {
 	res, err := withTransactionalMutation(ctx).TaskHistory.Query().Paginate(
 		ctx,
 		after,
@@ -1340,7 +1340,7 @@ func (r *queryResolver) TaskHistories(ctx context.Context, after *entgql.Cursor[
 }
 
 // Templates is the resolver for the templates field.
-func (r *queryResolver) Templates(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.TemplateOrder, where *generated.TemplateWhereInput) (*generated.TemplateConnection, error) {
+func (r *queryResolver) Templates(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.TemplateOrder, where *generated.TemplateWhereInput) (*generated.TemplateConnection, error) {
 	res, err := withTransactionalMutation(ctx).Template.Query().Paginate(
 		ctx,
 		after,
@@ -1374,7 +1374,7 @@ func (r *queryResolver) TemplateHistories(ctx context.Context, after *entgql.Cur
 }
 
 // Users is the resolver for the users field.
-func (r *queryResolver) Users(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.UserOrder, where *generated.UserWhereInput) (*generated.UserConnection, error) {
+func (r *queryResolver) Users(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.UserOrder, where *generated.UserWhereInput) (*generated.UserConnection, error) {
 	res, err := withTransactionalMutation(ctx).User.Query().Paginate(
 		ctx,
 		after,

--- a/internal/graphapi/entity_test.go
+++ b/internal/graphapi/entity_test.go
@@ -259,7 +259,8 @@ func (suite *GraphTestSuite) TestMutationCreateEntity() {
 
 			if tc.request.Note != nil {
 				require.Len(t, resp.CreateEntity.Entity.Notes, 1)
-				assert.Equal(t, tc.request.Note.Text, resp.CreateEntity.Entity.Notes[0].Text)
+				require.NotEmpty(t, resp.CreateEntity.Entity.Notes)
+				assert.Equal(t, tc.request.Note.Text, resp.CreateEntity.Entity.Notes.Edges[0].Node.Text)
 			}
 		})
 	}
@@ -382,7 +383,7 @@ func (suite *GraphTestSuite) TestMutationUpdateEntity() {
 				numNotes++
 
 				require.Len(t, resp.UpdateEntity.Entity.Notes, numNotes)
-				assert.Equal(t, tc.request.Note.Text, resp.UpdateEntity.Entity.Notes[0].Text)
+				assert.Equal(t, tc.request.Note.Text, resp.UpdateEntity.Entity.Notes.Edges[0].Node.Text)
 			}
 		})
 	}

--- a/internal/graphapi/entity_test.go
+++ b/internal/graphapi/entity_test.go
@@ -258,7 +258,7 @@ func (suite *GraphTestSuite) TestMutationCreateEntity() {
 			}
 
 			if tc.request.Note != nil {
-				require.Len(t, resp.CreateEntity.Entity.Notes, 1)
+				require.Len(t, resp.CreateEntity.Entity.Notes.Edges, 1)
 				require.NotEmpty(t, resp.CreateEntity.Entity.Notes)
 				assert.Equal(t, tc.request.Note.Text, resp.CreateEntity.Entity.Notes.Edges[0].Node.Text)
 			}
@@ -382,7 +382,7 @@ func (suite *GraphTestSuite) TestMutationUpdateEntity() {
 			if tc.request.Note != nil {
 				numNotes++
 
-				require.Len(t, resp.UpdateEntity.Entity.Notes, numNotes)
+				require.Len(t, resp.UpdateEntity.Entity.Notes.Edges, numNotes)
 				assert.Equal(t, tc.request.Note.Text, resp.UpdateEntity.Entity.Notes.Edges[0].Node.Text)
 			}
 		})

--- a/internal/graphapi/evidence_test.go
+++ b/internal/graphapi/evidence_test.go
@@ -407,21 +407,21 @@ func (suite *GraphTestSuite) TestMutationCreateEvidence() {
 			}
 
 			if tc.request.ProgramIDs != nil {
-				assert.Len(t, resp.CreateEvidence.Evidence.Programs, len(tc.request.ProgramIDs))
+				assert.Len(t, resp.CreateEvidence.Evidence.Programs.Edges, len(tc.request.ProgramIDs))
 			} else {
-				assert.Empty(t, resp.CreateEvidence.Evidence.Programs)
+				assert.Empty(t, resp.CreateEvidence.Evidence.Programs.Edges)
 			}
 
 			if tc.request.TaskIDs != nil {
-				assert.Len(t, resp.CreateEvidence.Evidence.Tasks, len(tc.request.TaskIDs))
+				assert.Len(t, resp.CreateEvidence.Evidence.Tasks.Edges, len(tc.request.TaskIDs))
 			} else {
-				assert.Empty(t, resp.CreateEvidence.Evidence.Tasks)
+				assert.Empty(t, resp.CreateEvidence.Evidence.Tasks.Edges)
 			}
 
 			if tc.files != nil && len(tc.files) > 0 {
-				assert.Len(t, resp.CreateEvidence.Evidence.Files, len(tc.files))
+				assert.Len(t, resp.CreateEvidence.Evidence.Files.Edges, len(tc.files))
 			} else {
-				assert.Empty(t, resp.CreateEvidence.Evidence.Files)
+				assert.Empty(t, resp.CreateEvidence.Evidence.Files.Edges)
 			}
 
 			// attempt to retrieve the created evidence by org owner, no matter who created it
@@ -532,7 +532,7 @@ func (suite *GraphTestSuite) TestMutationUpdateEvidence() {
 			}
 
 			if tc.files != nil && len(tc.files) > 0 {
-				assert.Len(t, resp.UpdateEvidence.Evidence.Files, len(tc.files))
+				assert.Len(t, resp.UpdateEvidence.Evidence.Files.Edges, len(tc.files))
 			}
 
 		})

--- a/internal/graphapi/generated/root_.generated.go
+++ b/internal/graphapi/generated/root_.generated.go
@@ -117,7 +117,7 @@ type ComplexityRoot struct {
 		ActionPlanType   func(childComplexity int) int
 		ApprovalRequired func(childComplexity int) int
 		Approver         func(childComplexity int) int
-		Control          func(childComplexity int) int
+		Control          func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlOrder, where *generated.ControlWhereInput) int
 		CreatedAt        func(childComplexity int) int
 		CreatedBy        func(childComplexity int) int
 		Delegate         func(childComplexity int) int
@@ -130,17 +130,17 @@ type ComplexityRoot struct {
 		Owner            func(childComplexity int) int
 		OwnerID          func(childComplexity int) int
 		Priority         func(childComplexity int) int
-		Program          func(childComplexity int) int
+		Program          func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ProgramOrder, where *generated.ProgramWhereInput) int
 		ReviewDue        func(childComplexity int) int
 		ReviewFrequency  func(childComplexity int) int
 		Revision         func(childComplexity int) int
-		Risk             func(childComplexity int) int
+		Risk             func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.RiskOrder, where *generated.RiskWhereInput) int
 		Source           func(childComplexity int) int
 		Status           func(childComplexity int) int
 		Tags             func(childComplexity int) int
 		UpdatedAt        func(childComplexity int) int
 		UpdatedBy        func(childComplexity int) int
-		User             func(childComplexity int) int
+		User             func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.UserOrder, where *generated.UserWhereInput) int
 	}
 
 	ActionPlanBulkCreatePayload struct {
@@ -239,8 +239,8 @@ type ComplexityRoot struct {
 		DeletedAt   func(childComplexity int) int
 		DeletedBy   func(childComplexity int) int
 		Email       func(childComplexity int) int
-		Entities    func(childComplexity int) int
-		Files       func(childComplexity int) int
+		Entities    func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.EntityOrder, where *generated.EntityWhereInput) int
+		Files       func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.FileWhereInput) int
 		FullName    func(childComplexity int) int
 		ID          func(childComplexity int) int
 		Owner       func(childComplexity int) int
@@ -318,13 +318,13 @@ type ComplexityRoot struct {
 	}
 
 	Control struct {
-		ActionPlans            func(childComplexity int) int
+		ActionPlans            func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ActionPlanOrder, where *generated.ActionPlanWhereInput) int
 		AssessmentMethods      func(childComplexity int) int
 		AssessmentObjectives   func(childComplexity int) int
 		BlockedGroups          func(childComplexity int) int
 		Category               func(childComplexity int) int
 		CategoryID             func(childComplexity int) int
-		ControlImplementations func(childComplexity int) int
+		ControlImplementations func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlImplementationOrder, where *generated.ControlImplementationWhereInput) int
 		ControlObjectives      func(childComplexity int) int
 		ControlOwner           func(childComplexity int) int
 		ControlQuestions       func(childComplexity int) int
@@ -337,29 +337,29 @@ type ComplexityRoot struct {
 		Description            func(childComplexity int) int
 		DisplayID              func(childComplexity int) int
 		Editors                func(childComplexity int) int
-		Evidence               func(childComplexity int) int
+		Evidence               func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.EvidenceOrder, where *generated.EvidenceWhereInput) int
 		ExampleEvidence        func(childComplexity int) int
 		ID                     func(childComplexity int) int
 		ImplementationGuidance func(childComplexity int) int
-		InternalPolicies       func(childComplexity int) int
+		InternalPolicies       func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.InternalPolicyWhereInput) int
 		MappedCategories       func(childComplexity int) int
-		MappedControls         func(childComplexity int) int
-		Narratives             func(childComplexity int) int
+		MappedControls         func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.MappedControlOrder, where *generated.MappedControlWhereInput) int
+		Narratives             func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.NarrativeOrder, where *generated.NarrativeWhereInput) int
 		Owner                  func(childComplexity int) int
 		OwnerID                func(childComplexity int) int
-		Procedures             func(childComplexity int) int
-		Programs               func(childComplexity int) int
+		Procedures             func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ProcedureWhereInput) int
+		Programs               func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ProgramOrder, where *generated.ProgramWhereInput) int
 		RefCode                func(childComplexity int) int
 		References             func(childComplexity int) int
-		Risks                  func(childComplexity int) int
+		Risks                  func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.RiskOrder, where *generated.RiskWhereInput) int
 		Source                 func(childComplexity int) int
 		Standard               func(childComplexity int) int
 		StandardID             func(childComplexity int) int
 		Status                 func(childComplexity int) int
 		Subcategory            func(childComplexity int) int
-		Subcontrols            func(childComplexity int) int
+		Subcontrols            func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.SubcontrolOrder, where *generated.SubcontrolWhereInput) int
 		Tags                   func(childComplexity int) int
-		Tasks                  func(childComplexity int) int
+		Tasks                  func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.TaskOrder, where *generated.TaskWhereInput) int
 		UpdatedAt              func(childComplexity int) int
 		UpdatedBy              func(childComplexity int) int
 		Viewers                func(childComplexity int) int
@@ -432,7 +432,7 @@ type ComplexityRoot struct {
 	}
 
 	ControlImplementation struct {
-		Controls           func(childComplexity int) int
+		Controls           func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlOrder, where *generated.ControlWhereInput) int
 		CreatedAt          func(childComplexity int) int
 		CreatedBy          func(childComplexity int) int
 		DeletedAt          func(childComplexity int) int
@@ -513,7 +513,7 @@ type ComplexityRoot struct {
 		BlockedGroups        func(childComplexity int) int
 		Category             func(childComplexity int) int
 		ControlObjectiveType func(childComplexity int) int
-		Controls             func(childComplexity int) int
+		Controls             func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlOrder, where *generated.ControlWhereInput) int
 		CreatedAt            func(childComplexity int) int
 		CreatedBy            func(childComplexity int) int
 		DeletedAt            func(childComplexity int) int
@@ -521,23 +521,23 @@ type ComplexityRoot struct {
 		DesiredOutcome       func(childComplexity int) int
 		DisplayID            func(childComplexity int) int
 		Editors              func(childComplexity int) int
-		Evidence             func(childComplexity int) int
+		Evidence             func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.EvidenceOrder, where *generated.EvidenceWhereInput) int
 		ID                   func(childComplexity int) int
-		InternalPolicies     func(childComplexity int) int
+		InternalPolicies     func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.InternalPolicyWhereInput) int
 		Name                 func(childComplexity int) int
-		Narratives           func(childComplexity int) int
+		Narratives           func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.NarrativeOrder, where *generated.NarrativeWhereInput) int
 		Owner                func(childComplexity int) int
 		OwnerID              func(childComplexity int) int
-		Procedures           func(childComplexity int) int
-		Programs             func(childComplexity int) int
+		Procedures           func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ProcedureWhereInput) int
+		Programs             func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ProgramOrder, where *generated.ProgramWhereInput) int
 		Revision             func(childComplexity int) int
-		Risks                func(childComplexity int) int
+		Risks                func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.RiskOrder, where *generated.RiskWhereInput) int
 		Source               func(childComplexity int) int
 		Status               func(childComplexity int) int
 		Subcategory          func(childComplexity int) int
-		Subcontrols          func(childComplexity int) int
+		Subcontrols          func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.SubcontrolOrder, where *generated.SubcontrolWhereInput) int
 		Tags                 func(childComplexity int) int
-		Tasks                func(childComplexity int) int
+		Tasks                func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.TaskOrder, where *generated.TaskWhereInput) int
 		UpdatedAt            func(childComplexity int) int
 		UpdatedBy            func(childComplexity int) int
 		Viewers              func(childComplexity int) int
@@ -623,8 +623,8 @@ type ComplexityRoot struct {
 		Data       func(childComplexity int) int
 		DeletedAt  func(childComplexity int) int
 		DeletedBy  func(childComplexity int) int
-		Entity     func(childComplexity int) int
-		Files      func(childComplexity int) int
+		Entity     func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.EntityOrder, where *generated.EntityWhereInput) int
+		Files      func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.FileWhereInput) int
 		ID         func(childComplexity int) int
 		Owner      func(childComplexity int) int
 		OwnerID    func(childComplexity int) int
@@ -695,21 +695,21 @@ type ComplexityRoot struct {
 	}
 
 	Entity struct {
-		Contacts     func(childComplexity int) int
+		Contacts     func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ContactOrder, where *generated.ContactWhereInput) int
 		CreatedAt    func(childComplexity int) int
 		CreatedBy    func(childComplexity int) int
 		DeletedAt    func(childComplexity int) int
 		DeletedBy    func(childComplexity int) int
 		Description  func(childComplexity int) int
 		DisplayName  func(childComplexity int) int
-		Documents    func(childComplexity int) int
+		Documents    func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.DocumentDataWhereInput) int
 		Domains      func(childComplexity int) int
 		EntityType   func(childComplexity int) int
 		EntityTypeID func(childComplexity int) int
-		Files        func(childComplexity int) int
+		Files        func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.FileWhereInput) int
 		ID           func(childComplexity int) int
 		Name         func(childComplexity int) int
-		Notes        func(childComplexity int) int
+		Notes        func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.NoteWhereInput) int
 		Owner        func(childComplexity int) int
 		OwnerID      func(childComplexity int) int
 		Status       func(childComplexity int) int
@@ -782,7 +782,7 @@ type ComplexityRoot struct {
 		CreatedBy func(childComplexity int) int
 		DeletedAt func(childComplexity int) int
 		DeletedBy func(childComplexity int) int
-		Entities  func(childComplexity int) int
+		Entities  func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.EntityOrder, where *generated.EntityWhereInput) int
 		ID        func(childComplexity int) int
 		Name      func(childComplexity int) int
 		Owner     func(childComplexity int) int
@@ -860,23 +860,23 @@ type ComplexityRoot struct {
 		CreatedBy           func(childComplexity int) int
 		EventID             func(childComplexity int) int
 		EventType           func(childComplexity int) int
-		File                func(childComplexity int) int
-		Group               func(childComplexity int) int
-		Groupmembership     func(childComplexity int) int
-		Hush                func(childComplexity int) int
+		File                func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.FileWhereInput) int
+		Group               func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.GroupOrder, where *generated.GroupWhereInput) int
+		Groupmembership     func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.GroupMembershipOrder, where *generated.GroupMembershipWhereInput) int
+		Hush                func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.HushOrder, where *generated.HushWhereInput) int
 		ID                  func(childComplexity int) int
-		Integration         func(childComplexity int) int
-		Invite              func(childComplexity int) int
+		Integration         func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.IntegrationOrder, where *generated.IntegrationWhereInput) int
+		Invite              func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.InviteOrder, where *generated.InviteWhereInput) int
 		Metadata            func(childComplexity int) int
-		Organization        func(childComplexity int) int
-		Orgmembership       func(childComplexity int) int
-		Orgsubscription     func(childComplexity int) int
-		PersonalAccessToken func(childComplexity int) int
-		Subscriber          func(childComplexity int) int
+		Organization        func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.OrganizationOrder, where *generated.OrganizationWhereInput) int
+		Orgmembership       func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.OrgMembershipOrder, where *generated.OrgMembershipWhereInput) int
+		Orgsubscription     func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.OrgSubscriptionOrder, where *generated.OrgSubscriptionWhereInput) int
+		PersonalAccessToken func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.PersonalAccessTokenWhereInput) int
+		Subscriber          func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.SubscriberOrder, where *generated.SubscriberWhereInput) int
 		Tags                func(childComplexity int) int
 		UpdatedAt           func(childComplexity int) int
 		UpdatedBy           func(childComplexity int) int
-		User                func(childComplexity int) int
+		User                func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.UserOrder, where *generated.UserWhereInput) int
 	}
 
 	EventBulkCreatePayload struct {
@@ -939,8 +939,8 @@ type ComplexityRoot struct {
 
 	Evidence struct {
 		CollectionProcedure func(childComplexity int) int
-		ControlObjectives   func(childComplexity int) int
-		Controls            func(childComplexity int) int
+		ControlObjectives   func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlObjectiveOrder, where *generated.ControlObjectiveWhereInput) int
+		Controls            func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlOrder, where *generated.ControlWhereInput) int
 		CreatedAt           func(childComplexity int) int
 		CreatedBy           func(childComplexity int) int
 		CreationDate        func(childComplexity int) int
@@ -948,19 +948,19 @@ type ComplexityRoot struct {
 		DeletedBy           func(childComplexity int) int
 		Description         func(childComplexity int) int
 		DisplayID           func(childComplexity int) int
-		Files               func(childComplexity int) int
+		Files               func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.FileWhereInput) int
 		ID                  func(childComplexity int) int
 		IsAutomated         func(childComplexity int) int
 		Name                func(childComplexity int) int
 		Owner               func(childComplexity int) int
 		OwnerID             func(childComplexity int) int
-		Programs            func(childComplexity int) int
+		Programs            func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ProgramOrder, where *generated.ProgramWhereInput) int
 		RenewalDate         func(childComplexity int) int
 		Source              func(childComplexity int) int
 		Status              func(childComplexity int) int
-		Subcontrols         func(childComplexity int) int
+		Subcontrols         func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.SubcontrolOrder, where *generated.SubcontrolWhereInput) int
 		Tags                func(childComplexity int) int
-		Tasks               func(childComplexity int) int
+		Tasks               func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.TaskOrder, where *generated.TaskWhereInput) int
 		URL                 func(childComplexity int) int
 		UpdatedAt           func(childComplexity int) int
 		UpdatedBy           func(childComplexity int) int
@@ -1035,25 +1035,25 @@ type ComplexityRoot struct {
 
 	File struct {
 		CategoryType          func(childComplexity int) int
-		Contact               func(childComplexity int) int
+		Contact               func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ContactOrder, where *generated.ContactWhereInput) int
 		CreatedAt             func(childComplexity int) int
 		CreatedBy             func(childComplexity int) int
 		DeletedAt             func(childComplexity int) int
 		DeletedBy             func(childComplexity int) int
 		DetectedContentType   func(childComplexity int) int
 		DetectedMimeType      func(childComplexity int) int
-		DocumentData          func(childComplexity int) int
-		Entity                func(childComplexity int) int
-		Events                func(childComplexity int) int
-		Evidence              func(childComplexity int) int
-		Group                 func(childComplexity int) int
+		DocumentData          func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.DocumentDataWhereInput) int
+		Entity                func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.EntityOrder, where *generated.EntityWhereInput) int
+		Events                func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.EventWhereInput) int
+		Evidence              func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.EvidenceOrder, where *generated.EvidenceWhereInput) int
+		Group                 func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.GroupOrder, where *generated.GroupWhereInput) int
 		ID                    func(childComplexity int) int
 		Md5Hash               func(childComplexity int) int
-		Organization          func(childComplexity int) int
-		OrganizationSetting   func(childComplexity int) int
+		Organization          func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.OrganizationOrder, where *generated.OrganizationWhereInput) int
+		OrganizationSetting   func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.OrganizationSettingWhereInput) int
 		PersistedFileSize     func(childComplexity int) int
 		PresignedURL          func(childComplexity int) int
-		Program               func(childComplexity int) int
+		Program               func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ProgramOrder, where *generated.ProgramWhereInput) int
 		ProvidedFileExtension func(childComplexity int) int
 		ProvidedFileName      func(childComplexity int) int
 		ProvidedFileSize      func(childComplexity int) int
@@ -1062,12 +1062,12 @@ type ComplexityRoot struct {
 		StorageVolume         func(childComplexity int) int
 		StoreKey              func(childComplexity int) int
 		Tags                  func(childComplexity int) int
-		Template              func(childComplexity int) int
+		Template              func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.TemplateOrder, where *generated.TemplateWhereInput) int
 		URI                   func(childComplexity int) int
 		UpdatedAt             func(childComplexity int) int
 		UpdatedBy             func(childComplexity int) int
-		User                  func(childComplexity int) int
-		UserSetting           func(childComplexity int) int
+		User                  func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.UserOrder, where *generated.UserWhereInput) int
+		UserSetting           func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.UserSettingWhereInput) int
 	}
 
 	FileConnection struct {
@@ -1141,11 +1141,11 @@ type ComplexityRoot struct {
 		Description                   func(childComplexity int) int
 		DisplayID                     func(childComplexity int) int
 		DisplayName                   func(childComplexity int) int
-		Events                        func(childComplexity int) int
-		Files                         func(childComplexity int) int
+		Events                        func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.EventWhereInput) int
+		Files                         func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.FileWhereInput) int
 		GravatarLogoURL               func(childComplexity int) int
 		ID                            func(childComplexity int) int
-		Integrations                  func(childComplexity int) int
+		Integrations                  func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.IntegrationOrder, where *generated.IntegrationWhereInput) int
 		InternalPolicyBlockedGroups   func(childComplexity int) int
 		InternalPolicyEditors         func(childComplexity int) int
 		IsManaged                     func(childComplexity int) int
@@ -1168,7 +1168,7 @@ type ComplexityRoot struct {
 		RiskViewers                   func(childComplexity int) int
 		Setting                       func(childComplexity int) int
 		Tags                          func(childComplexity int) int
-		Tasks                         func(childComplexity int) int
+		Tasks                         func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.TaskOrder, where *generated.TaskWhereInput) int
 		UpdatedAt                     func(childComplexity int) int
 		UpdatedBy                     func(childComplexity int) int
 		Users                         func(childComplexity int) int
@@ -1394,12 +1394,12 @@ type ComplexityRoot struct {
 		DeletedAt    func(childComplexity int) int
 		DeletedBy    func(childComplexity int) int
 		Description  func(childComplexity int) int
-		Events       func(childComplexity int) int
+		Events       func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.EventWhereInput) int
 		ID           func(childComplexity int) int
-		Integrations func(childComplexity int) int
+		Integrations func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.IntegrationOrder, where *generated.IntegrationWhereInput) int
 		Kind         func(childComplexity int) int
 		Name         func(childComplexity int) int
-		Organization func(childComplexity int) int
+		Organization func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.OrganizationOrder, where *generated.OrganizationWhereInput) int
 		SecretName   func(childComplexity int) int
 		UpdatedAt    func(childComplexity int) int
 		UpdatedBy    func(childComplexity int) int
@@ -1466,13 +1466,13 @@ type ComplexityRoot struct {
 		DeletedAt   func(childComplexity int) int
 		DeletedBy   func(childComplexity int) int
 		Description func(childComplexity int) int
-		Events      func(childComplexity int) int
+		Events      func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.EventWhereInput) int
 		ID          func(childComplexity int) int
 		Kind        func(childComplexity int) int
 		Name        func(childComplexity int) int
 		Owner       func(childComplexity int) int
 		OwnerID     func(childComplexity int) int
-		Secrets     func(childComplexity int) int
+		Secrets     func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.HushOrder, where *generated.HushWhereInput) int
 		Tags        func(childComplexity int) int
 		UpdatedAt   func(childComplexity int) int
 		UpdatedBy   func(childComplexity int) int
@@ -1542,8 +1542,8 @@ type ComplexityRoot struct {
 		ApprovalRequired  func(childComplexity int) int
 		Approver          func(childComplexity int) int
 		BlockedGroups     func(childComplexity int) int
-		ControlObjectives func(childComplexity int) int
-		Controls          func(childComplexity int) int
+		ControlObjectives func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlObjectiveOrder, where *generated.ControlObjectiveWhereInput) int
+		Controls          func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlOrder, where *generated.ControlWhereInput) int
 		CreatedAt         func(childComplexity int) int
 		CreatedBy         func(childComplexity int) int
 		Delegate          func(childComplexity int) int
@@ -1554,18 +1554,18 @@ type ComplexityRoot struct {
 		Editors           func(childComplexity int) int
 		ID                func(childComplexity int) int
 		Name              func(childComplexity int) int
-		Narratives        func(childComplexity int) int
+		Narratives        func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.NarrativeOrder, where *generated.NarrativeWhereInput) int
 		Owner             func(childComplexity int) int
 		OwnerID           func(childComplexity int) int
 		PolicyType        func(childComplexity int) int
-		Procedures        func(childComplexity int) int
-		Programs          func(childComplexity int) int
+		Procedures        func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ProcedureWhereInput) int
+		Programs          func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ProgramOrder, where *generated.ProgramWhereInput) int
 		ReviewDue         func(childComplexity int) int
 		ReviewFrequency   func(childComplexity int) int
 		Revision          func(childComplexity int) int
 		Status            func(childComplexity int) int
 		Tags              func(childComplexity int) int
-		Tasks             func(childComplexity int) int
+		Tasks             func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.TaskOrder, where *generated.TaskWhereInput) int
 		UpdatedAt         func(childComplexity int) int
 		UpdatedBy         func(childComplexity int) int
 	}
@@ -1641,7 +1641,7 @@ type ComplexityRoot struct {
 		CreatedBy    func(childComplexity int) int
 		DeletedAt    func(childComplexity int) int
 		DeletedBy    func(childComplexity int) int
-		Events       func(childComplexity int) int
+		Events       func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.EventWhereInput) int
 		Expires      func(childComplexity int) int
 		ID           func(childComplexity int) int
 		Owner        func(childComplexity int) int
@@ -1683,7 +1683,7 @@ type ComplexityRoot struct {
 	}
 
 	MappedControl struct {
-		Controls    func(childComplexity int) int
+		Controls    func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlOrder, where *generated.ControlWhereInput) int
 		CreatedAt   func(childComplexity int) int
 		CreatedBy   func(childComplexity int) int
 		DeletedAt   func(childComplexity int) int
@@ -1691,7 +1691,7 @@ type ComplexityRoot struct {
 		ID          func(childComplexity int) int
 		MappingType func(childComplexity int) int
 		Relation    func(childComplexity int) int
-		Subcontrols func(childComplexity int) int
+		Subcontrols func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.SubcontrolOrder, where *generated.SubcontrolWhereInput) int
 		Tags        func(childComplexity int) int
 		UpdatedAt   func(childComplexity int) int
 		UpdatedBy   func(childComplexity int) int
@@ -1947,8 +1947,8 @@ type ComplexityRoot struct {
 		Name          func(childComplexity int) int
 		Owner         func(childComplexity int) int
 		OwnerID       func(childComplexity int) int
-		Programs      func(childComplexity int) int
-		Satisfies     func(childComplexity int) int
+		Programs      func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ProgramOrder, where *generated.ProgramWhereInput) int
+		Satisfies     func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlOrder, where *generated.ControlWhereInput) int
 		Tags          func(childComplexity int) int
 		UpdatedAt     func(childComplexity int) int
 		UpdatedBy     func(childComplexity int) int
@@ -2091,7 +2091,7 @@ type ComplexityRoot struct {
 		CreatedBy      func(childComplexity int) int
 		DeletedAt      func(childComplexity int) int
 		DeletedBy      func(childComplexity int) int
-		Events         func(childComplexity int) int
+		Events         func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.EventWhereInput) int
 		ID             func(childComplexity int) int
 		Organization   func(childComplexity int) int
 		OrganizationID func(childComplexity int) int
@@ -2241,18 +2241,18 @@ type ComplexityRoot struct {
 	}
 
 	Organization struct {
-		APITokens                func(childComplexity int) int
-		ActionPlans              func(childComplexity int) int
+		APITokens                func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.APITokenWhereInput) int
+		ActionPlans              func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ActionPlanOrder, where *generated.ActionPlanWhereInput) int
 		AvatarFile               func(childComplexity int) int
 		AvatarLocalFileID        func(childComplexity int) int
 		AvatarRemoteURL          func(childComplexity int) int
 		AvatarUpdatedAt          func(childComplexity int) int
-		Children                 func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.OrganizationOrder, where *generated.OrganizationWhereInput) int
-		Contacts                 func(childComplexity int) int
+		Children                 func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.OrganizationOrder, where *generated.OrganizationWhereInput) int
+		Contacts                 func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ContactOrder, where *generated.ContactWhereInput) int
 		ControlCreators          func(childComplexity int) int
 		ControlObjectiveCreators func(childComplexity int) int
-		ControlObjectives        func(childComplexity int) int
-		Controls                 func(childComplexity int) int
+		ControlObjectives        func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlObjectiveOrder, where *generated.ControlObjectiveWhereInput) int
+		Controls                 func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlOrder, where *generated.ControlWhereInput) int
 		CreatedAt                func(childComplexity int) int
 		CreatedBy                func(childComplexity int) int
 		DedicatedDb              func(childComplexity int) int
@@ -2260,43 +2260,43 @@ type ComplexityRoot struct {
 		DeletedBy                func(childComplexity int) int
 		Description              func(childComplexity int) int
 		DisplayName              func(childComplexity int) int
-		DocumentData             func(childComplexity int) int
-		Entities                 func(childComplexity int) int
-		EntityTypes              func(childComplexity int) int
-		Events                   func(childComplexity int) int
-		Evidence                 func(childComplexity int) int
-		Files                    func(childComplexity int) int
+		DocumentData             func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.DocumentDataWhereInput) int
+		Entities                 func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.EntityOrder, where *generated.EntityWhereInput) int
+		EntityTypes              func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.EntityTypeOrder, where *generated.EntityTypeWhereInput) int
+		Events                   func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.EventWhereInput) int
+		Evidence                 func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.EvidenceOrder, where *generated.EvidenceWhereInput) int
+		Files                    func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.FileWhereInput) int
 		GroupCreators            func(childComplexity int) int
-		Groups                   func(childComplexity int) int
+		Groups                   func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.GroupOrder, where *generated.GroupWhereInput) int
 		ID                       func(childComplexity int) int
-		Integrations             func(childComplexity int) int
-		InternalPolicies         func(childComplexity int) int
+		Integrations             func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.IntegrationOrder, where *generated.IntegrationWhereInput) int
+		InternalPolicies         func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.InternalPolicyWhereInput) int
 		InternalPolicyCreators   func(childComplexity int) int
-		Invites                  func(childComplexity int) int
+		Invites                  func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.InviteOrder, where *generated.InviteWhereInput) int
 		Members                  func(childComplexity int) int
 		Name                     func(childComplexity int) int
 		NarrativeCreators        func(childComplexity int) int
-		Narratives               func(childComplexity int) int
-		Notes                    func(childComplexity int) int
+		Narratives               func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.NarrativeOrder, where *generated.NarrativeWhereInput) int
+		Notes                    func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.NoteWhereInput) int
 		OrgSubscriptions         func(childComplexity int) int
 		Parent                   func(childComplexity int) int
-		PersonalAccessTokens     func(childComplexity int) int
+		PersonalAccessTokens     func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.PersonalAccessTokenWhereInput) int
 		PersonalOrg              func(childComplexity int) int
 		ProcedureCreators        func(childComplexity int) int
-		Procedures               func(childComplexity int) int
+		Procedures               func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ProcedureWhereInput) int
 		ProgramCreators          func(childComplexity int) int
-		Programs                 func(childComplexity int) int
+		Programs                 func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ProgramOrder, where *generated.ProgramWhereInput) int
 		RiskCreators             func(childComplexity int) int
-		Risks                    func(childComplexity int) int
-		Secrets                  func(childComplexity int) int
+		Risks                    func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.RiskOrder, where *generated.RiskWhereInput) int
+		Secrets                  func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.HushOrder, where *generated.HushWhereInput) int
 		Setting                  func(childComplexity int) int
-		Standards                func(childComplexity int) int
-		Subcontrols              func(childComplexity int) int
-		Subscribers              func(childComplexity int) int
+		Standards                func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.StandardOrder, where *generated.StandardWhereInput) int
+		Subcontrols              func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.SubcontrolOrder, where *generated.SubcontrolWhereInput) int
+		Subscribers              func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.SubscriberOrder, where *generated.SubscriberWhereInput) int
 		Tags                     func(childComplexity int) int
-		Tasks                    func(childComplexity int) int
+		Tasks                    func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.TaskOrder, where *generated.TaskWhereInput) int
 		TemplateCreators         func(childComplexity int) int
-		Templates                func(childComplexity int) int
+		Templates                func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.TemplateOrder, where *generated.TemplateWhereInput) int
 		UpdatedAt                func(childComplexity int) int
 		UpdatedBy                func(childComplexity int) int
 		Users                    func(childComplexity int) int
@@ -2374,7 +2374,7 @@ type ComplexityRoot struct {
 		DeletedAt                   func(childComplexity int) int
 		DeletedBy                   func(childComplexity int) int
 		Domains                     func(childComplexity int) int
-		Files                       func(childComplexity int) int
+		Files                       func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.FileWhereInput) int
 		GeoLocation                 func(childComplexity int) int
 		ID                          func(childComplexity int) int
 		Organization                func(childComplexity int) int
@@ -2468,13 +2468,13 @@ type ComplexityRoot struct {
 		DeletedAt     func(childComplexity int) int
 		DeletedBy     func(childComplexity int) int
 		Description   func(childComplexity int) int
-		Events        func(childComplexity int) int
+		Events        func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.EventWhereInput) int
 		ExpiresAt     func(childComplexity int) int
 		ID            func(childComplexity int) int
 		IsActive      func(childComplexity int) int
 		LastUsedAt    func(childComplexity int) int
 		Name          func(childComplexity int) int
-		Organizations func(childComplexity int) int
+		Organizations func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.OrganizationOrder, where *generated.OrganizationWhereInput) int
 		Owner         func(childComplexity int) int
 		RevokedAt     func(childComplexity int) int
 		RevokedBy     func(childComplexity int) int
@@ -2521,7 +2521,7 @@ type ComplexityRoot struct {
 		ApprovalRequired func(childComplexity int) int
 		Approver         func(childComplexity int) int
 		BlockedGroups    func(childComplexity int) int
-		Controls         func(childComplexity int) int
+		Controls         func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlOrder, where *generated.ControlWhereInput) int
 		CreatedAt        func(childComplexity int) int
 		CreatedBy        func(childComplexity int) int
 		Delegate         func(childComplexity int) int
@@ -2531,20 +2531,20 @@ type ComplexityRoot struct {
 		DisplayID        func(childComplexity int) int
 		Editors          func(childComplexity int) int
 		ID               func(childComplexity int) int
-		InternalPolicies func(childComplexity int) int
+		InternalPolicies func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.InternalPolicyWhereInput) int
 		Name             func(childComplexity int) int
-		Narratives       func(childComplexity int) int
+		Narratives       func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.NarrativeOrder, where *generated.NarrativeWhereInput) int
 		Owner            func(childComplexity int) int
 		OwnerID          func(childComplexity int) int
 		ProcedureType    func(childComplexity int) int
-		Programs         func(childComplexity int) int
+		Programs         func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ProgramOrder, where *generated.ProgramWhereInput) int
 		ReviewDue        func(childComplexity int) int
 		ReviewFrequency  func(childComplexity int) int
 		Revision         func(childComplexity int) int
-		Risks            func(childComplexity int) int
+		Risks            func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.RiskOrder, where *generated.RiskWhereInput) int
 		Status           func(childComplexity int) int
 		Tags             func(childComplexity int) int
-		Tasks            func(childComplexity int) int
+		Tasks            func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.TaskOrder, where *generated.TaskWhereInput) int
 		UpdatedAt        func(childComplexity int) int
 		UpdatedBy        func(childComplexity int) int
 	}
@@ -2621,8 +2621,8 @@ type ComplexityRoot struct {
 		AuditorReady         func(childComplexity int) int
 		AuditorWriteComments func(childComplexity int) int
 		BlockedGroups        func(childComplexity int) int
-		ControlObjectives    func(childComplexity int) int
-		Controls             func(childComplexity int) int
+		ControlObjectives    func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlObjectiveOrder, where *generated.ControlObjectiveWhereInput) int
+		Controls             func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlOrder, where *generated.ControlWhereInput) int
 		CreatedAt            func(childComplexity int) int
 		CreatedBy            func(childComplexity int) int
 		DeletedAt            func(childComplexity int) int
@@ -2631,26 +2631,26 @@ type ComplexityRoot struct {
 		DisplayID            func(childComplexity int) int
 		Editors              func(childComplexity int) int
 		EndDate              func(childComplexity int) int
-		Evidence             func(childComplexity int) int
-		Files                func(childComplexity int) int
+		Evidence             func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.EvidenceOrder, where *generated.EvidenceWhereInput) int
+		Files                func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.FileWhereInput) int
 		ID                   func(childComplexity int) int
-		InternalPolicies     func(childComplexity int) int
-		Members              func(childComplexity int) int
+		InternalPolicies     func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.InternalPolicyWhereInput) int
+		Members              func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ProgramMembershipOrder, where *generated.ProgramMembershipWhereInput) int
 		Name                 func(childComplexity int) int
-		Narratives           func(childComplexity int) int
-		Notes                func(childComplexity int) int
+		Narratives           func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.NarrativeOrder, where *generated.NarrativeWhereInput) int
+		Notes                func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.NoteWhereInput) int
 		Owner                func(childComplexity int) int
 		OwnerID              func(childComplexity int) int
-		Procedures           func(childComplexity int) int
-		Risks                func(childComplexity int) int
+		Procedures           func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ProcedureWhereInput) int
+		Risks                func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.RiskOrder, where *generated.RiskWhereInput) int
 		StartDate            func(childComplexity int) int
 		Status               func(childComplexity int) int
-		Subcontrols          func(childComplexity int) int
+		Subcontrols          func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.SubcontrolOrder, where *generated.SubcontrolWhereInput) int
 		Tags                 func(childComplexity int) int
-		Tasks                func(childComplexity int) int
+		Tasks                func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.TaskOrder, where *generated.TaskWhereInput) int
 		UpdatedAt            func(childComplexity int) int
 		UpdatedBy            func(childComplexity int) int
-		Users                func(childComplexity int) int
+		Users                func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.UserOrder, where *generated.UserWhereInput) int
 		Viewers              func(childComplexity int) int
 	}
 
@@ -2794,9 +2794,9 @@ type ComplexityRoot struct {
 		APITokenSearch                   func(childComplexity int, query string) int
 		APITokens                        func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.APITokenWhereInput) int
 		ActionPlan                       func(childComplexity int, id string) int
-		ActionPlanHistories              func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ActionPlanHistoryWhereInput) int
+		ActionPlanHistories              func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ActionPlanHistoryOrder, where *generated.ActionPlanHistoryWhereInput) int
 		ActionPlanSearch                 func(childComplexity int, query string) int
-		ActionPlans                      func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ActionPlanWhereInput) int
+		ActionPlans                      func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ActionPlanOrder, where *generated.ActionPlanWhereInput) int
 		AdminAPITokenSearch              func(childComplexity int, query string) int
 		AdminActionPlanSearch            func(childComplexity int, query string) int
 		AdminContactSearch               func(childComplexity int, query string) int
@@ -2831,26 +2831,26 @@ type ComplexityRoot struct {
 		AdminUserSettingSearch           func(childComplexity int, query string) int
 		AuditLogs                        func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *model.AuditLogWhereInput) int
 		Contact                          func(childComplexity int, id string) int
-		ContactHistories                 func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ContactHistoryWhereInput) int
+		ContactHistories                 func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ContactHistoryOrder, where *generated.ContactHistoryWhereInput) int
 		ContactSearch                    func(childComplexity int, query string) int
-		Contacts                         func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ContactWhereInput) int
+		Contacts                         func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ContactOrder, where *generated.ContactWhereInput) int
 		Control                          func(childComplexity int, id string) int
-		ControlHistories                 func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ControlHistoryWhereInput) int
+		ControlHistories                 func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ControlHistoryOrder, where *generated.ControlHistoryWhereInput) int
 		ControlImplementation            func(childComplexity int, id string) int
-		ControlImplementationHistories   func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ControlImplementationHistoryWhereInput) int
+		ControlImplementationHistories   func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ControlImplementationHistoryOrder, where *generated.ControlImplementationHistoryWhereInput) int
 		ControlImplementationSearch      func(childComplexity int, query string) int
-		ControlImplementations           func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ControlImplementationWhereInput) int
+		ControlImplementations           func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlImplementationOrder, where *generated.ControlImplementationWhereInput) int
 		ControlObjective                 func(childComplexity int, id string) int
-		ControlObjectiveHistories        func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ControlObjectiveHistoryWhereInput) int
+		ControlObjectiveHistories        func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ControlObjectiveHistoryOrder, where *generated.ControlObjectiveHistoryWhereInput) int
 		ControlObjectiveSearch           func(childComplexity int, query string) int
-		ControlObjectives                func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ControlObjectiveWhereInput) int
+		ControlObjectives                func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlObjectiveOrder, where *generated.ControlObjectiveWhereInput) int
 		ControlSearch                    func(childComplexity int, query string) int
-		Controls                         func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ControlWhereInput) int
+		Controls                         func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlOrder, where *generated.ControlWhereInput) int
 		DocumentData                     func(childComplexity int, id string) int
 		DocumentDataHistories            func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.DocumentDataHistoryWhereInput) int
 		DocumentDataSearch               func(childComplexity int, query string) int
 		DocumentDataSlice                func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.DocumentDataWhereInput) int
-		Entities                         func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.EntityOrder, where *generated.EntityWhereInput) int
+		Entities                         func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.EntityOrder, where *generated.EntityWhereInput) int
 		Entity                           func(childComplexity int, id string) int
 		EntityHistories                  func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.EntityHistoryOrder, where *generated.EntityHistoryWhereInput) int
 		EntitySearch                     func(childComplexity int, query string) int
@@ -2863,9 +2863,9 @@ type ComplexityRoot struct {
 		EventSearch                      func(childComplexity int, query string) int
 		Events                           func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.EventWhereInput) int
 		Evidence                         func(childComplexity int, id string) int
-		EvidenceHistories                func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.EvidenceHistoryWhereInput) int
+		EvidenceHistories                func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.EvidenceHistoryOrder, where *generated.EvidenceHistoryWhereInput) int
 		EvidenceSearch                   func(childComplexity int, query string) int
-		Evidences                        func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.EvidenceWhereInput) int
+		Evidences                        func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.EvidenceOrder, where *generated.EvidenceWhereInput) int
 		File                             func(childComplexity int, id string) int
 		FileHistories                    func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.FileHistoryWhereInput) int
 		FileSearch                       func(childComplexity int, query string) int
@@ -2873,46 +2873,46 @@ type ComplexityRoot struct {
 		Group                            func(childComplexity int, id string) int
 		GroupHistories                   func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.GroupHistoryOrder, where *generated.GroupHistoryWhereInput) int
 		GroupMembership                  func(childComplexity int, id string) int
-		GroupMembershipHistories         func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.GroupMembershipHistoryWhereInput) int
-		GroupMemberships                 func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.GroupMembershipWhereInput) int
+		GroupMembershipHistories         func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.GroupMembershipHistoryOrder, where *generated.GroupMembershipHistoryWhereInput) int
+		GroupMemberships                 func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.GroupMembershipOrder, where *generated.GroupMembershipWhereInput) int
 		GroupSearch                      func(childComplexity int, query string) int
 		GroupSetting                     func(childComplexity int, id string) int
 		GroupSettingHistories            func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.GroupSettingHistoryWhereInput) int
 		GroupSettings                    func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.GroupSettingWhereInput) int
-		Groups                           func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.GroupOrder, where *generated.GroupWhereInput) int
+		Groups                           func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.GroupOrder, where *generated.GroupWhereInput) int
 		Hush                             func(childComplexity int, id string) int
 		HushHistories                    func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.HushHistoryOrder, where *generated.HushHistoryWhereInput) int
-		Hushes                           func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.HushOrder, where *generated.HushWhereInput) int
+		Hushes                           func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.HushOrder, where *generated.HushWhereInput) int
 		Integration                      func(childComplexity int, id string) int
 		IntegrationHistories             func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.IntegrationHistoryOrder, where *generated.IntegrationHistoryWhereInput) int
 		IntegrationSearch                func(childComplexity int, query string) int
-		Integrations                     func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.IntegrationOrder, where *generated.IntegrationWhereInput) int
+		Integrations                     func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.IntegrationOrder, where *generated.IntegrationWhereInput) int
 		InternalPolicies                 func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.InternalPolicyWhereInput) int
 		InternalPolicy                   func(childComplexity int, id string) int
 		InternalPolicyHistories          func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.InternalPolicyHistoryWhereInput) int
 		InternalPolicySearch             func(childComplexity int, query string) int
 		Invite                           func(childComplexity int, id string) int
-		Invites                          func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.InviteWhereInput) int
+		Invites                          func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.InviteOrder, where *generated.InviteWhereInput) int
 		MappedControl                    func(childComplexity int, id string) int
-		MappedControlHistories           func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.MappedControlHistoryWhereInput) int
+		MappedControlHistories           func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.MappedControlHistoryOrder, where *generated.MappedControlHistoryWhereInput) int
 		MappedControlSearch              func(childComplexity int, query string) int
-		MappedControls                   func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.MappedControlWhereInput) int
+		MappedControls                   func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.MappedControlOrder, where *generated.MappedControlWhereInput) int
 		Narrative                        func(childComplexity int, id string) int
-		NarrativeHistories               func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.NarrativeHistoryWhereInput) int
+		NarrativeHistories               func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.NarrativeHistoryOrder, where *generated.NarrativeHistoryWhereInput) int
 		NarrativeSearch                  func(childComplexity int, query string) int
-		Narratives                       func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.NarrativeWhereInput) int
+		Narratives                       func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.NarrativeOrder, where *generated.NarrativeWhereInput) int
 		Node                             func(childComplexity int, id string) int
 		Nodes                            func(childComplexity int, ids []string) int
 		Note                             func(childComplexity int, id string) int
 		NoteHistories                    func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.NoteHistoryWhereInput) int
 		Notes                            func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.NoteWhereInput) int
 		OrgMembership                    func(childComplexity int, id string) int
-		OrgMembershipHistories           func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.OrgMembershipHistoryWhereInput) int
-		OrgMemberships                   func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.OrgMembershipWhereInput) int
+		OrgMembershipHistories           func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.OrgMembershipHistoryOrder, where *generated.OrgMembershipHistoryWhereInput) int
+		OrgMemberships                   func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.OrgMembershipOrder, where *generated.OrgMembershipWhereInput) int
 		OrgSubscription                  func(childComplexity int, id string) int
-		OrgSubscriptionHistories         func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.OrgSubscriptionHistoryWhereInput) int
+		OrgSubscriptionHistories         func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.OrgSubscriptionHistoryOrder, where *generated.OrgSubscriptionHistoryWhereInput) int
 		OrgSubscriptionSearch            func(childComplexity int, query string) int
-		OrgSubscriptions                 func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.OrgSubscriptionWhereInput) int
+		OrgSubscriptions                 func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.OrgSubscriptionOrder, where *generated.OrgSubscriptionWhereInput) int
 		Organization                     func(childComplexity int, id string) int
 		OrganizationHistories            func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.OrganizationHistoryOrder, where *generated.OrganizationHistoryWhereInput) int
 		OrganizationSearch               func(childComplexity int, query string) int
@@ -2920,7 +2920,7 @@ type ComplexityRoot struct {
 		OrganizationSettingHistories     func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.OrganizationSettingHistoryWhereInput) int
 		OrganizationSettingSearch        func(childComplexity int, query string) int
 		OrganizationSettings             func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.OrganizationSettingWhereInput) int
-		Organizations                    func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.OrganizationOrder, where *generated.OrganizationWhereInput) int
+		Organizations                    func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.OrganizationOrder, where *generated.OrganizationWhereInput) int
 		PersonalAccessToken              func(childComplexity int, id string) int
 		PersonalAccessTokenSearch        func(childComplexity int, query string) int
 		PersonalAccessTokens             func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.PersonalAccessTokenWhereInput) int
@@ -2929,37 +2929,37 @@ type ComplexityRoot struct {
 		ProcedureSearch                  func(childComplexity int, query string) int
 		Procedures                       func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ProcedureWhereInput) int
 		Program                          func(childComplexity int, id string) int
-		ProgramHistories                 func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ProgramHistoryWhereInput) int
+		ProgramHistories                 func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ProgramHistoryOrder, where *generated.ProgramHistoryWhereInput) int
 		ProgramMembership                func(childComplexity int, id string) int
-		ProgramMembershipHistories       func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ProgramMembershipHistoryWhereInput) int
-		ProgramMemberships               func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ProgramMembershipWhereInput) int
+		ProgramMembershipHistories       func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ProgramMembershipHistoryOrder, where *generated.ProgramMembershipHistoryWhereInput) int
+		ProgramMemberships               func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ProgramMembershipOrder, where *generated.ProgramMembershipWhereInput) int
 		ProgramSearch                    func(childComplexity int, query string) int
-		Programs                         func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ProgramWhereInput) int
+		Programs                         func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ProgramOrder, where *generated.ProgramWhereInput) int
 		Risk                             func(childComplexity int, id string) int
-		RiskHistories                    func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.RiskHistoryWhereInput) int
+		RiskHistories                    func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.RiskHistoryOrder, where *generated.RiskHistoryWhereInput) int
 		RiskSearch                       func(childComplexity int, query string) int
-		Risks                            func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.RiskWhereInput) int
+		Risks                            func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.RiskOrder, where *generated.RiskWhereInput) int
 		Search                           func(childComplexity int, query string) int
 		Self                             func(childComplexity int) int
 		Standard                         func(childComplexity int, id string) int
-		StandardHistories                func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.StandardHistoryWhereInput) int
+		StandardHistories                func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.StandardHistoryOrder, where *generated.StandardHistoryWhereInput) int
 		StandardSearch                   func(childComplexity int, query string) int
-		Standards                        func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.StandardWhereInput) int
+		Standards                        func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.StandardOrder, where *generated.StandardWhereInput) int
 		Subcontrol                       func(childComplexity int, id string) int
-		SubcontrolHistories              func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.SubcontrolHistoryWhereInput) int
+		SubcontrolHistories              func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.SubcontrolHistoryOrder, where *generated.SubcontrolHistoryWhereInput) int
 		SubcontrolSearch                 func(childComplexity int, query string) int
-		Subcontrols                      func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.SubcontrolWhereInput) int
+		Subcontrols                      func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.SubcontrolOrder, where *generated.SubcontrolWhereInput) int
 		Subscriber                       func(childComplexity int, email string) int
 		SubscriberSearch                 func(childComplexity int, query string) int
-		Subscribers                      func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.SubscriberWhereInput) int
+		Subscribers                      func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.SubscriberOrder, where *generated.SubscriberWhereInput) int
 		Task                             func(childComplexity int, id string) int
-		TaskHistories                    func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.TaskHistoryWhereInput) int
+		TaskHistories                    func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.TaskHistoryOrder, where *generated.TaskHistoryWhereInput) int
 		TaskSearch                       func(childComplexity int, query string) int
-		Tasks                            func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.TaskWhereInput) int
+		Tasks                            func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.TaskOrder, where *generated.TaskWhereInput) int
 		Template                         func(childComplexity int, id string) int
 		TemplateHistories                func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.TemplateHistoryOrder, where *generated.TemplateHistoryWhereInput) int
 		TemplateSearch                   func(childComplexity int, query string) int
-		Templates                        func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.TemplateOrder, where *generated.TemplateWhereInput) int
+		Templates                        func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.TemplateOrder, where *generated.TemplateWhereInput) int
 		TfaSetting                       func(childComplexity int, id *string) int
 		TfaSettings                      func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.TFASettingWhereInput) int
 		User                             func(childComplexity int, id string) int
@@ -2969,15 +2969,15 @@ type ComplexityRoot struct {
 		UserSettingHistories             func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.UserSettingHistoryWhereInput) int
 		UserSettingSearch                func(childComplexity int, query string) int
 		UserSettings                     func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.UserSettingWhereInput) int
-		Users                            func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.UserOrder, where *generated.UserWhereInput) int
+		Users                            func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.UserOrder, where *generated.UserWhereInput) int
 	}
 
 	Risk struct {
-		ActionPlans   func(childComplexity int) int
+		ActionPlans   func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ActionPlanOrder, where *generated.ActionPlanWhereInput) int
 		BlockedGroups func(childComplexity int) int
 		BusinessCosts func(childComplexity int) int
 		Category      func(childComplexity int) int
-		Control       func(childComplexity int) int
+		Control       func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlOrder, where *generated.ControlWhereInput) int
 		CreatedAt     func(childComplexity int) int
 		CreatedBy     func(childComplexity int) int
 		Delegate      func(childComplexity int) int
@@ -2993,8 +2993,8 @@ type ComplexityRoot struct {
 		Name          func(childComplexity int) int
 		Owner         func(childComplexity int) int
 		OwnerID       func(childComplexity int) int
-		Procedure     func(childComplexity int) int
-		Programs      func(childComplexity int) int
+		Procedure     func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ProcedureWhereInput) int
+		Programs      func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ProgramOrder, where *generated.ProgramWhereInput) int
 		RiskType      func(childComplexity int) int
 		Score         func(childComplexity int) int
 		Stakeholder   func(childComplexity int) int
@@ -3080,7 +3080,7 @@ type ComplexityRoot struct {
 	}
 
 	Standard struct {
-		Controls             func(childComplexity int) int
+		Controls             func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlOrder, where *generated.ControlWhereInput) int
 		CreatedAt            func(childComplexity int) int
 		CreatedBy            func(childComplexity int) int
 		DeletedAt            func(childComplexity int) int
@@ -3181,14 +3181,14 @@ type ComplexityRoot struct {
 	}
 
 	Subcontrol struct {
-		ActionPlans            func(childComplexity int) int
+		ActionPlans            func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ActionPlanOrder, where *generated.ActionPlanWhereInput) int
 		AssessmentMethods      func(childComplexity int) int
 		AssessmentObjectives   func(childComplexity int) int
 		Category               func(childComplexity int) int
 		CategoryID             func(childComplexity int) int
 		Control                func(childComplexity int) int
 		ControlID              func(childComplexity int) int
-		ControlObjectives      func(childComplexity int) int
+		ControlObjectives      func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlObjectiveOrder, where *generated.ControlObjectiveWhereInput) int
 		ControlOwner           func(childComplexity int) int
 		ControlQuestions       func(childComplexity int) int
 		ControlType            func(childComplexity int) int
@@ -3199,25 +3199,25 @@ type ComplexityRoot struct {
 		DeletedBy              func(childComplexity int) int
 		Description            func(childComplexity int) int
 		DisplayID              func(childComplexity int) int
-		Evidence               func(childComplexity int) int
+		Evidence               func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.EvidenceOrder, where *generated.EvidenceWhereInput) int
 		ExampleEvidence        func(childComplexity int) int
 		ID                     func(childComplexity int) int
 		ImplementationGuidance func(childComplexity int) int
-		InternalPolicies       func(childComplexity int) int
+		InternalPolicies       func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.InternalPolicyWhereInput) int
 		MappedCategories       func(childComplexity int) int
 		MappedControls         func(childComplexity int) int
-		Narratives             func(childComplexity int) int
+		Narratives             func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.NarrativeOrder, where *generated.NarrativeWhereInput) int
 		Owner                  func(childComplexity int) int
 		OwnerID                func(childComplexity int) int
-		Procedures             func(childComplexity int) int
+		Procedures             func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ProcedureWhereInput) int
 		RefCode                func(childComplexity int) int
 		References             func(childComplexity int) int
-		Risks                  func(childComplexity int) int
+		Risks                  func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.RiskOrder, where *generated.RiskWhereInput) int
 		Source                 func(childComplexity int) int
 		Status                 func(childComplexity int) int
 		Subcategory            func(childComplexity int) int
 		Tags                   func(childComplexity int) int
-		Tasks                  func(childComplexity int) int
+		Tasks                  func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.TaskOrder, where *generated.TaskWhereInput) int
 		UpdatedAt              func(childComplexity int) int
 		UpdatedBy              func(childComplexity int) int
 	}
@@ -3303,7 +3303,7 @@ type ComplexityRoot struct {
 		DeletedAt     func(childComplexity int) int
 		DeletedBy     func(childComplexity int) int
 		Email         func(childComplexity int) int
-		Events        func(childComplexity int) int
+		Events        func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.EventWhereInput) int
 		ID            func(childComplexity int) int
 		Owner         func(childComplexity int) int
 		OwnerID       func(childComplexity int) int
@@ -3389,10 +3389,10 @@ type ComplexityRoot struct {
 		Assigner         func(childComplexity int) int
 		AssignerID       func(childComplexity int) int
 		Category         func(childComplexity int) int
-		Comments         func(childComplexity int) int
+		Comments         func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.NoteWhereInput) int
 		Completed        func(childComplexity int) int
-		Control          func(childComplexity int) int
-		ControlObjective func(childComplexity int) int
+		Control          func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlOrder, where *generated.ControlWhereInput) int
+		ControlObjective func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlObjectiveOrder, where *generated.ControlObjectiveWhereInput) int
 		CreatedAt        func(childComplexity int) int
 		CreatedBy        func(childComplexity int) int
 		DeletedAt        func(childComplexity int) int
@@ -3401,16 +3401,16 @@ type ComplexityRoot struct {
 		Details          func(childComplexity int) int
 		DisplayID        func(childComplexity int) int
 		Due              func(childComplexity int) int
-		Evidence         func(childComplexity int) int
-		Group            func(childComplexity int) int
+		Evidence         func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.EvidenceOrder, where *generated.EvidenceWhereInput) int
+		Group            func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.GroupOrder, where *generated.GroupWhereInput) int
 		ID               func(childComplexity int) int
-		InternalPolicy   func(childComplexity int) int
+		InternalPolicy   func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.InternalPolicyWhereInput) int
 		Owner            func(childComplexity int) int
 		OwnerID          func(childComplexity int) int
-		Procedure        func(childComplexity int) int
-		Program          func(childComplexity int) int
+		Procedure        func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.ProcedureWhereInput) int
+		Program          func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ProgramOrder, where *generated.ProgramWhereInput) int
 		Status           func(childComplexity int) int
-		Subcontrol       func(childComplexity int) int
+		Subcontrol       func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.SubcontrolOrder, where *generated.SubcontrolWhereInput) int
 		Tags             func(childComplexity int) int
 		Title            func(childComplexity int) int
 		UpdatedAt        func(childComplexity int) int
@@ -3490,8 +3490,8 @@ type ComplexityRoot struct {
 		DeletedAt    func(childComplexity int) int
 		DeletedBy    func(childComplexity int) int
 		Description  func(childComplexity int) int
-		Documents    func(childComplexity int) int
-		Files        func(childComplexity int) int
+		Documents    func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.DocumentDataWhereInput) int
+		Files        func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.FileWhereInput) int
 		ID           func(childComplexity int) int
 		Jsonconfig   func(childComplexity int) int
 		Name         func(childComplexity int) int
@@ -3567,9 +3567,9 @@ type ComplexityRoot struct {
 	}
 
 	User struct {
-		ActionPlans          func(childComplexity int) int
-		AssigneeTasks        func(childComplexity int) int
-		AssignerTasks        func(childComplexity int) int
+		ActionPlans          func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ActionPlanOrder, where *generated.ActionPlanWhereInput) int
+		AssigneeTasks        func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.TaskOrder, where *generated.TaskWhereInput) int
+		AssignerTasks        func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.TaskOrder, where *generated.TaskWhereInput) int
 		AuthProvider         func(childComplexity int) int
 		AvatarFile           func(childComplexity int) int
 		AvatarLocalFileID    func(childComplexity int) int
@@ -3582,8 +3582,8 @@ type ComplexityRoot struct {
 		DisplayID            func(childComplexity int) int
 		DisplayName          func(childComplexity int) int
 		Email                func(childComplexity int) int
-		Events               func(childComplexity int) int
-		Files                func(childComplexity int) int
+		Events               func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.EventWhereInput) int
+		Files                func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.FileWhereInput) int
 		FirstName            func(childComplexity int) int
 		GroupMemberships     func(childComplexity int) int
 		Groups               func(childComplexity int) int
@@ -3592,15 +3592,15 @@ type ComplexityRoot struct {
 		LastSeen             func(childComplexity int) int
 		OrgMemberships       func(childComplexity int) int
 		Organizations        func(childComplexity int) int
-		PersonalAccessTokens func(childComplexity int) int
+		PersonalAccessTokens func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.PersonalAccessTokenWhereInput) int
 		ProgramMemberships   func(childComplexity int) int
 		Programs             func(childComplexity int) int
 		Role                 func(childComplexity int) int
 		Setting              func(childComplexity int) int
 		Sub                  func(childComplexity int) int
-		Subcontrols          func(childComplexity int) int
+		Subcontrols          func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.SubcontrolOrder, where *generated.SubcontrolWhereInput) int
 		Tags                 func(childComplexity int) int
-		TfaSettings          func(childComplexity int) int
+		TfaSettings          func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.TFASettingWhereInput) int
 		UpdatedAt            func(childComplexity int) int
 		UpdatedBy            func(childComplexity int) int
 	}
@@ -3676,7 +3676,7 @@ type ComplexityRoot struct {
 		DeletedAt         func(childComplexity int) int
 		DeletedBy         func(childComplexity int) int
 		EmailConfirmed    func(childComplexity int) int
-		Files             func(childComplexity int) int
+		Files             func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, where *generated.FileWhereInput) int
 		ID                func(childComplexity int) int
 		IsTfaEnabled      func(childComplexity int) int
 		IsWebauthnAllowed func(childComplexity int) int
@@ -4011,7 +4011,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.ActionPlan.Control(childComplexity), true
+		args, err := ec.field_ActionPlan_control_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.ActionPlan.Control(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ControlOrder), args["where"].(*generated.ControlWhereInput)), true
 
 	case "ActionPlan.createdAt":
 		if e.complexity.ActionPlan.CreatedAt == nil {
@@ -4102,7 +4107,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.ActionPlan.Program(childComplexity), true
+		args, err := ec.field_ActionPlan_program_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.ActionPlan.Program(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ProgramOrder), args["where"].(*generated.ProgramWhereInput)), true
 
 	case "ActionPlan.reviewDue":
 		if e.complexity.ActionPlan.ReviewDue == nil {
@@ -4130,7 +4140,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.ActionPlan.Risk(childComplexity), true
+		args, err := ec.field_ActionPlan_risk_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.ActionPlan.Risk(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.RiskOrder), args["where"].(*generated.RiskWhereInput)), true
 
 	case "ActionPlan.source":
 		if e.complexity.ActionPlan.Source == nil {
@@ -4172,7 +4187,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.ActionPlan.User(childComplexity), true
+		args, err := ec.field_ActionPlan_user_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.ActionPlan.User(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.UserOrder), args["where"].(*generated.UserWhereInput)), true
 
 	case "ActionPlanBulkCreatePayload.actionPlans":
 		if e.complexity.ActionPlanBulkCreatePayload.ActionPlans == nil {
@@ -4571,14 +4591,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Contact.Entities(childComplexity), true
+		args, err := ec.field_Contact_entities_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Contact.Entities(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.EntityOrder), args["where"].(*generated.EntityWhereInput)), true
 
 	case "Contact.files":
 		if e.complexity.Contact.Files == nil {
 			break
 		}
 
-		return e.complexity.Contact.Files(childComplexity), true
+		args, err := ec.field_Contact_files_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Contact.Files(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.FileWhereInput)), true
 
 	case "Contact.fullName":
 		if e.complexity.Contact.FullName == nil {
@@ -4893,7 +4923,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Control.ActionPlans(childComplexity), true
+		args, err := ec.field_Control_actionPlans_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Control.ActionPlans(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ActionPlanOrder), args["where"].(*generated.ActionPlanWhereInput)), true
 
 	case "Control.assessmentMethods":
 		if e.complexity.Control.AssessmentMethods == nil {
@@ -4935,7 +4970,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Control.ControlImplementations(childComplexity), true
+		args, err := ec.field_Control_controlImplementations_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Control.ControlImplementations(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ControlImplementationOrder), args["where"].(*generated.ControlImplementationWhereInput)), true
 
 	case "Control.controlObjectives":
 		if e.complexity.Control.ControlObjectives == nil {
@@ -5026,7 +5066,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Control.Evidence(childComplexity), true
+		args, err := ec.field_Control_evidence_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Control.Evidence(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.EvidenceOrder), args["where"].(*generated.EvidenceWhereInput)), true
 
 	case "Control.exampleEvidence":
 		if e.complexity.Control.ExampleEvidence == nil {
@@ -5054,7 +5099,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Control.InternalPolicies(childComplexity), true
+		args, err := ec.field_Control_internalPolicies_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Control.InternalPolicies(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.InternalPolicyWhereInput)), true
 
 	case "Control.mappedCategories":
 		if e.complexity.Control.MappedCategories == nil {
@@ -5068,14 +5118,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Control.MappedControls(childComplexity), true
+		args, err := ec.field_Control_mappedControls_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Control.MappedControls(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.MappedControlOrder), args["where"].(*generated.MappedControlWhereInput)), true
 
 	case "Control.narratives":
 		if e.complexity.Control.Narratives == nil {
 			break
 		}
 
-		return e.complexity.Control.Narratives(childComplexity), true
+		args, err := ec.field_Control_narratives_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Control.Narratives(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.NarrativeOrder), args["where"].(*generated.NarrativeWhereInput)), true
 
 	case "Control.owner":
 		if e.complexity.Control.Owner == nil {
@@ -5096,14 +5156,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Control.Procedures(childComplexity), true
+		args, err := ec.field_Control_procedures_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Control.Procedures(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.ProcedureWhereInput)), true
 
 	case "Control.programs":
 		if e.complexity.Control.Programs == nil {
 			break
 		}
 
-		return e.complexity.Control.Programs(childComplexity), true
+		args, err := ec.field_Control_programs_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Control.Programs(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ProgramOrder), args["where"].(*generated.ProgramWhereInput)), true
 
 	case "Control.refCode":
 		if e.complexity.Control.RefCode == nil {
@@ -5124,7 +5194,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Control.Risks(childComplexity), true
+		args, err := ec.field_Control_risks_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Control.Risks(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.RiskOrder), args["where"].(*generated.RiskWhereInput)), true
 
 	case "Control.source":
 		if e.complexity.Control.Source == nil {
@@ -5166,7 +5241,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Control.Subcontrols(childComplexity), true
+		args, err := ec.field_Control_subcontrols_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Control.Subcontrols(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.SubcontrolOrder), args["where"].(*generated.SubcontrolWhereInput)), true
 
 	case "Control.tags":
 		if e.complexity.Control.Tags == nil {
@@ -5180,7 +5260,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Control.Tasks(childComplexity), true
+		args, err := ec.field_Control_tasks_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Control.Tasks(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.TaskOrder), args["where"].(*generated.TaskWhereInput)), true
 
 	case "Control.updatedAt":
 		if e.complexity.Control.UpdatedAt == nil {
@@ -5502,7 +5587,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.ControlImplementation.Controls(childComplexity), true
+		args, err := ec.field_ControlImplementation_controls_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.ControlImplementation.Controls(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ControlOrder), args["where"].(*generated.ControlWhereInput)), true
 
 	case "ControlImplementation.createdAt":
 		if e.complexity.ControlImplementation.CreatedAt == nil {
@@ -5838,7 +5928,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.ControlObjective.Controls(childComplexity), true
+		args, err := ec.field_ControlObjective_controls_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.ControlObjective.Controls(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ControlOrder), args["where"].(*generated.ControlWhereInput)), true
 
 	case "ControlObjective.createdAt":
 		if e.complexity.ControlObjective.CreatedAt == nil {
@@ -5894,7 +5989,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.ControlObjective.Evidence(childComplexity), true
+		args, err := ec.field_ControlObjective_evidence_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.ControlObjective.Evidence(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.EvidenceOrder), args["where"].(*generated.EvidenceWhereInput)), true
 
 	case "ControlObjective.id":
 		if e.complexity.ControlObjective.ID == nil {
@@ -5908,7 +6008,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.ControlObjective.InternalPolicies(childComplexity), true
+		args, err := ec.field_ControlObjective_internalPolicies_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.ControlObjective.InternalPolicies(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.InternalPolicyWhereInput)), true
 
 	case "ControlObjective.name":
 		if e.complexity.ControlObjective.Name == nil {
@@ -5922,7 +6027,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.ControlObjective.Narratives(childComplexity), true
+		args, err := ec.field_ControlObjective_narratives_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.ControlObjective.Narratives(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.NarrativeOrder), args["where"].(*generated.NarrativeWhereInput)), true
 
 	case "ControlObjective.owner":
 		if e.complexity.ControlObjective.Owner == nil {
@@ -5943,14 +6053,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.ControlObjective.Procedures(childComplexity), true
+		args, err := ec.field_ControlObjective_procedures_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.ControlObjective.Procedures(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.ProcedureWhereInput)), true
 
 	case "ControlObjective.programs":
 		if e.complexity.ControlObjective.Programs == nil {
 			break
 		}
 
-		return e.complexity.ControlObjective.Programs(childComplexity), true
+		args, err := ec.field_ControlObjective_programs_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.ControlObjective.Programs(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ProgramOrder), args["where"].(*generated.ProgramWhereInput)), true
 
 	case "ControlObjective.revision":
 		if e.complexity.ControlObjective.Revision == nil {
@@ -5964,7 +6084,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.ControlObjective.Risks(childComplexity), true
+		args, err := ec.field_ControlObjective_risks_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.ControlObjective.Risks(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.RiskOrder), args["where"].(*generated.RiskWhereInput)), true
 
 	case "ControlObjective.source":
 		if e.complexity.ControlObjective.Source == nil {
@@ -5992,7 +6117,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.ControlObjective.Subcontrols(childComplexity), true
+		args, err := ec.field_ControlObjective_subcontrols_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.ControlObjective.Subcontrols(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.SubcontrolOrder), args["where"].(*generated.SubcontrolWhereInput)), true
 
 	case "ControlObjective.tags":
 		if e.complexity.ControlObjective.Tags == nil {
@@ -6006,7 +6136,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.ControlObjective.Tasks(childComplexity), true
+		args, err := ec.field_ControlObjective_tasks_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.ControlObjective.Tasks(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.TaskOrder), args["where"].(*generated.TaskWhereInput)), true
 
 	case "ControlObjective.updatedAt":
 		if e.complexity.ControlObjective.UpdatedAt == nil {
@@ -6335,14 +6470,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.DocumentData.Entity(childComplexity), true
+		args, err := ec.field_DocumentData_entity_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.DocumentData.Entity(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.EntityOrder), args["where"].(*generated.EntityWhereInput)), true
 
 	case "DocumentData.files":
 		if e.complexity.DocumentData.Files == nil {
 			break
 		}
 
-		return e.complexity.DocumentData.Files(childComplexity), true
+		args, err := ec.field_DocumentData_files_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.DocumentData.Files(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.FileWhereInput)), true
 
 	case "DocumentData.id":
 		if e.complexity.DocumentData.ID == nil {
@@ -6608,7 +6753,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Entity.Contacts(childComplexity), true
+		args, err := ec.field_Entity_contacts_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Entity.Contacts(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ContactOrder), args["where"].(*generated.ContactWhereInput)), true
 
 	case "Entity.createdAt":
 		if e.complexity.Entity.CreatedAt == nil {
@@ -6657,7 +6807,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Entity.Documents(childComplexity), true
+		args, err := ec.field_Entity_documents_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Entity.Documents(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.DocumentDataWhereInput)), true
 
 	case "Entity.domains":
 		if e.complexity.Entity.Domains == nil {
@@ -6685,7 +6840,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Entity.Files(childComplexity), true
+		args, err := ec.field_Entity_files_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Entity.Files(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.FileWhereInput)), true
 
 	case "Entity.id":
 		if e.complexity.Entity.ID == nil {
@@ -6706,7 +6866,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Entity.Notes(childComplexity), true
+		args, err := ec.field_Entity_notes_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Entity.Notes(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.NoteWhereInput)), true
 
 	case "Entity.owner":
 		if e.complexity.Entity.Owner == nil {
@@ -7007,7 +7172,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.EntityType.Entities(childComplexity), true
+		args, err := ec.field_EntityType_entities_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.EntityType.Entities(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.EntityOrder), args["where"].(*generated.EntityWhereInput)), true
 
 	case "EntityType.id":
 		if e.complexity.EntityType.ID == nil {
@@ -7301,28 +7471,48 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Event.File(childComplexity), true
+		args, err := ec.field_Event_file_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Event.File(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.FileWhereInput)), true
 
 	case "Event.group":
 		if e.complexity.Event.Group == nil {
 			break
 		}
 
-		return e.complexity.Event.Group(childComplexity), true
+		args, err := ec.field_Event_group_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Event.Group(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.GroupOrder), args["where"].(*generated.GroupWhereInput)), true
 
 	case "Event.groupmembership":
 		if e.complexity.Event.Groupmembership == nil {
 			break
 		}
 
-		return e.complexity.Event.Groupmembership(childComplexity), true
+		args, err := ec.field_Event_groupmembership_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Event.Groupmembership(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.GroupMembershipOrder), args["where"].(*generated.GroupMembershipWhereInput)), true
 
 	case "Event.hush":
 		if e.complexity.Event.Hush == nil {
 			break
 		}
 
-		return e.complexity.Event.Hush(childComplexity), true
+		args, err := ec.field_Event_hush_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Event.Hush(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.HushOrder), args["where"].(*generated.HushWhereInput)), true
 
 	case "Event.id":
 		if e.complexity.Event.ID == nil {
@@ -7336,14 +7526,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Event.Integration(childComplexity), true
+		args, err := ec.field_Event_integration_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Event.Integration(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.IntegrationOrder), args["where"].(*generated.IntegrationWhereInput)), true
 
 	case "Event.invite":
 		if e.complexity.Event.Invite == nil {
 			break
 		}
 
-		return e.complexity.Event.Invite(childComplexity), true
+		args, err := ec.field_Event_invite_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Event.Invite(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.InviteOrder), args["where"].(*generated.InviteWhereInput)), true
 
 	case "Event.metadata":
 		if e.complexity.Event.Metadata == nil {
@@ -7357,35 +7557,60 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Event.Organization(childComplexity), true
+		args, err := ec.field_Event_organization_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Event.Organization(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.OrganizationOrder), args["where"].(*generated.OrganizationWhereInput)), true
 
 	case "Event.orgmembership":
 		if e.complexity.Event.Orgmembership == nil {
 			break
 		}
 
-		return e.complexity.Event.Orgmembership(childComplexity), true
+		args, err := ec.field_Event_orgmembership_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Event.Orgmembership(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.OrgMembershipOrder), args["where"].(*generated.OrgMembershipWhereInput)), true
 
 	case "Event.orgsubscription":
 		if e.complexity.Event.Orgsubscription == nil {
 			break
 		}
 
-		return e.complexity.Event.Orgsubscription(childComplexity), true
+		args, err := ec.field_Event_orgsubscription_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Event.Orgsubscription(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.OrgSubscriptionOrder), args["where"].(*generated.OrgSubscriptionWhereInput)), true
 
 	case "Event.personalAccessToken":
 		if e.complexity.Event.PersonalAccessToken == nil {
 			break
 		}
 
-		return e.complexity.Event.PersonalAccessToken(childComplexity), true
+		args, err := ec.field_Event_personalAccessToken_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Event.PersonalAccessToken(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.PersonalAccessTokenWhereInput)), true
 
 	case "Event.subscriber":
 		if e.complexity.Event.Subscriber == nil {
 			break
 		}
 
-		return e.complexity.Event.Subscriber(childComplexity), true
+		args, err := ec.field_Event_subscriber_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Event.Subscriber(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.SubscriberOrder), args["where"].(*generated.SubscriberWhereInput)), true
 
 	case "Event.tags":
 		if e.complexity.Event.Tags == nil {
@@ -7413,7 +7638,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Event.User(childComplexity), true
+		args, err := ec.field_Event_user_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Event.User(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.UserOrder), args["where"].(*generated.UserWhereInput)), true
 
 	case "EventBulkCreatePayload.events":
 		if e.complexity.EventBulkCreatePayload.Events == nil {
@@ -7623,14 +7853,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Evidence.ControlObjectives(childComplexity), true
+		args, err := ec.field_Evidence_controlObjectives_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Evidence.ControlObjectives(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ControlObjectiveOrder), args["where"].(*generated.ControlObjectiveWhereInput)), true
 
 	case "Evidence.controls":
 		if e.complexity.Evidence.Controls == nil {
 			break
 		}
 
-		return e.complexity.Evidence.Controls(childComplexity), true
+		args, err := ec.field_Evidence_controls_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Evidence.Controls(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ControlOrder), args["where"].(*generated.ControlWhereInput)), true
 
 	case "Evidence.createdAt":
 		if e.complexity.Evidence.CreatedAt == nil {
@@ -7686,7 +7926,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Evidence.Files(childComplexity), true
+		args, err := ec.field_Evidence_files_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Evidence.Files(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.FileWhereInput)), true
 
 	case "Evidence.id":
 		if e.complexity.Evidence.ID == nil {
@@ -7728,7 +7973,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Evidence.Programs(childComplexity), true
+		args, err := ec.field_Evidence_programs_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Evidence.Programs(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ProgramOrder), args["where"].(*generated.ProgramWhereInput)), true
 
 	case "Evidence.renewalDate":
 		if e.complexity.Evidence.RenewalDate == nil {
@@ -7756,7 +8006,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Evidence.Subcontrols(childComplexity), true
+		args, err := ec.field_Evidence_subcontrols_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Evidence.Subcontrols(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.SubcontrolOrder), args["where"].(*generated.SubcontrolWhereInput)), true
 
 	case "Evidence.tags":
 		if e.complexity.Evidence.Tags == nil {
@@ -7770,7 +8025,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Evidence.Tasks(childComplexity), true
+		args, err := ec.field_Evidence_tasks_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Evidence.Tasks(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.TaskOrder), args["where"].(*generated.TaskWhereInput)), true
 
 	case "Evidence.url":
 		if e.complexity.Evidence.URL == nil {
@@ -8064,7 +8324,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.File.Contact(childComplexity), true
+		args, err := ec.field_File_contact_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.File.Contact(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ContactOrder), args["where"].(*generated.ContactWhereInput)), true
 
 	case "File.createdAt":
 		if e.complexity.File.CreatedAt == nil {
@@ -8113,35 +8378,60 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.File.DocumentData(childComplexity), true
+		args, err := ec.field_File_documentData_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.File.DocumentData(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.DocumentDataWhereInput)), true
 
 	case "File.entity":
 		if e.complexity.File.Entity == nil {
 			break
 		}
 
-		return e.complexity.File.Entity(childComplexity), true
+		args, err := ec.field_File_entity_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.File.Entity(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.EntityOrder), args["where"].(*generated.EntityWhereInput)), true
 
 	case "File.events":
 		if e.complexity.File.Events == nil {
 			break
 		}
 
-		return e.complexity.File.Events(childComplexity), true
+		args, err := ec.field_File_events_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.File.Events(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.EventWhereInput)), true
 
 	case "File.evidence":
 		if e.complexity.File.Evidence == nil {
 			break
 		}
 
-		return e.complexity.File.Evidence(childComplexity), true
+		args, err := ec.field_File_evidence_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.File.Evidence(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.EvidenceOrder), args["where"].(*generated.EvidenceWhereInput)), true
 
 	case "File.group":
 		if e.complexity.File.Group == nil {
 			break
 		}
 
-		return e.complexity.File.Group(childComplexity), true
+		args, err := ec.field_File_group_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.File.Group(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.GroupOrder), args["where"].(*generated.GroupWhereInput)), true
 
 	case "File.id":
 		if e.complexity.File.ID == nil {
@@ -8162,14 +8452,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.File.Organization(childComplexity), true
+		args, err := ec.field_File_organization_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.File.Organization(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.OrganizationOrder), args["where"].(*generated.OrganizationWhereInput)), true
 
 	case "File.organizationSetting":
 		if e.complexity.File.OrganizationSetting == nil {
 			break
 		}
 
-		return e.complexity.File.OrganizationSetting(childComplexity), true
+		args, err := ec.field_File_organizationSetting_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.File.OrganizationSetting(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.OrganizationSettingWhereInput)), true
 
 	case "File.persistedFileSize":
 		if e.complexity.File.PersistedFileSize == nil {
@@ -8190,7 +8490,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.File.Program(childComplexity), true
+		args, err := ec.field_File_program_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.File.Program(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ProgramOrder), args["where"].(*generated.ProgramWhereInput)), true
 
 	case "File.providedFileExtension":
 		if e.complexity.File.ProvidedFileExtension == nil {
@@ -8253,7 +8558,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.File.Template(childComplexity), true
+		args, err := ec.field_File_template_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.File.Template(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.TemplateOrder), args["where"].(*generated.TemplateWhereInput)), true
 
 	case "File.uri":
 		if e.complexity.File.URI == nil {
@@ -8281,14 +8591,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.File.User(childComplexity), true
+		args, err := ec.field_File_user_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.File.User(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.UserOrder), args["where"].(*generated.UserWhereInput)), true
 
 	case "File.userSetting":
 		if e.complexity.File.UserSetting == nil {
 			break
 		}
 
-		return e.complexity.File.UserSetting(childComplexity), true
+		args, err := ec.field_File_userSetting_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.File.UserSetting(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.UserSettingWhereInput)), true
 
 	case "FileConnection.edges":
 		if e.complexity.FileConnection.Edges == nil {
@@ -8638,14 +8958,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Group.Events(childComplexity), true
+		args, err := ec.field_Group_events_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Group.Events(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.EventWhereInput)), true
 
 	case "Group.files":
 		if e.complexity.Group.Files == nil {
 			break
 		}
 
-		return e.complexity.Group.Files(childComplexity), true
+		args, err := ec.field_Group_files_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Group.Files(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.FileWhereInput)), true
 
 	case "Group.gravatarLogoURL":
 		if e.complexity.Group.GravatarLogoURL == nil {
@@ -8666,7 +8996,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Group.Integrations(childComplexity), true
+		args, err := ec.field_Group_integrations_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Group.Integrations(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.IntegrationOrder), args["where"].(*generated.IntegrationWhereInput)), true
 
 	case "Group.internalPolicyBlockedGroups":
 		if e.complexity.Group.InternalPolicyBlockedGroups == nil {
@@ -8827,7 +9162,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Group.Tasks(childComplexity), true
+		args, err := ec.field_Group_tasks_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Group.Tasks(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.TaskOrder), args["where"].(*generated.TaskWhereInput)), true
 
 	case "Group.updatedAt":
 		if e.complexity.Group.UpdatedAt == nil {
@@ -9737,7 +10077,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Hush.Events(childComplexity), true
+		args, err := ec.field_Hush_events_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Hush.Events(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.EventWhereInput)), true
 
 	case "Hush.id":
 		if e.complexity.Hush.ID == nil {
@@ -9751,7 +10096,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Hush.Integrations(childComplexity), true
+		args, err := ec.field_Hush_integrations_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Hush.Integrations(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.IntegrationOrder), args["where"].(*generated.IntegrationWhereInput)), true
 
 	case "Hush.kind":
 		if e.complexity.Hush.Kind == nil {
@@ -9772,7 +10122,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Hush.Organization(childComplexity), true
+		args, err := ec.field_Hush_organization_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Hush.Organization(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.OrganizationOrder), args["where"].(*generated.OrganizationWhereInput)), true
 
 	case "Hush.secretName":
 		if e.complexity.Hush.SecretName == nil {
@@ -10031,7 +10386,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Integration.Events(childComplexity), true
+		args, err := ec.field_Integration_events_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Integration.Events(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.EventWhereInput)), true
 
 	case "Integration.id":
 		if e.complexity.Integration.ID == nil {
@@ -10073,7 +10433,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Integration.Secrets(childComplexity), true
+		args, err := ec.field_Integration_secrets_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Integration.Secrets(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.HushOrder), args["where"].(*generated.HushWhereInput)), true
 
 	case "Integration.tags":
 		if e.complexity.Integration.Tags == nil {
@@ -10332,14 +10697,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.InternalPolicy.ControlObjectives(childComplexity), true
+		args, err := ec.field_InternalPolicy_controlObjectives_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.InternalPolicy.ControlObjectives(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ControlObjectiveOrder), args["where"].(*generated.ControlObjectiveWhereInput)), true
 
 	case "InternalPolicy.controls":
 		if e.complexity.InternalPolicy.Controls == nil {
 			break
 		}
 
-		return e.complexity.InternalPolicy.Controls(childComplexity), true
+		args, err := ec.field_InternalPolicy_controls_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.InternalPolicy.Controls(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ControlOrder), args["where"].(*generated.ControlWhereInput)), true
 
 	case "InternalPolicy.createdAt":
 		if e.complexity.InternalPolicy.CreatedAt == nil {
@@ -10416,7 +10791,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.InternalPolicy.Narratives(childComplexity), true
+		args, err := ec.field_InternalPolicy_narratives_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.InternalPolicy.Narratives(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.NarrativeOrder), args["where"].(*generated.NarrativeWhereInput)), true
 
 	case "InternalPolicy.owner":
 		if e.complexity.InternalPolicy.Owner == nil {
@@ -10444,14 +10824,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.InternalPolicy.Procedures(childComplexity), true
+		args, err := ec.field_InternalPolicy_procedures_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.InternalPolicy.Procedures(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.ProcedureWhereInput)), true
 
 	case "InternalPolicy.programs":
 		if e.complexity.InternalPolicy.Programs == nil {
 			break
 		}
 
-		return e.complexity.InternalPolicy.Programs(childComplexity), true
+		args, err := ec.field_InternalPolicy_programs_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.InternalPolicy.Programs(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ProgramOrder), args["where"].(*generated.ProgramWhereInput)), true
 
 	case "InternalPolicy.reviewDue":
 		if e.complexity.InternalPolicy.ReviewDue == nil {
@@ -10493,7 +10883,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.InternalPolicy.Tasks(childComplexity), true
+		args, err := ec.field_InternalPolicy_tasks_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.InternalPolicy.Tasks(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.TaskOrder), args["where"].(*generated.TaskWhereInput)), true
 
 	case "InternalPolicy.updatedAt":
 		if e.complexity.InternalPolicy.UpdatedAt == nil {
@@ -10794,7 +11189,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Invite.Events(childComplexity), true
+		args, err := ec.field_Invite_events_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Invite.Events(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.EventWhereInput)), true
 
 	case "Invite.expires":
 		if e.complexity.Invite.Expires == nil {
@@ -10941,7 +11341,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.MappedControl.Controls(childComplexity), true
+		args, err := ec.field_MappedControl_controls_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.MappedControl.Controls(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ControlOrder), args["where"].(*generated.ControlWhereInput)), true
 
 	case "MappedControl.createdAt":
 		if e.complexity.MappedControl.CreatedAt == nil {
@@ -10997,7 +11402,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.MappedControl.Subcontrols(childComplexity), true
+		args, err := ec.field_MappedControl_subcontrols_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.MappedControl.Subcontrols(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.SubcontrolOrder), args["where"].(*generated.SubcontrolWhereInput)), true
 
 	case "MappedControl.tags":
 		if e.complexity.MappedControl.Tags == nil {
@@ -13412,14 +13822,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Narrative.Programs(childComplexity), true
+		args, err := ec.field_Narrative_programs_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Narrative.Programs(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ProgramOrder), args["where"].(*generated.ProgramWhereInput)), true
 
 	case "Narrative.satisfies":
 		if e.complexity.Narrative.Satisfies == nil {
 			break
 		}
 
-		return e.complexity.Narrative.Satisfies(childComplexity), true
+		args, err := ec.field_Narrative_satisfies_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Narrative.Satisfies(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ControlOrder), args["where"].(*generated.ControlWhereInput)), true
 
 	case "Narrative.tags":
 		if e.complexity.Narrative.Tags == nil {
@@ -14021,7 +14441,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.OrgMembership.Events(childComplexity), true
+		args, err := ec.field_OrgMembership_events_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.OrgMembership.Events(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.EventWhereInput)), true
 
 	case "OrgMembership.id":
 		if e.complexity.OrgMembership.ID == nil {
@@ -14714,14 +15139,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Organization.APITokens(childComplexity), true
+		args, err := ec.field_Organization_apiTokens_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.APITokens(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.APITokenWhereInput)), true
 
 	case "Organization.actionPlans":
 		if e.complexity.Organization.ActionPlans == nil {
 			break
 		}
 
-		return e.complexity.Organization.ActionPlans(childComplexity), true
+		args, err := ec.field_Organization_actionPlans_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.ActionPlans(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ActionPlanOrder), args["where"].(*generated.ActionPlanWhereInput)), true
 
 	case "Organization.avatarFile":
 		if e.complexity.Organization.AvatarFile == nil {
@@ -14761,14 +15196,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Organization.Children(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.OrganizationOrder), args["where"].(*generated.OrganizationWhereInput)), true
+		return e.complexity.Organization.Children(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.OrganizationOrder), args["where"].(*generated.OrganizationWhereInput)), true
 
 	case "Organization.contacts":
 		if e.complexity.Organization.Contacts == nil {
 			break
 		}
 
-		return e.complexity.Organization.Contacts(childComplexity), true
+		args, err := ec.field_Organization_contacts_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.Contacts(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ContactOrder), args["where"].(*generated.ContactWhereInput)), true
 
 	case "Organization.controlCreators":
 		if e.complexity.Organization.ControlCreators == nil {
@@ -14789,14 +15229,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Organization.ControlObjectives(childComplexity), true
+		args, err := ec.field_Organization_controlObjectives_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.ControlObjectives(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ControlObjectiveOrder), args["where"].(*generated.ControlObjectiveWhereInput)), true
 
 	case "Organization.controls":
 		if e.complexity.Organization.Controls == nil {
 			break
 		}
 
-		return e.complexity.Organization.Controls(childComplexity), true
+		args, err := ec.field_Organization_controls_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.Controls(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ControlOrder), args["where"].(*generated.ControlWhereInput)), true
 
 	case "Organization.createdAt":
 		if e.complexity.Organization.CreatedAt == nil {
@@ -14852,42 +15302,72 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Organization.DocumentData(childComplexity), true
+		args, err := ec.field_Organization_documentData_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.DocumentData(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.DocumentDataWhereInput)), true
 
 	case "Organization.entities":
 		if e.complexity.Organization.Entities == nil {
 			break
 		}
 
-		return e.complexity.Organization.Entities(childComplexity), true
+		args, err := ec.field_Organization_entities_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.Entities(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.EntityOrder), args["where"].(*generated.EntityWhereInput)), true
 
 	case "Organization.entityTypes":
 		if e.complexity.Organization.EntityTypes == nil {
 			break
 		}
 
-		return e.complexity.Organization.EntityTypes(childComplexity), true
+		args, err := ec.field_Organization_entityTypes_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.EntityTypes(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.EntityTypeOrder), args["where"].(*generated.EntityTypeWhereInput)), true
 
 	case "Organization.events":
 		if e.complexity.Organization.Events == nil {
 			break
 		}
 
-		return e.complexity.Organization.Events(childComplexity), true
+		args, err := ec.field_Organization_events_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.Events(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.EventWhereInput)), true
 
 	case "Organization.evidence":
 		if e.complexity.Organization.Evidence == nil {
 			break
 		}
 
-		return e.complexity.Organization.Evidence(childComplexity), true
+		args, err := ec.field_Organization_evidence_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.Evidence(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.EvidenceOrder), args["where"].(*generated.EvidenceWhereInput)), true
 
 	case "Organization.files":
 		if e.complexity.Organization.Files == nil {
 			break
 		}
 
-		return e.complexity.Organization.Files(childComplexity), true
+		args, err := ec.field_Organization_files_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.Files(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.FileWhereInput)), true
 
 	case "Organization.groupCreators":
 		if e.complexity.Organization.GroupCreators == nil {
@@ -14901,7 +15381,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Organization.Groups(childComplexity), true
+		args, err := ec.field_Organization_groups_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.Groups(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.GroupOrder), args["where"].(*generated.GroupWhereInput)), true
 
 	case "Organization.id":
 		if e.complexity.Organization.ID == nil {
@@ -14915,14 +15400,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Organization.Integrations(childComplexity), true
+		args, err := ec.field_Organization_integrations_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.Integrations(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.IntegrationOrder), args["where"].(*generated.IntegrationWhereInput)), true
 
 	case "Organization.internalPolicies":
 		if e.complexity.Organization.InternalPolicies == nil {
 			break
 		}
 
-		return e.complexity.Organization.InternalPolicies(childComplexity), true
+		args, err := ec.field_Organization_internalPolicies_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.InternalPolicies(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.InternalPolicyWhereInput)), true
 
 	case "Organization.internalPolicyCreators":
 		if e.complexity.Organization.InternalPolicyCreators == nil {
@@ -14936,7 +15431,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Organization.Invites(childComplexity), true
+		args, err := ec.field_Organization_invites_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.Invites(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.InviteOrder), args["where"].(*generated.InviteWhereInput)), true
 
 	case "Organization.members":
 		if e.complexity.Organization.Members == nil {
@@ -14964,14 +15464,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Organization.Narratives(childComplexity), true
+		args, err := ec.field_Organization_narratives_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.Narratives(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.NarrativeOrder), args["where"].(*generated.NarrativeWhereInput)), true
 
 	case "Organization.notes":
 		if e.complexity.Organization.Notes == nil {
 			break
 		}
 
-		return e.complexity.Organization.Notes(childComplexity), true
+		args, err := ec.field_Organization_notes_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.Notes(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.NoteWhereInput)), true
 
 	case "Organization.orgSubscriptions":
 		if e.complexity.Organization.OrgSubscriptions == nil {
@@ -14992,7 +15502,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Organization.PersonalAccessTokens(childComplexity), true
+		args, err := ec.field_Organization_personalAccessTokens_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.PersonalAccessTokens(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.PersonalAccessTokenWhereInput)), true
 
 	case "Organization.personalOrg":
 		if e.complexity.Organization.PersonalOrg == nil {
@@ -15013,7 +15528,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Organization.Procedures(childComplexity), true
+		args, err := ec.field_Organization_procedures_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.Procedures(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.ProcedureWhereInput)), true
 
 	case "Organization.programCreators":
 		if e.complexity.Organization.ProgramCreators == nil {
@@ -15027,7 +15547,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Organization.Programs(childComplexity), true
+		args, err := ec.field_Organization_programs_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.Programs(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ProgramOrder), args["where"].(*generated.ProgramWhereInput)), true
 
 	case "Organization.riskCreators":
 		if e.complexity.Organization.RiskCreators == nil {
@@ -15041,14 +15566,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Organization.Risks(childComplexity), true
+		args, err := ec.field_Organization_risks_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.Risks(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.RiskOrder), args["where"].(*generated.RiskWhereInput)), true
 
 	case "Organization.secrets":
 		if e.complexity.Organization.Secrets == nil {
 			break
 		}
 
-		return e.complexity.Organization.Secrets(childComplexity), true
+		args, err := ec.field_Organization_secrets_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.Secrets(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.HushOrder), args["where"].(*generated.HushWhereInput)), true
 
 	case "Organization.setting":
 		if e.complexity.Organization.Setting == nil {
@@ -15062,21 +15597,36 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Organization.Standards(childComplexity), true
+		args, err := ec.field_Organization_standards_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.Standards(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.StandardOrder), args["where"].(*generated.StandardWhereInput)), true
 
 	case "Organization.subcontrols":
 		if e.complexity.Organization.Subcontrols == nil {
 			break
 		}
 
-		return e.complexity.Organization.Subcontrols(childComplexity), true
+		args, err := ec.field_Organization_subcontrols_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.Subcontrols(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.SubcontrolOrder), args["where"].(*generated.SubcontrolWhereInput)), true
 
 	case "Organization.subscribers":
 		if e.complexity.Organization.Subscribers == nil {
 			break
 		}
 
-		return e.complexity.Organization.Subscribers(childComplexity), true
+		args, err := ec.field_Organization_subscribers_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.Subscribers(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.SubscriberOrder), args["where"].(*generated.SubscriberWhereInput)), true
 
 	case "Organization.tags":
 		if e.complexity.Organization.Tags == nil {
@@ -15090,7 +15640,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Organization.Tasks(childComplexity), true
+		args, err := ec.field_Organization_tasks_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.Tasks(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.TaskOrder), args["where"].(*generated.TaskWhereInput)), true
 
 	case "Organization.templateCreators":
 		if e.complexity.Organization.TemplateCreators == nil {
@@ -15104,7 +15659,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Organization.Templates(childComplexity), true
+		args, err := ec.field_Organization_templates_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.Templates(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.TemplateOrder), args["where"].(*generated.TemplateWhereInput)), true
 
 	case "Organization.updatedAt":
 		if e.complexity.Organization.UpdatedAt == nil {
@@ -15440,7 +16000,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.OrganizationSetting.Files(childComplexity), true
+		args, err := ec.field_OrganizationSetting_files_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.OrganizationSetting.Files(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.FileWhereInput)), true
 
 	case "OrganizationSetting.geoLocation":
 		if e.complexity.OrganizationSetting.GeoLocation == nil {
@@ -15825,7 +16390,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.PersonalAccessToken.Events(childComplexity), true
+		args, err := ec.field_PersonalAccessToken_events_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.PersonalAccessToken.Events(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.EventWhereInput)), true
 
 	case "PersonalAccessToken.expiresAt":
 		if e.complexity.PersonalAccessToken.ExpiresAt == nil {
@@ -15867,7 +16437,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.PersonalAccessToken.Organizations(childComplexity), true
+		args, err := ec.field_PersonalAccessToken_organizations_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.PersonalAccessToken.Organizations(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.OrganizationOrder), args["where"].(*generated.OrganizationWhereInput)), true
 
 	case "PersonalAccessToken.owner":
 		if e.complexity.PersonalAccessToken.Owner == nil {
@@ -16028,7 +16603,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Procedure.Controls(childComplexity), true
+		args, err := ec.field_Procedure_controls_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Procedure.Controls(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ControlOrder), args["where"].(*generated.ControlWhereInput)), true
 
 	case "Procedure.createdAt":
 		if e.complexity.Procedure.CreatedAt == nil {
@@ -16098,7 +16678,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Procedure.InternalPolicies(childComplexity), true
+		args, err := ec.field_Procedure_internalPolicies_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Procedure.InternalPolicies(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.InternalPolicyWhereInput)), true
 
 	case "Procedure.name":
 		if e.complexity.Procedure.Name == nil {
@@ -16112,7 +16697,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Procedure.Narratives(childComplexity), true
+		args, err := ec.field_Procedure_narratives_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Procedure.Narratives(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.NarrativeOrder), args["where"].(*generated.NarrativeWhereInput)), true
 
 	case "Procedure.owner":
 		if e.complexity.Procedure.Owner == nil {
@@ -16140,7 +16730,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Procedure.Programs(childComplexity), true
+		args, err := ec.field_Procedure_programs_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Procedure.Programs(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ProgramOrder), args["where"].(*generated.ProgramWhereInput)), true
 
 	case "Procedure.reviewDue":
 		if e.complexity.Procedure.ReviewDue == nil {
@@ -16168,7 +16763,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Procedure.Risks(childComplexity), true
+		args, err := ec.field_Procedure_risks_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Procedure.Risks(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.RiskOrder), args["where"].(*generated.RiskWhereInput)), true
 
 	case "Procedure.status":
 		if e.complexity.Procedure.Status == nil {
@@ -16189,7 +16789,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Procedure.Tasks(childComplexity), true
+		args, err := ec.field_Procedure_tasks_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Procedure.Tasks(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.TaskOrder), args["where"].(*generated.TaskWhereInput)), true
 
 	case "Procedure.updatedAt":
 		if e.complexity.Procedure.UpdatedAt == nil {
@@ -16497,14 +17102,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Program.ControlObjectives(childComplexity), true
+		args, err := ec.field_Program_controlObjectives_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Program.ControlObjectives(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ControlObjectiveOrder), args["where"].(*generated.ControlObjectiveWhereInput)), true
 
 	case "Program.controls":
 		if e.complexity.Program.Controls == nil {
 			break
 		}
 
-		return e.complexity.Program.Controls(childComplexity), true
+		args, err := ec.field_Program_controls_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Program.Controls(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ControlOrder), args["where"].(*generated.ControlWhereInput)), true
 
 	case "Program.createdAt":
 		if e.complexity.Program.CreatedAt == nil {
@@ -16567,14 +17182,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Program.Evidence(childComplexity), true
+		args, err := ec.field_Program_evidence_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Program.Evidence(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.EvidenceOrder), args["where"].(*generated.EvidenceWhereInput)), true
 
 	case "Program.files":
 		if e.complexity.Program.Files == nil {
 			break
 		}
 
-		return e.complexity.Program.Files(childComplexity), true
+		args, err := ec.field_Program_files_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Program.Files(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.FileWhereInput)), true
 
 	case "Program.id":
 		if e.complexity.Program.ID == nil {
@@ -16588,14 +17213,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Program.InternalPolicies(childComplexity), true
+		args, err := ec.field_Program_internalPolicies_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Program.InternalPolicies(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.InternalPolicyWhereInput)), true
 
 	case "Program.members":
 		if e.complexity.Program.Members == nil {
 			break
 		}
 
-		return e.complexity.Program.Members(childComplexity), true
+		args, err := ec.field_Program_members_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Program.Members(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.ProgramMembershipOrder), args["where"].(*generated.ProgramMembershipWhereInput)), true
 
 	case "Program.name":
 		if e.complexity.Program.Name == nil {
@@ -16609,14 +17244,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Program.Narratives(childComplexity), true
+		args, err := ec.field_Program_narratives_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Program.Narratives(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.NarrativeOrder), args["where"].(*generated.NarrativeWhereInput)), true
 
 	case "Program.notes":
 		if e.complexity.Program.Notes == nil {
 			break
 		}
 
-		return e.complexity.Program.Notes(childComplexity), true
+		args, err := ec.field_Program_notes_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Program.Notes(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.NoteWhereInput)), true
 
 	case "Program.owner":
 		if e.complexity.Program.Owner == nil {
@@ -16637,14 +17282,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Program.Procedures(childComplexity), true
+		args, err := ec.field_Program_procedures_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Program.Procedures(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.ProcedureWhereInput)), true
 
 	case "Program.risks":
 		if e.complexity.Program.Risks == nil {
 			break
 		}
 
-		return e.complexity.Program.Risks(childComplexity), true
+		args, err := ec.field_Program_risks_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Program.Risks(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.RiskOrder), args["where"].(*generated.RiskWhereInput)), true
 
 	case "Program.startDate":
 		if e.complexity.Program.StartDate == nil {
@@ -16665,7 +17320,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Program.Subcontrols(childComplexity), true
+		args, err := ec.field_Program_subcontrols_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Program.Subcontrols(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.SubcontrolOrder), args["where"].(*generated.SubcontrolWhereInput)), true
 
 	case "Program.tags":
 		if e.complexity.Program.Tags == nil {
@@ -16679,7 +17339,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Program.Tasks(childComplexity), true
+		args, err := ec.field_Program_tasks_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Program.Tasks(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.TaskOrder), args["where"].(*generated.TaskWhereInput)), true
 
 	case "Program.updatedAt":
 		if e.complexity.Program.UpdatedAt == nil {
@@ -16700,7 +17365,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Program.Users(childComplexity), true
+		args, err := ec.field_Program_users_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Program.Users(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.UserOrder), args["where"].(*generated.UserWhereInput)), true
 
 	case "Program.viewers":
 		if e.complexity.Program.Viewers == nil {
@@ -17292,7 +17962,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.ActionPlanHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.ActionPlanHistoryWhereInput)), true
+		return e.complexity.Query.ActionPlanHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.ActionPlanHistoryOrder), args["where"].(*generated.ActionPlanHistoryWhereInput)), true
 
 	case "Query.actionPlanSearch":
 		if e.complexity.Query.ActionPlanSearch == nil {
@@ -17316,7 +17986,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.ActionPlans(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.ActionPlanWhereInput)), true
+		return e.complexity.Query.ActionPlans(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ActionPlanOrder), args["where"].(*generated.ActionPlanWhereInput)), true
 
 	case "Query.adminAPITokenSearch":
 		if e.complexity.Query.AdminAPITokenSearch == nil {
@@ -17736,7 +18406,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.ContactHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.ContactHistoryWhereInput)), true
+		return e.complexity.Query.ContactHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.ContactHistoryOrder), args["where"].(*generated.ContactHistoryWhereInput)), true
 
 	case "Query.contactSearch":
 		if e.complexity.Query.ContactSearch == nil {
@@ -17760,7 +18430,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Contacts(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.ContactWhereInput)), true
+		return e.complexity.Query.Contacts(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ContactOrder), args["where"].(*generated.ContactWhereInput)), true
 
 	case "Query.control":
 		if e.complexity.Query.Control == nil {
@@ -17784,7 +18454,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.ControlHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.ControlHistoryWhereInput)), true
+		return e.complexity.Query.ControlHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.ControlHistoryOrder), args["where"].(*generated.ControlHistoryWhereInput)), true
 
 	case "Query.controlImplementation":
 		if e.complexity.Query.ControlImplementation == nil {
@@ -17808,7 +18478,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.ControlImplementationHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.ControlImplementationHistoryWhereInput)), true
+		return e.complexity.Query.ControlImplementationHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.ControlImplementationHistoryOrder), args["where"].(*generated.ControlImplementationHistoryWhereInput)), true
 
 	case "Query.controlImplementationSearch":
 		if e.complexity.Query.ControlImplementationSearch == nil {
@@ -17832,7 +18502,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.ControlImplementations(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.ControlImplementationWhereInput)), true
+		return e.complexity.Query.ControlImplementations(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ControlImplementationOrder), args["where"].(*generated.ControlImplementationWhereInput)), true
 
 	case "Query.controlObjective":
 		if e.complexity.Query.ControlObjective == nil {
@@ -17856,7 +18526,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.ControlObjectiveHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.ControlObjectiveHistoryWhereInput)), true
+		return e.complexity.Query.ControlObjectiveHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.ControlObjectiveHistoryOrder), args["where"].(*generated.ControlObjectiveHistoryWhereInput)), true
 
 	case "Query.controlObjectiveSearch":
 		if e.complexity.Query.ControlObjectiveSearch == nil {
@@ -17880,7 +18550,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.ControlObjectives(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.ControlObjectiveWhereInput)), true
+		return e.complexity.Query.ControlObjectives(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ControlObjectiveOrder), args["where"].(*generated.ControlObjectiveWhereInput)), true
 
 	case "Query.controlSearch":
 		if e.complexity.Query.ControlSearch == nil {
@@ -17904,7 +18574,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Controls(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.ControlWhereInput)), true
+		return e.complexity.Query.Controls(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ControlOrder), args["where"].(*generated.ControlWhereInput)), true
 
 	case "Query.documentData":
 		if e.complexity.Query.DocumentData == nil {
@@ -17964,7 +18634,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Entities(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.EntityOrder), args["where"].(*generated.EntityWhereInput)), true
+		return e.complexity.Query.Entities(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.EntityOrder), args["where"].(*generated.EntityWhereInput)), true
 
 	case "Query.entity":
 		if e.complexity.Query.Entity == nil {
@@ -18120,7 +18790,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.EvidenceHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.EvidenceHistoryWhereInput)), true
+		return e.complexity.Query.EvidenceHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.EvidenceHistoryOrder), args["where"].(*generated.EvidenceHistoryWhereInput)), true
 
 	case "Query.evidenceSearch":
 		if e.complexity.Query.EvidenceSearch == nil {
@@ -18144,7 +18814,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Evidences(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.EvidenceWhereInput)), true
+		return e.complexity.Query.Evidences(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.EvidenceOrder), args["where"].(*generated.EvidenceWhereInput)), true
 
 	case "Query.file":
 		if e.complexity.Query.File == nil {
@@ -18240,7 +18910,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.GroupMembershipHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.GroupMembershipHistoryWhereInput)), true
+		return e.complexity.Query.GroupMembershipHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.GroupMembershipHistoryOrder), args["where"].(*generated.GroupMembershipHistoryWhereInput)), true
 
 	case "Query.groupMemberships":
 		if e.complexity.Query.GroupMemberships == nil {
@@ -18252,7 +18922,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.GroupMemberships(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.GroupMembershipWhereInput)), true
+		return e.complexity.Query.GroupMemberships(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.GroupMembershipOrder), args["where"].(*generated.GroupMembershipWhereInput)), true
 
 	case "Query.groupSearch":
 		if e.complexity.Query.GroupSearch == nil {
@@ -18312,7 +18982,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Groups(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.GroupOrder), args["where"].(*generated.GroupWhereInput)), true
+		return e.complexity.Query.Groups(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.GroupOrder), args["where"].(*generated.GroupWhereInput)), true
 
 	case "Query.hush":
 		if e.complexity.Query.Hush == nil {
@@ -18348,7 +19018,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Hushes(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.HushOrder), args["where"].(*generated.HushWhereInput)), true
+		return e.complexity.Query.Hushes(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.HushOrder), args["where"].(*generated.HushWhereInput)), true
 
 	case "Query.integration":
 		if e.complexity.Query.Integration == nil {
@@ -18396,7 +19066,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Integrations(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.IntegrationOrder), args["where"].(*generated.IntegrationWhereInput)), true
+		return e.complexity.Query.Integrations(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.IntegrationOrder), args["where"].(*generated.IntegrationWhereInput)), true
 
 	case "Query.internalPolicies":
 		if e.complexity.Query.InternalPolicies == nil {
@@ -18468,7 +19138,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Invites(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.InviteWhereInput)), true
+		return e.complexity.Query.Invites(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.InviteOrder), args["where"].(*generated.InviteWhereInput)), true
 
 	case "Query.mappedControl":
 		if e.complexity.Query.MappedControl == nil {
@@ -18492,7 +19162,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.MappedControlHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.MappedControlHistoryWhereInput)), true
+		return e.complexity.Query.MappedControlHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.MappedControlHistoryOrder), args["where"].(*generated.MappedControlHistoryWhereInput)), true
 
 	case "Query.mappedControlSearch":
 		if e.complexity.Query.MappedControlSearch == nil {
@@ -18516,7 +19186,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.MappedControls(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.MappedControlWhereInput)), true
+		return e.complexity.Query.MappedControls(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.MappedControlOrder), args["where"].(*generated.MappedControlWhereInput)), true
 
 	case "Query.narrative":
 		if e.complexity.Query.Narrative == nil {
@@ -18540,7 +19210,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.NarrativeHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.NarrativeHistoryWhereInput)), true
+		return e.complexity.Query.NarrativeHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.NarrativeHistoryOrder), args["where"].(*generated.NarrativeHistoryWhereInput)), true
 
 	case "Query.narrativeSearch":
 		if e.complexity.Query.NarrativeSearch == nil {
@@ -18564,7 +19234,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Narratives(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.NarrativeWhereInput)), true
+		return e.complexity.Query.Narratives(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.NarrativeOrder), args["where"].(*generated.NarrativeWhereInput)), true
 
 	case "Query.node":
 		if e.complexity.Query.Node == nil {
@@ -18648,7 +19318,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.OrgMembershipHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.OrgMembershipHistoryWhereInput)), true
+		return e.complexity.Query.OrgMembershipHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.OrgMembershipHistoryOrder), args["where"].(*generated.OrgMembershipHistoryWhereInput)), true
 
 	case "Query.orgMemberships":
 		if e.complexity.Query.OrgMemberships == nil {
@@ -18660,7 +19330,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.OrgMemberships(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.OrgMembershipWhereInput)), true
+		return e.complexity.Query.OrgMemberships(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.OrgMembershipOrder), args["where"].(*generated.OrgMembershipWhereInput)), true
 
 	case "Query.orgSubscription":
 		if e.complexity.Query.OrgSubscription == nil {
@@ -18684,7 +19354,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.OrgSubscriptionHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.OrgSubscriptionHistoryWhereInput)), true
+		return e.complexity.Query.OrgSubscriptionHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.OrgSubscriptionHistoryOrder), args["where"].(*generated.OrgSubscriptionHistoryWhereInput)), true
 
 	case "Query.orgSubscriptionSearch":
 		if e.complexity.Query.OrgSubscriptionSearch == nil {
@@ -18708,7 +19378,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.OrgSubscriptions(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.OrgSubscriptionWhereInput)), true
+		return e.complexity.Query.OrgSubscriptions(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.OrgSubscriptionOrder), args["where"].(*generated.OrgSubscriptionWhereInput)), true
 
 	case "Query.organization":
 		if e.complexity.Query.Organization == nil {
@@ -18804,7 +19474,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Organizations(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.OrganizationOrder), args["where"].(*generated.OrganizationWhereInput)), true
+		return e.complexity.Query.Organizations(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.OrganizationOrder), args["where"].(*generated.OrganizationWhereInput)), true
 
 	case "Query.personalAccessToken":
 		if e.complexity.Query.PersonalAccessToken == nil {
@@ -18912,7 +19582,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.ProgramHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.ProgramHistoryWhereInput)), true
+		return e.complexity.Query.ProgramHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.ProgramHistoryOrder), args["where"].(*generated.ProgramHistoryWhereInput)), true
 
 	case "Query.programMembership":
 		if e.complexity.Query.ProgramMembership == nil {
@@ -18936,7 +19606,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.ProgramMembershipHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.ProgramMembershipHistoryWhereInput)), true
+		return e.complexity.Query.ProgramMembershipHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.ProgramMembershipHistoryOrder), args["where"].(*generated.ProgramMembershipHistoryWhereInput)), true
 
 	case "Query.programMemberships":
 		if e.complexity.Query.ProgramMemberships == nil {
@@ -18948,7 +19618,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.ProgramMemberships(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.ProgramMembershipWhereInput)), true
+		return e.complexity.Query.ProgramMemberships(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.ProgramMembershipOrder), args["where"].(*generated.ProgramMembershipWhereInput)), true
 
 	case "Query.programSearch":
 		if e.complexity.Query.ProgramSearch == nil {
@@ -18972,7 +19642,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Programs(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.ProgramWhereInput)), true
+		return e.complexity.Query.Programs(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ProgramOrder), args["where"].(*generated.ProgramWhereInput)), true
 
 	case "Query.risk":
 		if e.complexity.Query.Risk == nil {
@@ -18996,7 +19666,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.RiskHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.RiskHistoryWhereInput)), true
+		return e.complexity.Query.RiskHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.RiskHistoryOrder), args["where"].(*generated.RiskHistoryWhereInput)), true
 
 	case "Query.riskSearch":
 		if e.complexity.Query.RiskSearch == nil {
@@ -19020,7 +19690,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Risks(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.RiskWhereInput)), true
+		return e.complexity.Query.Risks(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.RiskOrder), args["where"].(*generated.RiskWhereInput)), true
 
 	case "Query.search":
 		if e.complexity.Query.Search == nil {
@@ -19063,7 +19733,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.StandardHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.StandardHistoryWhereInput)), true
+		return e.complexity.Query.StandardHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.StandardHistoryOrder), args["where"].(*generated.StandardHistoryWhereInput)), true
 
 	case "Query.standardSearch":
 		if e.complexity.Query.StandardSearch == nil {
@@ -19087,7 +19757,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Standards(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.StandardWhereInput)), true
+		return e.complexity.Query.Standards(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.StandardOrder), args["where"].(*generated.StandardWhereInput)), true
 
 	case "Query.subcontrol":
 		if e.complexity.Query.Subcontrol == nil {
@@ -19111,7 +19781,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.SubcontrolHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.SubcontrolHistoryWhereInput)), true
+		return e.complexity.Query.SubcontrolHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.SubcontrolHistoryOrder), args["where"].(*generated.SubcontrolHistoryWhereInput)), true
 
 	case "Query.subcontrolSearch":
 		if e.complexity.Query.SubcontrolSearch == nil {
@@ -19135,7 +19805,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Subcontrols(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.SubcontrolWhereInput)), true
+		return e.complexity.Query.Subcontrols(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.SubcontrolOrder), args["where"].(*generated.SubcontrolWhereInput)), true
 
 	case "Query.subscriber":
 		if e.complexity.Query.Subscriber == nil {
@@ -19171,7 +19841,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Subscribers(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.SubscriberWhereInput)), true
+		return e.complexity.Query.Subscribers(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.SubscriberOrder), args["where"].(*generated.SubscriberWhereInput)), true
 
 	case "Query.task":
 		if e.complexity.Query.Task == nil {
@@ -19195,7 +19865,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.TaskHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.TaskHistoryWhereInput)), true
+		return e.complexity.Query.TaskHistories(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.TaskHistoryOrder), args["where"].(*generated.TaskHistoryWhereInput)), true
 
 	case "Query.taskSearch":
 		if e.complexity.Query.TaskSearch == nil {
@@ -19219,7 +19889,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Tasks(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.TaskWhereInput)), true
+		return e.complexity.Query.Tasks(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.TaskOrder), args["where"].(*generated.TaskWhereInput)), true
 
 	case "Query.template":
 		if e.complexity.Query.Template == nil {
@@ -19267,7 +19937,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Templates(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.TemplateOrder), args["where"].(*generated.TemplateWhereInput)), true
+		return e.complexity.Query.Templates(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.TemplateOrder), args["where"].(*generated.TemplateWhereInput)), true
 
 	case "Query.tfaSetting":
 		if e.complexity.Query.TfaSetting == nil {
@@ -19387,14 +20057,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.Users(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.UserOrder), args["where"].(*generated.UserWhereInput)), true
+		return e.complexity.Query.Users(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.UserOrder), args["where"].(*generated.UserWhereInput)), true
 
 	case "Risk.actionPlans":
 		if e.complexity.Risk.ActionPlans == nil {
 			break
 		}
 
-		return e.complexity.Risk.ActionPlans(childComplexity), true
+		args, err := ec.field_Risk_actionPlans_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Risk.ActionPlans(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ActionPlanOrder), args["where"].(*generated.ActionPlanWhereInput)), true
 
 	case "Risk.blockedGroups":
 		if e.complexity.Risk.BlockedGroups == nil {
@@ -19422,7 +20097,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Risk.Control(childComplexity), true
+		args, err := ec.field_Risk_control_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Risk.Control(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ControlOrder), args["where"].(*generated.ControlWhereInput)), true
 
 	case "Risk.createdAt":
 		if e.complexity.Risk.CreatedAt == nil {
@@ -19534,14 +20214,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Risk.Procedure(childComplexity), true
+		args, err := ec.field_Risk_procedure_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Risk.Procedure(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.ProcedureWhereInput)), true
 
 	case "Risk.programs":
 		if e.complexity.Risk.Programs == nil {
 			break
 		}
 
-		return e.complexity.Risk.Programs(childComplexity), true
+		args, err := ec.field_Risk_programs_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Risk.Programs(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ProgramOrder), args["where"].(*generated.ProgramWhereInput)), true
 
 	case "Risk.riskType":
 		if e.complexity.Risk.RiskType == nil {
@@ -19891,7 +20581,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Standard.Controls(childComplexity), true
+		args, err := ec.field_Standard_controls_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Standard.Controls(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ControlOrder), args["where"].(*generated.ControlWhereInput)), true
 
 	case "Standard.createdAt":
 		if e.complexity.Standard.CreatedAt == nil {
@@ -20367,7 +21062,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Subcontrol.ActionPlans(childComplexity), true
+		args, err := ec.field_Subcontrol_actionPlans_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Subcontrol.ActionPlans(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ActionPlanOrder), args["where"].(*generated.ActionPlanWhereInput)), true
 
 	case "Subcontrol.assessmentMethods":
 		if e.complexity.Subcontrol.AssessmentMethods == nil {
@@ -20416,7 +21116,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Subcontrol.ControlObjectives(childComplexity), true
+		args, err := ec.field_Subcontrol_controlObjectives_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Subcontrol.ControlObjectives(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ControlObjectiveOrder), args["where"].(*generated.ControlObjectiveWhereInput)), true
 
 	case "Subcontrol.controlOwner":
 		if e.complexity.Subcontrol.ControlOwner == nil {
@@ -20493,7 +21198,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Subcontrol.Evidence(childComplexity), true
+		args, err := ec.field_Subcontrol_evidence_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Subcontrol.Evidence(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.EvidenceOrder), args["where"].(*generated.EvidenceWhereInput)), true
 
 	case "Subcontrol.exampleEvidence":
 		if e.complexity.Subcontrol.ExampleEvidence == nil {
@@ -20521,7 +21231,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Subcontrol.InternalPolicies(childComplexity), true
+		args, err := ec.field_Subcontrol_internalPolicies_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Subcontrol.InternalPolicies(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.InternalPolicyWhereInput)), true
 
 	case "Subcontrol.mappedCategories":
 		if e.complexity.Subcontrol.MappedCategories == nil {
@@ -20542,7 +21257,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Subcontrol.Narratives(childComplexity), true
+		args, err := ec.field_Subcontrol_narratives_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Subcontrol.Narratives(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].(*generated.NarrativeOrder), args["where"].(*generated.NarrativeWhereInput)), true
 
 	case "Subcontrol.owner":
 		if e.complexity.Subcontrol.Owner == nil {
@@ -20563,7 +21283,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Subcontrol.Procedures(childComplexity), true
+		args, err := ec.field_Subcontrol_procedures_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Subcontrol.Procedures(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.ProcedureWhereInput)), true
 
 	case "Subcontrol.refCode":
 		if e.complexity.Subcontrol.RefCode == nil {
@@ -20584,7 +21309,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Subcontrol.Risks(childComplexity), true
+		args, err := ec.field_Subcontrol_risks_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Subcontrol.Risks(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.RiskOrder), args["where"].(*generated.RiskWhereInput)), true
 
 	case "Subcontrol.source":
 		if e.complexity.Subcontrol.Source == nil {
@@ -20619,7 +21349,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Subcontrol.Tasks(childComplexity), true
+		args, err := ec.field_Subcontrol_tasks_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Subcontrol.Tasks(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.TaskOrder), args["where"].(*generated.TaskWhereInput)), true
 
 	case "Subcontrol.updatedAt":
 		if e.complexity.Subcontrol.UpdatedAt == nil {
@@ -20990,7 +21725,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Subscriber.Events(childComplexity), true
+		args, err := ec.field_Subscriber_events_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Subscriber.Events(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.EventWhereInput)), true
 
 	case "Subscriber.id":
 		if e.complexity.Subscriber.ID == nil {
@@ -21319,7 +22059,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Task.Comments(childComplexity), true
+		args, err := ec.field_Task_comments_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Task.Comments(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.NoteWhereInput)), true
 
 	case "Task.completed":
 		if e.complexity.Task.Completed == nil {
@@ -21333,14 +22078,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Task.Control(childComplexity), true
+		args, err := ec.field_Task_control_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Task.Control(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ControlOrder), args["where"].(*generated.ControlWhereInput)), true
 
 	case "Task.controlObjective":
 		if e.complexity.Task.ControlObjective == nil {
 			break
 		}
 
-		return e.complexity.Task.ControlObjective(childComplexity), true
+		args, err := ec.field_Task_controlObjective_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Task.ControlObjective(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ControlObjectiveOrder), args["where"].(*generated.ControlObjectiveWhereInput)), true
 
 	case "Task.createdAt":
 		if e.complexity.Task.CreatedAt == nil {
@@ -21403,14 +22158,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Task.Evidence(childComplexity), true
+		args, err := ec.field_Task_evidence_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Task.Evidence(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.EvidenceOrder), args["where"].(*generated.EvidenceWhereInput)), true
 
 	case "Task.group":
 		if e.complexity.Task.Group == nil {
 			break
 		}
 
-		return e.complexity.Task.Group(childComplexity), true
+		args, err := ec.field_Task_group_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Task.Group(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.GroupOrder), args["where"].(*generated.GroupWhereInput)), true
 
 	case "Task.id":
 		if e.complexity.Task.ID == nil {
@@ -21424,7 +22189,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Task.InternalPolicy(childComplexity), true
+		args, err := ec.field_Task_internalPolicy_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Task.InternalPolicy(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.InternalPolicyWhereInput)), true
 
 	case "Task.owner":
 		if e.complexity.Task.Owner == nil {
@@ -21445,14 +22215,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Task.Procedure(childComplexity), true
+		args, err := ec.field_Task_procedure_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Task.Procedure(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.ProcedureWhereInput)), true
 
 	case "Task.program":
 		if e.complexity.Task.Program == nil {
 			break
 		}
 
-		return e.complexity.Task.Program(childComplexity), true
+		args, err := ec.field_Task_program_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Task.Program(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ProgramOrder), args["where"].(*generated.ProgramWhereInput)), true
 
 	case "Task.status":
 		if e.complexity.Task.Status == nil {
@@ -21466,7 +22246,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Task.Subcontrol(childComplexity), true
+		args, err := ec.field_Task_subcontrol_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Task.Subcontrol(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.SubcontrolOrder), args["where"].(*generated.SubcontrolWhereInput)), true
 
 	case "Task.tags":
 		if e.complexity.Task.Tags == nil {
@@ -21795,14 +22580,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Template.Documents(childComplexity), true
+		args, err := ec.field_Template_documents_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Template.Documents(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.DocumentDataWhereInput)), true
 
 	case "Template.files":
 		if e.complexity.Template.Files == nil {
 			break
 		}
 
-		return e.complexity.Template.Files(childComplexity), true
+		args, err := ec.field_Template_files_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Template.Files(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.FileWhereInput)), true
 
 	case "Template.id":
 		if e.complexity.Template.ID == nil {
@@ -22103,21 +22898,36 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.User.ActionPlans(childComplexity), true
+		args, err := ec.field_User_actionPlans_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.User.ActionPlans(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.ActionPlanOrder), args["where"].(*generated.ActionPlanWhereInput)), true
 
 	case "User.assigneeTasks":
 		if e.complexity.User.AssigneeTasks == nil {
 			break
 		}
 
-		return e.complexity.User.AssigneeTasks(childComplexity), true
+		args, err := ec.field_User_assigneeTasks_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.User.AssigneeTasks(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.TaskOrder), args["where"].(*generated.TaskWhereInput)), true
 
 	case "User.assignerTasks":
 		if e.complexity.User.AssignerTasks == nil {
 			break
 		}
 
-		return e.complexity.User.AssignerTasks(childComplexity), true
+		args, err := ec.field_User_assignerTasks_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.User.AssignerTasks(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.TaskOrder), args["where"].(*generated.TaskWhereInput)), true
 
 	case "User.authProvider":
 		if e.complexity.User.AuthProvider == nil {
@@ -22208,14 +23018,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.User.Events(childComplexity), true
+		args, err := ec.field_User_events_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.User.Events(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.EventWhereInput)), true
 
 	case "User.files":
 		if e.complexity.User.Files == nil {
 			break
 		}
 
-		return e.complexity.User.Files(childComplexity), true
+		args, err := ec.field_User_files_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.User.Files(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.FileWhereInput)), true
 
 	case "User.firstName":
 		if e.complexity.User.FirstName == nil {
@@ -22278,7 +23098,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.User.PersonalAccessTokens(childComplexity), true
+		args, err := ec.field_User_personalAccessTokens_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.User.PersonalAccessTokens(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.PersonalAccessTokenWhereInput)), true
 
 	case "User.programMemberships":
 		if e.complexity.User.ProgramMemberships == nil {
@@ -22320,7 +23145,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.User.Subcontrols(childComplexity), true
+		args, err := ec.field_User_subcontrols_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.User.Subcontrols(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.SubcontrolOrder), args["where"].(*generated.SubcontrolWhereInput)), true
 
 	case "User.tags":
 		if e.complexity.User.Tags == nil {
@@ -22334,7 +23164,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.User.TfaSettings(childComplexity), true
+		args, err := ec.field_User_tfaSettings_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.User.TfaSettings(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.TFASettingWhereInput)), true
 
 	case "User.updatedAt":
 		if e.complexity.User.UpdatedAt == nil {
@@ -22656,7 +23491,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.UserSetting.Files(childComplexity), true
+		args, err := ec.field_UserSetting_files_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.UserSetting.Files(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["where"].(*generated.FileWhereInput)), true
 
 	case "UserSetting.id":
 		if e.complexity.UserSetting.ID == nil {
@@ -22989,16 +23829,26 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	ec := executionContext{opCtx, e, 0, 0, make(chan graphql.DeferredResult)}
 	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
 		ec.unmarshalInputAPITokenWhereInput,
+		ec.unmarshalInputActionPlanHistoryOrder,
 		ec.unmarshalInputActionPlanHistoryWhereInput,
+		ec.unmarshalInputActionPlanOrder,
 		ec.unmarshalInputActionPlanWhereInput,
 		ec.unmarshalInputAuditLogWhereInput,
+		ec.unmarshalInputContactHistoryOrder,
 		ec.unmarshalInputContactHistoryWhereInput,
+		ec.unmarshalInputContactOrder,
 		ec.unmarshalInputContactWhereInput,
+		ec.unmarshalInputControlHistoryOrder,
 		ec.unmarshalInputControlHistoryWhereInput,
+		ec.unmarshalInputControlImplementationHistoryOrder,
 		ec.unmarshalInputControlImplementationHistoryWhereInput,
+		ec.unmarshalInputControlImplementationOrder,
 		ec.unmarshalInputControlImplementationWhereInput,
+		ec.unmarshalInputControlObjectiveHistoryOrder,
 		ec.unmarshalInputControlObjectiveHistoryWhereInput,
+		ec.unmarshalInputControlObjectiveOrder,
 		ec.unmarshalInputControlObjectiveWhereInput,
+		ec.unmarshalInputControlOrder,
 		ec.unmarshalInputControlWhereInput,
 		ec.unmarshalInputCreateAPITokenInput,
 		ec.unmarshalInputCreateActionPlanInput,
@@ -23055,14 +23905,18 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputEntityWhereInput,
 		ec.unmarshalInputEventHistoryWhereInput,
 		ec.unmarshalInputEventWhereInput,
+		ec.unmarshalInputEvidenceHistoryOrder,
 		ec.unmarshalInputEvidenceHistoryWhereInput,
+		ec.unmarshalInputEvidenceOrder,
 		ec.unmarshalInputEvidenceWhereInput,
 		ec.unmarshalInputFileHistoryWhereInput,
 		ec.unmarshalInputFileWhereInput,
 		ec.unmarshalInputGroupHistoryOrder,
 		ec.unmarshalInputGroupHistoryWhereInput,
 		ec.unmarshalInputGroupMembersInput,
+		ec.unmarshalInputGroupMembershipHistoryOrder,
 		ec.unmarshalInputGroupMembershipHistoryWhereInput,
+		ec.unmarshalInputGroupMembershipOrder,
 		ec.unmarshalInputGroupMembershipWhereInput,
 		ec.unmarshalInputGroupOrder,
 		ec.unmarshalInputGroupSettingHistoryWhereInput,
@@ -23078,18 +23932,27 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputIntegrationWhereInput,
 		ec.unmarshalInputInternalPolicyHistoryWhereInput,
 		ec.unmarshalInputInternalPolicyWhereInput,
+		ec.unmarshalInputInviteOrder,
 		ec.unmarshalInputInviteWhereInput,
+		ec.unmarshalInputMappedControlHistoryOrder,
 		ec.unmarshalInputMappedControlHistoryWhereInput,
+		ec.unmarshalInputMappedControlOrder,
 		ec.unmarshalInputMappedControlWhereInput,
+		ec.unmarshalInputNarrativeHistoryOrder,
 		ec.unmarshalInputNarrativeHistoryWhereInput,
+		ec.unmarshalInputNarrativeOrder,
 		ec.unmarshalInputNarrativeWhereInput,
 		ec.unmarshalInputNoteHistoryWhereInput,
 		ec.unmarshalInputNoteWhereInput,
 		ec.unmarshalInputOnboardingWhereInput,
 		ec.unmarshalInputOrgMembersInput,
+		ec.unmarshalInputOrgMembershipHistoryOrder,
 		ec.unmarshalInputOrgMembershipHistoryWhereInput,
+		ec.unmarshalInputOrgMembershipOrder,
 		ec.unmarshalInputOrgMembershipWhereInput,
+		ec.unmarshalInputOrgSubscriptionHistoryOrder,
 		ec.unmarshalInputOrgSubscriptionHistoryWhereInput,
+		ec.unmarshalInputOrgSubscriptionOrder,
 		ec.unmarshalInputOrgSubscriptionWhereInput,
 		ec.unmarshalInputOrganizationHistoryOrder,
 		ec.unmarshalInputOrganizationHistoryWhereInput,
@@ -23100,19 +23963,32 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputPersonalAccessTokenWhereInput,
 		ec.unmarshalInputProcedureHistoryWhereInput,
 		ec.unmarshalInputProcedureWhereInput,
+		ec.unmarshalInputProgramHistoryOrder,
 		ec.unmarshalInputProgramHistoryWhereInput,
+		ec.unmarshalInputProgramMembershipHistoryOrder,
 		ec.unmarshalInputProgramMembershipHistoryWhereInput,
+		ec.unmarshalInputProgramMembershipOrder,
 		ec.unmarshalInputProgramMembershipWhereInput,
+		ec.unmarshalInputProgramOrder,
 		ec.unmarshalInputProgramWhereInput,
+		ec.unmarshalInputRiskHistoryOrder,
 		ec.unmarshalInputRiskHistoryWhereInput,
+		ec.unmarshalInputRiskOrder,
 		ec.unmarshalInputRiskWhereInput,
+		ec.unmarshalInputStandardHistoryOrder,
 		ec.unmarshalInputStandardHistoryWhereInput,
+		ec.unmarshalInputStandardOrder,
 		ec.unmarshalInputStandardWhereInput,
+		ec.unmarshalInputSubcontrolHistoryOrder,
 		ec.unmarshalInputSubcontrolHistoryWhereInput,
+		ec.unmarshalInputSubcontrolOrder,
 		ec.unmarshalInputSubcontrolWhereInput,
+		ec.unmarshalInputSubscriberOrder,
 		ec.unmarshalInputSubscriberWhereInput,
 		ec.unmarshalInputTFASettingWhereInput,
+		ec.unmarshalInputTaskHistoryOrder,
 		ec.unmarshalInputTaskHistoryWhereInput,
+		ec.unmarshalInputTaskOrder,
 		ec.unmarshalInputTaskWhereInput,
 		ec.unmarshalInputTemplateHistoryOrder,
 		ec.unmarshalInputTemplateHistoryWhereInput,
@@ -24727,10 +25603,130 @@ type ActionPlan implements Node {
   """
   delegate: Group
   owner: Organization
-  risk: [Risk!]
-  control: [Control!]
-  user: [User!]
-  program: [Program!]
+  risk(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Risks returned from the connection.
+    """
+    orderBy: [RiskOrder!]
+
+    """
+    Filtering options for Risks returned from the connection.
+    """
+    where: RiskWhereInput
+  ): RiskConnection!
+  control(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
+    Filtering options for Controls returned from the connection.
+    """
+    where: ControlWhereInput
+  ): ControlConnection!
+  user(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Users returned from the connection.
+    """
+    orderBy: [UserOrder!]
+
+    """
+    Filtering options for Users returned from the connection.
+    """
+    where: UserWhereInput
+  ): UserConnection!
+  program(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Programs returned from the connection.
+    """
+    orderBy: [ProgramOrder!]
+
+    """
+    Filtering options for Programs returned from the connection.
+    """
+    where: ProgramWhereInput
+  ): ProgramConnection!
 }
 """
 A connection to a list of items.
@@ -24901,6 +25897,27 @@ enum ActionPlanHistoryOpType @goModel(model: "github.com/theopenlane/entx/histor
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for ActionPlanHistory connections
+"""
+input ActionPlanHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order ActionPlanHistories.
+  """
+  field: ActionPlanHistoryOrderField!
+}
+"""
+Properties by which ActionPlanHistory connections can be ordered.
+"""
+enum ActionPlanHistoryOrderField {
+  due_date
+  PRIORITY
+  source
 }
 """
 ActionPlanHistoryPriority is enum for the field priority
@@ -25227,6 +26244,27 @@ input ActionPlanHistoryWhereInput {
   sourceNotNil: Boolean
   sourceEqualFold: String
   sourceContainsFold: String
+}
+"""
+Ordering options for ActionPlan connections
+"""
+input ActionPlanOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order ActionPlans.
+  """
+  field: ActionPlanOrderField!
+}
+"""
+Properties by which ActionPlan connections can be ordered.
+"""
+enum ActionPlanOrderField {
+  due_date
+  PRIORITY
+  source
 }
 """
 ActionPlanPriority is enum for the field priority
@@ -25598,8 +26636,63 @@ type Contact implements Node {
   """
   status: ContactUserStatus!
   owner: Organization
-  entities: [Entity!]
-  files: [File!]
+  entities(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Entities returned from the connection.
+    """
+    orderBy: [EntityOrder!]
+
+    """
+    Filtering options for Entities returned from the connection.
+    """
+    where: EntityWhereInput
+  ): EntityConnection!
+  files(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Files returned from the connection.
+    """
+    where: FileWhereInput
+  ): FileConnection!
 }
 """
 A connection to a list of items.
@@ -25716,6 +26809,29 @@ enum ContactHistoryOpType @goModel(model: "github.com/theopenlane/entx/history.O
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for ContactHistory connections
+"""
+input ContactHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order ContactHistories.
+  """
+  field: ContactHistoryOrderField!
+}
+"""
+Properties by which ContactHistory connections can be ordered.
+"""
+enum ContactHistoryOrderField {
+  full_name
+  title
+  company
+  email
+  STATUS
 }
 """
 ContactHistoryUserStatus is enum for the field status
@@ -26008,6 +27124,29 @@ input ContactHistoryWhereInput {
   statusNEQ: ContactHistoryUserStatus
   statusIn: [ContactHistoryUserStatus!]
   statusNotIn: [ContactHistoryUserStatus!]
+}
+"""
+Ordering options for Contact connections
+"""
+input ContactOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order Contacts.
+  """
+  field: ContactOrderField!
+}
+"""
+Properties by which Contact connections can be ordered.
+"""
+enum ContactOrderField {
+  full_name
+  title
+  company
+  email
+  STATUS
 }
 """
 ContactUserStatus is enum for the field status
@@ -26378,24 +27517,338 @@ type Control implements Node {
   """
   viewers: [Group!]
   standard: Standard
-  programs: [Program!]
-  evidence: [Evidence!]
-  """
-  the implementation(s) of the control
-  """
-  controlImplementations: [ControlImplementation!]
-  """
-  mapped subcontrols that have a relation to another control or subcontrol
-  """
-  mappedControls: [MappedControl!]
+  programs(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Programs returned from the connection.
+    """
+    orderBy: [ProgramOrder!]
+
+    """
+    Filtering options for Programs returned from the connection.
+    """
+    where: ProgramWhereInput
+  ): ProgramConnection!
+  evidence(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Evidences returned from the connection.
+    """
+    orderBy: [EvidenceOrder!]
+
+    """
+    Filtering options for Evidences returned from the connection.
+    """
+    where: EvidenceWhereInput
+  ): EvidenceConnection!
+  controlImplementations(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for ControlImplementations returned from the connection.
+    """
+    orderBy: [ControlImplementationOrder!]
+
+    """
+    Filtering options for ControlImplementations returned from the connection.
+    """
+    where: ControlImplementationWhereInput
+  ): ControlImplementationConnection!
+  mappedControls(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for MappedControls returned from the connection.
+    """
+    orderBy: MappedControlOrder
+
+    """
+    Filtering options for MappedControls returned from the connection.
+    """
+    where: MappedControlWhereInput
+  ): MappedControlConnection!
   controlObjectives: [ControlObjective!]
-  subcontrols: [Subcontrol!]
-  tasks: [Task!]
-  narratives: [Narrative!]
-  risks: [Risk!]
-  actionPlans: [ActionPlan!]
-  procedures: [Procedure!]
-  internalPolicies: [InternalPolicy!]
+  subcontrols(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Subcontrols returned from the connection.
+    """
+    orderBy: [SubcontrolOrder!]
+
+    """
+    Filtering options for Subcontrols returned from the connection.
+    """
+    where: SubcontrolWhereInput
+  ): SubcontrolConnection!
+  tasks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Tasks returned from the connection.
+    """
+    orderBy: [TaskOrder!]
+
+    """
+    Filtering options for Tasks returned from the connection.
+    """
+    where: TaskWhereInput
+  ): TaskConnection!
+  narratives(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Narratives returned from the connection.
+    """
+    orderBy: NarrativeOrder
+
+    """
+    Filtering options for Narratives returned from the connection.
+    """
+    where: NarrativeWhereInput
+  ): NarrativeConnection!
+  risks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Risks returned from the connection.
+    """
+    orderBy: [RiskOrder!]
+
+    """
+    Filtering options for Risks returned from the connection.
+    """
+    where: RiskWhereInput
+  ): RiskConnection!
+  actionPlans(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for ActionPlans returned from the connection.
+    """
+    orderBy: [ActionPlanOrder!]
+
+    """
+    Filtering options for ActionPlans returned from the connection.
+    """
+    where: ActionPlanWhereInput
+  ): ActionPlanConnection!
+  procedures(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Procedures returned from the connection.
+    """
+    where: ProcedureWhereInput
+  ): ProcedureConnection!
+  internalPolicies(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for InternalPolicies returned from the connection.
+    """
+    where: InternalPolicyWhereInput
+  ): InternalPolicyConnection!
   """
   the group of users who are responsible for the control, will be assigned tasks, approval, etc.
   """
@@ -26596,6 +28049,29 @@ enum ControlHistoryOpType @goModel(model: "github.com/theopenlane/entx/history.O
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for ControlHistory connections
+"""
+input ControlHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order ControlHistories.
+  """
+  field: ControlHistoryOrderField!
+}
+"""
+Properties by which ControlHistory connections can be ordered.
+"""
+enum ControlHistoryOrderField {
+  status
+  SOURCE
+  CONTROL_TYPE
+  category
+  subcategory
 }
 """
 ControlHistoryWhereInput is used for filtering ControlHistory objects.
@@ -26956,7 +28432,37 @@ type ControlImplementation implements Node {
   details of the control implementation
   """
   details: String
-  controls: [Control!]
+  controls(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
+    Filtering options for Controls returned from the connection.
+    """
+    where: ControlWhereInput
+  ): ControlConnection!
 }
 """
 A connection to a list of items.
@@ -27081,6 +28587,28 @@ enum ControlImplementationHistoryOpType @goModel(model: "github.com/theopenlane/
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for ControlImplementationHistory connections
+"""
+input ControlImplementationHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order ControlImplementationHistories.
+  """
+  field: ControlImplementationHistoryOrderField!
+}
+"""
+Properties by which ControlImplementationHistory connections can be ordered.
+"""
+enum ControlImplementationHistoryOrderField {
+  STATUS
+  implementation_date
+  verified
+  verification_date
 }
 """
 ControlImplementationHistoryWhereInput is used for filtering ControlImplementationHistory objects.
@@ -27292,6 +28820,28 @@ input ControlImplementationHistoryWhereInput {
   detailsNotNil: Boolean
   detailsEqualFold: String
   detailsContainsFold: String
+}
+"""
+Ordering options for ControlImplementation connections
+"""
+input ControlImplementationOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order ControlImplementations.
+  """
+  field: ControlImplementationOrderField!
+}
+"""
+Properties by which ControlImplementation connections can be ordered.
+"""
+enum ControlImplementationOrderField {
+  STATUS
+  implementation_date
+  verified
+  verification_date
 }
 """
 ControlImplementationWhereInput is used for filtering ControlImplementation objects.
@@ -27538,15 +29088,275 @@ type ControlObjective implements Node {
   provides view access to the risk to members of the group
   """
   viewers: [Group!]
-  programs: [Program!]
-  evidence: [Evidence!]
-  controls: [Control!]
-  subcontrols: [Subcontrol!]
-  internalPolicies: [InternalPolicy!]
-  procedures: [Procedure!]
-  risks: [Risk!]
-  narratives: [Narrative!]
-  tasks: [Task!]
+  programs(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Programs returned from the connection.
+    """
+    orderBy: [ProgramOrder!]
+
+    """
+    Filtering options for Programs returned from the connection.
+    """
+    where: ProgramWhereInput
+  ): ProgramConnection!
+  evidence(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Evidences returned from the connection.
+    """
+    orderBy: [EvidenceOrder!]
+
+    """
+    Filtering options for Evidences returned from the connection.
+    """
+    where: EvidenceWhereInput
+  ): EvidenceConnection!
+  controls(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
+    Filtering options for Controls returned from the connection.
+    """
+    where: ControlWhereInput
+  ): ControlConnection!
+  subcontrols(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Subcontrols returned from the connection.
+    """
+    orderBy: [SubcontrolOrder!]
+
+    """
+    Filtering options for Subcontrols returned from the connection.
+    """
+    where: SubcontrolWhereInput
+  ): SubcontrolConnection!
+  internalPolicies(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for InternalPolicies returned from the connection.
+    """
+    where: InternalPolicyWhereInput
+  ): InternalPolicyConnection!
+  procedures(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Procedures returned from the connection.
+    """
+    where: ProcedureWhereInput
+  ): ProcedureConnection!
+  risks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Risks returned from the connection.
+    """
+    orderBy: [RiskOrder!]
+
+    """
+    Filtering options for Risks returned from the connection.
+    """
+    where: RiskWhereInput
+  ): RiskConnection!
+  narratives(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Narratives returned from the connection.
+    """
+    orderBy: NarrativeOrder
+
+    """
+    Filtering options for Narratives returned from the connection.
+    """
+    where: NarrativeWhereInput
+  ): NarrativeConnection!
+  tasks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Tasks returned from the connection.
+    """
+    orderBy: [TaskOrder!]
+
+    """
+    Filtering options for Tasks returned from the connection.
+    """
+    where: TaskWhereInput
+  ): TaskConnection!
 }
 """
 A connection to a list of items.
@@ -27689,6 +29499,30 @@ enum ControlObjectiveHistoryOpType @goModel(model: "github.com/theopenlane/entx/
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for ControlObjectiveHistory connections
+"""
+input ControlObjectiveHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order ControlObjectiveHistories.
+  """
+  field: ControlObjectiveHistoryOrderField!
+}
+"""
+Properties by which ControlObjectiveHistory connections can be ordered.
+"""
+enum ControlObjectiveHistoryOrderField {
+  name
+  status
+  SOURCE
+  control_objective_type
+  category
+  subcategory
 }
 """
 ControlObjectiveHistoryWhereInput is used for filtering ControlObjectiveHistory objects.
@@ -28007,6 +29841,30 @@ input ControlObjectiveHistoryWhereInput {
   subcategoryNotNil: Boolean
   subcategoryEqualFold: String
   subcategoryContainsFold: String
+}
+"""
+Ordering options for ControlObjective connections
+"""
+input ControlObjectiveOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order ControlObjectives.
+  """
+  field: ControlObjectiveOrderField!
+}
+"""
+Properties by which ControlObjective connections can be ordered.
+"""
+enum ControlObjectiveOrderField {
+  name
+  status
+  SOURCE
+  control_objective_type
+  category
+  subcategory
 }
 """
 ControlObjectiveWhereInput is used for filtering ControlObjective objects.
@@ -28354,6 +30212,29 @@ input ControlObjectiveWhereInput {
   """
   hasTasks: Boolean
   hasTasksWith: [TaskWhereInput!]
+}
+"""
+Ordering options for Control connections
+"""
+input ControlOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order Controls.
+  """
+  field: ControlOrderField!
+}
+"""
+Properties by which Control connections can be ordered.
+"""
+enum ControlOrderField {
+  status
+  SOURCE
+  CONTROL_TYPE
+  category
+  subcategory
 }
 """
 ControlWhereInput is used for filtering Control objects.
@@ -30346,8 +32227,63 @@ type DocumentData implements Node {
   data: Map!
   owner: Organization
   template: Template!
-  entity: [Entity!]
-  files: [File!]
+  entity(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Entities returned from the connection.
+    """
+    orderBy: [EntityOrder!]
+
+    """
+    Filtering options for Entities returned from the connection.
+    """
+    where: EntityWhereInput
+  ): EntityConnection!
+  files(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Files returned from the connection.
+    """
+    where: FileWhereInput
+  ): FileConnection!
 }
 """
 A connection to a list of items.
@@ -30840,10 +32776,115 @@ type Entity implements Node {
   """
   status: String
   owner: Organization
-  contacts: [Contact!]
-  documents: [DocumentData!]
-  notes: [Note!]
-  files: [File!]
+  contacts(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Contacts returned from the connection.
+    """
+    orderBy: [ContactOrder!]
+
+    """
+    Filtering options for Contacts returned from the connection.
+    """
+    where: ContactWhereInput
+  ): ContactConnection!
+  documents(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for DocumentDataSlice returned from the connection.
+    """
+    where: DocumentDataWhereInput
+  ): DocumentDataConnection!
+  notes(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Notes returned from the connection.
+    """
+    where: NoteWhereInput
+  ): NoteConnection!
+  files(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Files returned from the connection.
+    """
+    where: FileWhereInput
+  ): FileConnection!
   entityType: EntityType
 }
 """
@@ -30977,6 +33018,7 @@ Properties by which EntityHistory connections can be ordered.
 enum EntityHistoryOrderField {
   name
   display_name
+  status
 }
 """
 EntityHistoryWhereInput is used for filtering EntityHistory objects.
@@ -31238,6 +33280,7 @@ Properties by which Entity connections can be ordered.
 enum EntityOrderField {
   name
   display_name
+  status
 }
 type EntityType implements Node {
   id: ID!
@@ -31260,7 +33303,37 @@ type EntityType implements Node {
   """
   name: String!
   owner: Organization
-  entities: [Entity!]
+  entities(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Entities returned from the connection.
+    """
+    orderBy: [EntityOrder!]
+
+    """
+    Filtering options for Entities returned from the connection.
+    """
+    where: EntityWhereInput
+  ): EntityConnection!
 }
 """
 A connection to a list of items.
@@ -31985,18 +34058,368 @@ type Event implements Node {
   correlationID: String
   eventType: String!
   metadata: Map
-  user: [User!]
-  group: [Group!]
-  integration: [Integration!]
-  organization: [Organization!]
-  invite: [Invite!]
-  personalAccessToken: [PersonalAccessToken!]
-  hush: [Hush!]
-  orgmembership: [OrgMembership!]
-  groupmembership: [GroupMembership!]
-  subscriber: [Subscriber!]
-  file: [File!]
-  orgsubscription: [OrgSubscription!]
+  user(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Users returned from the connection.
+    """
+    orderBy: [UserOrder!]
+
+    """
+    Filtering options for Users returned from the connection.
+    """
+    where: UserWhereInput
+  ): UserConnection!
+  group(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Groups returned from the connection.
+    """
+    orderBy: [GroupOrder!]
+
+    """
+    Filtering options for Groups returned from the connection.
+    """
+    where: GroupWhereInput
+  ): GroupConnection!
+  integration(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Integrations returned from the connection.
+    """
+    orderBy: [IntegrationOrder!]
+
+    """
+    Filtering options for Integrations returned from the connection.
+    """
+    where: IntegrationWhereInput
+  ): IntegrationConnection!
+  organization(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Organizations returned from the connection.
+    """
+    orderBy: [OrganizationOrder!]
+
+    """
+    Filtering options for Organizations returned from the connection.
+    """
+    where: OrganizationWhereInput
+  ): OrganizationConnection!
+  invite(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Invites returned from the connection.
+    """
+    orderBy: [InviteOrder!]
+
+    """
+    Filtering options for Invites returned from the connection.
+    """
+    where: InviteWhereInput
+  ): InviteConnection!
+  personalAccessToken(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for PersonalAccessTokens returned from the connection.
+    """
+    where: PersonalAccessTokenWhereInput
+  ): PersonalAccessTokenConnection!
+  hush(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Hushes returned from the connection.
+    """
+    orderBy: [HushOrder!]
+
+    """
+    Filtering options for Hushes returned from the connection.
+    """
+    where: HushWhereInput
+  ): HushConnection!
+  orgmembership(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for OrgMemberships returned from the connection.
+    """
+    orderBy: OrgMembershipOrder
+
+    """
+    Filtering options for OrgMemberships returned from the connection.
+    """
+    where: OrgMembershipWhereInput
+  ): OrgMembershipConnection!
+  groupmembership(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for GroupMemberships returned from the connection.
+    """
+    orderBy: GroupMembershipOrder
+
+    """
+    Filtering options for GroupMemberships returned from the connection.
+    """
+    where: GroupMembershipWhereInput
+  ): GroupMembershipConnection!
+  subscriber(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Subscribers returned from the connection.
+    """
+    orderBy: [SubscriberOrder!]
+
+    """
+    Filtering options for Subscribers returned from the connection.
+    """
+    where: SubscriberWhereInput
+  ): SubscriberConnection!
+  file(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Files returned from the connection.
+    """
+    where: FileWhereInput
+  ): FileConnection!
+  orgsubscription(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for OrgSubscriptions returned from the connection.
+    """
+    orderBy: OrgSubscriptionOrder
+
+    """
+    Filtering options for OrgSubscriptions returned from the connection.
+    """
+    where: OrgSubscriptionWhereInput
+  ): OrgSubscriptionConnection!
 }
 """
 A connection to a list of items.
@@ -32509,12 +34932,187 @@ type Evidence implements Node {
   """
   status: EvidenceEvidenceStatus
   owner: Organization
-  controlObjectives: [ControlObjective!]
-  controls: [Control!]
-  subcontrols: [Subcontrol!]
-  files: [File!]
-  programs: [Program!]
-  tasks: [Task!]
+  controlObjectives(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for ControlObjectives returned from the connection.
+    """
+    orderBy: [ControlObjectiveOrder!]
+
+    """
+    Filtering options for ControlObjectives returned from the connection.
+    """
+    where: ControlObjectiveWhereInput
+  ): ControlObjectiveConnection!
+  controls(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
+    Filtering options for Controls returned from the connection.
+    """
+    where: ControlWhereInput
+  ): ControlConnection!
+  subcontrols(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Subcontrols returned from the connection.
+    """
+    orderBy: [SubcontrolOrder!]
+
+    """
+    Filtering options for Subcontrols returned from the connection.
+    """
+    where: SubcontrolWhereInput
+  ): SubcontrolConnection!
+  files(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Files returned from the connection.
+    """
+    where: FileWhereInput
+  ): FileConnection!
+  programs(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Programs returned from the connection.
+    """
+    orderBy: [ProgramOrder!]
+
+    """
+    Filtering options for Programs returned from the connection.
+    """
+    where: ProgramWhereInput
+  ): ProgramConnection!
+  tasks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Tasks returned from the connection.
+    """
+    orderBy: [TaskOrder!]
+
+    """
+    Filtering options for Tasks returned from the connection.
+    """
+    where: TaskWhereInput
+  ): TaskConnection!
 }
 """
 A connection to a list of items.
@@ -32663,6 +35261,28 @@ enum EvidenceHistoryOpType @goModel(model: "github.com/theopenlane/entx/history.
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for EvidenceHistory connections
+"""
+input EvidenceHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order EvidenceHistories.
+  """
+  field: EvidenceHistoryOrderField!
+}
+"""
+Properties by which EvidenceHistory connections can be ordered.
+"""
+enum EvidenceHistoryOrderField {
+  name
+  creation_date
+  renewal_date
+  STATUS
 }
 """
 EvidenceHistoryWhereInput is used for filtering EvidenceHistory objects.
@@ -32976,6 +35596,28 @@ input EvidenceHistoryWhereInput {
   statusNotIn: [EvidenceHistoryEvidenceStatus!]
   statusIsNil: Boolean
   statusNotNil: Boolean
+}
+"""
+Ordering options for Evidence connections
+"""
+input EvidenceOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order Evidences.
+  """
+  field: EvidenceOrderField!
+}
+"""
+Properties by which Evidence connections can be ordered.
+"""
+enum EvidenceOrderField {
+  name
+  creation_date
+  renewal_date
+  STATUS
 }
 """
 EvidenceWhereInput is used for filtering Evidence objects.
@@ -33350,18 +35992,358 @@ type File implements Node {
   the storage path is the second-level directory of the file path, typically the correlating logical object ID the file is associated with; files can be stand alone objects and not always correlated to a logical one, so this path of the tree may be empty
   """
   storagePath: String
-  user: [User!]
-  organization: [Organization!]
-  group: [Group!]
-  contact: [Contact!]
-  entity: [Entity!]
-  userSetting: [UserSetting!]
-  organizationSetting: [OrganizationSetting!]
-  template: [Template!]
-  documentData: [DocumentData!]
-  events: [Event!]
-  program: [Program!]
-  evidence: [Evidence!]
+  user(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Users returned from the connection.
+    """
+    orderBy: [UserOrder!]
+
+    """
+    Filtering options for Users returned from the connection.
+    """
+    where: UserWhereInput
+  ): UserConnection!
+  organization(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Organizations returned from the connection.
+    """
+    orderBy: [OrganizationOrder!]
+
+    """
+    Filtering options for Organizations returned from the connection.
+    """
+    where: OrganizationWhereInput
+  ): OrganizationConnection!
+  group(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Groups returned from the connection.
+    """
+    orderBy: [GroupOrder!]
+
+    """
+    Filtering options for Groups returned from the connection.
+    """
+    where: GroupWhereInput
+  ): GroupConnection!
+  contact(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Contacts returned from the connection.
+    """
+    orderBy: [ContactOrder!]
+
+    """
+    Filtering options for Contacts returned from the connection.
+    """
+    where: ContactWhereInput
+  ): ContactConnection!
+  entity(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Entities returned from the connection.
+    """
+    orderBy: [EntityOrder!]
+
+    """
+    Filtering options for Entities returned from the connection.
+    """
+    where: EntityWhereInput
+  ): EntityConnection!
+  userSetting(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for UserSettings returned from the connection.
+    """
+    where: UserSettingWhereInput
+  ): UserSettingConnection!
+  organizationSetting(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for OrganizationSettings returned from the connection.
+    """
+    where: OrganizationSettingWhereInput
+  ): OrganizationSettingConnection!
+  template(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Templates returned from the connection.
+    """
+    orderBy: [TemplateOrder!]
+
+    """
+    Filtering options for Templates returned from the connection.
+    """
+    where: TemplateWhereInput
+  ): TemplateConnection!
+  documentData(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for DocumentDataSlice returned from the connection.
+    """
+    where: DocumentDataWhereInput
+  ): DocumentDataConnection!
+  events(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Events returned from the connection.
+    """
+    where: EventWhereInput
+  ): EventConnection!
+  program(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Programs returned from the connection.
+    """
+    orderBy: [ProgramOrder!]
+
+    """
+    Filtering options for Programs returned from the connection.
+    """
+    where: ProgramWhereInput
+  ): ProgramConnection!
+  evidence(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Evidences returned from the connection.
+    """
+    orderBy: [EvidenceOrder!]
+
+    """
+    Filtering options for Evidences returned from the connection.
+    """
+    where: EvidenceWhereInput
+  ): EvidenceConnection!
 }
 """
 A connection to a list of items.
@@ -34324,10 +37306,120 @@ type Group implements Node {
   narrativeViewers: [Narrative!]
   setting: GroupSetting
   users: [User!]
-  events: [Event!]
-  integrations: [Integration!]
-  files: [File!]
-  tasks: [Task!]
+  events(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Events returned from the connection.
+    """
+    where: EventWhereInput
+  ): EventConnection!
+  integrations(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Integrations returned from the connection.
+    """
+    orderBy: [IntegrationOrder!]
+
+    """
+    Filtering options for Integrations returned from the connection.
+    """
+    where: IntegrationWhereInput
+  ): IntegrationConnection!
+  files(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Files returned from the connection.
+    """
+    where: FileWhereInput
+  ): FileConnection!
+  tasks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Tasks returned from the connection.
+    """
+    orderBy: [TaskOrder!]
+
+    """
+    Filtering options for Tasks returned from the connection.
+    """
+    where: TaskWhereInput
+  ): TaskConnection!
   members: [GroupMembership!]
 }
 """
@@ -34789,6 +37881,25 @@ enum GroupMembershipHistoryOpType @goModel(model: "github.com/theopenlane/entx/h
   DELETE
 }
 """
+Ordering options for GroupMembershipHistory connections
+"""
+input GroupMembershipHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order GroupMembershipHistories.
+  """
+  field: GroupMembershipHistoryOrderField!
+}
+"""
+Properties by which GroupMembershipHistory connections can be ordered.
+"""
+enum GroupMembershipHistoryOrderField {
+  ROLE
+}
+"""
 GroupMembershipHistoryRole is enum for the field role
 """
 enum GroupMembershipHistoryRole @goModel(model: "github.com/theopenlane/core/pkg/enums.Role") {
@@ -34984,6 +38095,25 @@ input GroupMembershipHistoryWhereInput {
   userIDHasSuffix: String
   userIDEqualFold: String
   userIDContainsFold: String
+}
+"""
+Ordering options for GroupMembership connections
+"""
+input GroupMembershipOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order GroupMemberships.
+  """
+  field: GroupMembershipOrderField!
+}
+"""
+Properties by which GroupMembership connections can be ordered.
+"""
+enum GroupMembershipOrderField {
+  ROLE
 }
 """
 GroupMembershipRole is enum for the field role
@@ -36006,12 +39136,94 @@ type Hush implements Node {
   the generic name of a secret associated with the organization
   """
   secretName: String
-  """
-  the integration associated with the secret
-  """
-  integrations: [Integration!]
-  organization: [Organization!]
-  events: [Event!]
+  integrations(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Integrations returned from the connection.
+    """
+    orderBy: [IntegrationOrder!]
+
+    """
+    Filtering options for Integrations returned from the connection.
+    """
+    where: IntegrationWhereInput
+  ): IntegrationConnection!
+  organization(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Organizations returned from the connection.
+    """
+    orderBy: [OrganizationOrder!]
+
+    """
+    Filtering options for Organizations returned from the connection.
+    """
+    where: OrganizationWhereInput
+  ): OrganizationConnection!
+  events(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Events returned from the connection.
+    """
+    where: EventWhereInput
+  ): EventConnection!
 }
 """
 A connection to a list of items.
@@ -36560,11 +39772,63 @@ type Integration implements Node {
   description: String
   kind: String
   owner: Organization
-  """
-  the secrets associated with the integration
-  """
-  secrets: [Hush!]
-  events: [Event!]
+  secrets(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Hushes returned from the connection.
+    """
+    orderBy: [HushOrder!]
+
+    """
+    Filtering options for Hushes returned from the connection.
+    """
+    where: HushWhereInput
+  ): HushConnection!
+  events(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Events returned from the connection.
+    """
+    where: EventWhereInput
+  ): EventConnection!
 }
 """
 A connection to a list of items.
@@ -37157,12 +40421,187 @@ type InternalPolicy implements Node {
   temporary delegates for the policy, used for temporary approval
   """
   delegate: Group
-  controlObjectives: [ControlObjective!]
-  controls: [Control!]
-  procedures: [Procedure!]
-  narratives: [Narrative!]
-  tasks: [Task!]
-  programs: [Program!]
+  controlObjectives(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for ControlObjectives returned from the connection.
+    """
+    orderBy: [ControlObjectiveOrder!]
+
+    """
+    Filtering options for ControlObjectives returned from the connection.
+    """
+    where: ControlObjectiveWhereInput
+  ): ControlObjectiveConnection!
+  controls(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
+    Filtering options for Controls returned from the connection.
+    """
+    where: ControlWhereInput
+  ): ControlConnection!
+  procedures(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Procedures returned from the connection.
+    """
+    where: ProcedureWhereInput
+  ): ProcedureConnection!
+  narratives(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Narratives returned from the connection.
+    """
+    orderBy: NarrativeOrder
+
+    """
+    Filtering options for Narratives returned from the connection.
+    """
+    where: NarrativeWhereInput
+  ): NarrativeConnection!
+  tasks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Tasks returned from the connection.
+    """
+    orderBy: [TaskOrder!]
+
+    """
+    Filtering options for Tasks returned from the connection.
+    """
+    where: TaskWhereInput
+  ): TaskConnection!
+  programs(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Programs returned from the connection.
+    """
+    orderBy: [ProgramOrder!]
+
+    """
+    Filtering options for Programs returned from the connection.
+    """
+    where: ProgramWhereInput
+  ): ProgramConnection!
 }
 """
 A connection to a list of items.
@@ -37965,7 +41404,32 @@ type Invite implements Node {
   """
   requestorID: String
   owner: Organization
-  events: [Event!]
+  events(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Events returned from the connection.
+    """
+    where: EventWhereInput
+  ): EventConnection!
 }
 """
 A connection to a list of items.
@@ -38005,6 +41469,27 @@ enum InviteInviteStatus @goModel(model: "github.com/theopenlane/core/pkg/enums.I
   APPROVAL_REQUIRED
   INVITATION_ACCEPTED
   INVITATION_EXPIRED
+}
+"""
+Ordering options for Invite connections
+"""
+input InviteOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order Invites.
+  """
+  field: InviteOrderField!
+}
+"""
+Properties by which Invite connections can be ordered.
+"""
+enum InviteOrderField {
+  expires
+  STATUS
+  send_attempts
 }
 """
 InviteRole is enum for the field role
@@ -38256,14 +41741,68 @@ type MappedControl implements Node {
   description of how the two controls are related
   """
   relation: String
-  """
-  mapped controls that have a relation to each other
-  """
-  controls: [Control!]
-  """
-  mapped subcontrols that have a relation to each other
-  """
-  subcontrols: [Subcontrol!]
+  controls(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
+    Filtering options for Controls returned from the connection.
+    """
+    where: ControlWhereInput
+  ): ControlConnection!
+  subcontrols(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Subcontrols returned from the connection.
+    """
+    orderBy: [SubcontrolOrder!]
+
+    """
+    Filtering options for Subcontrols returned from the connection.
+    """
+    where: SubcontrolWhereInput
+  ): SubcontrolConnection!
 }
 """
 A connection to a list of items.
@@ -38356,6 +41895,25 @@ enum MappedControlHistoryOpType @goModel(model: "github.com/theopenlane/entx/his
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for MappedControlHistory connections
+"""
+input MappedControlHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order MappedControlHistories.
+  """
+  field: MappedControlHistoryOrderField!
+}
+"""
+Properties by which MappedControlHistory connections can be ordered.
+"""
+enum MappedControlHistoryOrderField {
+  mapping_type
 }
 """
 MappedControlHistoryWhereInput is used for filtering MappedControlHistory objects.
@@ -38543,6 +42101,25 @@ input MappedControlHistoryWhereInput {
   relationNotNil: Boolean
   relationEqualFold: String
   relationContainsFold: String
+}
+"""
+Ordering options for MappedControl connections
+"""
+input MappedControlOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order MappedControls.
+  """
+  field: MappedControlOrderField!
+}
+"""
+Properties by which MappedControl connections can be ordered.
+"""
+enum MappedControlOrderField {
+  mapping_type
 }
 """
 MappedControlWhereInput is used for filtering MappedControl objects.
@@ -38750,11 +42327,68 @@ type Narrative implements Node {
   provides view access to the risk to members of the group
   """
   viewers: [Group!]
-  """
-  which controls are satisfied by the narrative
-  """
-  satisfies: [Control!]
-  programs: [Program!]
+  satisfies(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
+    Filtering options for Controls returned from the connection.
+    """
+    where: ControlWhereInput
+  ): ControlConnection!
+  programs(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Programs returned from the connection.
+    """
+    orderBy: [ProgramOrder!]
+
+    """
+    Filtering options for Programs returned from the connection.
+    """
+    where: ProgramWhereInput
+  ): ProgramConnection!
 }
 """
 A connection to a list of items.
@@ -38859,6 +42493,25 @@ enum NarrativeHistoryOpType @goModel(model: "github.com/theopenlane/entx/history
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for NarrativeHistory connections
+"""
+input NarrativeHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order NarrativeHistories.
+  """
+  field: NarrativeHistoryOrderField!
+}
+"""
+Properties by which NarrativeHistory connections can be ordered.
+"""
+enum NarrativeHistoryOrderField {
+  name
 }
 """
 NarrativeHistoryWhereInput is used for filtering NarrativeHistory objects.
@@ -39096,6 +42749,25 @@ input NarrativeHistoryWhereInput {
   detailsNotNil: Boolean
   detailsEqualFold: String
   detailsContainsFold: String
+}
+"""
+Ordering options for Narrative connections
+"""
+input NarrativeOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order Narratives.
+  """
+  field: NarrativeOrderField!
+}
+"""
+Properties by which Narrative connections can be ordered.
+"""
+enum NarrativeOrderField {
+  name
 }
 """
 NarrativeWhereInput is used for filtering Narrative objects.
@@ -39974,7 +43646,32 @@ type OrgMembership implements Node {
   userID: ID!
   organization: Organization!
   user: User!
-  events: [Event!]
+  events(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Events returned from the connection.
+    """
+    where: EventWhereInput
+  ): EventConnection!
 }
 """
 A connection to a list of items.
@@ -40058,6 +43755,25 @@ enum OrgMembershipHistoryOpType @goModel(model: "github.com/theopenlane/entx/his
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for OrgMembershipHistory connections
+"""
+input OrgMembershipHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order OrgMembershipHistories.
+  """
+  field: OrgMembershipHistoryOrderField!
+}
+"""
+Properties by which OrgMembershipHistory connections can be ordered.
+"""
+enum OrgMembershipHistoryOrderField {
+  ROLE
 }
 """
 OrgMembershipHistoryRole is enum for the field role
@@ -40256,6 +43972,25 @@ input OrgMembershipHistoryWhereInput {
   userIDHasSuffix: String
   userIDEqualFold: String
   userIDContainsFold: String
+}
+"""
+Ordering options for OrgMembership connections
+"""
+input OrgMembershipOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order OrgMemberships.
+  """
+  field: OrgMembershipOrderField!
+}
+"""
+Properties by which OrgMembership connections can be ordered.
+"""
+enum OrgMembershipOrderField {
+  ROLE
 }
 """
 OrgMembershipRole is enum for the field role
@@ -40599,6 +44334,30 @@ enum OrgSubscriptionHistoryOpType @goModel(model: "github.com/theopenlane/entx/h
   DELETE
 }
 """
+Ordering options for OrgSubscriptionHistory connections
+"""
+input OrgSubscriptionHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order OrgSubscriptionHistories.
+  """
+  field: OrgSubscriptionHistoryOrderField!
+}
+"""
+Properties by which OrgSubscriptionHistory connections can be ordered.
+"""
+enum OrgSubscriptionHistoryOrderField {
+  product_tier
+  stripe_subscription_status
+  active
+  expires_at
+  trial_expires_at
+  days_until_due
+}
+"""
 OrgSubscriptionHistoryWhereInput is used for filtering OrgSubscriptionHistory objects.
 Input was generated by ent.
 """
@@ -40912,6 +44671,30 @@ input OrgSubscriptionHistoryWhereInput {
   paymentMethodAddedNEQ: Boolean
   paymentMethodAddedIsNil: Boolean
   paymentMethodAddedNotNil: Boolean
+}
+"""
+Ordering options for OrgSubscription connections
+"""
+input OrgSubscriptionOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order OrgSubscriptions.
+  """
+  field: OrgSubscriptionOrderField!
+}
+"""
+Properties by which OrgSubscription connections can be ordered.
+"""
+enum OrgSubscriptionOrderField {
+  product_tier
+  stripe_subscription_status
+  active
+  expires_at
+  trial_expires_at
+  days_until_due
 }
 """
 OrgSubscriptionWhereInput is used for filtering OrgSubscription objects.
@@ -41307,7 +45090,7 @@ type Organization implements Node {
     """
     Ordering options for Organizations returned from the connection.
     """
-    orderBy: OrganizationOrder
+    orderBy: [OrganizationOrder!]
 
     """
     Filtering options for Organizations returned from the connection.
@@ -41315,36 +45098,806 @@ type Organization implements Node {
     where: OrganizationWhereInput
   ): OrganizationConnection!
   setting: OrganizationSetting
-  personalAccessTokens: [PersonalAccessToken!]
-  apiTokens: [APIToken!]
+  personalAccessTokens(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for PersonalAccessTokens returned from the connection.
+    """
+    where: PersonalAccessTokenWhereInput
+  ): PersonalAccessTokenConnection!
+  apiTokens(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for APITokens returned from the connection.
+    """
+    where: APITokenWhereInput
+  ): APITokenConnection!
   users: [User!]
-  files: [File!]
-  events: [Event!]
-  secrets: [Hush!]
+  files(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Files returned from the connection.
+    """
+    where: FileWhereInput
+  ): FileConnection!
+  events(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Events returned from the connection.
+    """
+    where: EventWhereInput
+  ): EventConnection!
+  secrets(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Hushes returned from the connection.
+    """
+    orderBy: [HushOrder!]
+
+    """
+    Filtering options for Hushes returned from the connection.
+    """
+    where: HushWhereInput
+  ): HushConnection!
   avatarFile: File
-  groups: [Group!]
-  templates: [Template!]
-  integrations: [Integration!]
-  documentData: [DocumentData!]
+  groups(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Groups returned from the connection.
+    """
+    orderBy: [GroupOrder!]
+
+    """
+    Filtering options for Groups returned from the connection.
+    """
+    where: GroupWhereInput
+  ): GroupConnection!
+  templates(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Templates returned from the connection.
+    """
+    orderBy: [TemplateOrder!]
+
+    """
+    Filtering options for Templates returned from the connection.
+    """
+    where: TemplateWhereInput
+  ): TemplateConnection!
+  integrations(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Integrations returned from the connection.
+    """
+    orderBy: [IntegrationOrder!]
+
+    """
+    Filtering options for Integrations returned from the connection.
+    """
+    where: IntegrationWhereInput
+  ): IntegrationConnection!
+  documentData(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for DocumentDataSlice returned from the connection.
+    """
+    where: DocumentDataWhereInput
+  ): DocumentDataConnection!
   orgSubscriptions: [OrgSubscription!]
-  invites: [Invite!]
-  subscribers: [Subscriber!]
-  entities: [Entity!]
-  entityTypes: [EntityType!]
-  contacts: [Contact!]
-  notes: [Note!]
-  tasks: [Task!]
-  programs: [Program!]
-  procedures: [Procedure!]
-  internalPolicies: [InternalPolicy!]
-  risks: [Risk!]
-  controlObjectives: [ControlObjective!]
-  narratives: [Narrative!]
-  controls: [Control!]
-  subcontrols: [Subcontrol!]
-  evidence: [Evidence!]
-  standards: [Standard!]
-  actionPlans: [ActionPlan!]
+  invites(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Invites returned from the connection.
+    """
+    orderBy: [InviteOrder!]
+
+    """
+    Filtering options for Invites returned from the connection.
+    """
+    where: InviteWhereInput
+  ): InviteConnection!
+  subscribers(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Subscribers returned from the connection.
+    """
+    orderBy: [SubscriberOrder!]
+
+    """
+    Filtering options for Subscribers returned from the connection.
+    """
+    where: SubscriberWhereInput
+  ): SubscriberConnection!
+  entities(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Entities returned from the connection.
+    """
+    orderBy: [EntityOrder!]
+
+    """
+    Filtering options for Entities returned from the connection.
+    """
+    where: EntityWhereInput
+  ): EntityConnection!
+  entityTypes(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for EntityTypes returned from the connection.
+    """
+    orderBy: EntityTypeOrder
+
+    """
+    Filtering options for EntityTypes returned from the connection.
+    """
+    where: EntityTypeWhereInput
+  ): EntityTypeConnection!
+  contacts(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Contacts returned from the connection.
+    """
+    orderBy: [ContactOrder!]
+
+    """
+    Filtering options for Contacts returned from the connection.
+    """
+    where: ContactWhereInput
+  ): ContactConnection!
+  notes(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Notes returned from the connection.
+    """
+    where: NoteWhereInput
+  ): NoteConnection!
+  tasks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Tasks returned from the connection.
+    """
+    orderBy: [TaskOrder!]
+
+    """
+    Filtering options for Tasks returned from the connection.
+    """
+    where: TaskWhereInput
+  ): TaskConnection!
+  programs(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Programs returned from the connection.
+    """
+    orderBy: [ProgramOrder!]
+
+    """
+    Filtering options for Programs returned from the connection.
+    """
+    where: ProgramWhereInput
+  ): ProgramConnection!
+  procedures(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Procedures returned from the connection.
+    """
+    where: ProcedureWhereInput
+  ): ProcedureConnection!
+  internalPolicies(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for InternalPolicies returned from the connection.
+    """
+    where: InternalPolicyWhereInput
+  ): InternalPolicyConnection!
+  risks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Risks returned from the connection.
+    """
+    orderBy: [RiskOrder!]
+
+    """
+    Filtering options for Risks returned from the connection.
+    """
+    where: RiskWhereInput
+  ): RiskConnection!
+  controlObjectives(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for ControlObjectives returned from the connection.
+    """
+    orderBy: [ControlObjectiveOrder!]
+
+    """
+    Filtering options for ControlObjectives returned from the connection.
+    """
+    where: ControlObjectiveWhereInput
+  ): ControlObjectiveConnection!
+  narratives(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Narratives returned from the connection.
+    """
+    orderBy: NarrativeOrder
+
+    """
+    Filtering options for Narratives returned from the connection.
+    """
+    where: NarrativeWhereInput
+  ): NarrativeConnection!
+  controls(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
+    Filtering options for Controls returned from the connection.
+    """
+    where: ControlWhereInput
+  ): ControlConnection!
+  subcontrols(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Subcontrols returned from the connection.
+    """
+    orderBy: [SubcontrolOrder!]
+
+    """
+    Filtering options for Subcontrols returned from the connection.
+    """
+    where: SubcontrolWhereInput
+  ): SubcontrolConnection!
+  evidence(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Evidences returned from the connection.
+    """
+    orderBy: [EvidenceOrder!]
+
+    """
+    Filtering options for Evidences returned from the connection.
+    """
+    where: EvidenceWhereInput
+  ): EvidenceConnection!
+  standards(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Standards returned from the connection.
+    """
+    orderBy: [StandardOrder!]
+
+    """
+    Filtering options for Standards returned from the connection.
+    """
+    where: StandardWhereInput
+  ): StandardConnection!
+  actionPlans(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for ActionPlans returned from the connection.
+    """
+    orderBy: [ActionPlanOrder!]
+
+    """
+    Filtering options for ActionPlans returned from the connection.
+    """
+    where: ActionPlanWhereInput
+  ): ActionPlanConnection!
   members: [OrgMembership!]
 }
 """
@@ -41797,7 +46350,32 @@ type OrganizationSetting implements Node {
   """
   allowedEmailDomains: [String!]
   organization: Organization
-  files: [File!]
+  files(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Files returned from the connection.
+    """
+    where: FileWhereInput
+  ): FileConnection!
 }
 """
 A connection to a list of items.
@@ -42909,11 +47487,63 @@ type PersonalAccessToken implements Node {
   """
   revokedAt: Time
   owner: User!
-  """
-  the organization(s) the token is associated with
-  """
-  organizations: [Organization!]
-  events: [Event!]
+  organizations(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Organizations returned from the connection.
+    """
+    orderBy: [OrganizationOrder!]
+
+    """
+    Filtering options for Organizations returned from the connection.
+    """
+    where: OrganizationWhereInput
+  ): OrganizationConnection!
+  events(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Events returned from the connection.
+    """
+    where: EventWhereInput
+  ): EventConnection!
 }
 """
 A connection to a list of items.
@@ -43242,12 +47872,187 @@ type Procedure implements Node {
   temporary delegates for the procedure, used for temporary approval
   """
   delegate: Group
-  controls: [Control!]
-  internalPolicies: [InternalPolicy!]
-  narratives: [Narrative!]
-  risks: [Risk!]
-  tasks: [Task!]
-  programs: [Program!]
+  controls(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
+    Filtering options for Controls returned from the connection.
+    """
+    where: ControlWhereInput
+  ): ControlConnection!
+  internalPolicies(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for InternalPolicies returned from the connection.
+    """
+    where: InternalPolicyWhereInput
+  ): InternalPolicyConnection!
+  narratives(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Narratives returned from the connection.
+    """
+    orderBy: NarrativeOrder
+
+    """
+    Filtering options for Narratives returned from the connection.
+    """
+    where: NarrativeWhereInput
+  ): NarrativeConnection!
+  risks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Risks returned from the connection.
+    """
+    orderBy: [RiskOrder!]
+
+    """
+    Filtering options for Risks returned from the connection.
+    """
+    where: RiskWhereInput
+  ): RiskConnection!
+  tasks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Tasks returned from the connection.
+    """
+    orderBy: [TaskOrder!]
+
+    """
+    Filtering options for Tasks returned from the connection.
+    """
+    where: TaskWhereInput
+  ): TaskConnection!
+  programs(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Programs returned from the connection.
+    """
+    orderBy: [ProgramOrder!]
+
+    """
+    Filtering options for Programs returned from the connection.
+    """
+    where: ProgramWhereInput
+  ): ProgramConnection!
 }
 """
 A connection to a list of items.
@@ -44081,20 +48886,390 @@ type Program implements Node {
   provides view access to the risk to members of the group
   """
   viewers: [Group!]
-  controls: [Control!]
-  subcontrols: [Subcontrol!]
-  controlObjectives: [ControlObjective!]
-  internalPolicies: [InternalPolicy!]
-  procedures: [Procedure!]
-  risks: [Risk!]
-  tasks: [Task!]
-  notes: [Note!]
-  files: [File!]
-  evidence: [Evidence!]
-  narratives: [Narrative!]
+  controls(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
+    Filtering options for Controls returned from the connection.
+    """
+    where: ControlWhereInput
+  ): ControlConnection!
+  subcontrols(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Subcontrols returned from the connection.
+    """
+    orderBy: [SubcontrolOrder!]
+
+    """
+    Filtering options for Subcontrols returned from the connection.
+    """
+    where: SubcontrolWhereInput
+  ): SubcontrolConnection!
+  controlObjectives(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for ControlObjectives returned from the connection.
+    """
+    orderBy: [ControlObjectiveOrder!]
+
+    """
+    Filtering options for ControlObjectives returned from the connection.
+    """
+    where: ControlObjectiveWhereInput
+  ): ControlObjectiveConnection!
+  internalPolicies(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for InternalPolicies returned from the connection.
+    """
+    where: InternalPolicyWhereInput
+  ): InternalPolicyConnection!
+  procedures(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Procedures returned from the connection.
+    """
+    where: ProcedureWhereInput
+  ): ProcedureConnection!
+  risks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Risks returned from the connection.
+    """
+    orderBy: [RiskOrder!]
+
+    """
+    Filtering options for Risks returned from the connection.
+    """
+    where: RiskWhereInput
+  ): RiskConnection!
+  tasks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Tasks returned from the connection.
+    """
+    orderBy: [TaskOrder!]
+
+    """
+    Filtering options for Tasks returned from the connection.
+    """
+    where: TaskWhereInput
+  ): TaskConnection!
+  notes(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Notes returned from the connection.
+    """
+    where: NoteWhereInput
+  ): NoteConnection!
+  files(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Files returned from the connection.
+    """
+    where: FileWhereInput
+  ): FileConnection!
+  evidence(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Evidences returned from the connection.
+    """
+    orderBy: [EvidenceOrder!]
+
+    """
+    Filtering options for Evidences returned from the connection.
+    """
+    where: EvidenceWhereInput
+  ): EvidenceConnection!
+  narratives(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Narratives returned from the connection.
+    """
+    orderBy: NarrativeOrder
+
+    """
+    Filtering options for Narratives returned from the connection.
+    """
+    where: NarrativeWhereInput
+  ): NarrativeConnection!
   actionPlans: [ActionPlan!]
-  users: [User!]
-  members: [ProgramMembership!]
+  users(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Users returned from the connection.
+    """
+    orderBy: [UserOrder!]
+
+    """
+    Filtering options for Users returned from the connection.
+    """
+    where: UserWhereInput
+  ): UserConnection!
+  members(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for ProgramMemberships returned from the connection.
+    """
+    orderBy: ProgramMembershipOrder
+
+    """
+    Filtering options for ProgramMemberships returned from the connection.
+    """
+    where: ProgramMembershipWhereInput
+  ): ProgramMembershipConnection!
 }
 """
 A connection to a list of items.
@@ -44219,6 +49394,28 @@ enum ProgramHistoryOpType @goModel(model: "github.com/theopenlane/entx/history.O
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for ProgramHistory connections
+"""
+input ProgramHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order ProgramHistories.
+  """
+  field: ProgramHistoryOrderField!
+}
+"""
+Properties by which ProgramHistory connections can be ordered.
+"""
+enum ProgramHistoryOrderField {
+  name
+  STATUS
+  start_date
+  end_date
 }
 """
 ProgramHistoryProgramStatus is enum for the field status
@@ -44595,6 +49792,25 @@ enum ProgramMembershipHistoryOpType @goModel(model: "github.com/theopenlane/entx
   DELETE
 }
 """
+Ordering options for ProgramMembershipHistory connections
+"""
+input ProgramMembershipHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order ProgramMembershipHistories.
+  """
+  field: ProgramMembershipHistoryOrderField!
+}
+"""
+Properties by which ProgramMembershipHistory connections can be ordered.
+"""
+enum ProgramMembershipHistoryOrderField {
+  ROLE
+}
+"""
 ProgramMembershipHistoryRole is enum for the field role
 """
 enum ProgramMembershipHistoryRole @goModel(model: "github.com/theopenlane/core/pkg/enums.Role") {
@@ -44792,6 +50008,25 @@ input ProgramMembershipHistoryWhereInput {
   userIDContainsFold: String
 }
 """
+Ordering options for ProgramMembership connections
+"""
+input ProgramMembershipOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order ProgramMemberships.
+  """
+  field: ProgramMembershipOrderField!
+}
+"""
+Properties by which ProgramMembership connections can be ordered.
+"""
+enum ProgramMembershipOrderField {
+  ROLE
+}
+"""
 ProgramMembershipRole is enum for the field role
 """
 enum ProgramMembershipRole @goModel(model: "github.com/theopenlane/core/pkg/enums.Role") {
@@ -44919,6 +50154,28 @@ input ProgramMembershipWhereInput {
   roleNEQ: ProgramMembershipRole
   roleIn: [ProgramMembershipRole!]
   roleNotIn: [ProgramMembershipRole!]
+}
+"""
+Ordering options for Program connections
+"""
+input ProgramOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order Programs.
+  """
+  field: ProgramOrderField!
+}
+"""
+Properties by which Program connections can be ordered.
+"""
+enum ProgramOrderField {
+  name
+  STATUS
+  start_date
+  end_date
 }
 """
 ProgramProgramStatus is enum for the field status
@@ -45318,6 +50575,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for ActionPlans returned from the connection.
+    """
+    orderBy: [ActionPlanOrder!]
+
+    """
     Filtering options for ActionPlans returned from the connection.
     """
     where: ActionPlanWhereInput
@@ -45342,6 +50604,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for ActionPlanHistories returned from the connection.
+    """
+    orderBy: ActionPlanHistoryOrder
 
     """
     Filtering options for ActionPlanHistories returned from the connection.
@@ -45370,6 +50637,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for Contacts returned from the connection.
+    """
+    orderBy: [ContactOrder!]
+
+    """
     Filtering options for Contacts returned from the connection.
     """
     where: ContactWhereInput
@@ -45394,6 +50666,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for ContactHistories returned from the connection.
+    """
+    orderBy: ContactHistoryOrder
 
     """
     Filtering options for ContactHistories returned from the connection.
@@ -45422,6 +50699,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
     Filtering options for Controls returned from the connection.
     """
     where: ControlWhereInput
@@ -45446,6 +50728,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for ControlHistories returned from the connection.
+    """
+    orderBy: ControlHistoryOrder
 
     """
     Filtering options for ControlHistories returned from the connection.
@@ -45474,6 +50761,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for ControlImplementations returned from the connection.
+    """
+    orderBy: [ControlImplementationOrder!]
+
+    """
     Filtering options for ControlImplementations returned from the connection.
     """
     where: ControlImplementationWhereInput
@@ -45498,6 +50790,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for ControlImplementationHistories returned from the connection.
+    """
+    orderBy: ControlImplementationHistoryOrder
 
     """
     Filtering options for ControlImplementationHistories returned from the connection.
@@ -45526,6 +50823,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for ControlObjectives returned from the connection.
+    """
+    orderBy: [ControlObjectiveOrder!]
+
+    """
     Filtering options for ControlObjectives returned from the connection.
     """
     where: ControlObjectiveWhereInput
@@ -45550,6 +50852,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for ControlObjectiveHistories returned from the connection.
+    """
+    orderBy: ControlObjectiveHistoryOrder
 
     """
     Filtering options for ControlObjectiveHistories returned from the connection.
@@ -45632,7 +50939,7 @@ type Query {
     """
     Ordering options for Entities returned from the connection.
     """
-    orderBy: EntityOrder
+    orderBy: [EntityOrder!]
 
     """
     Filtering options for Entities returned from the connection.
@@ -45806,6 +51113,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for Evidences returned from the connection.
+    """
+    orderBy: [EvidenceOrder!]
+
+    """
     Filtering options for Evidences returned from the connection.
     """
     where: EvidenceWhereInput
@@ -45830,6 +51142,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for EvidenceHistories returned from the connection.
+    """
+    orderBy: EvidenceHistoryOrder
 
     """
     Filtering options for EvidenceHistories returned from the connection.
@@ -45912,7 +51229,7 @@ type Query {
     """
     Ordering options for Groups returned from the connection.
     """
-    orderBy: GroupOrder
+    orderBy: [GroupOrder!]
 
     """
     Filtering options for Groups returned from the connection.
@@ -45972,6 +51289,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for GroupMemberships returned from the connection.
+    """
+    orderBy: GroupMembershipOrder
+
+    """
     Filtering options for GroupMemberships returned from the connection.
     """
     where: GroupMembershipWhereInput
@@ -45996,6 +51318,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for GroupMembershipHistories returned from the connection.
+    """
+    orderBy: GroupMembershipHistoryOrder
 
     """
     Filtering options for GroupMembershipHistories returned from the connection.
@@ -46078,7 +51405,7 @@ type Query {
     """
     Ordering options for Hushes returned from the connection.
     """
-    orderBy: HushOrder
+    orderBy: [HushOrder!]
 
     """
     Filtering options for Hushes returned from the connection.
@@ -46140,7 +51467,7 @@ type Query {
     """
     Ordering options for Integrations returned from the connection.
     """
-    orderBy: IntegrationOrder
+    orderBy: [IntegrationOrder!]
 
     """
     Filtering options for Integrations returned from the connection.
@@ -46252,6 +51579,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for Invites returned from the connection.
+    """
+    orderBy: [InviteOrder!]
+
+    """
     Filtering options for Invites returned from the connection.
     """
     where: InviteWhereInput
@@ -46276,6 +51608,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for MappedControls returned from the connection.
+    """
+    orderBy: MappedControlOrder
 
     """
     Filtering options for MappedControls returned from the connection.
@@ -46304,6 +51641,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for MappedControlHistories returned from the connection.
+    """
+    orderBy: MappedControlHistoryOrder
+
+    """
     Filtering options for MappedControlHistories returned from the connection.
     """
     where: MappedControlHistoryWhereInput
@@ -46330,6 +51672,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for Narratives returned from the connection.
+    """
+    orderBy: NarrativeOrder
+
+    """
     Filtering options for Narratives returned from the connection.
     """
     where: NarrativeWhereInput
@@ -46354,6 +51701,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for NarrativeHistories returned from the connection.
+    """
+    orderBy: NarrativeHistoryOrder
 
     """
     Filtering options for NarrativeHistories returned from the connection.
@@ -46434,6 +51786,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for OrgMemberships returned from the connection.
+    """
+    orderBy: OrgMembershipOrder
+
+    """
     Filtering options for OrgMemberships returned from the connection.
     """
     where: OrgMembershipWhereInput
@@ -46458,6 +51815,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for OrgMembershipHistories returned from the connection.
+    """
+    orderBy: OrgMembershipHistoryOrder
 
     """
     Filtering options for OrgMembershipHistories returned from the connection.
@@ -46486,6 +51848,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for OrgSubscriptions returned from the connection.
+    """
+    orderBy: OrgSubscriptionOrder
+
+    """
     Filtering options for OrgSubscriptions returned from the connection.
     """
     where: OrgSubscriptionWhereInput
@@ -46510,6 +51877,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for OrgSubscriptionHistories returned from the connection.
+    """
+    orderBy: OrgSubscriptionHistoryOrder
 
     """
     Filtering options for OrgSubscriptionHistories returned from the connection.
@@ -46540,7 +51912,7 @@ type Query {
     """
     Ordering options for Organizations returned from the connection.
     """
-    orderBy: OrganizationOrder
+    orderBy: [OrganizationOrder!]
 
     """
     Filtering options for Organizations returned from the connection.
@@ -46730,6 +52102,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for Programs returned from the connection.
+    """
+    orderBy: [ProgramOrder!]
+
+    """
     Filtering options for Programs returned from the connection.
     """
     where: ProgramWhereInput
@@ -46754,6 +52131,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for ProgramHistories returned from the connection.
+    """
+    orderBy: ProgramHistoryOrder
 
     """
     Filtering options for ProgramHistories returned from the connection.
@@ -46782,6 +52164,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for ProgramMemberships returned from the connection.
+    """
+    orderBy: ProgramMembershipOrder
+
+    """
     Filtering options for ProgramMemberships returned from the connection.
     """
     where: ProgramMembershipWhereInput
@@ -46806,6 +52193,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for ProgramMembershipHistories returned from the connection.
+    """
+    orderBy: ProgramMembershipHistoryOrder
 
     """
     Filtering options for ProgramMembershipHistories returned from the connection.
@@ -46834,6 +52226,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for Risks returned from the connection.
+    """
+    orderBy: [RiskOrder!]
+
+    """
     Filtering options for Risks returned from the connection.
     """
     where: RiskWhereInput
@@ -46858,6 +52255,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for RiskHistories returned from the connection.
+    """
+    orderBy: RiskHistoryOrder
 
     """
     Filtering options for RiskHistories returned from the connection.
@@ -46886,6 +52288,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for Standards returned from the connection.
+    """
+    orderBy: [StandardOrder!]
+
+    """
     Filtering options for Standards returned from the connection.
     """
     where: StandardWhereInput
@@ -46910,6 +52317,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for StandardHistories returned from the connection.
+    """
+    orderBy: StandardHistoryOrder
 
     """
     Filtering options for StandardHistories returned from the connection.
@@ -46938,6 +52350,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for Subcontrols returned from the connection.
+    """
+    orderBy: [SubcontrolOrder!]
+
+    """
     Filtering options for Subcontrols returned from the connection.
     """
     where: SubcontrolWhereInput
@@ -46964,6 +52381,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for SubcontrolHistories returned from the connection.
+    """
+    orderBy: SubcontrolHistoryOrder
+
+    """
     Filtering options for SubcontrolHistories returned from the connection.
     """
     where: SubcontrolHistoryWhereInput
@@ -46988,6 +52410,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for Subscribers returned from the connection.
+    """
+    orderBy: [SubscriberOrder!]
 
     """
     Filtering options for Subscribers returned from the connection.
@@ -47042,6 +52469,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for Tasks returned from the connection.
+    """
+    orderBy: [TaskOrder!]
+
+    """
     Filtering options for Tasks returned from the connection.
     """
     where: TaskWhereInput
@@ -47066,6 +52498,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for TaskHistories returned from the connection.
+    """
+    orderBy: TaskHistoryOrder
 
     """
     Filtering options for TaskHistories returned from the connection.
@@ -47096,7 +52533,7 @@ type Query {
     """
     Ordering options for Templates returned from the connection.
     """
-    orderBy: TemplateOrder
+    orderBy: [TemplateOrder!]
 
     """
     Filtering options for Templates returned from the connection.
@@ -47158,7 +52595,7 @@ type Query {
     """
     Ordering options for Users returned from the connection.
     """
-    orderBy: UserOrder
+    orderBy: [UserOrder!]
 
     """
     Filtering options for Users returned from the connection.
@@ -47322,10 +52759,125 @@ type Risk implements Node {
   provides view access to the risk to members of the group
   """
   viewers: [Group!]
-  control: [Control!]
-  procedure: [Procedure!]
-  actionPlans: [ActionPlan!]
-  programs: [Program!]
+  control(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
+    Filtering options for Controls returned from the connection.
+    """
+    where: ControlWhereInput
+  ): ControlConnection!
+  procedure(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Procedures returned from the connection.
+    """
+    where: ProcedureWhereInput
+  ): ProcedureConnection!
+  actionPlans(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for ActionPlans returned from the connection.
+    """
+    orderBy: [ActionPlanOrder!]
+
+    """
+    Filtering options for ActionPlans returned from the connection.
+    """
+    where: ActionPlanWhereInput
+  ): ActionPlanConnection!
+  programs(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Programs returned from the connection.
+    """
+    orderBy: [ProgramOrder!]
+
+    """
+    Filtering options for Programs returned from the connection.
+    """
+    where: ProgramWhereInput
+  ): ProgramConnection!
   """
   the group of users who are responsible for risk oversight
   """
@@ -47466,6 +53018,32 @@ enum RiskHistoryOpType @goModel(model: "github.com/theopenlane/entx/history.OpTy
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for RiskHistory connections
+"""
+input RiskHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order RiskHistories.
+  """
+  field: RiskHistoryOrderField!
+}
+"""
+Properties by which RiskHistory connections can be ordered.
+"""
+enum RiskHistoryOrderField {
+  name
+  STATUS
+  risk_type
+  category
+  IMPACT
+  LIKELIHOOD
+  score
+  business_costs
 }
 """
 RiskHistoryRiskImpact is enum for the field impact
@@ -47824,6 +53402,32 @@ input RiskHistoryWhereInput {
   businessCostsNotNil: Boolean
   businessCostsEqualFold: String
   businessCostsContainsFold: String
+}
+"""
+Ordering options for Risk connections
+"""
+input RiskOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order Risks.
+  """
+  field: RiskOrderField!
+}
+"""
+Properties by which Risk connections can be ordered.
+"""
+enum RiskOrderField {
+  name
+  STATUS
+  risk_type
+  category
+  IMPACT
+  LIKELIHOOD
+  score
+  business_costs
 }
 """
 RiskRiskImpact is enum for the field impact
@@ -48274,7 +53878,37 @@ type Standard implements Node {
   """
   version: String
   owner: Organization
-  controls: [Control!]
+  controls(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
+    Filtering options for Controls returned from the connection.
+    """
+    where: ControlWhereInput
+  ): ControlConnection!
 }
 """
 A connection to a list of items.
@@ -48423,6 +54057,30 @@ enum StandardHistoryOpType @goModel(model: "github.com/theopenlane/entx/history.
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for StandardHistory connections
+"""
+input StandardHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order StandardHistories.
+  """
+  field: StandardHistoryOrderField!
+}
+"""
+Properties by which StandardHistory connections can be ordered.
+"""
+enum StandardHistoryOrderField {
+  name
+  short_name
+  framework
+  governing_body
+  STATUS
+  standard_type
 }
 """
 StandardHistoryStandardStatus is enum for the field status
@@ -48808,6 +54466,30 @@ input StandardHistoryWhereInput {
   versionNotNil: Boolean
   versionEqualFold: String
   versionContainsFold: String
+}
+"""
+Ordering options for Standard connections
+"""
+input StandardOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order Standards.
+  """
+  field: StandardOrderField!
+}
+"""
+Properties by which Standard connections can be ordered.
+"""
+enum StandardOrderField {
+  name
+  short_name
+  framework
+  governing_body
+  STATUS
+  standard_type
 }
 """
 StandardStandardStatus is enum for the field status
@@ -49258,14 +54940,244 @@ type Subcontrol implements Node {
   mapped subcontrols that have a relation to another control or subcontrol
   """
   mappedControls: [MappedControl!]
-  evidence: [Evidence!]
-  controlObjectives: [ControlObjective!]
-  tasks: [Task!]
-  narratives: [Narrative!]
-  risks: [Risk!]
-  actionPlans: [ActionPlan!]
-  procedures: [Procedure!]
-  internalPolicies: [InternalPolicy!]
+  evidence(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Evidences returned from the connection.
+    """
+    orderBy: [EvidenceOrder!]
+
+    """
+    Filtering options for Evidences returned from the connection.
+    """
+    where: EvidenceWhereInput
+  ): EvidenceConnection!
+  controlObjectives(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for ControlObjectives returned from the connection.
+    """
+    orderBy: [ControlObjectiveOrder!]
+
+    """
+    Filtering options for ControlObjectives returned from the connection.
+    """
+    where: ControlObjectiveWhereInput
+  ): ControlObjectiveConnection!
+  tasks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Tasks returned from the connection.
+    """
+    orderBy: [TaskOrder!]
+
+    """
+    Filtering options for Tasks returned from the connection.
+    """
+    where: TaskWhereInput
+  ): TaskConnection!
+  narratives(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Narratives returned from the connection.
+    """
+    orderBy: NarrativeOrder
+
+    """
+    Filtering options for Narratives returned from the connection.
+    """
+    where: NarrativeWhereInput
+  ): NarrativeConnection!
+  risks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Risks returned from the connection.
+    """
+    orderBy: [RiskOrder!]
+
+    """
+    Filtering options for Risks returned from the connection.
+    """
+    where: RiskWhereInput
+  ): RiskConnection!
+  actionPlans(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for ActionPlans returned from the connection.
+    """
+    orderBy: [ActionPlanOrder!]
+
+    """
+    Filtering options for ActionPlans returned from the connection.
+    """
+    where: ActionPlanWhereInput
+  ): ActionPlanConnection!
+  procedures(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Procedures returned from the connection.
+    """
+    where: ProcedureWhereInput
+  ): ProcedureConnection!
+  internalPolicies(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for InternalPolicies returned from the connection.
+    """
+    where: InternalPolicyWhereInput
+  ): InternalPolicyConnection!
   """
   the user who is responsible for the subcontrol, defaults to the parent control owner if not set
   """
@@ -49466,6 +55378,30 @@ enum SubcontrolHistoryOpType @goModel(model: "github.com/theopenlane/entx/histor
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for SubcontrolHistory connections
+"""
+input SubcontrolHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order SubcontrolHistories.
+  """
+  field: SubcontrolHistoryOrderField!
+}
+"""
+Properties by which SubcontrolHistory connections can be ordered.
+"""
+enum SubcontrolHistoryOrderField {
+  status
+  SOURCE
+  CONTROL_TYPE
+  category
+  subcategory
+  ref_code
 }
 """
 SubcontrolHistoryWhereInput is used for filtering SubcontrolHistory objects.
@@ -49791,6 +55727,30 @@ input SubcontrolHistoryWhereInput {
   controlIDHasSuffix: String
   controlIDEqualFold: String
   controlIDContainsFold: String
+}
+"""
+Ordering options for Subcontrol connections
+"""
+input SubcontrolOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order Subcontrols.
+  """
+  field: SubcontrolOrderField!
+}
+"""
+Properties by which Subcontrol connections can be ordered.
+"""
+enum SubcontrolOrderField {
+  status
+  SOURCE
+  CONTROL_TYPE
+  category
+  subcategory
+  ref_code
 }
 """
 SubcontrolWhereInput is used for filtering Subcontrol objects.
@@ -50183,7 +56143,32 @@ type Subscriber implements Node {
   """
   active: Boolean!
   owner: Organization
-  events: [Event!]
+  events(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Events returned from the connection.
+    """
+    where: EventWhereInput
+  ): EventConnection!
 }
 """
 A connection to a list of items.
@@ -50214,6 +56199,26 @@ type SubscriberEdge {
   A cursor for use in pagination.
   """
   cursor: Cursor!
+}
+"""
+Ordering options for Subscriber connections
+"""
+input SubscriberOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order Subscribers.
+  """
+  field: SubscriberOrderField!
+}
+"""
+Properties by which Subscriber connections can be ordered.
+"""
+enum SubscriberOrderField {
+  email
+  active
 }
 """
 SubscriberWhereInput is used for filtering Subscriber objects.
@@ -50646,18 +56651,270 @@ type Task implements Node {
   owner: Organization
   assigner: User
   assignee: User
-  """
-  conversations related to the task
-  """
-  comments: [Note!]
-  group: [Group!]
-  internalPolicy: [InternalPolicy!]
-  procedure: [Procedure!]
-  control: [Control!]
-  controlObjective: [ControlObjective!]
-  subcontrol: [Subcontrol!]
-  program: [Program!]
-  evidence: [Evidence!]
+  comments(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Notes returned from the connection.
+    """
+    where: NoteWhereInput
+  ): NoteConnection!
+  group(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Groups returned from the connection.
+    """
+    orderBy: [GroupOrder!]
+
+    """
+    Filtering options for Groups returned from the connection.
+    """
+    where: GroupWhereInput
+  ): GroupConnection!
+  internalPolicy(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for InternalPolicies returned from the connection.
+    """
+    where: InternalPolicyWhereInput
+  ): InternalPolicyConnection!
+  procedure(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Procedures returned from the connection.
+    """
+    where: ProcedureWhereInput
+  ): ProcedureConnection!
+  control(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
+    Filtering options for Controls returned from the connection.
+    """
+    where: ControlWhereInput
+  ): ControlConnection!
+  controlObjective(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for ControlObjectives returned from the connection.
+    """
+    orderBy: [ControlObjectiveOrder!]
+
+    """
+    Filtering options for ControlObjectives returned from the connection.
+    """
+    where: ControlObjectiveWhereInput
+  ): ControlObjectiveConnection!
+  subcontrol(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Subcontrols returned from the connection.
+    """
+    orderBy: [SubcontrolOrder!]
+
+    """
+    Filtering options for Subcontrols returned from the connection.
+    """
+    where: SubcontrolWhereInput
+  ): SubcontrolConnection!
+  program(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Programs returned from the connection.
+    """
+    orderBy: [ProgramOrder!]
+
+    """
+    Filtering options for Programs returned from the connection.
+    """
+    where: ProgramWhereInput
+  ): ProgramConnection!
+  evidence(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Evidences returned from the connection.
+    """
+    orderBy: [EvidenceOrder!]
+
+    """
+    Filtering options for Evidences returned from the connection.
+    """
+    where: EvidenceWhereInput
+  ): EvidenceConnection!
 }
 """
 A connection to a list of items.
@@ -50786,6 +57043,29 @@ enum TaskHistoryOpType @goModel(model: "github.com/theopenlane/entx/history.OpTy
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for TaskHistory connections
+"""
+input TaskHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order TaskHistories.
+  """
+  field: TaskHistoryOrderField!
+}
+"""
+Properties by which TaskHistory connections can be ordered.
+"""
+enum TaskHistoryOrderField {
+  title
+  STATUS
+  category
+  due
+  completed
 }
 """
 TaskHistoryTaskStatus is enum for the field status
@@ -51120,6 +57400,29 @@ input TaskHistoryWhereInput {
   assignerIDNotNil: Boolean
   assignerIDEqualFold: String
   assignerIDContainsFold: String
+}
+"""
+Ordering options for Task connections
+"""
+input TaskOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order Tasks.
+  """
+  field: TaskOrderField!
+}
+"""
+Properties by which Task connections can be ordered.
+"""
+enum TaskOrderField {
+  title
+  STATUS
+  category
+  due
+  completed
 }
 """
 TaskTaskStatus is enum for the field status
@@ -51516,8 +57819,58 @@ type Template implements Node {
   """
   uischema: Map
   owner: Organization
-  documents: [DocumentData!]
-  files: [File!]
+  documents(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for DocumentDataSlice returned from the connection.
+    """
+    where: DocumentDataWhereInput
+  ): DocumentDataConnection!
+  files(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Files returned from the connection.
+    """
+    where: FileWhereInput
+  ): FileConnection!
 }
 """
 A connection to a list of items.
@@ -51659,6 +58012,7 @@ Properties by which TemplateHistory connections can be ordered.
 """
 enum TemplateHistoryOrderField {
   name
+  TEMPLATE_TYPE
 }
 """
 TemplateHistoryWhereInput is used for filtering TemplateHistory objects.
@@ -51888,6 +58242,7 @@ Properties by which Template connections can be ordered.
 """
 enum TemplateOrderField {
   name
+  TEMPLATE_TYPE
 }
 """
 TemplateWhereInput is used for filtering Template objects.
@@ -54377,18 +60732,238 @@ type User implements Node {
   the user's role
   """
   role: UserRole
-  personalAccessTokens: [PersonalAccessToken!]
-  tfaSettings: [TFASetting!]
+  personalAccessTokens(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for PersonalAccessTokens returned from the connection.
+    """
+    where: PersonalAccessTokenWhereInput
+  ): PersonalAccessTokenConnection!
+  tfaSettings(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for TFASettings returned from the connection.
+    """
+    where: TFASettingWhereInput
+  ): TFASettingConnection!
   setting: UserSetting!
   groups: [Group!]
   organizations: [Organization!]
-  files: [File!]
+  files(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Files returned from the connection.
+    """
+    where: FileWhereInput
+  ): FileConnection!
   avatarFile: File
-  events: [Event!]
-  actionPlans: [ActionPlan!]
-  subcontrols: [Subcontrol!]
-  assignerTasks: [Task!]
-  assigneeTasks: [Task!]
+  events(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Events returned from the connection.
+    """
+    where: EventWhereInput
+  ): EventConnection!
+  actionPlans(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for ActionPlans returned from the connection.
+    """
+    orderBy: [ActionPlanOrder!]
+
+    """
+    Filtering options for ActionPlans returned from the connection.
+    """
+    where: ActionPlanWhereInput
+  ): ActionPlanConnection!
+  subcontrols(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Subcontrols returned from the connection.
+    """
+    orderBy: [SubcontrolOrder!]
+
+    """
+    Filtering options for Subcontrols returned from the connection.
+    """
+    where: SubcontrolWhereInput
+  ): SubcontrolConnection!
+  assignerTasks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Tasks returned from the connection.
+    """
+    orderBy: [TaskOrder!]
+
+    """
+    Filtering options for Tasks returned from the connection.
+    """
+    where: TaskWhereInput
+  ): TaskConnection!
+  assigneeTasks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Tasks returned from the connection.
+    """
+    orderBy: [TaskOrder!]
+
+    """
+    Filtering options for Tasks returned from the connection.
+    """
+    where: TaskWhereInput
+  ): TaskConnection!
   programs: [Program!]
   groupMemberships: [GroupMembership!]
   orgMemberships: [OrgMembership!]
@@ -54970,7 +61545,32 @@ type UserSetting implements Node {
   organization to load on user login
   """
   defaultOrg: Organization
-  files: [File!]
+  files(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Files returned from the connection.
+    """
+    where: FileWhereInput
+  ): FileConnection!
 }
 """
 A connection to a list of items.

--- a/internal/graphapi/narrative_test.go
+++ b/internal/graphapi/narrative_test.go
@@ -102,7 +102,7 @@ func (suite *GraphTestSuite) TestQueryNarrative() {
 			assert.Equal(t, tc.queryID, resp.Narrative.ID)
 			assert.NotEmpty(t, resp.Narrative.Name)
 
-			require.Len(t, resp.Narrative.Programs, 1)
+			require.Len(t, resp.Narrative.Programs.Edges, 1)
 			assert.NotEmpty(t, resp.Narrative.Programs.Edges[0].Node.ID)
 		})
 	}
@@ -330,13 +330,13 @@ func (suite *GraphTestSuite) TestMutationCreateNarrative() {
 			// ensure the program is set
 			if len(tc.request.ProgramIDs) > 0 {
 				require.NotEmpty(t, resp.CreateNarrative.Narrative.Programs)
-				require.Len(t, resp.CreateNarrative.Narrative.Programs, len(tc.request.ProgramIDs))
+				require.Len(t, resp.CreateNarrative.Narrative.Programs.Edges, len(tc.request.ProgramIDs))
 
 				for i, p := range resp.CreateNarrative.Narrative.Programs.Edges {
 					assert.Equal(t, tc.request.ProgramIDs[i], p.Node.ID)
 				}
 			} else {
-				assert.Empty(t, resp.CreateNarrative.Narrative.Programs)
+				assert.Empty(t, resp.CreateNarrative.Narrative.Programs.Edges)
 			}
 
 			if tc.request.Description != nil {

--- a/internal/graphapi/narrative_test.go
+++ b/internal/graphapi/narrative_test.go
@@ -103,7 +103,7 @@ func (suite *GraphTestSuite) TestQueryNarrative() {
 			assert.NotEmpty(t, resp.Narrative.Name)
 
 			require.Len(t, resp.Narrative.Programs, 1)
-			assert.NotEmpty(t, resp.Narrative.Programs[0].ID)
+			assert.NotEmpty(t, resp.Narrative.Programs.Edges[0].Node.ID)
 		})
 	}
 }
@@ -332,8 +332,8 @@ func (suite *GraphTestSuite) TestMutationCreateNarrative() {
 				require.NotEmpty(t, resp.CreateNarrative.Narrative.Programs)
 				require.Len(t, resp.CreateNarrative.Narrative.Programs, len(tc.request.ProgramIDs))
 
-				for i, p := range resp.CreateNarrative.Narrative.Programs {
-					assert.Equal(t, tc.request.ProgramIDs[i], p.ID)
+				for i, p := range resp.CreateNarrative.Narrative.Programs.Edges {
+					assert.Equal(t, tc.request.ProgramIDs[i], p.Node.ID)
 				}
 			} else {
 				assert.Empty(t, resp.CreateNarrative.Narrative.Programs)

--- a/internal/graphapi/personalaccesstoken_test.go
+++ b/internal/graphapi/personalaccesstoken_test.go
@@ -188,13 +188,13 @@ func (suite *GraphTestSuite) TestMutationCreatePersonalAccessToken() {
 
 			// check organization is set if provided
 			if tc.input.OrganizationIDs != nil {
-				assert.Len(t, resp.CreatePersonalAccessToken.PersonalAccessToken.Organizations, len(tc.input.OrganizationIDs))
+				assert.Len(t, resp.CreatePersonalAccessToken.PersonalAccessToken.Organizations.Edges, len(tc.input.OrganizationIDs))
 
 				for _, orgID := range resp.CreatePersonalAccessToken.PersonalAccessToken.Organizations.Edges {
 					assert.Contains(t, tc.input.OrganizationIDs, orgID.Node.ID)
 				}
 			} else {
-				assert.Len(t, resp.CreatePersonalAccessToken.PersonalAccessToken.Organizations, 0)
+				assert.Len(t, resp.CreatePersonalAccessToken.PersonalAccessToken.Organizations.Edges, 0)
 			}
 
 			// ensure the owner is the user that made the request
@@ -308,11 +308,11 @@ func (suite *GraphTestSuite) TestMutationUpdatePersonalAccessToken() {
 				assert.Empty(t, resp.UpdatePersonalAccessToken.PersonalAccessToken.ExpiresAt)
 			}
 
-			assert.Len(t, resp.UpdatePersonalAccessToken.PersonalAccessToken.Organizations, len(tc.input.AddOrganizationIDs)+1)
+			assert.Len(t, resp.UpdatePersonalAccessToken.PersonalAccessToken.Organizations.Edges, len(tc.input.AddOrganizationIDs)+1)
 
 			// Ensure its removed
 			if tc.input.RemoveOrganizationIDs != nil {
-				assert.Len(t, resp.UpdatePersonalAccessToken.PersonalAccessToken.Organizations, 1)
+				assert.Len(t, resp.UpdatePersonalAccessToken.PersonalAccessToken.Organizations.Edges, 1)
 			}
 
 			assert.Equal(t, testUser1.ID, resp.UpdatePersonalAccessToken.PersonalAccessToken.Owner.ID)

--- a/internal/graphapi/personalaccesstoken_test.go
+++ b/internal/graphapi/personalaccesstoken_test.go
@@ -190,8 +190,8 @@ func (suite *GraphTestSuite) TestMutationCreatePersonalAccessToken() {
 			if tc.input.OrganizationIDs != nil {
 				assert.Len(t, resp.CreatePersonalAccessToken.PersonalAccessToken.Organizations, len(tc.input.OrganizationIDs))
 
-				for _, orgID := range resp.CreatePersonalAccessToken.PersonalAccessToken.Organizations {
-					assert.Contains(t, tc.input.OrganizationIDs, orgID.ID)
+				for _, orgID := range resp.CreatePersonalAccessToken.PersonalAccessToken.Organizations.Edges {
+					assert.Contains(t, tc.input.OrganizationIDs, orgID.Node.ID)
 				}
 			} else {
 				assert.Len(t, resp.CreatePersonalAccessToken.PersonalAccessToken.Organizations, 0)

--- a/internal/graphapi/program_test.go
+++ b/internal/graphapi/program_test.go
@@ -71,8 +71,8 @@ func (suite *GraphTestSuite) TestQueryProgram() {
 
 			assert.Equal(t, program.ID, resp.Program.ID)
 			assert.Equal(t, program.Name, resp.Program.Name)
-			assert.Len(t, resp.Program.Procedures, 1)
-			assert.Len(t, resp.Program.InternalPolicies, 1)
+			assert.Len(t, resp.Program.Procedures.Edges, 1)
+			assert.Len(t, resp.Program.InternalPolicies.Edges, 1)
 		})
 	}
 }
@@ -147,8 +147,8 @@ func (suite *GraphTestSuite) TestQueryPrograms() {
 
 			for _, edge := range resp.Programs.Edges {
 				require.NotNil(t, edge.Node)
-				assert.Len(t, edge.Node.Procedures, 1)
-				assert.Len(t, edge.Node.InternalPolicies, 1)
+				assert.Len(t, edge.Node.Procedures.Edges, 1)
+				assert.Len(t, edge.Node.InternalPolicies.Edges, 1)
 			}
 		})
 	}
@@ -368,14 +368,14 @@ func (suite *GraphTestSuite) TestMutationCreateProgram() {
 
 			// check edges
 			if len(tc.request.ProcedureIDs) > 0 {
-				require.Len(t, resp.CreateProgram.Program.Procedures, 1)
+				require.Len(t, resp.CreateProgram.Program.Procedures.Edges, 1)
 				for _, edge := range resp.CreateProgram.Program.Procedures.Edges {
 					assert.Equal(t, procedure.ID, edge.Node.ID)
 				}
 			}
 
 			if len(tc.request.InternalPolicyIDs) > 0 {
-				require.Len(t, resp.CreateProgram.Program.InternalPolicies, 1)
+				require.Len(t, resp.CreateProgram.Program.InternalPolicies.Edges, 1)
 				for _, edge := range resp.CreateProgram.Program.InternalPolicies.Edges {
 					assert.Equal(t, policy.ID, edge.Node.ID)
 				}
@@ -653,14 +653,14 @@ func (suite *GraphTestSuite) TestMutationUpdateProgram() {
 
 			// check edges
 			if len(tc.request.AddProcedureIDs) > 0 {
-				require.Len(t, resp.UpdateProgram.Program.Procedures, 1)
+				require.Len(t, resp.UpdateProgram.Program.Procedures.Edges, 1)
 				for _, edge := range resp.UpdateProgram.Program.Procedures.Edges {
 					assert.Equal(t, procedure1.ID, edge.Node.ID)
 				}
 			}
 
 			if len(tc.request.AddInternalPolicyIDs) > 0 {
-				require.Len(t, resp.UpdateProgram.Program.InternalPolicies, 1)
+				require.Len(t, resp.UpdateProgram.Program.InternalPolicies.Edges, 1)
 				for _, edge := range resp.UpdateProgram.Program.InternalPolicies.Edges {
 					assert.Equal(t, policy1.ID, edge.Node.ID)
 				}
@@ -694,7 +694,7 @@ func (suite *GraphTestSuite) TestMutationUpdateProgram() {
 			}
 
 			if len(tc.request.AddProgramMembers) > 0 {
-				require.Len(t, resp.UpdateProgram.Program.Members, 3)
+				require.Len(t, resp.UpdateProgram.Program.Members.Edges, 3)
 
 				// it should have the owner and the admin user and the other user added in the test setup
 				require.Equal(t, testUser1.ID, resp.UpdateProgram.Program.Members.Edges[0].Node.User.ID)
@@ -704,7 +704,7 @@ func (suite *GraphTestSuite) TestMutationUpdateProgram() {
 
 			// member was removed, ensure there are two members left
 			if len(tc.request.RemoveProgramMembers) > 0 {
-				require.Len(t, resp.UpdateProgram.Program.Members, 2)
+				require.Len(t, resp.UpdateProgram.Program.Members.Edges, 2)
 
 				// it should have the owner and the admin user
 				require.Equal(t, testUser1.ID, resp.UpdateProgram.Program.Members.Edges[0].Node.User.ID)

--- a/internal/graphapi/program_test.go
+++ b/internal/graphapi/program_test.go
@@ -369,15 +369,15 @@ func (suite *GraphTestSuite) TestMutationCreateProgram() {
 			// check edges
 			if len(tc.request.ProcedureIDs) > 0 {
 				require.Len(t, resp.CreateProgram.Program.Procedures, 1)
-				for _, edge := range resp.CreateProgram.Program.Procedures {
-					assert.Equal(t, procedure.ID, edge.ID)
+				for _, edge := range resp.CreateProgram.Program.Procedures.Edges {
+					assert.Equal(t, procedure.ID, edge.Node.ID)
 				}
 			}
 
 			if len(tc.request.InternalPolicyIDs) > 0 {
 				require.Len(t, resp.CreateProgram.Program.InternalPolicies, 1)
-				for _, edge := range resp.CreateProgram.Program.InternalPolicies {
-					assert.Equal(t, policy.ID, edge.ID)
+				for _, edge := range resp.CreateProgram.Program.InternalPolicies.Edges {
+					assert.Equal(t, policy.ID, edge.Node.ID)
 				}
 			}
 
@@ -654,15 +654,15 @@ func (suite *GraphTestSuite) TestMutationUpdateProgram() {
 			// check edges
 			if len(tc.request.AddProcedureIDs) > 0 {
 				require.Len(t, resp.UpdateProgram.Program.Procedures, 1)
-				for _, edge := range resp.UpdateProgram.Program.Procedures {
-					assert.Equal(t, procedure1.ID, edge.ID)
+				for _, edge := range resp.UpdateProgram.Program.Procedures.Edges {
+					assert.Equal(t, procedure1.ID, edge.Node.ID)
 				}
 			}
 
 			if len(tc.request.AddInternalPolicyIDs) > 0 {
 				require.Len(t, resp.UpdateProgram.Program.InternalPolicies, 1)
-				for _, edge := range resp.UpdateProgram.Program.InternalPolicies {
-					assert.Equal(t, policy1.ID, edge.ID)
+				for _, edge := range resp.UpdateProgram.Program.InternalPolicies.Edges {
+					assert.Equal(t, policy1.ID, edge.Node.ID)
 				}
 			}
 
@@ -697,9 +697,9 @@ func (suite *GraphTestSuite) TestMutationUpdateProgram() {
 				require.Len(t, resp.UpdateProgram.Program.Members, 3)
 
 				// it should have the owner and the admin user and the other user added in the test setup
-				require.Equal(t, testUser1.ID, resp.UpdateProgram.Program.Members[0].User.ID)
-				require.Equal(t, programUser.ID, resp.UpdateProgram.Program.Members[1].User.ID)
-				require.Equal(t, adminUser.ID, resp.UpdateProgram.Program.Members[2].User.ID)
+				require.Equal(t, testUser1.ID, resp.UpdateProgram.Program.Members.Edges[0].Node.User.ID)
+				require.Equal(t, programUser.ID, resp.UpdateProgram.Program.Members.Edges[1].Node.User.ID)
+				require.Equal(t, adminUser.ID, resp.UpdateProgram.Program.Members.Edges[2].Node.User.ID)
 			}
 
 			// member was removed, ensure there are two members left
@@ -707,7 +707,7 @@ func (suite *GraphTestSuite) TestMutationUpdateProgram() {
 				require.Len(t, resp.UpdateProgram.Program.Members, 2)
 
 				// it should have the owner and the admin user
-				require.Equal(t, testUser1.ID, resp.UpdateProgram.Program.Members[0].User.ID)
+				require.Equal(t, testUser1.ID, resp.UpdateProgram.Program.Members.Edges[0].Node.User.ID)
 			}
 		})
 	}

--- a/internal/graphapi/programextended_test.go
+++ b/internal/graphapi/programextended_test.go
@@ -62,7 +62,7 @@ func (suite *GraphTestSuite) TestMutationCreateProgramWithMembers() {
 			assert.Equal(t, tc.request.Program.Name, resp.CreateProgramWithMembers.Program.Name)
 
 			// the creator is automatically added as an admin, and the members are added in addition
-			assert.Len(t, resp.CreateProgramWithMembers.Program.Members, len(tc.request.Members)+1)
+			assert.Len(t, resp.CreateProgramWithMembers.Program.Members.Edges, len(tc.request.Members)+1)
 		})
 	}
 }
@@ -155,19 +155,19 @@ func (suite *GraphTestSuite) TestMutationCreateFullProgram() {
 			assert.Equal(t, tc.request.Program.Name, resp.CreateFullProgram.Program.Name)
 
 			// the creator is automatically added as an admin, and the members are added in addition
-			assert.Len(t, resp.CreateFullProgram.Program.Members, len(tc.request.Members)+1)
+			assert.Len(t, resp.CreateFullProgram.Program.Members.Edges, len(tc.request.Members)+1)
 
-			require.NotNil(t, resp.CreateFullProgram.Program.Controls)
-			assert.Len(t, resp.CreateFullProgram.Program.Controls, len(tc.request.Controls))
+			require.NotNil(t, resp.CreateFullProgram.Program.Controls.Edges)
+			assert.Len(t, resp.CreateFullProgram.Program.Controls.Edges, len(tc.request.Controls))
 
 			assert.NotNil(t, resp.CreateFullProgram.Program.Controls.Edges[0].Node.Subcontrols)
 			assert.Equal(t, 2, len(resp.CreateFullProgram.Program.Controls.Edges[0].Node.Subcontrols.Edges))
 
-			require.NotNil(t, resp.CreateFullProgram.Program.Risks)
-			assert.Len(t, resp.CreateFullProgram.Program.Risks, len(tc.request.Risks))
+			require.NotNil(t, resp.CreateFullProgram.Program.Risks.Edges)
+			assert.Len(t, resp.CreateFullProgram.Program.Risks.Edges, len(tc.request.Risks))
 
-			require.NotNil(t, resp.CreateFullProgram.Program.InternalPolicies)
-			assert.Len(t, resp.CreateFullProgram.Program.InternalPolicies, len(tc.request.InternalPolicies))
+			require.NotNil(t, resp.CreateFullProgram.Program.InternalPolicies.Edges)
+			assert.Len(t, resp.CreateFullProgram.Program.InternalPolicies.Edges, len(tc.request.InternalPolicies))
 		})
 	}
 }

--- a/internal/graphapi/programextended_test.go
+++ b/internal/graphapi/programextended_test.go
@@ -160,8 +160,8 @@ func (suite *GraphTestSuite) TestMutationCreateFullProgram() {
 			require.NotNil(t, resp.CreateFullProgram.Program.Controls)
 			assert.Len(t, resp.CreateFullProgram.Program.Controls, len(tc.request.Controls))
 
-			assert.NotNil(t, resp.CreateFullProgram.Program.Controls[0].Subcontrols)
-			assert.Equal(t, 2, len(resp.CreateFullProgram.Program.Controls[0].Subcontrols))
+			assert.NotNil(t, resp.CreateFullProgram.Program.Controls.Edges[0].Node.Subcontrols)
+			assert.Equal(t, 2, len(resp.CreateFullProgram.Program.Controls.Edges[0].Node.Subcontrols.Edges))
 
 			require.NotNil(t, resp.CreateFullProgram.Program.Risks)
 			assert.Len(t, resp.CreateFullProgram.Program.Risks, len(tc.request.Risks))

--- a/internal/graphapi/query/control.graphql
+++ b/internal/graphapi/query/control.graphql
@@ -96,9 +96,13 @@ mutation CreateControl($input: CreateControlInput!) {
         name
       }
       programs {
-        id
-        displayID
-        name
+        edges {
+          node {
+            id
+            displayID
+            name
+          }
+        }
       }
       editors {
         id
@@ -165,9 +169,13 @@ query GetAllControls {
           governingBody
         }
         programs {
-          id
-          displayID
-          name
+          edges {
+            node {
+              id
+              displayID
+              name
+            }
+          }
         }
         editors {
           id
@@ -227,9 +235,13 @@ query GetControlByID($controlId: ID!) {
       governingBody
     }
     programs {
-      id
-      displayID
-      name
+      edges {
+        node {
+          id
+          displayID
+          name
+        }
+      }
     }
     editors {
       id
@@ -289,9 +301,13 @@ query GetControls($where: ControlWhereInput) {
           governingBody
         }
         programs {
-          id
-          displayID
-          name
+          edges {
+            node {
+              id
+              displayID
+              name
+            }
+          }
         }
         editors {
           id
@@ -352,9 +368,13 @@ mutation UpdateControl($updateControlId: ID!, $input: UpdateControlInput!) {
         governingBody
       }
       programs {
-        id
-        displayID
-        name
+        edges {
+          node {
+            id
+            displayID
+            name
+          }
+        }
       }
       editors {
         id

--- a/internal/graphapi/query/controlobjective.graphql
+++ b/internal/graphapi/query/controlobjective.graphql
@@ -65,15 +65,23 @@ mutation CreateControlObjective($input: CreateControlObjectiveInput!) {
       updatedBy
       revision
       controls {
-        id
-        displayID
-        refCode
-        description
+        edges {
+          node {
+            id
+            displayID
+            refCode
+            description
+          }
+        }
       }
       programs {
-          id
-          displayID
-          name
+        edges {
+          node {
+            id
+            displayID
+            name
+          }
+        }
       }
       editors {
         id
@@ -118,15 +126,23 @@ query GetAllControlObjectives {
         updatedBy
         revision
         controls {
-          id
-          displayID
-          refCode
-          description
+          edges {
+            node {
+              id
+              displayID
+              refCode
+              description
+            }
+          }
         }
         programs {
-            id
-            displayID
-            name
+          edges {
+            node {
+              id
+              displayID
+              name
+            }
+          }
         }
         editors {
           id
@@ -163,28 +179,36 @@ query GetControlObjectiveByID($controlObjectiveId: ID!) {
     updatedBy
     revision
     controls {
-        id
-        displayID
-        refCode
-        description
+      edges {
+        node {
+          id
+          displayID
+          refCode
+          description
+        }
       }
-      programs {
+    }
+    programs {
+      edges {
+        node {
           id
           displayID
           name
+        }
       }
-      editors {
-        id
-        name
-      }
-      viewers {
-        id
-        name
-      }
-      blockedGroups{
-        id
-        name
-      }
+    }
+    editors {
+      id
+      name
+    }
+    viewers {
+      id
+      name
+    }
+    blockedGroups{
+      id
+      name
+    }
   }
 }
 
@@ -209,15 +233,23 @@ query GetControlObjectives($where: ControlObjectiveWhereInput) {
         updatedBy
         revision
         controls {
-          id
-          displayID
-          refCode
-          description
+          edges {
+            node {
+              id
+              displayID
+              refCode
+              description
+            }
+          }
         }
         programs {
-          id
-          displayID
-          name
+          edges {
+            node {
+              id
+              displayID
+              name
+            }
+          }
         }
         editors {
           id
@@ -256,15 +288,23 @@ mutation UpdateControlObjective($updateControlObjectiveId: ID!, $input: UpdateCo
       updatedBy
       revision
       controls {
-        id
-        displayID
-        refCode
-        description
+        edges {
+          node {
+            id
+            displayID
+            refCode
+            description
+          }
+        }
       }
       programs {
-          id
-          displayID
-          name
+        edges {
+          node {
+            id
+            displayID
+            name
+          }
+        }
       }
       editors {
         id

--- a/internal/graphapi/query/entity.graphql
+++ b/internal/graphapi/query/entity.graphql
@@ -8,9 +8,13 @@ mutation CreateBulkCSVEntity($input: Upload!) {
       status
       domains
       notes {
-        text
-        updatedAt
-        updatedBy
+        edges {
+          node {
+            text
+            updatedAt
+            updatedBy
+          }
+        }
       }
       entityType {
         name
@@ -35,9 +39,13 @@ mutation CreateBulkEntity($input: [CreateEntityInput!]) {
       status
       domains
       notes {
-        text
-        updatedAt
-        updatedBy
+        edges {
+          node {
+            text
+            updatedAt
+            updatedBy
+          }
+        }
       }
       entityType {
         name
@@ -62,9 +70,13 @@ mutation CreateEntity($input: CreateEntityInput!) {
       status
       domains
       notes {
-        text
-        updatedAt
-        updatedBy
+        edges {
+          node {
+            text
+            updatedAt
+            updatedBy
+          }
+        }
       }
       entityType {
         name
@@ -96,9 +108,13 @@ query GetAllEntities {
         status
         domains
         notes {
-          text
-          updatedAt
-          updatedBy
+          edges {
+            node {
+              text
+              updatedAt
+              updatedBy
+            }
+          }
         }
         entityType {
           name
@@ -125,9 +141,13 @@ query GetEntities($where: EntityWhereInput) {
         status
         domains
         notes {
-          text
-          updatedAt
-          updatedBy
+          edges {
+            node {
+              text
+              updatedAt
+              updatedBy
+            }
+          }
         }
         entityType {
           name
@@ -152,9 +172,13 @@ query GetEntityByID($entityId: ID!) {
     status
     domains
     notes {
-      text
-      updatedAt
-      updatedBy
+      edges {
+        node {
+          text
+          updatedAt
+          updatedBy
+        }
+      }
     }
     entityType {
       name
@@ -163,13 +187,17 @@ query GetEntityByID($entityId: ID!) {
     name
     ownerID
     contacts {
-      id
-      fullName
-      email
-      title
-      company
-      address
-      phoneNumber
+      edges {
+        node {
+          id
+          fullName
+          email
+          title
+          company
+          address
+          phoneNumber
+        }
+      }
     }
     tags
     updatedAt
@@ -187,9 +215,13 @@ mutation UpdateEntity($updateEntityId: ID!, $input: UpdateEntityInput!) {
       status
       domains
       notes {
-        text
-        updatedAt
-        updatedBy
+        edges {
+          node {
+            text
+            updatedAt
+            updatedBy
+          }
+        }
       }
       entityType {
         name

--- a/internal/graphapi/query/event.graphql
+++ b/internal/graphapi/query/event.graphql
@@ -7,31 +7,67 @@ mutation CreateBulkCSVEvent($input: Upload!) {
       eventType
       metadata
       user {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       group {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       integration {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       organization {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       invite {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       personalAccessToken {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       hush {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       orgmembership {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       groupmembership {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
     }
   }
@@ -46,31 +82,67 @@ mutation CreateBulkEvent($input: [CreateEventInput!]) {
       eventType
       metadata
       user {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       group {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       integration {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       organization {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       invite {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       personalAccessToken {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       hush {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       orgmembership {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       groupmembership {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
     }
   }
@@ -85,31 +157,67 @@ mutation CreateEvent($input: CreateEventInput!) {
       eventType
       metadata
       user {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       group {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       integration {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       organization {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       invite {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       personalAccessToken {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       hush {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       orgmembership {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       groupmembership {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
     }
   }
@@ -135,31 +243,67 @@ query GetAllEvents {
         eventType
         metadata
         user {
-          id
+          edges {
+            node {
+              id
+            }
+          }
         }
         group {
-          id
+          edges {
+            node {
+              id
+            }
+          }
         }
         integration {
-          id
+          edges {
+            node {
+              id
+            }
+          }
         }
         organization {
-          id
+          edges {
+            node {
+              id
+            }
+          }
         }
         invite {
-          id
+          edges {
+            node {
+              id
+            }
+          }
         }
         personalAccessToken {
-          id
+          edges {
+            node {
+              id
+            }
+          }
         }
         hush {
-          id
+          edges {
+            node {
+              id
+            }
+          }
         }
         orgmembership {
-          id
+          edges {
+            node {
+              id
+            }
+          }
         }
         groupmembership {
-          id
+          edges {
+            node {
+              id
+            }
+          }
         }
       }
     }
@@ -178,31 +322,67 @@ query GetEventByID($eventId: ID!) {
     eventType
     metadata
     user {
-      id
+      edges {
+        node {
+          id
+        }
+      }
     }
     group {
-      id
+      edges {
+        node {
+          id
+        }
+      }
     }
     integration {
-      id
+      edges {
+        node {
+          id
+        }
+      }
     }
     organization {
-      id
+      edges {
+        node {
+          id
+        }
+      }
     }
     invite {
-      id
+      edges {
+        node {
+          id
+        }
+      }
     }
     personalAccessToken {
-      id
+      edges {
+        node {
+          id
+        }
+      }
     }
     hush {
-      id
+      edges {
+        node {
+          id
+        }
+      }
     }
     orgmembership {
-      id
+      edges {
+        node {
+          id
+        }
+      }
     }
     groupmembership {
-      id
+      edges {
+        node {
+          id
+        }
+      }
     }
   }
 }
@@ -234,31 +414,67 @@ mutation UpdateEvent($updateEventId: ID!, $input: UpdateEventInput!) {
       eventType
       metadata
       user {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       group {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       integration {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       organization {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       invite {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       personalAccessToken {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       hush {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       orgmembership {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       groupmembership {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
     }
   }

--- a/internal/graphapi/query/evidence.graphql
+++ b/internal/graphapi/query/evidence.graphql
@@ -19,32 +19,56 @@ mutation CreateEvidence($input: CreateEvidenceInput!, $evidenceFiles: [Upload!])
       updatedBy
       url
       files {
-        id
-        presignedURL
+        edges {
+          node {
+            id
+            presignedURL
+          }
+        }
       }
       programs {
-        id
-        displayID
-        name
+        edges {
+          node {
+            id
+            displayID
+            name
+          }
+        }
       }
       tasks {
-        id
-        displayID
+        edges {
+          node {
+            id
+            displayID
+          }
+        }
       }
       controls {
-        id
-        displayID
-        refCode
+        edges {
+          node {
+            id
+            displayID
+            refCode
+          }
+        }
       }
       subcontrols {
-        id
-        displayID
-        refCode
+        edges {
+          node {
+            id
+            displayID
+            refCode
+          }
+        }
       }
       controlObjectives {
-        id
-        displayID
-        name
+        edges {
+          node {
+            id
+            displayID
+            name
+          }
+        }
       }
     }
   }
@@ -78,32 +102,56 @@ query GetAllEvidences {
         updatedBy
         url
         files {
-          id
-          presignedURL
+          edges {
+            node {
+              id
+              presignedURL
+            }
+          }
         }
         programs {
-          id
-          displayID
-          name
+          edges {
+            node {
+              id
+              displayID
+              name
+            }
+          }
         }
         tasks {
-          id
-          displayID
+          edges {
+            node {
+              id
+              displayID
+            }
+          }
         }
         controls {
-          id
-          displayID
-          refCode
+          edges {
+            node {
+              id
+              displayID
+              refCode
+            }
+          }
         }
         subcontrols {
-          id
-          displayID
-          refCode
+          edges {
+            node {
+              id
+              displayID
+              refCode
+            }
+          }
         }
         controlObjectives {
-          id
-          displayID
-          name
+          edges {
+            node {
+              id
+              displayID
+              name
+            }
+          }
         }
       }
     }
@@ -130,32 +178,56 @@ query GetEvidenceByID($evidenceId: ID!) {
     updatedBy
     url
     files {
-      id
-      presignedURL
+      edges {
+        node {
+          id
+          presignedURL
+        }
+      }
     }
     programs {
-      id
-      displayID
-      name
+      edges {
+        node {
+          id
+          displayID
+          name
+        }
+      }
     }
     tasks {
-      id
-      displayID
+      edges {
+        node {
+          id
+          displayID
+        }
+      }
     }
     controls {
-      id
-      displayID
-      refCode
+      edges {
+        node {
+          id
+          displayID
+          refCode
+        }
+      }
     }
     subcontrols {
-      id
-      displayID
-      refCode
+      edges {
+        node {
+          id
+          displayID
+          refCode
+        }
+      }
     }
     controlObjectives {
-      id
-      displayID
-      name
+      edges {
+        node {
+          id
+          displayID
+          name
+        }
+      }
     }
   }
 }
@@ -182,32 +254,56 @@ query GetEvidences($where: EvidenceWhereInput) {
         updatedBy
         url
         files {
-          id
-          presignedURL
+          edges {
+            node {
+              id
+              presignedURL
+            }
+          }
         }
         programs {
-          id
-          displayID
-          name
+          edges {
+            node {
+              id
+              displayID
+              name
+            }
+          }
         }
         tasks {
-          id
-          displayID
+          edges {
+            node {
+              id
+              displayID
+            }
+          }
         }
         controls {
-          id
-          displayID
-          refCode
+          edges {
+            node {
+              id
+              displayID
+              refCode
+            }
+          }
         }
         subcontrols {
-          id
-          displayID
-          refCode
+          edges {
+            node {
+              id
+              displayID
+              refCode
+            }
+          }
         }
         controlObjectives {
-          id
-          displayID
-          name
+          edges {
+            node {
+              id
+              displayID
+              name
+            }
+          }
         }
       }
     }
@@ -239,32 +335,56 @@ mutation UpdateEvidence($updateEvidenceId: ID!, $input: UpdateEvidenceInput!, $e
       updatedBy
       url
       files {
-        id
-        presignedURL
+        edges {
+          node {
+            id
+            presignedURL
+          }
+        }
       }
       programs {
-        id
-        displayID
-        name
+        edges {
+          node {
+            id
+            displayID
+            name
+          }
+        }
       }
       tasks {
-        id
-        displayID
+        edges {
+          node {
+            id
+            displayID
+          }
+        }
       }
       controls {
-        id
-        displayID
-        refCode
+        edges {
+          node {
+            id
+            displayID
+            refCode
+          }
+        }
       }
       subcontrols {
-        id
-        displayID
-        refCode
+        edges {
+          node {
+            id
+            displayID
+            refCode
+          }
+        }
       }
       controlObjectives {
-        id
-        displayID
-        name
+        edges {
+          node {
+            id
+            displayID
+            name
+          }
+        }
       }
     }
   }

--- a/internal/graphapi/query/hush.graphql
+++ b/internal/graphapi/query/hush.graphql
@@ -7,13 +7,25 @@ mutation CreateBulkCSVHush($input: Upload!) {
       name
       secretName
       integrations {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       organization {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       events {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
     }
   }
@@ -28,13 +40,25 @@ mutation CreateBulkHush($input: [CreateHushInput!]) {
       name
       secretName
       integrations {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       organization {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       events {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
     }
   }
@@ -49,13 +73,25 @@ mutation CreateHush($input: CreateHushInput!) {
       name
       secretName
       integrations {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       organization {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       events {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
     }
   }
@@ -71,13 +107,25 @@ query GetAllHushes {
         name
         secretName
         integrations {
-          id
+          edges {
+            node {
+              id
+            }
+          }
         }
         organization {
-          id
+          edges {
+            node {
+              id
+            }
+          }
         }
         events {
-          id
+          edges {
+            node {
+              id
+            }
+          }
         }
         createdAt
         updatedAt
@@ -96,13 +144,25 @@ query GetHushByID($hushId: ID!) {
     name
     secretName
     integrations {
-      id
+      edges {
+        node {
+          id
+        }
+      }
     }
     organization {
-      id
+      edges {
+        node {
+          id
+        }
+      }
     }
     events {
-      id
+      edges {
+        node {
+          id
+        }
+      }
     }
     createdAt
     updatedAt
@@ -121,13 +181,25 @@ query GetHushes($where: HushWhereInput) {
         name
         secretName
         integrations {
-          id
+          edges {
+            node {
+              id
+            }
+          }
         }
         organization {
-          id
+          edges {
+            node {
+              id
+            }
+          }
         }
         events {
-          id
+          edges {
+            node {
+              id
+            }
+          }
         }
         createdAt
         updatedAt
@@ -147,13 +219,25 @@ mutation UpdateHush($updateHushId: ID!, $input: UpdateHushInput!) {
       name
       secretName
       integrations {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       organization {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       events {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
     }
   }

--- a/internal/graphapi/query/integration.graphql
+++ b/internal/graphapi/query/integration.graphql
@@ -10,10 +10,18 @@ mutation CreateBulkCSVIntegration($input: Upload!) {
         id
       }
       secrets {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       events {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
     }
   }
@@ -31,10 +39,18 @@ mutation CreateBulkIntegration($input: [CreateIntegrationInput!]) {
         id
       }
       secrets {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       events {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
     }
   }
@@ -52,10 +68,18 @@ mutation CreateIntegration($input: CreateIntegrationInput!) {
         id
       }
       secrets {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       events {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
     }
   }
@@ -80,10 +104,18 @@ query GetAllIntegrations {
           id
         }
         secrets {
-          id
+          edges {
+            node {
+              id
+            }
+          }
         }
         events {
-          id
+          edges {
+            node {
+              id
+            }
+          }
         }
         createdAt
         createdBy
@@ -105,10 +137,18 @@ query GetIntegrationByID($integrationId: ID!) {
       id
     }
     secrets {
-      id
+      edges {
+        node {
+          id
+        }
+      }
     }
     events {
-      id
+      edges {
+        node {
+          id
+        }
+      }
     }
     createdAt
     createdBy
@@ -130,10 +170,18 @@ query GetIntegrations($where: IntegrationWhereInput) {
           id
         }
         secrets {
-          id
+          edges {
+            node {
+              id
+            }
+          }
         }
         events {
-          id
+          edges {
+            node {
+              id
+            }
+          }
         }
         createdAt
         createdBy
@@ -156,10 +204,18 @@ mutation UpdateIntegration($updateIntegrationId: ID!, $input: UpdateIntegrationI
         id
       }
       secrets {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       events {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
     }
   }

--- a/internal/graphapi/query/invite.graphql
+++ b/internal/graphapi/query/invite.graphql
@@ -90,11 +90,15 @@ query InvitesByOrgID($where: InviteWhereInput) {
         owner {
           id
           invites {
-            recipient
-            requestorID
-            role
-            sendAttempts
-            status
+            edges {
+              node {
+                recipient
+                requestorID
+                role
+                sendAttempts
+                status
+              }
+            }
           }
         }
       }

--- a/internal/graphapi/query/mappedcontrol.graphql
+++ b/internal/graphapi/query/mappedcontrol.graphql
@@ -8,14 +8,22 @@ mutation CreateBulkCSVMappedControl($input: Upload!) {
       mappingType
       relation
       controls {
-        id
-        refCode
-        description
+        edges {
+          node {
+            id
+            refCode
+            description
+          }
+        }
       }
       subcontrols {
-        id
-        refCode
-        description
+        edges {
+          node {
+            id
+            refCode
+            description
+          }
+        }
       }
       tags
       updatedAt
@@ -34,14 +42,22 @@ mutation CreateBulkMappedControl($input: [CreateMappedControlInput!]) {
       relation
       tags
       controls {
-        id
-        refCode
-        description
+        edges {
+          node {
+            id
+            refCode
+            description
+          }
+        }
       }
       subcontrols {
-        id
-        refCode
-        description
+        edges {
+          node {
+            id
+            refCode
+            description
+          }
+        }
       }
       updatedAt
       updatedBy
@@ -58,14 +74,22 @@ mutation CreateMappedControl($input: CreateMappedControlInput!) {
       mappingType
       relation
       controls {
-        id
-        refCode
-        description
+        edges {
+          node {
+            id
+            refCode
+            description
+          }
+        }
       }
       subcontrols {
-        id
-        refCode
-        description
+        edges {
+          node {
+            id
+            refCode
+            description
+          }
+        }
       }
       tags
       updatedAt
@@ -90,14 +114,22 @@ query GetAllMappedControls {
         mappingType
         relation
         controls {
-          id
-          refCode
-          description
+          edges {
+            node {
+              id
+              refCode
+              description
+            }
+          }
         }
         subcontrols {
-          id
-          refCode
-          description
+          edges {
+            node {
+              id
+              refCode
+              description
+            }
+          }
         }
         tags
         updatedAt
@@ -114,14 +146,22 @@ query GetMappedControlByID($mappedControlId: ID!) {
     mappingType
     relation
     controls {
-      id
-      refCode
-      description
+      edges {
+        node {
+          id
+          refCode
+          description
+        }
+      }
     }
     subcontrols {
-      id
-      refCode
-      description
+      edges {
+        node {
+          id
+          refCode
+          description
+        }
+      }
     }
     tags
     updatedAt
@@ -139,14 +179,22 @@ query GetMappedControls($where: MappedControlWhereInput) {
         mappingType
         relation
         controls {
-          id
-          refCode
-          description
+          edges {
+            node {
+              id
+              refCode
+              description
+            }
+          }
         }
         subcontrols {
-          id
-          refCode
-          description
+          edges {
+            node {
+              id
+              refCode
+              description
+            }
+          }
         }
         tags
         updatedAt
@@ -164,14 +212,22 @@ mutation UpdateMappedControl($updateMappedControlId: ID!, $input: UpdateMappedCo
       mappingType
       relation
       controls {
-        id
-        refCode
-        description
+        edges {
+          node {
+            id
+            refCode
+            description
+          }
+        }
       }
       subcontrols {
-        id
-        refCode
-        description
+        edges {
+          node {
+            id
+            refCode
+            description
+          }
+        }
       }
       tags
       updatedAt

--- a/internal/graphapi/query/narrative.graphql
+++ b/internal/graphapi/query/narrative.graphql
@@ -46,8 +46,12 @@ mutation CreateNarrative($input: CreateNarrativeInput!) {
       updatedAt
       updatedBy
       programs {
-        id
-        name
+        edges {
+          node {
+            id
+            name
+          }
+        }
       }
       editors {
         id
@@ -86,8 +90,12 @@ query GetAllNarratives {
         updatedAt
         updatedBy
         programs {
-          id
-          name
+          edges {
+            node {
+              id
+              name
+            }
+          }
         }
         editors {
           id
@@ -119,8 +127,12 @@ query GetNarrativeByID($narrativeId: ID!) {
     updatedAt
     updatedBy
     programs {
-      id
-      name
+      edges {
+        node {
+          id
+          name
+        }
+      }
     }
     editors {
       id
@@ -152,8 +164,12 @@ query GetNarratives($where: NarrativeWhereInput) {
         updatedAt
         updatedBy
         programs {
-          id
-          name
+          edges {
+            node {
+              id
+              name
+            }
+          }
         }
         editors {
           id
@@ -186,8 +202,12 @@ mutation UpdateNarrative($updateNarrativeId: ID!, $input: UpdateNarrativeInput!)
       updatedAt
       updatedBy
       programs {
-        id
-        name
+        edges {
+          node {
+            id
+            name
+          }
+        }
       }
       editors {
         id

--- a/internal/graphapi/query/personalaccesstoken.graphql
+++ b/internal/graphapi/query/personalaccesstoken.graphql
@@ -18,8 +18,12 @@ mutation CreatePersonalAccessToken($input: CreatePersonalAccessTokenInput!) {
       updatedAt
       updatedBy
       organizations {
-        id
-        name
+        edges {
+          node {
+            id
+            name
+          }
+        }
       }
       owner {
         id
@@ -55,8 +59,12 @@ query GetAllPersonalAccessTokens {
         updatedAt
         updatedBy
         organizations {
-          id
-          name
+          edges {
+            node {
+              id
+              name
+            }
+          }
         }
       }
     }
@@ -82,10 +90,14 @@ query GetPersonalAccessTokenByID($personalAccessTokenId: ID!) {
     updatedAt
     updatedBy
     organizations {
-      id
-      name
+      edges {
+        node {
+          id
+          name
+        }
+      }
     }
-}
+  }
 }
 
 query GetPersonalAccessTokens($where: PersonalAccessTokenWhereInput) {
@@ -109,9 +121,13 @@ query GetPersonalAccessTokens($where: PersonalAccessTokenWhereInput) {
         updatedAt
         updatedBy
         organizations {
-          id
-          name
+          edges {
+            node {
+              id
+              name
+            }
           }
+        }
     }
   }
 }
@@ -137,8 +153,12 @@ mutation UpdatePersonalAccessToken($updatePersonalAccessTokenId: ID!, $input: Up
       updatedAt
       updatedBy
       organizations {
-        id
-        name
+        edges {
+          node {
+            id
+            name
+          }
+        }
       }
       owner {
         id

--- a/internal/graphapi/query/program.graphql
+++ b/internal/graphapi/query/program.graphql
@@ -50,8 +50,12 @@ mutation CreateControlWithSubcontrols($input: CreateControlWithSubcontrolsInput!
       id
       refCode
       subcontrols {
-        id
-        refCode
+        edges {
+          node {
+            id
+            refCode
+          }
+        }
       }
     }
   }
@@ -64,30 +68,54 @@ mutation CreateFullProgram($input: CreateFullProgramInput!) {
       id
       displayID
       members {
-        id
+        edges {
+          node {
+            id
+          }
+        }
       }
       controls {
-        id
-        refCode
-        subcontrols {
-          id
-          refCode
+        edges {
+          node {
+            id
+            refCode
+            subcontrols {
+              edges {
+                node {
+                  id
+                  refCode
+                }
+              }
+            }
+          }
         }
       }
       risks {
-        id
-        displayID
-        name
+        edges {
+          node {
+            id
+            displayID
+            name
+          }
+        }
       }
       internalPolicies {
-        id
-        displayID
-        name
+        edges {
+          node {
+            id
+            displayID
+            name
+          }
+        }
       }
       procedures {
-        id
-        displayID
-        name
+        edges {
+          node {
+            id
+            displayID
+            name
+          }
+        }
       }
     }
   }
@@ -113,32 +141,40 @@ mutation CreateProgram($input: CreateProgramInput!) {
       updatedAt
       updatedBy
       procedures {
-        createdAt
-        createdBy
-        details
-        id
-        displayID
-        name
-        procedureType
-        status
-        tags
-        updatedAt
-        updatedBy
-        revision
+        edges {
+          node {
+            createdAt
+            createdBy
+            details
+            id
+            displayID
+            name
+            procedureType
+            status
+            tags
+            updatedAt
+            updatedBy
+            revision
+          }
+        }
       }
       internalPolicies {
-        createdAt
-        createdBy
-        details
-        id
-        displayID
-        name
-        policyType
-        status
-        tags
-        updatedAt
-        updatedBy
-        revision
+        edges {
+          node {
+            createdAt
+            createdBy
+            details
+            id
+            displayID
+            name
+            policyType
+            status
+            tags
+            updatedAt
+            updatedBy
+            revision
+          }
+        }
       }
       editors {
         id
@@ -163,11 +199,15 @@ mutation CreateProgramWithMembers($input: CreateProgramWithMembersInput!) {
       id
       displayID
       members {
-        id
-        user {
-          id
-          firstName
-          lastName
+        edges {
+          node {
+            id
+            user {
+              id
+              firstName
+              lastName
+            }
+          }
         }
       }
     }
@@ -201,32 +241,40 @@ query GetAllPrograms {
         updatedAt
         updatedBy
         procedures {
-          createdAt
-          createdBy
-          details
-          id
-          displayID
-          name
-          procedureType
-          status
-          tags
-          updatedAt
-          updatedBy
-          revision
+          edges {
+            node {
+              createdAt
+              createdBy
+              details
+              id
+              displayID
+              name
+              procedureType
+              status
+              tags
+              updatedAt
+              updatedBy
+              revision
+            }
+          }
         }
         internalPolicies {
-          createdAt
-          createdBy
-          details
-          id
-          displayID
-          name
-          policyType
-          status
-          tags
-          updatedAt
-          updatedBy
-          revision
+          edges {
+            node {
+              createdAt
+              createdBy
+              details
+              id
+              displayID
+              name
+              policyType
+              status
+              tags
+              updatedAt
+              updatedBy
+              revision
+            }
+          }
         }
         editors {
           id
@@ -241,11 +289,15 @@ query GetAllPrograms {
           name
         }
         members {
-          id
-          user {
-            id
-            firstName
-            lastName
+          edges {
+            node {
+              id
+              user {
+                id
+                firstName
+                lastName
+              }
+            }
           }
         }
       }
@@ -272,32 +324,40 @@ query GetProgramByID($programId: ID!) {
     updatedAt
     updatedBy
     procedures {
-      createdAt
-      createdBy
-      details
-      id
-      displayID
-      name
-      procedureType
-      status
-      tags
-      updatedAt
-      updatedBy
-      revision
+      edges {
+        node {
+          createdAt
+          createdBy
+          details
+          id
+          displayID
+          name
+          procedureType
+          status
+          tags
+          updatedAt
+          updatedBy
+          revision
+        }
+      }
     }
     internalPolicies {
-      createdAt
-      createdBy
-      details
-      id
-      displayID
-      name
-      policyType
-      status
-      tags
-      updatedAt
-      updatedBy
-      revision
+      edges {
+        node {
+          createdAt
+          createdBy
+          details
+          id
+          displayID
+          name
+          policyType
+          status
+          tags
+          updatedAt
+          updatedBy
+          revision
+        }
+      }
     }
     editors {
       id
@@ -312,11 +372,15 @@ query GetProgramByID($programId: ID!) {
       name
     }
     members {
-      id
-      user {
-        id
-        firstName
-        lastName
+      edges {
+        node {
+          id
+          user {
+            id
+            firstName
+            lastName
+          }
+        }
       }
     }
   }
@@ -343,32 +407,40 @@ query GetPrograms($where: ProgramWhereInput) {
         updatedAt
         updatedBy
         procedures {
-          createdAt
-          createdBy
-          details
-          id
-          displayID
-          name
-          procedureType
-          status
-          tags
-          updatedAt
-          updatedBy
-          revision
+          edges {
+            node {
+              createdAt
+              createdBy
+              details
+              id
+              displayID
+              name
+              procedureType
+              status
+              tags
+              updatedAt
+              updatedBy
+              revision
+            }
+          }
         }
         internalPolicies {
-          createdAt
-          createdBy
-          details
-          id
-          displayID
-          name
-          policyType
-          status
-          tags
-          updatedAt
-          updatedBy
-          revision
+          edges {
+            node {
+              createdAt
+              createdBy
+              details
+              id
+              displayID
+              name
+              policyType
+              status
+              tags
+              updatedAt
+              updatedBy
+              revision
+            }
+          }
         }
         editors {
           id
@@ -383,11 +455,15 @@ query GetPrograms($where: ProgramWhereInput) {
           name
         }
         members {
-          id
-          user {
-            id
-            firstName
-            lastName
+          edges {
+            node {
+              id
+              user {
+                id
+                firstName
+                lastName
+              }
+            }
           }
         }
       }
@@ -414,30 +490,40 @@ mutation UpdateProgram($updateProgramId: ID!, $input: UpdateProgramInput!) {
       updatedAt
       updatedBy
       procedures {
-        createdAt
-        createdBy
-        details
-        id
-        name
-        procedureType
-        status
-        tags
-        updatedAt
-        updatedBy
-        revision
+        edges {
+          node {
+            createdAt
+            createdBy
+            details
+            id
+            displayID
+            name
+            procedureType
+            status
+            tags
+            updatedAt
+            updatedBy
+            revision
+          }
+        }
       }
       internalPolicies {
-        createdAt
-        createdBy
-        details
-        id
-        name
-        policyType
-        status
-        tags
-        updatedAt
-        updatedBy
-        revision
+        edges {
+          node {
+            createdAt
+            createdBy
+            details
+            id
+            displayID
+            name
+            policyType
+            status
+            tags
+            updatedAt
+            updatedBy
+            revision
+          }
+        }
       }
       editors {
         id
@@ -452,11 +538,15 @@ mutation UpdateProgram($updateProgramId: ID!, $input: UpdateProgramInput!) {
         name
       }
       members {
-        id
-        user {
-          id
-          firstName
-          lastName
+        edges {
+          node {
+            id
+            user {
+              id
+              firstName
+              lastName
+            }
+          }
         }
       }
     }

--- a/internal/graphapi/query/risk.graphql
+++ b/internal/graphapi/query/risk.graphql
@@ -64,8 +64,12 @@ mutation CreateRisk($input: CreateRiskInput!) {
       updatedAt
       updatedBy
       programs {
-        id
-        name
+        edges {
+          node {
+            id
+            name
+          }
+        }
       }
       editors {
         id
@@ -111,8 +115,12 @@ query GetAllRisks {
         updatedAt
         updatedBy
         programs {
-          id
-          name
+          edges {
+            node {
+              id
+              name
+            }
+          }
         }
         editors {
           id
@@ -151,8 +159,12 @@ query GetRiskByID($riskId: ID!) {
     updatedAt
     updatedBy
     programs {
-      id
-      name
+      edges {
+        node {
+          id
+          name
+        }
+      }
     }
     editors {
       id
@@ -191,8 +203,12 @@ query GetRisks($where: RiskWhereInput) {
         updatedAt
         updatedBy
         programs {
-          id
-          name
+          edges {
+            node {
+              id
+              name
+            }
+          }
         }
         editors {
           id
@@ -232,8 +248,12 @@ mutation UpdateRisk($updateRiskId: ID!, $input: UpdateRiskInput!) {
       updatedAt
       updatedBy
       programs {
-        id
-        name
+        edges {
+          node {
+            id
+            name
+          }
+        }
       }
       editors {
         id

--- a/internal/graphapi/query/search.graphql
+++ b/internal/graphapi/query/search.graphql
@@ -17,6 +17,7 @@ query GlobalSearch($query: String!) {
       }
       ... on ContactSearchResult {
         contacts {
+          email
           fullName
           id
           tags
@@ -81,6 +82,7 @@ query GlobalSearch($query: String!) {
         evidences {
           displayID
           id
+          name
           tags
         }
       }
@@ -183,6 +185,9 @@ query GlobalSearch($query: String!) {
       }
       ... on StandardSearchResult {
         standards {
+          domains
+          framework
+          governingBody
           id
           name
           shortName

--- a/internal/graphapi/query/task.graphql
+++ b/internal/graphapi/query/task.graphql
@@ -18,13 +18,17 @@ mutation CreateBulkCSVTask($input: Upload!) {
       details
       category
       comments {
-        id
-        displayID
-        text
-        createdAt
-        createdBy
-        updatedAt
-        updatedBy
+        edges {
+          node {
+            id
+            displayID
+            text
+            createdAt
+            createdBy
+            updatedAt
+            updatedBy
+          }
+        }
       }
       due
       id
@@ -58,13 +62,17 @@ mutation CreateBulkTask($input: [CreateTaskInput!]) {
       details
       category
       comments {
-        id
-        displayID
-        text
-        createdAt
-        createdBy
-        updatedAt
-        updatedBy
+        edges {
+          node {
+            id
+            displayID
+            text
+            createdAt
+            createdBy
+            updatedAt
+            updatedBy
+          }
+        }
       }
       due
       id
@@ -98,13 +106,17 @@ mutation CreateTask($input: CreateTaskInput!) {
       details
       category
       comments {
-        id
-        displayID
-        text
-        createdAt
-        createdBy
-        updatedAt
-        updatedBy
+        edges {
+          node {
+            id
+            displayID
+            text
+            createdAt
+            createdBy
+            updatedAt
+            updatedBy
+          }
+        }
       }
       due
       id
@@ -150,13 +162,17 @@ query GetAllTasks {
         details
         category
         comments {
-          id
-          displayID
-          text
-          createdAt
-          createdBy
-          updatedAt
-          updatedBy
+          edges {
+            node {
+              id
+              displayID
+              text
+              createdAt
+              createdBy
+              updatedAt
+              updatedBy
+            }
+          }
         }
         due
         id
@@ -194,13 +210,17 @@ query GetTaskByID($taskId: ID!) {
     details
     category
     comments {
-      id
-      displayID
-      text
-      createdAt
-      createdBy
-      updatedAt
-      updatedBy
+      edges {
+        node {
+          id
+          displayID
+          text
+          createdAt
+          createdBy
+          updatedAt
+          updatedBy
+        }
+      }
     }
     due
     id
@@ -234,13 +254,17 @@ query GetTasks($where: TaskWhereInput) {
         details
         category
         comments {
-          id
-          displayID
-          text
-          createdAt
-          createdBy
-          updatedAt
-          updatedBy
+          edges {
+            node {
+              id
+              displayID
+              text
+              createdAt
+              createdBy
+              updatedAt
+              updatedBy
+            }
+          }
         }
         due
         id
@@ -275,13 +299,17 @@ mutation UpdateTask($updateTaskId: ID!, $input: UpdateTaskInput!) {
       details
       category
       comments {
-        id
-        displayID
-        text
-        createdAt
-        createdBy
-        updatedAt
-        updatedBy
+        edges {
+          node {
+            id
+            displayID
+            text
+            createdAt
+            createdBy
+            updatedAt
+            updatedBy
+          }
+        }
       }
       due
       id
@@ -315,13 +343,17 @@ mutation UpdateTaskComment($updateTaskCommentId: ID!, $input: UpdateNoteInput!) 
       details
       category
       comments {
-        id
-        displayID
-        text
-        createdAt
-        createdBy
-        updatedAt
-        updatedBy
+        edges {
+          node {
+            id
+            displayID
+            text
+            createdAt
+            createdBy
+            updatedAt
+            updatedBy
+          }
+        }
       }
       due
       id

--- a/internal/graphapi/query/user.graphql
+++ b/internal/graphapi/query/user.graphql
@@ -113,8 +113,12 @@ query GetSelf {
       updatedBy
     }
     tfaSettings {
-      totpAllowed
-      verified
+      edges {
+        node {
+          totpAllowed
+          verified
+        }
+      }
     }
     createdAt
     createdBy

--- a/internal/graphapi/risk_test.go
+++ b/internal/graphapi/risk_test.go
@@ -102,7 +102,7 @@ func (suite *GraphTestSuite) TestQueryRisk() {
 			assert.NotEmpty(t, resp.Risk.Name)
 
 			require.Len(t, resp.Risk.Programs, 1)
-			assert.NotEmpty(t, resp.Risk.Programs[0].ID)
+			assert.NotEmpty(t, resp.Risk.Programs.Edges[0].Node.ID)
 		})
 	}
 }
@@ -333,8 +333,8 @@ func (suite *GraphTestSuite) TestMutationCreateRisk() {
 				require.NotEmpty(t, resp.CreateRisk.Risk.Programs)
 				require.Len(t, resp.CreateRisk.Risk.Programs, len(tc.request.ProgramIDs))
 
-				for i, p := range resp.CreateRisk.Risk.Programs {
-					assert.Equal(t, tc.request.ProgramIDs[i], p.ID)
+				for i, p := range resp.CreateRisk.Risk.Programs.Edges {
+					assert.Equal(t, tc.request.ProgramIDs[i], p.Node.ID)
 				}
 			} else {
 				assert.Empty(t, resp.CreateRisk.Risk.Programs)

--- a/internal/graphapi/risk_test.go
+++ b/internal/graphapi/risk_test.go
@@ -101,7 +101,7 @@ func (suite *GraphTestSuite) TestQueryRisk() {
 			assert.Equal(t, tc.queryID, resp.Risk.ID)
 			assert.NotEmpty(t, resp.Risk.Name)
 
-			require.Len(t, resp.Risk.Programs, 1)
+			require.Len(t, resp.Risk.Programs.Edges, 1)
 			assert.NotEmpty(t, resp.Risk.Programs.Edges[0].Node.ID)
 		})
 	}
@@ -330,14 +330,14 @@ func (suite *GraphTestSuite) TestMutationCreateRisk() {
 
 			// ensure the program is set
 			if len(tc.request.ProgramIDs) > 0 {
-				require.NotEmpty(t, resp.CreateRisk.Risk.Programs)
-				require.Len(t, resp.CreateRisk.Risk.Programs, len(tc.request.ProgramIDs))
+				require.NotEmpty(t, resp.CreateRisk.Risk.Programs.Edges)
+				require.Len(t, resp.CreateRisk.Risk.Programs.Edges, len(tc.request.ProgramIDs))
 
 				for i, p := range resp.CreateRisk.Risk.Programs.Edges {
 					assert.Equal(t, tc.request.ProgramIDs[i], p.Node.ID)
 				}
 			} else {
-				assert.Empty(t, resp.CreateRisk.Risk.Programs)
+				assert.Empty(t, resp.CreateRisk.Risk.Programs.Edges)
 			}
 
 			if tc.request.Status != nil {

--- a/internal/graphapi/schema/ent.graphql
+++ b/internal/graphapi/schema/ent.graphql
@@ -384,10 +384,130 @@ type ActionPlan implements Node {
   """
   delegate: Group
   owner: Organization
-  risk: [Risk!]
-  control: [Control!]
-  user: [User!]
-  program: [Program!]
+  risk(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Risks returned from the connection.
+    """
+    orderBy: [RiskOrder!]
+
+    """
+    Filtering options for Risks returned from the connection.
+    """
+    where: RiskWhereInput
+  ): RiskConnection!
+  control(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
+    Filtering options for Controls returned from the connection.
+    """
+    where: ControlWhereInput
+  ): ControlConnection!
+  user(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Users returned from the connection.
+    """
+    orderBy: [UserOrder!]
+
+    """
+    Filtering options for Users returned from the connection.
+    """
+    where: UserWhereInput
+  ): UserConnection!
+  program(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Programs returned from the connection.
+    """
+    orderBy: [ProgramOrder!]
+
+    """
+    Filtering options for Programs returned from the connection.
+    """
+    where: ProgramWhereInput
+  ): ProgramConnection!
 }
 """
 A connection to a list of items.
@@ -558,6 +678,27 @@ enum ActionPlanHistoryOpType @goModel(model: "github.com/theopenlane/entx/histor
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for ActionPlanHistory connections
+"""
+input ActionPlanHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order ActionPlanHistories.
+  """
+  field: ActionPlanHistoryOrderField!
+}
+"""
+Properties by which ActionPlanHistory connections can be ordered.
+"""
+enum ActionPlanHistoryOrderField {
+  due_date
+  PRIORITY
+  source
 }
 """
 ActionPlanHistoryPriority is enum for the field priority
@@ -884,6 +1025,27 @@ input ActionPlanHistoryWhereInput {
   sourceNotNil: Boolean
   sourceEqualFold: String
   sourceContainsFold: String
+}
+"""
+Ordering options for ActionPlan connections
+"""
+input ActionPlanOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order ActionPlans.
+  """
+  field: ActionPlanOrderField!
+}
+"""
+Properties by which ActionPlan connections can be ordered.
+"""
+enum ActionPlanOrderField {
+  due_date
+  PRIORITY
+  source
 }
 """
 ActionPlanPriority is enum for the field priority
@@ -1255,8 +1417,63 @@ type Contact implements Node {
   """
   status: ContactUserStatus!
   owner: Organization
-  entities: [Entity!]
-  files: [File!]
+  entities(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Entities returned from the connection.
+    """
+    orderBy: [EntityOrder!]
+
+    """
+    Filtering options for Entities returned from the connection.
+    """
+    where: EntityWhereInput
+  ): EntityConnection!
+  files(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Files returned from the connection.
+    """
+    where: FileWhereInput
+  ): FileConnection!
 }
 """
 A connection to a list of items.
@@ -1373,6 +1590,29 @@ enum ContactHistoryOpType @goModel(model: "github.com/theopenlane/entx/history.O
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for ContactHistory connections
+"""
+input ContactHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order ContactHistories.
+  """
+  field: ContactHistoryOrderField!
+}
+"""
+Properties by which ContactHistory connections can be ordered.
+"""
+enum ContactHistoryOrderField {
+  full_name
+  title
+  company
+  email
+  STATUS
 }
 """
 ContactHistoryUserStatus is enum for the field status
@@ -1665,6 +1905,29 @@ input ContactHistoryWhereInput {
   statusNEQ: ContactHistoryUserStatus
   statusIn: [ContactHistoryUserStatus!]
   statusNotIn: [ContactHistoryUserStatus!]
+}
+"""
+Ordering options for Contact connections
+"""
+input ContactOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order Contacts.
+  """
+  field: ContactOrderField!
+}
+"""
+Properties by which Contact connections can be ordered.
+"""
+enum ContactOrderField {
+  full_name
+  title
+  company
+  email
+  STATUS
 }
 """
 ContactUserStatus is enum for the field status
@@ -2035,24 +2298,338 @@ type Control implements Node {
   """
   viewers: [Group!]
   standard: Standard
-  programs: [Program!]
-  evidence: [Evidence!]
-  """
-  the implementation(s) of the control
-  """
-  controlImplementations: [ControlImplementation!]
-  """
-  mapped subcontrols that have a relation to another control or subcontrol
-  """
-  mappedControls: [MappedControl!]
+  programs(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Programs returned from the connection.
+    """
+    orderBy: [ProgramOrder!]
+
+    """
+    Filtering options for Programs returned from the connection.
+    """
+    where: ProgramWhereInput
+  ): ProgramConnection!
+  evidence(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Evidences returned from the connection.
+    """
+    orderBy: [EvidenceOrder!]
+
+    """
+    Filtering options for Evidences returned from the connection.
+    """
+    where: EvidenceWhereInput
+  ): EvidenceConnection!
+  controlImplementations(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for ControlImplementations returned from the connection.
+    """
+    orderBy: [ControlImplementationOrder!]
+
+    """
+    Filtering options for ControlImplementations returned from the connection.
+    """
+    where: ControlImplementationWhereInput
+  ): ControlImplementationConnection!
+  mappedControls(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for MappedControls returned from the connection.
+    """
+    orderBy: MappedControlOrder
+
+    """
+    Filtering options for MappedControls returned from the connection.
+    """
+    where: MappedControlWhereInput
+  ): MappedControlConnection!
   controlObjectives: [ControlObjective!]
-  subcontrols: [Subcontrol!]
-  tasks: [Task!]
-  narratives: [Narrative!]
-  risks: [Risk!]
-  actionPlans: [ActionPlan!]
-  procedures: [Procedure!]
-  internalPolicies: [InternalPolicy!]
+  subcontrols(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Subcontrols returned from the connection.
+    """
+    orderBy: [SubcontrolOrder!]
+
+    """
+    Filtering options for Subcontrols returned from the connection.
+    """
+    where: SubcontrolWhereInput
+  ): SubcontrolConnection!
+  tasks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Tasks returned from the connection.
+    """
+    orderBy: [TaskOrder!]
+
+    """
+    Filtering options for Tasks returned from the connection.
+    """
+    where: TaskWhereInput
+  ): TaskConnection!
+  narratives(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Narratives returned from the connection.
+    """
+    orderBy: NarrativeOrder
+
+    """
+    Filtering options for Narratives returned from the connection.
+    """
+    where: NarrativeWhereInput
+  ): NarrativeConnection!
+  risks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Risks returned from the connection.
+    """
+    orderBy: [RiskOrder!]
+
+    """
+    Filtering options for Risks returned from the connection.
+    """
+    where: RiskWhereInput
+  ): RiskConnection!
+  actionPlans(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for ActionPlans returned from the connection.
+    """
+    orderBy: [ActionPlanOrder!]
+
+    """
+    Filtering options for ActionPlans returned from the connection.
+    """
+    where: ActionPlanWhereInput
+  ): ActionPlanConnection!
+  procedures(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Procedures returned from the connection.
+    """
+    where: ProcedureWhereInput
+  ): ProcedureConnection!
+  internalPolicies(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for InternalPolicies returned from the connection.
+    """
+    where: InternalPolicyWhereInput
+  ): InternalPolicyConnection!
   """
   the group of users who are responsible for the control, will be assigned tasks, approval, etc.
   """
@@ -2253,6 +2830,29 @@ enum ControlHistoryOpType @goModel(model: "github.com/theopenlane/entx/history.O
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for ControlHistory connections
+"""
+input ControlHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order ControlHistories.
+  """
+  field: ControlHistoryOrderField!
+}
+"""
+Properties by which ControlHistory connections can be ordered.
+"""
+enum ControlHistoryOrderField {
+  status
+  SOURCE
+  CONTROL_TYPE
+  category
+  subcategory
 }
 """
 ControlHistoryWhereInput is used for filtering ControlHistory objects.
@@ -2613,7 +3213,37 @@ type ControlImplementation implements Node {
   details of the control implementation
   """
   details: String
-  controls: [Control!]
+  controls(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
+    Filtering options for Controls returned from the connection.
+    """
+    where: ControlWhereInput
+  ): ControlConnection!
 }
 """
 A connection to a list of items.
@@ -2738,6 +3368,28 @@ enum ControlImplementationHistoryOpType @goModel(model: "github.com/theopenlane/
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for ControlImplementationHistory connections
+"""
+input ControlImplementationHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order ControlImplementationHistories.
+  """
+  field: ControlImplementationHistoryOrderField!
+}
+"""
+Properties by which ControlImplementationHistory connections can be ordered.
+"""
+enum ControlImplementationHistoryOrderField {
+  STATUS
+  implementation_date
+  verified
+  verification_date
 }
 """
 ControlImplementationHistoryWhereInput is used for filtering ControlImplementationHistory objects.
@@ -2949,6 +3601,28 @@ input ControlImplementationHistoryWhereInput {
   detailsNotNil: Boolean
   detailsEqualFold: String
   detailsContainsFold: String
+}
+"""
+Ordering options for ControlImplementation connections
+"""
+input ControlImplementationOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order ControlImplementations.
+  """
+  field: ControlImplementationOrderField!
+}
+"""
+Properties by which ControlImplementation connections can be ordered.
+"""
+enum ControlImplementationOrderField {
+  STATUS
+  implementation_date
+  verified
+  verification_date
 }
 """
 ControlImplementationWhereInput is used for filtering ControlImplementation objects.
@@ -3195,15 +3869,275 @@ type ControlObjective implements Node {
   provides view access to the risk to members of the group
   """
   viewers: [Group!]
-  programs: [Program!]
-  evidence: [Evidence!]
-  controls: [Control!]
-  subcontrols: [Subcontrol!]
-  internalPolicies: [InternalPolicy!]
-  procedures: [Procedure!]
-  risks: [Risk!]
-  narratives: [Narrative!]
-  tasks: [Task!]
+  programs(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Programs returned from the connection.
+    """
+    orderBy: [ProgramOrder!]
+
+    """
+    Filtering options for Programs returned from the connection.
+    """
+    where: ProgramWhereInput
+  ): ProgramConnection!
+  evidence(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Evidences returned from the connection.
+    """
+    orderBy: [EvidenceOrder!]
+
+    """
+    Filtering options for Evidences returned from the connection.
+    """
+    where: EvidenceWhereInput
+  ): EvidenceConnection!
+  controls(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
+    Filtering options for Controls returned from the connection.
+    """
+    where: ControlWhereInput
+  ): ControlConnection!
+  subcontrols(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Subcontrols returned from the connection.
+    """
+    orderBy: [SubcontrolOrder!]
+
+    """
+    Filtering options for Subcontrols returned from the connection.
+    """
+    where: SubcontrolWhereInput
+  ): SubcontrolConnection!
+  internalPolicies(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for InternalPolicies returned from the connection.
+    """
+    where: InternalPolicyWhereInput
+  ): InternalPolicyConnection!
+  procedures(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Procedures returned from the connection.
+    """
+    where: ProcedureWhereInput
+  ): ProcedureConnection!
+  risks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Risks returned from the connection.
+    """
+    orderBy: [RiskOrder!]
+
+    """
+    Filtering options for Risks returned from the connection.
+    """
+    where: RiskWhereInput
+  ): RiskConnection!
+  narratives(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Narratives returned from the connection.
+    """
+    orderBy: NarrativeOrder
+
+    """
+    Filtering options for Narratives returned from the connection.
+    """
+    where: NarrativeWhereInput
+  ): NarrativeConnection!
+  tasks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Tasks returned from the connection.
+    """
+    orderBy: [TaskOrder!]
+
+    """
+    Filtering options for Tasks returned from the connection.
+    """
+    where: TaskWhereInput
+  ): TaskConnection!
 }
 """
 A connection to a list of items.
@@ -3346,6 +4280,30 @@ enum ControlObjectiveHistoryOpType @goModel(model: "github.com/theopenlane/entx/
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for ControlObjectiveHistory connections
+"""
+input ControlObjectiveHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order ControlObjectiveHistories.
+  """
+  field: ControlObjectiveHistoryOrderField!
+}
+"""
+Properties by which ControlObjectiveHistory connections can be ordered.
+"""
+enum ControlObjectiveHistoryOrderField {
+  name
+  status
+  SOURCE
+  control_objective_type
+  category
+  subcategory
 }
 """
 ControlObjectiveHistoryWhereInput is used for filtering ControlObjectiveHistory objects.
@@ -3664,6 +4622,30 @@ input ControlObjectiveHistoryWhereInput {
   subcategoryNotNil: Boolean
   subcategoryEqualFold: String
   subcategoryContainsFold: String
+}
+"""
+Ordering options for ControlObjective connections
+"""
+input ControlObjectiveOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order ControlObjectives.
+  """
+  field: ControlObjectiveOrderField!
+}
+"""
+Properties by which ControlObjective connections can be ordered.
+"""
+enum ControlObjectiveOrderField {
+  name
+  status
+  SOURCE
+  control_objective_type
+  category
+  subcategory
 }
 """
 ControlObjectiveWhereInput is used for filtering ControlObjective objects.
@@ -4011,6 +4993,29 @@ input ControlObjectiveWhereInput {
   """
   hasTasks: Boolean
   hasTasksWith: [TaskWhereInput!]
+}
+"""
+Ordering options for Control connections
+"""
+input ControlOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order Controls.
+  """
+  field: ControlOrderField!
+}
+"""
+Properties by which Control connections can be ordered.
+"""
+enum ControlOrderField {
+  status
+  SOURCE
+  CONTROL_TYPE
+  category
+  subcategory
 }
 """
 ControlWhereInput is used for filtering Control objects.
@@ -6003,8 +7008,63 @@ type DocumentData implements Node {
   data: Map!
   owner: Organization
   template: Template!
-  entity: [Entity!]
-  files: [File!]
+  entity(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Entities returned from the connection.
+    """
+    orderBy: [EntityOrder!]
+
+    """
+    Filtering options for Entities returned from the connection.
+    """
+    where: EntityWhereInput
+  ): EntityConnection!
+  files(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Files returned from the connection.
+    """
+    where: FileWhereInput
+  ): FileConnection!
 }
 """
 A connection to a list of items.
@@ -6497,10 +7557,115 @@ type Entity implements Node {
   """
   status: String
   owner: Organization
-  contacts: [Contact!]
-  documents: [DocumentData!]
-  notes: [Note!]
-  files: [File!]
+  contacts(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Contacts returned from the connection.
+    """
+    orderBy: [ContactOrder!]
+
+    """
+    Filtering options for Contacts returned from the connection.
+    """
+    where: ContactWhereInput
+  ): ContactConnection!
+  documents(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for DocumentDataSlice returned from the connection.
+    """
+    where: DocumentDataWhereInput
+  ): DocumentDataConnection!
+  notes(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Notes returned from the connection.
+    """
+    where: NoteWhereInput
+  ): NoteConnection!
+  files(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Files returned from the connection.
+    """
+    where: FileWhereInput
+  ): FileConnection!
   entityType: EntityType
 }
 """
@@ -6634,6 +7799,7 @@ Properties by which EntityHistory connections can be ordered.
 enum EntityHistoryOrderField {
   name
   display_name
+  status
 }
 """
 EntityHistoryWhereInput is used for filtering EntityHistory objects.
@@ -6895,6 +8061,7 @@ Properties by which Entity connections can be ordered.
 enum EntityOrderField {
   name
   display_name
+  status
 }
 type EntityType implements Node {
   id: ID!
@@ -6917,7 +8084,37 @@ type EntityType implements Node {
   """
   name: String!
   owner: Organization
-  entities: [Entity!]
+  entities(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Entities returned from the connection.
+    """
+    orderBy: [EntityOrder!]
+
+    """
+    Filtering options for Entities returned from the connection.
+    """
+    where: EntityWhereInput
+  ): EntityConnection!
 }
 """
 A connection to a list of items.
@@ -7642,18 +8839,368 @@ type Event implements Node {
   correlationID: String
   eventType: String!
   metadata: Map
-  user: [User!]
-  group: [Group!]
-  integration: [Integration!]
-  organization: [Organization!]
-  invite: [Invite!]
-  personalAccessToken: [PersonalAccessToken!]
-  hush: [Hush!]
-  orgmembership: [OrgMembership!]
-  groupmembership: [GroupMembership!]
-  subscriber: [Subscriber!]
-  file: [File!]
-  orgsubscription: [OrgSubscription!]
+  user(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Users returned from the connection.
+    """
+    orderBy: [UserOrder!]
+
+    """
+    Filtering options for Users returned from the connection.
+    """
+    where: UserWhereInput
+  ): UserConnection!
+  group(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Groups returned from the connection.
+    """
+    orderBy: [GroupOrder!]
+
+    """
+    Filtering options for Groups returned from the connection.
+    """
+    where: GroupWhereInput
+  ): GroupConnection!
+  integration(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Integrations returned from the connection.
+    """
+    orderBy: [IntegrationOrder!]
+
+    """
+    Filtering options for Integrations returned from the connection.
+    """
+    where: IntegrationWhereInput
+  ): IntegrationConnection!
+  organization(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Organizations returned from the connection.
+    """
+    orderBy: [OrganizationOrder!]
+
+    """
+    Filtering options for Organizations returned from the connection.
+    """
+    where: OrganizationWhereInput
+  ): OrganizationConnection!
+  invite(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Invites returned from the connection.
+    """
+    orderBy: [InviteOrder!]
+
+    """
+    Filtering options for Invites returned from the connection.
+    """
+    where: InviteWhereInput
+  ): InviteConnection!
+  personalAccessToken(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for PersonalAccessTokens returned from the connection.
+    """
+    where: PersonalAccessTokenWhereInput
+  ): PersonalAccessTokenConnection!
+  hush(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Hushes returned from the connection.
+    """
+    orderBy: [HushOrder!]
+
+    """
+    Filtering options for Hushes returned from the connection.
+    """
+    where: HushWhereInput
+  ): HushConnection!
+  orgmembership(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for OrgMemberships returned from the connection.
+    """
+    orderBy: OrgMembershipOrder
+
+    """
+    Filtering options for OrgMemberships returned from the connection.
+    """
+    where: OrgMembershipWhereInput
+  ): OrgMembershipConnection!
+  groupmembership(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for GroupMemberships returned from the connection.
+    """
+    orderBy: GroupMembershipOrder
+
+    """
+    Filtering options for GroupMemberships returned from the connection.
+    """
+    where: GroupMembershipWhereInput
+  ): GroupMembershipConnection!
+  subscriber(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Subscribers returned from the connection.
+    """
+    orderBy: [SubscriberOrder!]
+
+    """
+    Filtering options for Subscribers returned from the connection.
+    """
+    where: SubscriberWhereInput
+  ): SubscriberConnection!
+  file(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Files returned from the connection.
+    """
+    where: FileWhereInput
+  ): FileConnection!
+  orgsubscription(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for OrgSubscriptions returned from the connection.
+    """
+    orderBy: OrgSubscriptionOrder
+
+    """
+    Filtering options for OrgSubscriptions returned from the connection.
+    """
+    where: OrgSubscriptionWhereInput
+  ): OrgSubscriptionConnection!
 }
 """
 A connection to a list of items.
@@ -8166,12 +9713,187 @@ type Evidence implements Node {
   """
   status: EvidenceEvidenceStatus
   owner: Organization
-  controlObjectives: [ControlObjective!]
-  controls: [Control!]
-  subcontrols: [Subcontrol!]
-  files: [File!]
-  programs: [Program!]
-  tasks: [Task!]
+  controlObjectives(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for ControlObjectives returned from the connection.
+    """
+    orderBy: [ControlObjectiveOrder!]
+
+    """
+    Filtering options for ControlObjectives returned from the connection.
+    """
+    where: ControlObjectiveWhereInput
+  ): ControlObjectiveConnection!
+  controls(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
+    Filtering options for Controls returned from the connection.
+    """
+    where: ControlWhereInput
+  ): ControlConnection!
+  subcontrols(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Subcontrols returned from the connection.
+    """
+    orderBy: [SubcontrolOrder!]
+
+    """
+    Filtering options for Subcontrols returned from the connection.
+    """
+    where: SubcontrolWhereInput
+  ): SubcontrolConnection!
+  files(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Files returned from the connection.
+    """
+    where: FileWhereInput
+  ): FileConnection!
+  programs(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Programs returned from the connection.
+    """
+    orderBy: [ProgramOrder!]
+
+    """
+    Filtering options for Programs returned from the connection.
+    """
+    where: ProgramWhereInput
+  ): ProgramConnection!
+  tasks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Tasks returned from the connection.
+    """
+    orderBy: [TaskOrder!]
+
+    """
+    Filtering options for Tasks returned from the connection.
+    """
+    where: TaskWhereInput
+  ): TaskConnection!
 }
 """
 A connection to a list of items.
@@ -8320,6 +10042,28 @@ enum EvidenceHistoryOpType @goModel(model: "github.com/theopenlane/entx/history.
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for EvidenceHistory connections
+"""
+input EvidenceHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order EvidenceHistories.
+  """
+  field: EvidenceHistoryOrderField!
+}
+"""
+Properties by which EvidenceHistory connections can be ordered.
+"""
+enum EvidenceHistoryOrderField {
+  name
+  creation_date
+  renewal_date
+  STATUS
 }
 """
 EvidenceHistoryWhereInput is used for filtering EvidenceHistory objects.
@@ -8633,6 +10377,28 @@ input EvidenceHistoryWhereInput {
   statusNotIn: [EvidenceHistoryEvidenceStatus!]
   statusIsNil: Boolean
   statusNotNil: Boolean
+}
+"""
+Ordering options for Evidence connections
+"""
+input EvidenceOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order Evidences.
+  """
+  field: EvidenceOrderField!
+}
+"""
+Properties by which Evidence connections can be ordered.
+"""
+enum EvidenceOrderField {
+  name
+  creation_date
+  renewal_date
+  STATUS
 }
 """
 EvidenceWhereInput is used for filtering Evidence objects.
@@ -9007,18 +10773,358 @@ type File implements Node {
   the storage path is the second-level directory of the file path, typically the correlating logical object ID the file is associated with; files can be stand alone objects and not always correlated to a logical one, so this path of the tree may be empty
   """
   storagePath: String
-  user: [User!]
-  organization: [Organization!]
-  group: [Group!]
-  contact: [Contact!]
-  entity: [Entity!]
-  userSetting: [UserSetting!]
-  organizationSetting: [OrganizationSetting!]
-  template: [Template!]
-  documentData: [DocumentData!]
-  events: [Event!]
-  program: [Program!]
-  evidence: [Evidence!]
+  user(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Users returned from the connection.
+    """
+    orderBy: [UserOrder!]
+
+    """
+    Filtering options for Users returned from the connection.
+    """
+    where: UserWhereInput
+  ): UserConnection!
+  organization(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Organizations returned from the connection.
+    """
+    orderBy: [OrganizationOrder!]
+
+    """
+    Filtering options for Organizations returned from the connection.
+    """
+    where: OrganizationWhereInput
+  ): OrganizationConnection!
+  group(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Groups returned from the connection.
+    """
+    orderBy: [GroupOrder!]
+
+    """
+    Filtering options for Groups returned from the connection.
+    """
+    where: GroupWhereInput
+  ): GroupConnection!
+  contact(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Contacts returned from the connection.
+    """
+    orderBy: [ContactOrder!]
+
+    """
+    Filtering options for Contacts returned from the connection.
+    """
+    where: ContactWhereInput
+  ): ContactConnection!
+  entity(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Entities returned from the connection.
+    """
+    orderBy: [EntityOrder!]
+
+    """
+    Filtering options for Entities returned from the connection.
+    """
+    where: EntityWhereInput
+  ): EntityConnection!
+  userSetting(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for UserSettings returned from the connection.
+    """
+    where: UserSettingWhereInput
+  ): UserSettingConnection!
+  organizationSetting(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for OrganizationSettings returned from the connection.
+    """
+    where: OrganizationSettingWhereInput
+  ): OrganizationSettingConnection!
+  template(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Templates returned from the connection.
+    """
+    orderBy: [TemplateOrder!]
+
+    """
+    Filtering options for Templates returned from the connection.
+    """
+    where: TemplateWhereInput
+  ): TemplateConnection!
+  documentData(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for DocumentDataSlice returned from the connection.
+    """
+    where: DocumentDataWhereInput
+  ): DocumentDataConnection!
+  events(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Events returned from the connection.
+    """
+    where: EventWhereInput
+  ): EventConnection!
+  program(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Programs returned from the connection.
+    """
+    orderBy: [ProgramOrder!]
+
+    """
+    Filtering options for Programs returned from the connection.
+    """
+    where: ProgramWhereInput
+  ): ProgramConnection!
+  evidence(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Evidences returned from the connection.
+    """
+    orderBy: [EvidenceOrder!]
+
+    """
+    Filtering options for Evidences returned from the connection.
+    """
+    where: EvidenceWhereInput
+  ): EvidenceConnection!
 }
 """
 A connection to a list of items.
@@ -9981,10 +12087,120 @@ type Group implements Node {
   narrativeViewers: [Narrative!]
   setting: GroupSetting
   users: [User!]
-  events: [Event!]
-  integrations: [Integration!]
-  files: [File!]
-  tasks: [Task!]
+  events(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Events returned from the connection.
+    """
+    where: EventWhereInput
+  ): EventConnection!
+  integrations(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Integrations returned from the connection.
+    """
+    orderBy: [IntegrationOrder!]
+
+    """
+    Filtering options for Integrations returned from the connection.
+    """
+    where: IntegrationWhereInput
+  ): IntegrationConnection!
+  files(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Files returned from the connection.
+    """
+    where: FileWhereInput
+  ): FileConnection!
+  tasks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Tasks returned from the connection.
+    """
+    orderBy: [TaskOrder!]
+
+    """
+    Filtering options for Tasks returned from the connection.
+    """
+    where: TaskWhereInput
+  ): TaskConnection!
   members: [GroupMembership!]
 }
 """
@@ -10446,6 +12662,25 @@ enum GroupMembershipHistoryOpType @goModel(model: "github.com/theopenlane/entx/h
   DELETE
 }
 """
+Ordering options for GroupMembershipHistory connections
+"""
+input GroupMembershipHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order GroupMembershipHistories.
+  """
+  field: GroupMembershipHistoryOrderField!
+}
+"""
+Properties by which GroupMembershipHistory connections can be ordered.
+"""
+enum GroupMembershipHistoryOrderField {
+  ROLE
+}
+"""
 GroupMembershipHistoryRole is enum for the field role
 """
 enum GroupMembershipHistoryRole @goModel(model: "github.com/theopenlane/core/pkg/enums.Role") {
@@ -10641,6 +12876,25 @@ input GroupMembershipHistoryWhereInput {
   userIDHasSuffix: String
   userIDEqualFold: String
   userIDContainsFold: String
+}
+"""
+Ordering options for GroupMembership connections
+"""
+input GroupMembershipOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order GroupMemberships.
+  """
+  field: GroupMembershipOrderField!
+}
+"""
+Properties by which GroupMembership connections can be ordered.
+"""
+enum GroupMembershipOrderField {
+  ROLE
 }
 """
 GroupMembershipRole is enum for the field role
@@ -11663,12 +13917,94 @@ type Hush implements Node {
   the generic name of a secret associated with the organization
   """
   secretName: String
-  """
-  the integration associated with the secret
-  """
-  integrations: [Integration!]
-  organization: [Organization!]
-  events: [Event!]
+  integrations(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Integrations returned from the connection.
+    """
+    orderBy: [IntegrationOrder!]
+
+    """
+    Filtering options for Integrations returned from the connection.
+    """
+    where: IntegrationWhereInput
+  ): IntegrationConnection!
+  organization(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Organizations returned from the connection.
+    """
+    orderBy: [OrganizationOrder!]
+
+    """
+    Filtering options for Organizations returned from the connection.
+    """
+    where: OrganizationWhereInput
+  ): OrganizationConnection!
+  events(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Events returned from the connection.
+    """
+    where: EventWhereInput
+  ): EventConnection!
 }
 """
 A connection to a list of items.
@@ -12217,11 +14553,63 @@ type Integration implements Node {
   description: String
   kind: String
   owner: Organization
-  """
-  the secrets associated with the integration
-  """
-  secrets: [Hush!]
-  events: [Event!]
+  secrets(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Hushes returned from the connection.
+    """
+    orderBy: [HushOrder!]
+
+    """
+    Filtering options for Hushes returned from the connection.
+    """
+    where: HushWhereInput
+  ): HushConnection!
+  events(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Events returned from the connection.
+    """
+    where: EventWhereInput
+  ): EventConnection!
 }
 """
 A connection to a list of items.
@@ -12814,12 +15202,187 @@ type InternalPolicy implements Node {
   temporary delegates for the policy, used for temporary approval
   """
   delegate: Group
-  controlObjectives: [ControlObjective!]
-  controls: [Control!]
-  procedures: [Procedure!]
-  narratives: [Narrative!]
-  tasks: [Task!]
-  programs: [Program!]
+  controlObjectives(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for ControlObjectives returned from the connection.
+    """
+    orderBy: [ControlObjectiveOrder!]
+
+    """
+    Filtering options for ControlObjectives returned from the connection.
+    """
+    where: ControlObjectiveWhereInput
+  ): ControlObjectiveConnection!
+  controls(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
+    Filtering options for Controls returned from the connection.
+    """
+    where: ControlWhereInput
+  ): ControlConnection!
+  procedures(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Procedures returned from the connection.
+    """
+    where: ProcedureWhereInput
+  ): ProcedureConnection!
+  narratives(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Narratives returned from the connection.
+    """
+    orderBy: NarrativeOrder
+
+    """
+    Filtering options for Narratives returned from the connection.
+    """
+    where: NarrativeWhereInput
+  ): NarrativeConnection!
+  tasks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Tasks returned from the connection.
+    """
+    orderBy: [TaskOrder!]
+
+    """
+    Filtering options for Tasks returned from the connection.
+    """
+    where: TaskWhereInput
+  ): TaskConnection!
+  programs(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Programs returned from the connection.
+    """
+    orderBy: [ProgramOrder!]
+
+    """
+    Filtering options for Programs returned from the connection.
+    """
+    where: ProgramWhereInput
+  ): ProgramConnection!
 }
 """
 A connection to a list of items.
@@ -13622,7 +16185,32 @@ type Invite implements Node {
   """
   requestorID: String
   owner: Organization
-  events: [Event!]
+  events(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Events returned from the connection.
+    """
+    where: EventWhereInput
+  ): EventConnection!
 }
 """
 A connection to a list of items.
@@ -13662,6 +16250,27 @@ enum InviteInviteStatus @goModel(model: "github.com/theopenlane/core/pkg/enums.I
   APPROVAL_REQUIRED
   INVITATION_ACCEPTED
   INVITATION_EXPIRED
+}
+"""
+Ordering options for Invite connections
+"""
+input InviteOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order Invites.
+  """
+  field: InviteOrderField!
+}
+"""
+Properties by which Invite connections can be ordered.
+"""
+enum InviteOrderField {
+  expires
+  STATUS
+  send_attempts
 }
 """
 InviteRole is enum for the field role
@@ -13913,14 +16522,68 @@ type MappedControl implements Node {
   description of how the two controls are related
   """
   relation: String
-  """
-  mapped controls that have a relation to each other
-  """
-  controls: [Control!]
-  """
-  mapped subcontrols that have a relation to each other
-  """
-  subcontrols: [Subcontrol!]
+  controls(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
+    Filtering options for Controls returned from the connection.
+    """
+    where: ControlWhereInput
+  ): ControlConnection!
+  subcontrols(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Subcontrols returned from the connection.
+    """
+    orderBy: [SubcontrolOrder!]
+
+    """
+    Filtering options for Subcontrols returned from the connection.
+    """
+    where: SubcontrolWhereInput
+  ): SubcontrolConnection!
 }
 """
 A connection to a list of items.
@@ -14013,6 +16676,25 @@ enum MappedControlHistoryOpType @goModel(model: "github.com/theopenlane/entx/his
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for MappedControlHistory connections
+"""
+input MappedControlHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order MappedControlHistories.
+  """
+  field: MappedControlHistoryOrderField!
+}
+"""
+Properties by which MappedControlHistory connections can be ordered.
+"""
+enum MappedControlHistoryOrderField {
+  mapping_type
 }
 """
 MappedControlHistoryWhereInput is used for filtering MappedControlHistory objects.
@@ -14200,6 +16882,25 @@ input MappedControlHistoryWhereInput {
   relationNotNil: Boolean
   relationEqualFold: String
   relationContainsFold: String
+}
+"""
+Ordering options for MappedControl connections
+"""
+input MappedControlOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order MappedControls.
+  """
+  field: MappedControlOrderField!
+}
+"""
+Properties by which MappedControl connections can be ordered.
+"""
+enum MappedControlOrderField {
+  mapping_type
 }
 """
 MappedControlWhereInput is used for filtering MappedControl objects.
@@ -14407,11 +17108,68 @@ type Narrative implements Node {
   provides view access to the risk to members of the group
   """
   viewers: [Group!]
-  """
-  which controls are satisfied by the narrative
-  """
-  satisfies: [Control!]
-  programs: [Program!]
+  satisfies(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
+    Filtering options for Controls returned from the connection.
+    """
+    where: ControlWhereInput
+  ): ControlConnection!
+  programs(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Programs returned from the connection.
+    """
+    orderBy: [ProgramOrder!]
+
+    """
+    Filtering options for Programs returned from the connection.
+    """
+    where: ProgramWhereInput
+  ): ProgramConnection!
 }
 """
 A connection to a list of items.
@@ -14516,6 +17274,25 @@ enum NarrativeHistoryOpType @goModel(model: "github.com/theopenlane/entx/history
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for NarrativeHistory connections
+"""
+input NarrativeHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order NarrativeHistories.
+  """
+  field: NarrativeHistoryOrderField!
+}
+"""
+Properties by which NarrativeHistory connections can be ordered.
+"""
+enum NarrativeHistoryOrderField {
+  name
 }
 """
 NarrativeHistoryWhereInput is used for filtering NarrativeHistory objects.
@@ -14753,6 +17530,25 @@ input NarrativeHistoryWhereInput {
   detailsNotNil: Boolean
   detailsEqualFold: String
   detailsContainsFold: String
+}
+"""
+Ordering options for Narrative connections
+"""
+input NarrativeOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order Narratives.
+  """
+  field: NarrativeOrderField!
+}
+"""
+Properties by which Narrative connections can be ordered.
+"""
+enum NarrativeOrderField {
+  name
 }
 """
 NarrativeWhereInput is used for filtering Narrative objects.
@@ -15631,7 +18427,32 @@ type OrgMembership implements Node {
   userID: ID!
   organization: Organization!
   user: User!
-  events: [Event!]
+  events(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Events returned from the connection.
+    """
+    where: EventWhereInput
+  ): EventConnection!
 }
 """
 A connection to a list of items.
@@ -15715,6 +18536,25 @@ enum OrgMembershipHistoryOpType @goModel(model: "github.com/theopenlane/entx/his
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for OrgMembershipHistory connections
+"""
+input OrgMembershipHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order OrgMembershipHistories.
+  """
+  field: OrgMembershipHistoryOrderField!
+}
+"""
+Properties by which OrgMembershipHistory connections can be ordered.
+"""
+enum OrgMembershipHistoryOrderField {
+  ROLE
 }
 """
 OrgMembershipHistoryRole is enum for the field role
@@ -15913,6 +18753,25 @@ input OrgMembershipHistoryWhereInput {
   userIDHasSuffix: String
   userIDEqualFold: String
   userIDContainsFold: String
+}
+"""
+Ordering options for OrgMembership connections
+"""
+input OrgMembershipOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order OrgMemberships.
+  """
+  field: OrgMembershipOrderField!
+}
+"""
+Properties by which OrgMembership connections can be ordered.
+"""
+enum OrgMembershipOrderField {
+  ROLE
 }
 """
 OrgMembershipRole is enum for the field role
@@ -16256,6 +19115,30 @@ enum OrgSubscriptionHistoryOpType @goModel(model: "github.com/theopenlane/entx/h
   DELETE
 }
 """
+Ordering options for OrgSubscriptionHistory connections
+"""
+input OrgSubscriptionHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order OrgSubscriptionHistories.
+  """
+  field: OrgSubscriptionHistoryOrderField!
+}
+"""
+Properties by which OrgSubscriptionHistory connections can be ordered.
+"""
+enum OrgSubscriptionHistoryOrderField {
+  product_tier
+  stripe_subscription_status
+  active
+  expires_at
+  trial_expires_at
+  days_until_due
+}
+"""
 OrgSubscriptionHistoryWhereInput is used for filtering OrgSubscriptionHistory objects.
 Input was generated by ent.
 """
@@ -16569,6 +19452,30 @@ input OrgSubscriptionHistoryWhereInput {
   paymentMethodAddedNEQ: Boolean
   paymentMethodAddedIsNil: Boolean
   paymentMethodAddedNotNil: Boolean
+}
+"""
+Ordering options for OrgSubscription connections
+"""
+input OrgSubscriptionOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order OrgSubscriptions.
+  """
+  field: OrgSubscriptionOrderField!
+}
+"""
+Properties by which OrgSubscription connections can be ordered.
+"""
+enum OrgSubscriptionOrderField {
+  product_tier
+  stripe_subscription_status
+  active
+  expires_at
+  trial_expires_at
+  days_until_due
 }
 """
 OrgSubscriptionWhereInput is used for filtering OrgSubscription objects.
@@ -16964,7 +19871,7 @@ type Organization implements Node {
     """
     Ordering options for Organizations returned from the connection.
     """
-    orderBy: OrganizationOrder
+    orderBy: [OrganizationOrder!]
 
     """
     Filtering options for Organizations returned from the connection.
@@ -16972,36 +19879,806 @@ type Organization implements Node {
     where: OrganizationWhereInput
   ): OrganizationConnection!
   setting: OrganizationSetting
-  personalAccessTokens: [PersonalAccessToken!]
-  apiTokens: [APIToken!]
+  personalAccessTokens(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for PersonalAccessTokens returned from the connection.
+    """
+    where: PersonalAccessTokenWhereInput
+  ): PersonalAccessTokenConnection!
+  apiTokens(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for APITokens returned from the connection.
+    """
+    where: APITokenWhereInput
+  ): APITokenConnection!
   users: [User!]
-  files: [File!]
-  events: [Event!]
-  secrets: [Hush!]
+  files(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Files returned from the connection.
+    """
+    where: FileWhereInput
+  ): FileConnection!
+  events(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Events returned from the connection.
+    """
+    where: EventWhereInput
+  ): EventConnection!
+  secrets(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Hushes returned from the connection.
+    """
+    orderBy: [HushOrder!]
+
+    """
+    Filtering options for Hushes returned from the connection.
+    """
+    where: HushWhereInput
+  ): HushConnection!
   avatarFile: File
-  groups: [Group!]
-  templates: [Template!]
-  integrations: [Integration!]
-  documentData: [DocumentData!]
+  groups(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Groups returned from the connection.
+    """
+    orderBy: [GroupOrder!]
+
+    """
+    Filtering options for Groups returned from the connection.
+    """
+    where: GroupWhereInput
+  ): GroupConnection!
+  templates(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Templates returned from the connection.
+    """
+    orderBy: [TemplateOrder!]
+
+    """
+    Filtering options for Templates returned from the connection.
+    """
+    where: TemplateWhereInput
+  ): TemplateConnection!
+  integrations(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Integrations returned from the connection.
+    """
+    orderBy: [IntegrationOrder!]
+
+    """
+    Filtering options for Integrations returned from the connection.
+    """
+    where: IntegrationWhereInput
+  ): IntegrationConnection!
+  documentData(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for DocumentDataSlice returned from the connection.
+    """
+    where: DocumentDataWhereInput
+  ): DocumentDataConnection!
   orgSubscriptions: [OrgSubscription!]
-  invites: [Invite!]
-  subscribers: [Subscriber!]
-  entities: [Entity!]
-  entityTypes: [EntityType!]
-  contacts: [Contact!]
-  notes: [Note!]
-  tasks: [Task!]
-  programs: [Program!]
-  procedures: [Procedure!]
-  internalPolicies: [InternalPolicy!]
-  risks: [Risk!]
-  controlObjectives: [ControlObjective!]
-  narratives: [Narrative!]
-  controls: [Control!]
-  subcontrols: [Subcontrol!]
-  evidence: [Evidence!]
-  standards: [Standard!]
-  actionPlans: [ActionPlan!]
+  invites(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Invites returned from the connection.
+    """
+    orderBy: [InviteOrder!]
+
+    """
+    Filtering options for Invites returned from the connection.
+    """
+    where: InviteWhereInput
+  ): InviteConnection!
+  subscribers(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Subscribers returned from the connection.
+    """
+    orderBy: [SubscriberOrder!]
+
+    """
+    Filtering options for Subscribers returned from the connection.
+    """
+    where: SubscriberWhereInput
+  ): SubscriberConnection!
+  entities(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Entities returned from the connection.
+    """
+    orderBy: [EntityOrder!]
+
+    """
+    Filtering options for Entities returned from the connection.
+    """
+    where: EntityWhereInput
+  ): EntityConnection!
+  entityTypes(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for EntityTypes returned from the connection.
+    """
+    orderBy: EntityTypeOrder
+
+    """
+    Filtering options for EntityTypes returned from the connection.
+    """
+    where: EntityTypeWhereInput
+  ): EntityTypeConnection!
+  contacts(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Contacts returned from the connection.
+    """
+    orderBy: [ContactOrder!]
+
+    """
+    Filtering options for Contacts returned from the connection.
+    """
+    where: ContactWhereInput
+  ): ContactConnection!
+  notes(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Notes returned from the connection.
+    """
+    where: NoteWhereInput
+  ): NoteConnection!
+  tasks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Tasks returned from the connection.
+    """
+    orderBy: [TaskOrder!]
+
+    """
+    Filtering options for Tasks returned from the connection.
+    """
+    where: TaskWhereInput
+  ): TaskConnection!
+  programs(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Programs returned from the connection.
+    """
+    orderBy: [ProgramOrder!]
+
+    """
+    Filtering options for Programs returned from the connection.
+    """
+    where: ProgramWhereInput
+  ): ProgramConnection!
+  procedures(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Procedures returned from the connection.
+    """
+    where: ProcedureWhereInput
+  ): ProcedureConnection!
+  internalPolicies(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for InternalPolicies returned from the connection.
+    """
+    where: InternalPolicyWhereInput
+  ): InternalPolicyConnection!
+  risks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Risks returned from the connection.
+    """
+    orderBy: [RiskOrder!]
+
+    """
+    Filtering options for Risks returned from the connection.
+    """
+    where: RiskWhereInput
+  ): RiskConnection!
+  controlObjectives(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for ControlObjectives returned from the connection.
+    """
+    orderBy: [ControlObjectiveOrder!]
+
+    """
+    Filtering options for ControlObjectives returned from the connection.
+    """
+    where: ControlObjectiveWhereInput
+  ): ControlObjectiveConnection!
+  narratives(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Narratives returned from the connection.
+    """
+    orderBy: NarrativeOrder
+
+    """
+    Filtering options for Narratives returned from the connection.
+    """
+    where: NarrativeWhereInput
+  ): NarrativeConnection!
+  controls(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
+    Filtering options for Controls returned from the connection.
+    """
+    where: ControlWhereInput
+  ): ControlConnection!
+  subcontrols(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Subcontrols returned from the connection.
+    """
+    orderBy: [SubcontrolOrder!]
+
+    """
+    Filtering options for Subcontrols returned from the connection.
+    """
+    where: SubcontrolWhereInput
+  ): SubcontrolConnection!
+  evidence(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Evidences returned from the connection.
+    """
+    orderBy: [EvidenceOrder!]
+
+    """
+    Filtering options for Evidences returned from the connection.
+    """
+    where: EvidenceWhereInput
+  ): EvidenceConnection!
+  standards(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Standards returned from the connection.
+    """
+    orderBy: [StandardOrder!]
+
+    """
+    Filtering options for Standards returned from the connection.
+    """
+    where: StandardWhereInput
+  ): StandardConnection!
+  actionPlans(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for ActionPlans returned from the connection.
+    """
+    orderBy: [ActionPlanOrder!]
+
+    """
+    Filtering options for ActionPlans returned from the connection.
+    """
+    where: ActionPlanWhereInput
+  ): ActionPlanConnection!
   members: [OrgMembership!]
 }
 """
@@ -17454,7 +21131,32 @@ type OrganizationSetting implements Node {
   """
   allowedEmailDomains: [String!]
   organization: Organization
-  files: [File!]
+  files(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Files returned from the connection.
+    """
+    where: FileWhereInput
+  ): FileConnection!
 }
 """
 A connection to a list of items.
@@ -18566,11 +22268,63 @@ type PersonalAccessToken implements Node {
   """
   revokedAt: Time
   owner: User!
-  """
-  the organization(s) the token is associated with
-  """
-  organizations: [Organization!]
-  events: [Event!]
+  organizations(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Organizations returned from the connection.
+    """
+    orderBy: [OrganizationOrder!]
+
+    """
+    Filtering options for Organizations returned from the connection.
+    """
+    where: OrganizationWhereInput
+  ): OrganizationConnection!
+  events(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Events returned from the connection.
+    """
+    where: EventWhereInput
+  ): EventConnection!
 }
 """
 A connection to a list of items.
@@ -18899,12 +22653,187 @@ type Procedure implements Node {
   temporary delegates for the procedure, used for temporary approval
   """
   delegate: Group
-  controls: [Control!]
-  internalPolicies: [InternalPolicy!]
-  narratives: [Narrative!]
-  risks: [Risk!]
-  tasks: [Task!]
-  programs: [Program!]
+  controls(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
+    Filtering options for Controls returned from the connection.
+    """
+    where: ControlWhereInput
+  ): ControlConnection!
+  internalPolicies(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for InternalPolicies returned from the connection.
+    """
+    where: InternalPolicyWhereInput
+  ): InternalPolicyConnection!
+  narratives(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Narratives returned from the connection.
+    """
+    orderBy: NarrativeOrder
+
+    """
+    Filtering options for Narratives returned from the connection.
+    """
+    where: NarrativeWhereInput
+  ): NarrativeConnection!
+  risks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Risks returned from the connection.
+    """
+    orderBy: [RiskOrder!]
+
+    """
+    Filtering options for Risks returned from the connection.
+    """
+    where: RiskWhereInput
+  ): RiskConnection!
+  tasks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Tasks returned from the connection.
+    """
+    orderBy: [TaskOrder!]
+
+    """
+    Filtering options for Tasks returned from the connection.
+    """
+    where: TaskWhereInput
+  ): TaskConnection!
+  programs(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Programs returned from the connection.
+    """
+    orderBy: [ProgramOrder!]
+
+    """
+    Filtering options for Programs returned from the connection.
+    """
+    where: ProgramWhereInput
+  ): ProgramConnection!
 }
 """
 A connection to a list of items.
@@ -19738,20 +23667,390 @@ type Program implements Node {
   provides view access to the risk to members of the group
   """
   viewers: [Group!]
-  controls: [Control!]
-  subcontrols: [Subcontrol!]
-  controlObjectives: [ControlObjective!]
-  internalPolicies: [InternalPolicy!]
-  procedures: [Procedure!]
-  risks: [Risk!]
-  tasks: [Task!]
-  notes: [Note!]
-  files: [File!]
-  evidence: [Evidence!]
-  narratives: [Narrative!]
+  controls(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
+    Filtering options for Controls returned from the connection.
+    """
+    where: ControlWhereInput
+  ): ControlConnection!
+  subcontrols(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Subcontrols returned from the connection.
+    """
+    orderBy: [SubcontrolOrder!]
+
+    """
+    Filtering options for Subcontrols returned from the connection.
+    """
+    where: SubcontrolWhereInput
+  ): SubcontrolConnection!
+  controlObjectives(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for ControlObjectives returned from the connection.
+    """
+    orderBy: [ControlObjectiveOrder!]
+
+    """
+    Filtering options for ControlObjectives returned from the connection.
+    """
+    where: ControlObjectiveWhereInput
+  ): ControlObjectiveConnection!
+  internalPolicies(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for InternalPolicies returned from the connection.
+    """
+    where: InternalPolicyWhereInput
+  ): InternalPolicyConnection!
+  procedures(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Procedures returned from the connection.
+    """
+    where: ProcedureWhereInput
+  ): ProcedureConnection!
+  risks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Risks returned from the connection.
+    """
+    orderBy: [RiskOrder!]
+
+    """
+    Filtering options for Risks returned from the connection.
+    """
+    where: RiskWhereInput
+  ): RiskConnection!
+  tasks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Tasks returned from the connection.
+    """
+    orderBy: [TaskOrder!]
+
+    """
+    Filtering options for Tasks returned from the connection.
+    """
+    where: TaskWhereInput
+  ): TaskConnection!
+  notes(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Notes returned from the connection.
+    """
+    where: NoteWhereInput
+  ): NoteConnection!
+  files(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Files returned from the connection.
+    """
+    where: FileWhereInput
+  ): FileConnection!
+  evidence(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Evidences returned from the connection.
+    """
+    orderBy: [EvidenceOrder!]
+
+    """
+    Filtering options for Evidences returned from the connection.
+    """
+    where: EvidenceWhereInput
+  ): EvidenceConnection!
+  narratives(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Narratives returned from the connection.
+    """
+    orderBy: NarrativeOrder
+
+    """
+    Filtering options for Narratives returned from the connection.
+    """
+    where: NarrativeWhereInput
+  ): NarrativeConnection!
   actionPlans: [ActionPlan!]
-  users: [User!]
-  members: [ProgramMembership!]
+  users(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Users returned from the connection.
+    """
+    orderBy: [UserOrder!]
+
+    """
+    Filtering options for Users returned from the connection.
+    """
+    where: UserWhereInput
+  ): UserConnection!
+  members(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for ProgramMemberships returned from the connection.
+    """
+    orderBy: ProgramMembershipOrder
+
+    """
+    Filtering options for ProgramMemberships returned from the connection.
+    """
+    where: ProgramMembershipWhereInput
+  ): ProgramMembershipConnection!
 }
 """
 A connection to a list of items.
@@ -19876,6 +24175,28 @@ enum ProgramHistoryOpType @goModel(model: "github.com/theopenlane/entx/history.O
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for ProgramHistory connections
+"""
+input ProgramHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order ProgramHistories.
+  """
+  field: ProgramHistoryOrderField!
+}
+"""
+Properties by which ProgramHistory connections can be ordered.
+"""
+enum ProgramHistoryOrderField {
+  name
+  STATUS
+  start_date
+  end_date
 }
 """
 ProgramHistoryProgramStatus is enum for the field status
@@ -20252,6 +24573,25 @@ enum ProgramMembershipHistoryOpType @goModel(model: "github.com/theopenlane/entx
   DELETE
 }
 """
+Ordering options for ProgramMembershipHistory connections
+"""
+input ProgramMembershipHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order ProgramMembershipHistories.
+  """
+  field: ProgramMembershipHistoryOrderField!
+}
+"""
+Properties by which ProgramMembershipHistory connections can be ordered.
+"""
+enum ProgramMembershipHistoryOrderField {
+  ROLE
+}
+"""
 ProgramMembershipHistoryRole is enum for the field role
 """
 enum ProgramMembershipHistoryRole @goModel(model: "github.com/theopenlane/core/pkg/enums.Role") {
@@ -20449,6 +24789,25 @@ input ProgramMembershipHistoryWhereInput {
   userIDContainsFold: String
 }
 """
+Ordering options for ProgramMembership connections
+"""
+input ProgramMembershipOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order ProgramMemberships.
+  """
+  field: ProgramMembershipOrderField!
+}
+"""
+Properties by which ProgramMembership connections can be ordered.
+"""
+enum ProgramMembershipOrderField {
+  ROLE
+}
+"""
 ProgramMembershipRole is enum for the field role
 """
 enum ProgramMembershipRole @goModel(model: "github.com/theopenlane/core/pkg/enums.Role") {
@@ -20576,6 +24935,28 @@ input ProgramMembershipWhereInput {
   roleNEQ: ProgramMembershipRole
   roleIn: [ProgramMembershipRole!]
   roleNotIn: [ProgramMembershipRole!]
+}
+"""
+Ordering options for Program connections
+"""
+input ProgramOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order Programs.
+  """
+  field: ProgramOrderField!
+}
+"""
+Properties by which Program connections can be ordered.
+"""
+enum ProgramOrderField {
+  name
+  STATUS
+  start_date
+  end_date
 }
 """
 ProgramProgramStatus is enum for the field status
@@ -20975,6 +25356,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for ActionPlans returned from the connection.
+    """
+    orderBy: [ActionPlanOrder!]
+
+    """
     Filtering options for ActionPlans returned from the connection.
     """
     where: ActionPlanWhereInput
@@ -20999,6 +25385,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for ActionPlanHistories returned from the connection.
+    """
+    orderBy: ActionPlanHistoryOrder
 
     """
     Filtering options for ActionPlanHistories returned from the connection.
@@ -21027,6 +25418,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for Contacts returned from the connection.
+    """
+    orderBy: [ContactOrder!]
+
+    """
     Filtering options for Contacts returned from the connection.
     """
     where: ContactWhereInput
@@ -21051,6 +25447,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for ContactHistories returned from the connection.
+    """
+    orderBy: ContactHistoryOrder
 
     """
     Filtering options for ContactHistories returned from the connection.
@@ -21079,6 +25480,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
     Filtering options for Controls returned from the connection.
     """
     where: ControlWhereInput
@@ -21103,6 +25509,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for ControlHistories returned from the connection.
+    """
+    orderBy: ControlHistoryOrder
 
     """
     Filtering options for ControlHistories returned from the connection.
@@ -21131,6 +25542,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for ControlImplementations returned from the connection.
+    """
+    orderBy: [ControlImplementationOrder!]
+
+    """
     Filtering options for ControlImplementations returned from the connection.
     """
     where: ControlImplementationWhereInput
@@ -21155,6 +25571,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for ControlImplementationHistories returned from the connection.
+    """
+    orderBy: ControlImplementationHistoryOrder
 
     """
     Filtering options for ControlImplementationHistories returned from the connection.
@@ -21183,6 +25604,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for ControlObjectives returned from the connection.
+    """
+    orderBy: [ControlObjectiveOrder!]
+
+    """
     Filtering options for ControlObjectives returned from the connection.
     """
     where: ControlObjectiveWhereInput
@@ -21207,6 +25633,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for ControlObjectiveHistories returned from the connection.
+    """
+    orderBy: ControlObjectiveHistoryOrder
 
     """
     Filtering options for ControlObjectiveHistories returned from the connection.
@@ -21289,7 +25720,7 @@ type Query {
     """
     Ordering options for Entities returned from the connection.
     """
-    orderBy: EntityOrder
+    orderBy: [EntityOrder!]
 
     """
     Filtering options for Entities returned from the connection.
@@ -21463,6 +25894,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for Evidences returned from the connection.
+    """
+    orderBy: [EvidenceOrder!]
+
+    """
     Filtering options for Evidences returned from the connection.
     """
     where: EvidenceWhereInput
@@ -21487,6 +25923,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for EvidenceHistories returned from the connection.
+    """
+    orderBy: EvidenceHistoryOrder
 
     """
     Filtering options for EvidenceHistories returned from the connection.
@@ -21569,7 +26010,7 @@ type Query {
     """
     Ordering options for Groups returned from the connection.
     """
-    orderBy: GroupOrder
+    orderBy: [GroupOrder!]
 
     """
     Filtering options for Groups returned from the connection.
@@ -21629,6 +26070,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for GroupMemberships returned from the connection.
+    """
+    orderBy: GroupMembershipOrder
+
+    """
     Filtering options for GroupMemberships returned from the connection.
     """
     where: GroupMembershipWhereInput
@@ -21653,6 +26099,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for GroupMembershipHistories returned from the connection.
+    """
+    orderBy: GroupMembershipHistoryOrder
 
     """
     Filtering options for GroupMembershipHistories returned from the connection.
@@ -21735,7 +26186,7 @@ type Query {
     """
     Ordering options for Hushes returned from the connection.
     """
-    orderBy: HushOrder
+    orderBy: [HushOrder!]
 
     """
     Filtering options for Hushes returned from the connection.
@@ -21797,7 +26248,7 @@ type Query {
     """
     Ordering options for Integrations returned from the connection.
     """
-    orderBy: IntegrationOrder
+    orderBy: [IntegrationOrder!]
 
     """
     Filtering options for Integrations returned from the connection.
@@ -21909,6 +26360,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for Invites returned from the connection.
+    """
+    orderBy: [InviteOrder!]
+
+    """
     Filtering options for Invites returned from the connection.
     """
     where: InviteWhereInput
@@ -21933,6 +26389,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for MappedControls returned from the connection.
+    """
+    orderBy: MappedControlOrder
 
     """
     Filtering options for MappedControls returned from the connection.
@@ -21961,6 +26422,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for MappedControlHistories returned from the connection.
+    """
+    orderBy: MappedControlHistoryOrder
+
+    """
     Filtering options for MappedControlHistories returned from the connection.
     """
     where: MappedControlHistoryWhereInput
@@ -21987,6 +26453,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for Narratives returned from the connection.
+    """
+    orderBy: NarrativeOrder
+
+    """
     Filtering options for Narratives returned from the connection.
     """
     where: NarrativeWhereInput
@@ -22011,6 +26482,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for NarrativeHistories returned from the connection.
+    """
+    orderBy: NarrativeHistoryOrder
 
     """
     Filtering options for NarrativeHistories returned from the connection.
@@ -22091,6 +26567,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for OrgMemberships returned from the connection.
+    """
+    orderBy: OrgMembershipOrder
+
+    """
     Filtering options for OrgMemberships returned from the connection.
     """
     where: OrgMembershipWhereInput
@@ -22115,6 +26596,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for OrgMembershipHistories returned from the connection.
+    """
+    orderBy: OrgMembershipHistoryOrder
 
     """
     Filtering options for OrgMembershipHistories returned from the connection.
@@ -22143,6 +26629,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for OrgSubscriptions returned from the connection.
+    """
+    orderBy: OrgSubscriptionOrder
+
+    """
     Filtering options for OrgSubscriptions returned from the connection.
     """
     where: OrgSubscriptionWhereInput
@@ -22167,6 +26658,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for OrgSubscriptionHistories returned from the connection.
+    """
+    orderBy: OrgSubscriptionHistoryOrder
 
     """
     Filtering options for OrgSubscriptionHistories returned from the connection.
@@ -22197,7 +26693,7 @@ type Query {
     """
     Ordering options for Organizations returned from the connection.
     """
-    orderBy: OrganizationOrder
+    orderBy: [OrganizationOrder!]
 
     """
     Filtering options for Organizations returned from the connection.
@@ -22387,6 +26883,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for Programs returned from the connection.
+    """
+    orderBy: [ProgramOrder!]
+
+    """
     Filtering options for Programs returned from the connection.
     """
     where: ProgramWhereInput
@@ -22411,6 +26912,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for ProgramHistories returned from the connection.
+    """
+    orderBy: ProgramHistoryOrder
 
     """
     Filtering options for ProgramHistories returned from the connection.
@@ -22439,6 +26945,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for ProgramMemberships returned from the connection.
+    """
+    orderBy: ProgramMembershipOrder
+
+    """
     Filtering options for ProgramMemberships returned from the connection.
     """
     where: ProgramMembershipWhereInput
@@ -22463,6 +26974,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for ProgramMembershipHistories returned from the connection.
+    """
+    orderBy: ProgramMembershipHistoryOrder
 
     """
     Filtering options for ProgramMembershipHistories returned from the connection.
@@ -22491,6 +27007,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for Risks returned from the connection.
+    """
+    orderBy: [RiskOrder!]
+
+    """
     Filtering options for Risks returned from the connection.
     """
     where: RiskWhereInput
@@ -22515,6 +27036,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for RiskHistories returned from the connection.
+    """
+    orderBy: RiskHistoryOrder
 
     """
     Filtering options for RiskHistories returned from the connection.
@@ -22543,6 +27069,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for Standards returned from the connection.
+    """
+    orderBy: [StandardOrder!]
+
+    """
     Filtering options for Standards returned from the connection.
     """
     where: StandardWhereInput
@@ -22567,6 +27098,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for StandardHistories returned from the connection.
+    """
+    orderBy: StandardHistoryOrder
 
     """
     Filtering options for StandardHistories returned from the connection.
@@ -22595,6 +27131,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for Subcontrols returned from the connection.
+    """
+    orderBy: [SubcontrolOrder!]
+
+    """
     Filtering options for Subcontrols returned from the connection.
     """
     where: SubcontrolWhereInput
@@ -22621,6 +27162,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for SubcontrolHistories returned from the connection.
+    """
+    orderBy: SubcontrolHistoryOrder
+
+    """
     Filtering options for SubcontrolHistories returned from the connection.
     """
     where: SubcontrolHistoryWhereInput
@@ -22645,6 +27191,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for Subscribers returned from the connection.
+    """
+    orderBy: [SubscriberOrder!]
 
     """
     Filtering options for Subscribers returned from the connection.
@@ -22699,6 +27250,11 @@ type Query {
     last: Int
 
     """
+    Ordering options for Tasks returned from the connection.
+    """
+    orderBy: [TaskOrder!]
+
+    """
     Filtering options for Tasks returned from the connection.
     """
     where: TaskWhereInput
@@ -22723,6 +27279,11 @@ type Query {
     Returns the last _n_ elements from the list.
     """
     last: Int
+
+    """
+    Ordering options for TaskHistories returned from the connection.
+    """
+    orderBy: TaskHistoryOrder
 
     """
     Filtering options for TaskHistories returned from the connection.
@@ -22753,7 +27314,7 @@ type Query {
     """
     Ordering options for Templates returned from the connection.
     """
-    orderBy: TemplateOrder
+    orderBy: [TemplateOrder!]
 
     """
     Filtering options for Templates returned from the connection.
@@ -22815,7 +27376,7 @@ type Query {
     """
     Ordering options for Users returned from the connection.
     """
-    orderBy: UserOrder
+    orderBy: [UserOrder!]
 
     """
     Filtering options for Users returned from the connection.
@@ -22979,10 +27540,125 @@ type Risk implements Node {
   provides view access to the risk to members of the group
   """
   viewers: [Group!]
-  control: [Control!]
-  procedure: [Procedure!]
-  actionPlans: [ActionPlan!]
-  programs: [Program!]
+  control(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
+    Filtering options for Controls returned from the connection.
+    """
+    where: ControlWhereInput
+  ): ControlConnection!
+  procedure(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Procedures returned from the connection.
+    """
+    where: ProcedureWhereInput
+  ): ProcedureConnection!
+  actionPlans(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for ActionPlans returned from the connection.
+    """
+    orderBy: [ActionPlanOrder!]
+
+    """
+    Filtering options for ActionPlans returned from the connection.
+    """
+    where: ActionPlanWhereInput
+  ): ActionPlanConnection!
+  programs(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Programs returned from the connection.
+    """
+    orderBy: [ProgramOrder!]
+
+    """
+    Filtering options for Programs returned from the connection.
+    """
+    where: ProgramWhereInput
+  ): ProgramConnection!
   """
   the group of users who are responsible for risk oversight
   """
@@ -23123,6 +27799,32 @@ enum RiskHistoryOpType @goModel(model: "github.com/theopenlane/entx/history.OpTy
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for RiskHistory connections
+"""
+input RiskHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order RiskHistories.
+  """
+  field: RiskHistoryOrderField!
+}
+"""
+Properties by which RiskHistory connections can be ordered.
+"""
+enum RiskHistoryOrderField {
+  name
+  STATUS
+  risk_type
+  category
+  IMPACT
+  LIKELIHOOD
+  score
+  business_costs
 }
 """
 RiskHistoryRiskImpact is enum for the field impact
@@ -23481,6 +28183,32 @@ input RiskHistoryWhereInput {
   businessCostsNotNil: Boolean
   businessCostsEqualFold: String
   businessCostsContainsFold: String
+}
+"""
+Ordering options for Risk connections
+"""
+input RiskOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order Risks.
+  """
+  field: RiskOrderField!
+}
+"""
+Properties by which Risk connections can be ordered.
+"""
+enum RiskOrderField {
+  name
+  STATUS
+  risk_type
+  category
+  IMPACT
+  LIKELIHOOD
+  score
+  business_costs
 }
 """
 RiskRiskImpact is enum for the field impact
@@ -23931,7 +28659,37 @@ type Standard implements Node {
   """
   version: String
   owner: Organization
-  controls: [Control!]
+  controls(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
+    Filtering options for Controls returned from the connection.
+    """
+    where: ControlWhereInput
+  ): ControlConnection!
 }
 """
 A connection to a list of items.
@@ -24080,6 +28838,30 @@ enum StandardHistoryOpType @goModel(model: "github.com/theopenlane/entx/history.
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for StandardHistory connections
+"""
+input StandardHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order StandardHistories.
+  """
+  field: StandardHistoryOrderField!
+}
+"""
+Properties by which StandardHistory connections can be ordered.
+"""
+enum StandardHistoryOrderField {
+  name
+  short_name
+  framework
+  governing_body
+  STATUS
+  standard_type
 }
 """
 StandardHistoryStandardStatus is enum for the field status
@@ -24465,6 +29247,30 @@ input StandardHistoryWhereInput {
   versionNotNil: Boolean
   versionEqualFold: String
   versionContainsFold: String
+}
+"""
+Ordering options for Standard connections
+"""
+input StandardOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order Standards.
+  """
+  field: StandardOrderField!
+}
+"""
+Properties by which Standard connections can be ordered.
+"""
+enum StandardOrderField {
+  name
+  short_name
+  framework
+  governing_body
+  STATUS
+  standard_type
 }
 """
 StandardStandardStatus is enum for the field status
@@ -24915,14 +29721,244 @@ type Subcontrol implements Node {
   mapped subcontrols that have a relation to another control or subcontrol
   """
   mappedControls: [MappedControl!]
-  evidence: [Evidence!]
-  controlObjectives: [ControlObjective!]
-  tasks: [Task!]
-  narratives: [Narrative!]
-  risks: [Risk!]
-  actionPlans: [ActionPlan!]
-  procedures: [Procedure!]
-  internalPolicies: [InternalPolicy!]
+  evidence(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Evidences returned from the connection.
+    """
+    orderBy: [EvidenceOrder!]
+
+    """
+    Filtering options for Evidences returned from the connection.
+    """
+    where: EvidenceWhereInput
+  ): EvidenceConnection!
+  controlObjectives(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for ControlObjectives returned from the connection.
+    """
+    orderBy: [ControlObjectiveOrder!]
+
+    """
+    Filtering options for ControlObjectives returned from the connection.
+    """
+    where: ControlObjectiveWhereInput
+  ): ControlObjectiveConnection!
+  tasks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Tasks returned from the connection.
+    """
+    orderBy: [TaskOrder!]
+
+    """
+    Filtering options for Tasks returned from the connection.
+    """
+    where: TaskWhereInput
+  ): TaskConnection!
+  narratives(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Narratives returned from the connection.
+    """
+    orderBy: NarrativeOrder
+
+    """
+    Filtering options for Narratives returned from the connection.
+    """
+    where: NarrativeWhereInput
+  ): NarrativeConnection!
+  risks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Risks returned from the connection.
+    """
+    orderBy: [RiskOrder!]
+
+    """
+    Filtering options for Risks returned from the connection.
+    """
+    where: RiskWhereInput
+  ): RiskConnection!
+  actionPlans(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for ActionPlans returned from the connection.
+    """
+    orderBy: [ActionPlanOrder!]
+
+    """
+    Filtering options for ActionPlans returned from the connection.
+    """
+    where: ActionPlanWhereInput
+  ): ActionPlanConnection!
+  procedures(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Procedures returned from the connection.
+    """
+    where: ProcedureWhereInput
+  ): ProcedureConnection!
+  internalPolicies(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for InternalPolicies returned from the connection.
+    """
+    where: InternalPolicyWhereInput
+  ): InternalPolicyConnection!
   """
   the user who is responsible for the subcontrol, defaults to the parent control owner if not set
   """
@@ -25123,6 +30159,30 @@ enum SubcontrolHistoryOpType @goModel(model: "github.com/theopenlane/entx/histor
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for SubcontrolHistory connections
+"""
+input SubcontrolHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order SubcontrolHistories.
+  """
+  field: SubcontrolHistoryOrderField!
+}
+"""
+Properties by which SubcontrolHistory connections can be ordered.
+"""
+enum SubcontrolHistoryOrderField {
+  status
+  SOURCE
+  CONTROL_TYPE
+  category
+  subcategory
+  ref_code
 }
 """
 SubcontrolHistoryWhereInput is used for filtering SubcontrolHistory objects.
@@ -25448,6 +30508,30 @@ input SubcontrolHistoryWhereInput {
   controlIDHasSuffix: String
   controlIDEqualFold: String
   controlIDContainsFold: String
+}
+"""
+Ordering options for Subcontrol connections
+"""
+input SubcontrolOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order Subcontrols.
+  """
+  field: SubcontrolOrderField!
+}
+"""
+Properties by which Subcontrol connections can be ordered.
+"""
+enum SubcontrolOrderField {
+  status
+  SOURCE
+  CONTROL_TYPE
+  category
+  subcategory
+  ref_code
 }
 """
 SubcontrolWhereInput is used for filtering Subcontrol objects.
@@ -25840,7 +30924,32 @@ type Subscriber implements Node {
   """
   active: Boolean!
   owner: Organization
-  events: [Event!]
+  events(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Events returned from the connection.
+    """
+    where: EventWhereInput
+  ): EventConnection!
 }
 """
 A connection to a list of items.
@@ -25871,6 +30980,26 @@ type SubscriberEdge {
   A cursor for use in pagination.
   """
   cursor: Cursor!
+}
+"""
+Ordering options for Subscriber connections
+"""
+input SubscriberOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order Subscribers.
+  """
+  field: SubscriberOrderField!
+}
+"""
+Properties by which Subscriber connections can be ordered.
+"""
+enum SubscriberOrderField {
+  email
+  active
 }
 """
 SubscriberWhereInput is used for filtering Subscriber objects.
@@ -26303,18 +31432,270 @@ type Task implements Node {
   owner: Organization
   assigner: User
   assignee: User
-  """
-  conversations related to the task
-  """
-  comments: [Note!]
-  group: [Group!]
-  internalPolicy: [InternalPolicy!]
-  procedure: [Procedure!]
-  control: [Control!]
-  controlObjective: [ControlObjective!]
-  subcontrol: [Subcontrol!]
-  program: [Program!]
-  evidence: [Evidence!]
+  comments(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Notes returned from the connection.
+    """
+    where: NoteWhereInput
+  ): NoteConnection!
+  group(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Groups returned from the connection.
+    """
+    orderBy: [GroupOrder!]
+
+    """
+    Filtering options for Groups returned from the connection.
+    """
+    where: GroupWhereInput
+  ): GroupConnection!
+  internalPolicy(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for InternalPolicies returned from the connection.
+    """
+    where: InternalPolicyWhereInput
+  ): InternalPolicyConnection!
+  procedure(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Procedures returned from the connection.
+    """
+    where: ProcedureWhereInput
+  ): ProcedureConnection!
+  control(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Controls returned from the connection.
+    """
+    orderBy: [ControlOrder!]
+
+    """
+    Filtering options for Controls returned from the connection.
+    """
+    where: ControlWhereInput
+  ): ControlConnection!
+  controlObjective(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for ControlObjectives returned from the connection.
+    """
+    orderBy: [ControlObjectiveOrder!]
+
+    """
+    Filtering options for ControlObjectives returned from the connection.
+    """
+    where: ControlObjectiveWhereInput
+  ): ControlObjectiveConnection!
+  subcontrol(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Subcontrols returned from the connection.
+    """
+    orderBy: [SubcontrolOrder!]
+
+    """
+    Filtering options for Subcontrols returned from the connection.
+    """
+    where: SubcontrolWhereInput
+  ): SubcontrolConnection!
+  program(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Programs returned from the connection.
+    """
+    orderBy: [ProgramOrder!]
+
+    """
+    Filtering options for Programs returned from the connection.
+    """
+    where: ProgramWhereInput
+  ): ProgramConnection!
+  evidence(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Evidences returned from the connection.
+    """
+    orderBy: [EvidenceOrder!]
+
+    """
+    Filtering options for Evidences returned from the connection.
+    """
+    where: EvidenceWhereInput
+  ): EvidenceConnection!
 }
 """
 A connection to a list of items.
@@ -26443,6 +31824,29 @@ enum TaskHistoryOpType @goModel(model: "github.com/theopenlane/entx/history.OpTy
   INSERT
   UPDATE
   DELETE
+}
+"""
+Ordering options for TaskHistory connections
+"""
+input TaskHistoryOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order TaskHistories.
+  """
+  field: TaskHistoryOrderField!
+}
+"""
+Properties by which TaskHistory connections can be ordered.
+"""
+enum TaskHistoryOrderField {
+  title
+  STATUS
+  category
+  due
+  completed
 }
 """
 TaskHistoryTaskStatus is enum for the field status
@@ -26777,6 +32181,29 @@ input TaskHistoryWhereInput {
   assignerIDNotNil: Boolean
   assignerIDEqualFold: String
   assignerIDContainsFold: String
+}
+"""
+Ordering options for Task connections
+"""
+input TaskOrder {
+  """
+  The ordering direction.
+  """
+  direction: OrderDirection! = ASC
+  """
+  The field by which to order Tasks.
+  """
+  field: TaskOrderField!
+}
+"""
+Properties by which Task connections can be ordered.
+"""
+enum TaskOrderField {
+  title
+  STATUS
+  category
+  due
+  completed
 }
 """
 TaskTaskStatus is enum for the field status
@@ -27173,8 +32600,58 @@ type Template implements Node {
   """
   uischema: Map
   owner: Organization
-  documents: [DocumentData!]
-  files: [File!]
+  documents(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for DocumentDataSlice returned from the connection.
+    """
+    where: DocumentDataWhereInput
+  ): DocumentDataConnection!
+  files(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Files returned from the connection.
+    """
+    where: FileWhereInput
+  ): FileConnection!
 }
 """
 A connection to a list of items.
@@ -27316,6 +32793,7 @@ Properties by which TemplateHistory connections can be ordered.
 """
 enum TemplateHistoryOrderField {
   name
+  TEMPLATE_TYPE
 }
 """
 TemplateHistoryWhereInput is used for filtering TemplateHistory objects.
@@ -27545,6 +33023,7 @@ Properties by which Template connections can be ordered.
 """
 enum TemplateOrderField {
   name
+  TEMPLATE_TYPE
 }
 """
 TemplateWhereInput is used for filtering Template objects.
@@ -30034,18 +35513,238 @@ type User implements Node {
   the user's role
   """
   role: UserRole
-  personalAccessTokens: [PersonalAccessToken!]
-  tfaSettings: [TFASetting!]
+  personalAccessTokens(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for PersonalAccessTokens returned from the connection.
+    """
+    where: PersonalAccessTokenWhereInput
+  ): PersonalAccessTokenConnection!
+  tfaSettings(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for TFASettings returned from the connection.
+    """
+    where: TFASettingWhereInput
+  ): TFASettingConnection!
   setting: UserSetting!
   groups: [Group!]
   organizations: [Organization!]
-  files: [File!]
+  files(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Files returned from the connection.
+    """
+    where: FileWhereInput
+  ): FileConnection!
   avatarFile: File
-  events: [Event!]
-  actionPlans: [ActionPlan!]
-  subcontrols: [Subcontrol!]
-  assignerTasks: [Task!]
-  assigneeTasks: [Task!]
+  events(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Events returned from the connection.
+    """
+    where: EventWhereInput
+  ): EventConnection!
+  actionPlans(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for ActionPlans returned from the connection.
+    """
+    orderBy: [ActionPlanOrder!]
+
+    """
+    Filtering options for ActionPlans returned from the connection.
+    """
+    where: ActionPlanWhereInput
+  ): ActionPlanConnection!
+  subcontrols(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Subcontrols returned from the connection.
+    """
+    orderBy: [SubcontrolOrder!]
+
+    """
+    Filtering options for Subcontrols returned from the connection.
+    """
+    where: SubcontrolWhereInput
+  ): SubcontrolConnection!
+  assignerTasks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Tasks returned from the connection.
+    """
+    orderBy: [TaskOrder!]
+
+    """
+    Filtering options for Tasks returned from the connection.
+    """
+    where: TaskWhereInput
+  ): TaskConnection!
+  assigneeTasks(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Tasks returned from the connection.
+    """
+    orderBy: [TaskOrder!]
+
+    """
+    Filtering options for Tasks returned from the connection.
+    """
+    where: TaskWhereInput
+  ): TaskConnection!
   programs: [Program!]
   groupMemberships: [GroupMembership!]
   orgMemberships: [OrgMembership!]
@@ -30627,7 +36326,32 @@ type UserSetting implements Node {
   organization to load on user login
   """
   defaultOrg: Organization
-  files: [File!]
+  files(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Filtering options for Files returned from the connection.
+    """
+    where: FileWhereInput
+  ): FileConnection!
 }
 """
 A connection to a list of items.

--- a/internal/graphapi/search.go
+++ b/internal/graphapi/search.go
@@ -126,11 +126,12 @@ func adminSearchActionPlans(ctx context.Context, query string) ([]*generated.Act
 func searchContacts(ctx context.Context, query string) ([]*generated.Contact, error) {
 	return withTransactionalMutation(ctx).Contact.Query().Where(
 		contact.Or(
+			contact.EmailContainsFold(query),    // search by Email
 			contact.FullNameContainsFold(query), // search by FullName
 			contact.ID(query),                   // search equal to ID
 			func(s *sql.Selector) {
 				likeQuery := "%" + query + "%"
-				s.Where(sql.ExprP("(tags)::text LIKE $3", likeQuery)) // search by Tags
+				s.Where(sql.ExprP("(tags)::text LIKE $4", likeQuery)) // search by Tags
 			},
 		),
 	).All(ctx)
@@ -437,11 +438,12 @@ func adminSearchEvents(ctx context.Context, query string) ([]*generated.Event, e
 func searchEvidences(ctx context.Context, query string) ([]*generated.Evidence, error) {
 	return withTransactionalMutation(ctx).Evidence.Query().Where(
 		evidence.Or(
-			evidence.DisplayID(query), // search equal to DisplayID
-			evidence.ID(query),        // search equal to ID
+			evidence.DisplayID(query),        // search equal to DisplayID
+			evidence.ID(query),               // search equal to ID
+			evidence.NameContainsFold(query), // search by Name
 			func(s *sql.Selector) {
 				likeQuery := "%" + query + "%"
-				s.Where(sql.ExprP("(tags)::text LIKE $3", likeQuery)) // search by Tags
+				s.Where(sql.ExprP("(tags)::text LIKE $4", likeQuery)) // search by Tags
 			},
 		),
 	).All(ctx)
@@ -938,12 +940,18 @@ func adminSearchRisks(ctx context.Context, query string) ([]*generated.Risk, err
 func searchStandards(ctx context.Context, query string) ([]*generated.Standard, error) {
 	return withTransactionalMutation(ctx).Standard.Query().Where(
 		standard.Or(
-			standard.ID(query),                    // search equal to ID
-			standard.NameContainsFold(query),      // search by Name
-			standard.ShortNameContainsFold(query), // search by ShortName
 			func(s *sql.Selector) {
 				likeQuery := "%" + query + "%"
-				s.Where(sql.ExprP("(tags)::text LIKE $4", likeQuery)) // search by Tags
+				s.Where(sql.ExprP("(domains)::text LIKE $1", likeQuery)) // search by Domains
+			},
+			standard.FrameworkContainsFold(query),     // search by Framework
+			standard.GoverningBodyContainsFold(query), // search by GoverningBody
+			standard.ID(query),                        // search equal to ID
+			standard.NameContainsFold(query),          // search by Name
+			standard.ShortNameContainsFold(query),     // search by ShortName
+			func(s *sql.Selector) {
+				likeQuery := "%" + query + "%"
+				s.Where(sql.ExprP("(tags)::text LIKE $7", likeQuery)) // search by Tags
 			},
 		),
 	).All(ctx)

--- a/internal/graphapi/task_test.go
+++ b/internal/graphapi/task_test.go
@@ -496,11 +496,11 @@ func (suite *GraphTestSuite) TestMutationUpdateTask() {
 
 				if tc.request.AddComment != nil {
 					assert.NotEmpty(t, resp.UpdateTask.Task.Comments)
-					assert.Equal(t, tc.request.AddComment.Text, resp.UpdateTask.Task.Comments[0].Text)
+					assert.Equal(t, tc.request.AddComment.Text, resp.UpdateTask.Task.Comments.Edges[0].Node.Text)
 
 					// there should only be one comment
 					require.Len(t, resp.UpdateTask.Task.Comments, 1)
-					taskCommentID = resp.UpdateTask.Task.Comments[0].ID
+					taskCommentID = resp.UpdateTask.Task.Comments.Edges[0].Node.ID
 
 					// user shouldn't be able to see the comment
 					checkResp, err := suite.client.api.GetNoteByID(viewOnlyUser.UserCtx, taskCommentID)
@@ -525,7 +525,7 @@ func (suite *GraphTestSuite) TestMutationUpdateTask() {
 
 				// should only have the original comment
 				require.Len(t, commentResp.UpdateTaskComment.Task.Comments, 1)
-				assert.Equal(t, *tc.updateCommentRequest.Text, commentResp.UpdateTaskComment.Task.Comments[0].Text)
+				assert.Equal(t, *tc.updateCommentRequest.Text, commentResp.UpdateTaskComment.Task.Comments.Edges[0].Node.Text)
 			}
 		})
 	}

--- a/internal/graphapi/task_test.go
+++ b/internal/graphapi/task_test.go
@@ -495,11 +495,11 @@ func (suite *GraphTestSuite) TestMutationUpdateTask() {
 				}
 
 				if tc.request.AddComment != nil {
-					assert.NotEmpty(t, resp.UpdateTask.Task.Comments)
+					assert.NotEmpty(t, resp.UpdateTask.Task.Comments.Edges)
 					assert.Equal(t, tc.request.AddComment.Text, resp.UpdateTask.Task.Comments.Edges[0].Node.Text)
 
 					// there should only be one comment
-					require.Len(t, resp.UpdateTask.Task.Comments, 1)
+					require.Len(t, resp.UpdateTask.Task.Comments.Edges, 1)
 					taskCommentID = resp.UpdateTask.Task.Comments.Edges[0].Node.ID
 
 					// user shouldn't be able to see the comment
@@ -518,13 +518,13 @@ func (suite *GraphTestSuite) TestMutationUpdateTask() {
 					assert.NotNil(t, checkResp)
 				} else if tc.request.DeleteComment != nil {
 					// should not have any comments
-					assert.Len(t, resp.UpdateTask.Task.Comments, 0)
+					assert.Len(t, resp.UpdateTask.Task.Comments.Edges, 0)
 				}
 			} else if tc.updateCommentRequest != nil {
 				require.NotNil(t, commentResp)
 
 				// should only have the original comment
-				require.Len(t, commentResp.UpdateTaskComment.Task.Comments, 1)
+				require.Len(t, commentResp.UpdateTaskComment.Task.Comments.Edges, 1)
 				assert.Equal(t, *tc.updateCommentRequest.Text, commentResp.UpdateTaskComment.Task.Comments.Edges[0].Node.Text)
 			}
 		})

--- a/pkg/openlaneclient/graphclient.go
+++ b/pkg/openlaneclient/graphclient.go
@@ -6578,29 +6578,51 @@ func (t *CreateControl_CreateControl_Control_Delegate) GetName() string {
 	return t.Name
 }
 
-type CreateControl_CreateControl_Control_Programs struct {
+type CreateControl_CreateControl_Control_Programs_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	Name      string "json:\"name\" graphql:\"name\""
 }
 
-func (t *CreateControl_CreateControl_Control_Programs) GetDisplayID() string {
+func (t *CreateControl_CreateControl_Control_Programs_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &CreateControl_CreateControl_Control_Programs{}
+		t = &CreateControl_CreateControl_Control_Programs_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *CreateControl_CreateControl_Control_Programs) GetID() string {
+func (t *CreateControl_CreateControl_Control_Programs_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateControl_CreateControl_Control_Programs{}
+		t = &CreateControl_CreateControl_Control_Programs_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *CreateControl_CreateControl_Control_Programs) GetName() string {
+func (t *CreateControl_CreateControl_Control_Programs_Edges_Node) GetName() string {
+	if t == nil {
+		t = &CreateControl_CreateControl_Control_Programs_Edges_Node{}
+	}
+	return t.Name
+}
+
+type CreateControl_CreateControl_Control_Programs_Edges struct {
+	Node *CreateControl_CreateControl_Control_Programs_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateControl_CreateControl_Control_Programs_Edges) GetNode() *CreateControl_CreateControl_Control_Programs_Edges_Node {
+	if t == nil {
+		t = &CreateControl_CreateControl_Control_Programs_Edges{}
+	}
+	return t.Node
+}
+
+type CreateControl_CreateControl_Control_Programs struct {
+	Edges []*CreateControl_CreateControl_Control_Programs_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateControl_CreateControl_Control_Programs) GetEdges() []*CreateControl_CreateControl_Control_Programs_Edges {
 	if t == nil {
 		t = &CreateControl_CreateControl_Control_Programs{}
 	}
-	return t.Name
+	return t.Edges
 }
 
 type CreateControl_CreateControl_Control_Editors struct {
@@ -6677,7 +6699,7 @@ type CreateControl_CreateControl_Control struct {
 	ImplementationGuidance []*models.ImplementationGuidance                     "json:\"implementationGuidance,omitempty\" graphql:\"implementationGuidance\""
 	MappedCategories       []string                                             "json:\"mappedCategories,omitempty\" graphql:\"mappedCategories\""
 	OwnerID                *string                                              "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Programs               []*CreateControl_CreateControl_Control_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
+	Programs               CreateControl_CreateControl_Control_Programs         "json:\"programs\" graphql:\"programs\""
 	RefCode                string                                               "json:\"refCode\" graphql:\"refCode\""
 	References             []*models.Reference                                  "json:\"references,omitempty\" graphql:\"references\""
 	Source                 *enums.ControlSource                                 "json:\"source,omitempty\" graphql:\"source\""
@@ -6804,11 +6826,11 @@ func (t *CreateControl_CreateControl_Control) GetOwnerID() *string {
 	}
 	return t.OwnerID
 }
-func (t *CreateControl_CreateControl_Control) GetPrograms() []*CreateControl_CreateControl_Control_Programs {
+func (t *CreateControl_CreateControl_Control) GetPrograms() *CreateControl_CreateControl_Control_Programs {
 	if t == nil {
 		t = &CreateControl_CreateControl_Control{}
 	}
-	return t.Programs
+	return &t.Programs
 }
 func (t *CreateControl_CreateControl_Control) GetRefCode() string {
 	if t == nil {
@@ -6961,29 +6983,51 @@ func (t *GetAllControls_Controls_Edges_Node_Standard) GetShortName() *string {
 	return t.ShortName
 }
 
-type GetAllControls_Controls_Edges_Node_Programs struct {
+type GetAllControls_Controls_Edges_Node_Programs_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	Name      string "json:\"name\" graphql:\"name\""
 }
 
-func (t *GetAllControls_Controls_Edges_Node_Programs) GetDisplayID() string {
+func (t *GetAllControls_Controls_Edges_Node_Programs_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetAllControls_Controls_Edges_Node_Programs{}
+		t = &GetAllControls_Controls_Edges_Node_Programs_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetAllControls_Controls_Edges_Node_Programs) GetID() string {
+func (t *GetAllControls_Controls_Edges_Node_Programs_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetAllControls_Controls_Edges_Node_Programs{}
+		t = &GetAllControls_Controls_Edges_Node_Programs_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetAllControls_Controls_Edges_Node_Programs) GetName() string {
+func (t *GetAllControls_Controls_Edges_Node_Programs_Edges_Node) GetName() string {
+	if t == nil {
+		t = &GetAllControls_Controls_Edges_Node_Programs_Edges_Node{}
+	}
+	return t.Name
+}
+
+type GetAllControls_Controls_Edges_Node_Programs_Edges struct {
+	Node *GetAllControls_Controls_Edges_Node_Programs_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllControls_Controls_Edges_Node_Programs_Edges) GetNode() *GetAllControls_Controls_Edges_Node_Programs_Edges_Node {
+	if t == nil {
+		t = &GetAllControls_Controls_Edges_Node_Programs_Edges{}
+	}
+	return t.Node
+}
+
+type GetAllControls_Controls_Edges_Node_Programs struct {
+	Edges []*GetAllControls_Controls_Edges_Node_Programs_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetAllControls_Controls_Edges_Node_Programs) GetEdges() []*GetAllControls_Controls_Edges_Node_Programs_Edges {
 	if t == nil {
 		t = &GetAllControls_Controls_Edges_Node_Programs{}
 	}
-	return t.Name
+	return t.Edges
 }
 
 type GetAllControls_Controls_Edges_Node_Editors struct {
@@ -7060,7 +7104,7 @@ type GetAllControls_Controls_Edges_Node struct {
 	ImplementationGuidance []*models.ImplementationGuidance                    "json:\"implementationGuidance,omitempty\" graphql:\"implementationGuidance\""
 	MappedCategories       []string                                            "json:\"mappedCategories,omitempty\" graphql:\"mappedCategories\""
 	OwnerID                *string                                             "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Programs               []*GetAllControls_Controls_Edges_Node_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
+	Programs               GetAllControls_Controls_Edges_Node_Programs         "json:\"programs\" graphql:\"programs\""
 	RefCode                string                                              "json:\"refCode\" graphql:\"refCode\""
 	References             []*models.Reference                                 "json:\"references,omitempty\" graphql:\"references\""
 	Source                 *enums.ControlSource                                "json:\"source,omitempty\" graphql:\"source\""
@@ -7188,11 +7232,11 @@ func (t *GetAllControls_Controls_Edges_Node) GetOwnerID() *string {
 	}
 	return t.OwnerID
 }
-func (t *GetAllControls_Controls_Edges_Node) GetPrograms() []*GetAllControls_Controls_Edges_Node_Programs {
+func (t *GetAllControls_Controls_Edges_Node) GetPrograms() *GetAllControls_Controls_Edges_Node_Programs {
 	if t == nil {
 		t = &GetAllControls_Controls_Edges_Node{}
 	}
-	return t.Programs
+	return &t.Programs
 }
 func (t *GetAllControls_Controls_Edges_Node) GetRefCode() string {
 	if t == nil {
@@ -7351,29 +7395,51 @@ func (t *GetControlByID_Control_Standard) GetShortName() *string {
 	return t.ShortName
 }
 
-type GetControlByID_Control_Programs struct {
+type GetControlByID_Control_Programs_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	Name      string "json:\"name\" graphql:\"name\""
 }
 
-func (t *GetControlByID_Control_Programs) GetDisplayID() string {
+func (t *GetControlByID_Control_Programs_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetControlByID_Control_Programs{}
+		t = &GetControlByID_Control_Programs_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetControlByID_Control_Programs) GetID() string {
+func (t *GetControlByID_Control_Programs_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetControlByID_Control_Programs{}
+		t = &GetControlByID_Control_Programs_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetControlByID_Control_Programs) GetName() string {
+func (t *GetControlByID_Control_Programs_Edges_Node) GetName() string {
+	if t == nil {
+		t = &GetControlByID_Control_Programs_Edges_Node{}
+	}
+	return t.Name
+}
+
+type GetControlByID_Control_Programs_Edges struct {
+	Node *GetControlByID_Control_Programs_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetControlByID_Control_Programs_Edges) GetNode() *GetControlByID_Control_Programs_Edges_Node {
+	if t == nil {
+		t = &GetControlByID_Control_Programs_Edges{}
+	}
+	return t.Node
+}
+
+type GetControlByID_Control_Programs struct {
+	Edges []*GetControlByID_Control_Programs_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetControlByID_Control_Programs) GetEdges() []*GetControlByID_Control_Programs_Edges {
 	if t == nil {
 		t = &GetControlByID_Control_Programs{}
 	}
-	return t.Name
+	return t.Edges
 }
 
 type GetControlByID_Control_Editors struct {
@@ -7450,7 +7516,7 @@ type GetControlByID_Control struct {
 	ImplementationGuidance []*models.ImplementationGuidance        "json:\"implementationGuidance,omitempty\" graphql:\"implementationGuidance\""
 	MappedCategories       []string                                "json:\"mappedCategories,omitempty\" graphql:\"mappedCategories\""
 	OwnerID                *string                                 "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Programs               []*GetControlByID_Control_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
+	Programs               GetControlByID_Control_Programs         "json:\"programs\" graphql:\"programs\""
 	RefCode                string                                  "json:\"refCode\" graphql:\"refCode\""
 	References             []*models.Reference                     "json:\"references,omitempty\" graphql:\"references\""
 	Source                 *enums.ControlSource                    "json:\"source,omitempty\" graphql:\"source\""
@@ -7578,11 +7644,11 @@ func (t *GetControlByID_Control) GetOwnerID() *string {
 	}
 	return t.OwnerID
 }
-func (t *GetControlByID_Control) GetPrograms() []*GetControlByID_Control_Programs {
+func (t *GetControlByID_Control) GetPrograms() *GetControlByID_Control_Programs {
 	if t == nil {
 		t = &GetControlByID_Control{}
 	}
-	return t.Programs
+	return &t.Programs
 }
 func (t *GetControlByID_Control) GetRefCode() string {
 	if t == nil {
@@ -7719,29 +7785,51 @@ func (t *GetControls_Controls_Edges_Node_Standard) GetShortName() *string {
 	return t.ShortName
 }
 
-type GetControls_Controls_Edges_Node_Programs struct {
+type GetControls_Controls_Edges_Node_Programs_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	Name      string "json:\"name\" graphql:\"name\""
 }
 
-func (t *GetControls_Controls_Edges_Node_Programs) GetDisplayID() string {
+func (t *GetControls_Controls_Edges_Node_Programs_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetControls_Controls_Edges_Node_Programs{}
+		t = &GetControls_Controls_Edges_Node_Programs_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetControls_Controls_Edges_Node_Programs) GetID() string {
+func (t *GetControls_Controls_Edges_Node_Programs_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetControls_Controls_Edges_Node_Programs{}
+		t = &GetControls_Controls_Edges_Node_Programs_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetControls_Controls_Edges_Node_Programs) GetName() string {
+func (t *GetControls_Controls_Edges_Node_Programs_Edges_Node) GetName() string {
+	if t == nil {
+		t = &GetControls_Controls_Edges_Node_Programs_Edges_Node{}
+	}
+	return t.Name
+}
+
+type GetControls_Controls_Edges_Node_Programs_Edges struct {
+	Node *GetControls_Controls_Edges_Node_Programs_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetControls_Controls_Edges_Node_Programs_Edges) GetNode() *GetControls_Controls_Edges_Node_Programs_Edges_Node {
+	if t == nil {
+		t = &GetControls_Controls_Edges_Node_Programs_Edges{}
+	}
+	return t.Node
+}
+
+type GetControls_Controls_Edges_Node_Programs struct {
+	Edges []*GetControls_Controls_Edges_Node_Programs_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetControls_Controls_Edges_Node_Programs) GetEdges() []*GetControls_Controls_Edges_Node_Programs_Edges {
 	if t == nil {
 		t = &GetControls_Controls_Edges_Node_Programs{}
 	}
-	return t.Name
+	return t.Edges
 }
 
 type GetControls_Controls_Edges_Node_Editors struct {
@@ -7818,7 +7906,7 @@ type GetControls_Controls_Edges_Node struct {
 	ImplementationGuidance []*models.ImplementationGuidance                 "json:\"implementationGuidance,omitempty\" graphql:\"implementationGuidance\""
 	MappedCategories       []string                                         "json:\"mappedCategories,omitempty\" graphql:\"mappedCategories\""
 	OwnerID                *string                                          "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Programs               []*GetControls_Controls_Edges_Node_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
+	Programs               GetControls_Controls_Edges_Node_Programs         "json:\"programs\" graphql:\"programs\""
 	RefCode                string                                           "json:\"refCode\" graphql:\"refCode\""
 	References             []*models.Reference                              "json:\"references,omitempty\" graphql:\"references\""
 	Source                 *enums.ControlSource                             "json:\"source,omitempty\" graphql:\"source\""
@@ -7946,11 +8034,11 @@ func (t *GetControls_Controls_Edges_Node) GetOwnerID() *string {
 	}
 	return t.OwnerID
 }
-func (t *GetControls_Controls_Edges_Node) GetPrograms() []*GetControls_Controls_Edges_Node_Programs {
+func (t *GetControls_Controls_Edges_Node) GetPrograms() *GetControls_Controls_Edges_Node_Programs {
 	if t == nil {
 		t = &GetControls_Controls_Edges_Node{}
 	}
-	return t.Programs
+	return &t.Programs
 }
 func (t *GetControls_Controls_Edges_Node) GetRefCode() string {
 	if t == nil {
@@ -8109,29 +8197,51 @@ func (t *UpdateControl_UpdateControl_Control_Standard) GetShortName() *string {
 	return t.ShortName
 }
 
-type UpdateControl_UpdateControl_Control_Programs struct {
+type UpdateControl_UpdateControl_Control_Programs_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	Name      string "json:\"name\" graphql:\"name\""
 }
 
-func (t *UpdateControl_UpdateControl_Control_Programs) GetDisplayID() string {
+func (t *UpdateControl_UpdateControl_Control_Programs_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &UpdateControl_UpdateControl_Control_Programs{}
+		t = &UpdateControl_UpdateControl_Control_Programs_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *UpdateControl_UpdateControl_Control_Programs) GetID() string {
+func (t *UpdateControl_UpdateControl_Control_Programs_Edges_Node) GetID() string {
 	if t == nil {
-		t = &UpdateControl_UpdateControl_Control_Programs{}
+		t = &UpdateControl_UpdateControl_Control_Programs_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *UpdateControl_UpdateControl_Control_Programs) GetName() string {
+func (t *UpdateControl_UpdateControl_Control_Programs_Edges_Node) GetName() string {
+	if t == nil {
+		t = &UpdateControl_UpdateControl_Control_Programs_Edges_Node{}
+	}
+	return t.Name
+}
+
+type UpdateControl_UpdateControl_Control_Programs_Edges struct {
+	Node *UpdateControl_UpdateControl_Control_Programs_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateControl_UpdateControl_Control_Programs_Edges) GetNode() *UpdateControl_UpdateControl_Control_Programs_Edges_Node {
+	if t == nil {
+		t = &UpdateControl_UpdateControl_Control_Programs_Edges{}
+	}
+	return t.Node
+}
+
+type UpdateControl_UpdateControl_Control_Programs struct {
+	Edges []*UpdateControl_UpdateControl_Control_Programs_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *UpdateControl_UpdateControl_Control_Programs) GetEdges() []*UpdateControl_UpdateControl_Control_Programs_Edges {
 	if t == nil {
 		t = &UpdateControl_UpdateControl_Control_Programs{}
 	}
-	return t.Name
+	return t.Edges
 }
 
 type UpdateControl_UpdateControl_Control_Editors struct {
@@ -8208,7 +8318,7 @@ type UpdateControl_UpdateControl_Control struct {
 	ImplementationGuidance []*models.ImplementationGuidance                     "json:\"implementationGuidance,omitempty\" graphql:\"implementationGuidance\""
 	MappedCategories       []string                                             "json:\"mappedCategories,omitempty\" graphql:\"mappedCategories\""
 	OwnerID                *string                                              "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Programs               []*UpdateControl_UpdateControl_Control_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
+	Programs               UpdateControl_UpdateControl_Control_Programs         "json:\"programs\" graphql:\"programs\""
 	RefCode                string                                               "json:\"refCode\" graphql:\"refCode\""
 	References             []*models.Reference                                  "json:\"references,omitempty\" graphql:\"references\""
 	Source                 *enums.ControlSource                                 "json:\"source,omitempty\" graphql:\"source\""
@@ -8336,11 +8446,11 @@ func (t *UpdateControl_UpdateControl_Control) GetOwnerID() *string {
 	}
 	return t.OwnerID
 }
-func (t *UpdateControl_UpdateControl_Control) GetPrograms() []*UpdateControl_UpdateControl_Control_Programs {
+func (t *UpdateControl_UpdateControl_Control) GetPrograms() *UpdateControl_UpdateControl_Control_Programs {
 	if t == nil {
 		t = &UpdateControl_UpdateControl_Control{}
 	}
-	return t.Programs
+	return &t.Programs
 }
 func (t *UpdateControl_UpdateControl_Control) GetRefCode() string {
 	if t == nil {
@@ -10018,61 +10128,105 @@ func (t *CreateBulkControlObjective_CreateBulkControlObjective) GetControlObject
 	return t.ControlObjectives
 }
 
-type CreateControlObjective_CreateControlObjective_ControlObjective_Controls struct {
+type CreateControlObjective_CreateControlObjective_ControlObjective_Controls_Edges_Node struct {
 	Description *string "json:\"description,omitempty\" graphql:\"description\""
 	DisplayID   string  "json:\"displayID\" graphql:\"displayID\""
 	ID          string  "json:\"id\" graphql:\"id\""
 	RefCode     string  "json:\"refCode\" graphql:\"refCode\""
 }
 
-func (t *CreateControlObjective_CreateControlObjective_ControlObjective_Controls) GetDescription() *string {
+func (t *CreateControlObjective_CreateControlObjective_ControlObjective_Controls_Edges_Node) GetDescription() *string {
 	if t == nil {
-		t = &CreateControlObjective_CreateControlObjective_ControlObjective_Controls{}
+		t = &CreateControlObjective_CreateControlObjective_ControlObjective_Controls_Edges_Node{}
 	}
 	return t.Description
 }
-func (t *CreateControlObjective_CreateControlObjective_ControlObjective_Controls) GetDisplayID() string {
+func (t *CreateControlObjective_CreateControlObjective_ControlObjective_Controls_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &CreateControlObjective_CreateControlObjective_ControlObjective_Controls{}
+		t = &CreateControlObjective_CreateControlObjective_ControlObjective_Controls_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *CreateControlObjective_CreateControlObjective_ControlObjective_Controls) GetID() string {
+func (t *CreateControlObjective_CreateControlObjective_ControlObjective_Controls_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateControlObjective_CreateControlObjective_ControlObjective_Controls{}
+		t = &CreateControlObjective_CreateControlObjective_ControlObjective_Controls_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *CreateControlObjective_CreateControlObjective_ControlObjective_Controls) GetRefCode() string {
+func (t *CreateControlObjective_CreateControlObjective_ControlObjective_Controls_Edges_Node) GetRefCode() string {
 	if t == nil {
-		t = &CreateControlObjective_CreateControlObjective_ControlObjective_Controls{}
+		t = &CreateControlObjective_CreateControlObjective_ControlObjective_Controls_Edges_Node{}
 	}
 	return t.RefCode
 }
 
-type CreateControlObjective_CreateControlObjective_ControlObjective_Programs struct {
+type CreateControlObjective_CreateControlObjective_ControlObjective_Controls_Edges struct {
+	Node *CreateControlObjective_CreateControlObjective_ControlObjective_Controls_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateControlObjective_CreateControlObjective_ControlObjective_Controls_Edges) GetNode() *CreateControlObjective_CreateControlObjective_ControlObjective_Controls_Edges_Node {
+	if t == nil {
+		t = &CreateControlObjective_CreateControlObjective_ControlObjective_Controls_Edges{}
+	}
+	return t.Node
+}
+
+type CreateControlObjective_CreateControlObjective_ControlObjective_Controls struct {
+	Edges []*CreateControlObjective_CreateControlObjective_ControlObjective_Controls_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateControlObjective_CreateControlObjective_ControlObjective_Controls) GetEdges() []*CreateControlObjective_CreateControlObjective_ControlObjective_Controls_Edges {
+	if t == nil {
+		t = &CreateControlObjective_CreateControlObjective_ControlObjective_Controls{}
+	}
+	return t.Edges
+}
+
+type CreateControlObjective_CreateControlObjective_ControlObjective_Programs_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	Name      string "json:\"name\" graphql:\"name\""
 }
 
-func (t *CreateControlObjective_CreateControlObjective_ControlObjective_Programs) GetDisplayID() string {
+func (t *CreateControlObjective_CreateControlObjective_ControlObjective_Programs_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &CreateControlObjective_CreateControlObjective_ControlObjective_Programs{}
+		t = &CreateControlObjective_CreateControlObjective_ControlObjective_Programs_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *CreateControlObjective_CreateControlObjective_ControlObjective_Programs) GetID() string {
+func (t *CreateControlObjective_CreateControlObjective_ControlObjective_Programs_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateControlObjective_CreateControlObjective_ControlObjective_Programs{}
+		t = &CreateControlObjective_CreateControlObjective_ControlObjective_Programs_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *CreateControlObjective_CreateControlObjective_ControlObjective_Programs) GetName() string {
+func (t *CreateControlObjective_CreateControlObjective_ControlObjective_Programs_Edges_Node) GetName() string {
+	if t == nil {
+		t = &CreateControlObjective_CreateControlObjective_ControlObjective_Programs_Edges_Node{}
+	}
+	return t.Name
+}
+
+type CreateControlObjective_CreateControlObjective_ControlObjective_Programs_Edges struct {
+	Node *CreateControlObjective_CreateControlObjective_ControlObjective_Programs_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateControlObjective_CreateControlObjective_ControlObjective_Programs_Edges) GetNode() *CreateControlObjective_CreateControlObjective_ControlObjective_Programs_Edges_Node {
+	if t == nil {
+		t = &CreateControlObjective_CreateControlObjective_ControlObjective_Programs_Edges{}
+	}
+	return t.Node
+}
+
+type CreateControlObjective_CreateControlObjective_ControlObjective_Programs struct {
+	Edges []*CreateControlObjective_CreateControlObjective_ControlObjective_Programs_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateControlObjective_CreateControlObjective_ControlObjective_Programs) GetEdges() []*CreateControlObjective_CreateControlObjective_ControlObjective_Programs_Edges {
 	if t == nil {
 		t = &CreateControlObjective_CreateControlObjective_ControlObjective_Programs{}
 	}
-	return t.Name
+	return t.Edges
 }
 
 type CreateControlObjective_CreateControlObjective_ControlObjective_Editors struct {
@@ -10133,7 +10287,7 @@ type CreateControlObjective_CreateControlObjective_ControlObjective struct {
 	BlockedGroups        []*CreateControlObjective_CreateControlObjective_ControlObjective_BlockedGroups "json:\"blockedGroups,omitempty\" graphql:\"blockedGroups\""
 	Category             *string                                                                         "json:\"category,omitempty\" graphql:\"category\""
 	ControlObjectiveType *string                                                                         "json:\"controlObjectiveType,omitempty\" graphql:\"controlObjectiveType\""
-	Controls             []*CreateControlObjective_CreateControlObjective_ControlObjective_Controls      "json:\"controls,omitempty\" graphql:\"controls\""
+	Controls             CreateControlObjective_CreateControlObjective_ControlObjective_Controls         "json:\"controls\" graphql:\"controls\""
 	CreatedAt            *time.Time                                                                      "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy            *string                                                                         "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	DesiredOutcome       *string                                                                         "json:\"desiredOutcome,omitempty\" graphql:\"desiredOutcome\""
@@ -10142,7 +10296,7 @@ type CreateControlObjective_CreateControlObjective_ControlObjective struct {
 	ID                   string                                                                          "json:\"id\" graphql:\"id\""
 	Name                 string                                                                          "json:\"name\" graphql:\"name\""
 	OwnerID              *string                                                                         "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Programs             []*CreateControlObjective_CreateControlObjective_ControlObjective_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
+	Programs             CreateControlObjective_CreateControlObjective_ControlObjective_Programs         "json:\"programs\" graphql:\"programs\""
 	Revision             *string                                                                         "json:\"revision,omitempty\" graphql:\"revision\""
 	Source               *enums.ControlSource                                                            "json:\"source,omitempty\" graphql:\"source\""
 	Status               *string                                                                         "json:\"status,omitempty\" graphql:\"status\""
@@ -10171,11 +10325,11 @@ func (t *CreateControlObjective_CreateControlObjective_ControlObjective) GetCont
 	}
 	return t.ControlObjectiveType
 }
-func (t *CreateControlObjective_CreateControlObjective_ControlObjective) GetControls() []*CreateControlObjective_CreateControlObjective_ControlObjective_Controls {
+func (t *CreateControlObjective_CreateControlObjective_ControlObjective) GetControls() *CreateControlObjective_CreateControlObjective_ControlObjective_Controls {
 	if t == nil {
 		t = &CreateControlObjective_CreateControlObjective_ControlObjective{}
 	}
-	return t.Controls
+	return &t.Controls
 }
 func (t *CreateControlObjective_CreateControlObjective_ControlObjective) GetCreatedAt() *time.Time {
 	if t == nil {
@@ -10225,11 +10379,11 @@ func (t *CreateControlObjective_CreateControlObjective_ControlObjective) GetOwne
 	}
 	return t.OwnerID
 }
-func (t *CreateControlObjective_CreateControlObjective_ControlObjective) GetPrograms() []*CreateControlObjective_CreateControlObjective_ControlObjective_Programs {
+func (t *CreateControlObjective_CreateControlObjective_ControlObjective) GetPrograms() *CreateControlObjective_CreateControlObjective_ControlObjective_Programs {
 	if t == nil {
 		t = &CreateControlObjective_CreateControlObjective_ControlObjective{}
 	}
-	return t.Programs
+	return &t.Programs
 }
 func (t *CreateControlObjective_CreateControlObjective_ControlObjective) GetRevision() *string {
 	if t == nil {
@@ -10302,61 +10456,105 @@ func (t *DeleteControlObjective_DeleteControlObjective) GetDeletedID() string {
 	return t.DeletedID
 }
 
-type GetAllControlObjectives_ControlObjectives_Edges_Node_Controls struct {
+type GetAllControlObjectives_ControlObjectives_Edges_Node_Controls_Edges_Node struct {
 	Description *string "json:\"description,omitempty\" graphql:\"description\""
 	DisplayID   string  "json:\"displayID\" graphql:\"displayID\""
 	ID          string  "json:\"id\" graphql:\"id\""
 	RefCode     string  "json:\"refCode\" graphql:\"refCode\""
 }
 
-func (t *GetAllControlObjectives_ControlObjectives_Edges_Node_Controls) GetDescription() *string {
+func (t *GetAllControlObjectives_ControlObjectives_Edges_Node_Controls_Edges_Node) GetDescription() *string {
 	if t == nil {
-		t = &GetAllControlObjectives_ControlObjectives_Edges_Node_Controls{}
+		t = &GetAllControlObjectives_ControlObjectives_Edges_Node_Controls_Edges_Node{}
 	}
 	return t.Description
 }
-func (t *GetAllControlObjectives_ControlObjectives_Edges_Node_Controls) GetDisplayID() string {
+func (t *GetAllControlObjectives_ControlObjectives_Edges_Node_Controls_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetAllControlObjectives_ControlObjectives_Edges_Node_Controls{}
+		t = &GetAllControlObjectives_ControlObjectives_Edges_Node_Controls_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetAllControlObjectives_ControlObjectives_Edges_Node_Controls) GetID() string {
+func (t *GetAllControlObjectives_ControlObjectives_Edges_Node_Controls_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetAllControlObjectives_ControlObjectives_Edges_Node_Controls{}
+		t = &GetAllControlObjectives_ControlObjectives_Edges_Node_Controls_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetAllControlObjectives_ControlObjectives_Edges_Node_Controls) GetRefCode() string {
+func (t *GetAllControlObjectives_ControlObjectives_Edges_Node_Controls_Edges_Node) GetRefCode() string {
 	if t == nil {
-		t = &GetAllControlObjectives_ControlObjectives_Edges_Node_Controls{}
+		t = &GetAllControlObjectives_ControlObjectives_Edges_Node_Controls_Edges_Node{}
 	}
 	return t.RefCode
 }
 
-type GetAllControlObjectives_ControlObjectives_Edges_Node_Programs struct {
+type GetAllControlObjectives_ControlObjectives_Edges_Node_Controls_Edges struct {
+	Node *GetAllControlObjectives_ControlObjectives_Edges_Node_Controls_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllControlObjectives_ControlObjectives_Edges_Node_Controls_Edges) GetNode() *GetAllControlObjectives_ControlObjectives_Edges_Node_Controls_Edges_Node {
+	if t == nil {
+		t = &GetAllControlObjectives_ControlObjectives_Edges_Node_Controls_Edges{}
+	}
+	return t.Node
+}
+
+type GetAllControlObjectives_ControlObjectives_Edges_Node_Controls struct {
+	Edges []*GetAllControlObjectives_ControlObjectives_Edges_Node_Controls_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetAllControlObjectives_ControlObjectives_Edges_Node_Controls) GetEdges() []*GetAllControlObjectives_ControlObjectives_Edges_Node_Controls_Edges {
+	if t == nil {
+		t = &GetAllControlObjectives_ControlObjectives_Edges_Node_Controls{}
+	}
+	return t.Edges
+}
+
+type GetAllControlObjectives_ControlObjectives_Edges_Node_Programs_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	Name      string "json:\"name\" graphql:\"name\""
 }
 
-func (t *GetAllControlObjectives_ControlObjectives_Edges_Node_Programs) GetDisplayID() string {
+func (t *GetAllControlObjectives_ControlObjectives_Edges_Node_Programs_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetAllControlObjectives_ControlObjectives_Edges_Node_Programs{}
+		t = &GetAllControlObjectives_ControlObjectives_Edges_Node_Programs_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetAllControlObjectives_ControlObjectives_Edges_Node_Programs) GetID() string {
+func (t *GetAllControlObjectives_ControlObjectives_Edges_Node_Programs_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetAllControlObjectives_ControlObjectives_Edges_Node_Programs{}
+		t = &GetAllControlObjectives_ControlObjectives_Edges_Node_Programs_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetAllControlObjectives_ControlObjectives_Edges_Node_Programs) GetName() string {
+func (t *GetAllControlObjectives_ControlObjectives_Edges_Node_Programs_Edges_Node) GetName() string {
+	if t == nil {
+		t = &GetAllControlObjectives_ControlObjectives_Edges_Node_Programs_Edges_Node{}
+	}
+	return t.Name
+}
+
+type GetAllControlObjectives_ControlObjectives_Edges_Node_Programs_Edges struct {
+	Node *GetAllControlObjectives_ControlObjectives_Edges_Node_Programs_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllControlObjectives_ControlObjectives_Edges_Node_Programs_Edges) GetNode() *GetAllControlObjectives_ControlObjectives_Edges_Node_Programs_Edges_Node {
+	if t == nil {
+		t = &GetAllControlObjectives_ControlObjectives_Edges_Node_Programs_Edges{}
+	}
+	return t.Node
+}
+
+type GetAllControlObjectives_ControlObjectives_Edges_Node_Programs struct {
+	Edges []*GetAllControlObjectives_ControlObjectives_Edges_Node_Programs_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetAllControlObjectives_ControlObjectives_Edges_Node_Programs) GetEdges() []*GetAllControlObjectives_ControlObjectives_Edges_Node_Programs_Edges {
 	if t == nil {
 		t = &GetAllControlObjectives_ControlObjectives_Edges_Node_Programs{}
 	}
-	return t.Name
+	return t.Edges
 }
 
 type GetAllControlObjectives_ControlObjectives_Edges_Node_Editors struct {
@@ -10417,7 +10615,7 @@ type GetAllControlObjectives_ControlObjectives_Edges_Node struct {
 	BlockedGroups        []*GetAllControlObjectives_ControlObjectives_Edges_Node_BlockedGroups "json:\"blockedGroups,omitempty\" graphql:\"blockedGroups\""
 	Category             *string                                                               "json:\"category,omitempty\" graphql:\"category\""
 	ControlObjectiveType *string                                                               "json:\"controlObjectiveType,omitempty\" graphql:\"controlObjectiveType\""
-	Controls             []*GetAllControlObjectives_ControlObjectives_Edges_Node_Controls      "json:\"controls,omitempty\" graphql:\"controls\""
+	Controls             GetAllControlObjectives_ControlObjectives_Edges_Node_Controls         "json:\"controls\" graphql:\"controls\""
 	CreatedAt            *time.Time                                                            "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy            *string                                                               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	DesiredOutcome       *string                                                               "json:\"desiredOutcome,omitempty\" graphql:\"desiredOutcome\""
@@ -10426,7 +10624,7 @@ type GetAllControlObjectives_ControlObjectives_Edges_Node struct {
 	ID                   string                                                                "json:\"id\" graphql:\"id\""
 	Name                 string                                                                "json:\"name\" graphql:\"name\""
 	OwnerID              *string                                                               "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Programs             []*GetAllControlObjectives_ControlObjectives_Edges_Node_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
+	Programs             GetAllControlObjectives_ControlObjectives_Edges_Node_Programs         "json:\"programs\" graphql:\"programs\""
 	Revision             *string                                                               "json:\"revision,omitempty\" graphql:\"revision\""
 	Source               *enums.ControlSource                                                  "json:\"source,omitempty\" graphql:\"source\""
 	Status               *string                                                               "json:\"status,omitempty\" graphql:\"status\""
@@ -10455,11 +10653,11 @@ func (t *GetAllControlObjectives_ControlObjectives_Edges_Node) GetControlObjecti
 	}
 	return t.ControlObjectiveType
 }
-func (t *GetAllControlObjectives_ControlObjectives_Edges_Node) GetControls() []*GetAllControlObjectives_ControlObjectives_Edges_Node_Controls {
+func (t *GetAllControlObjectives_ControlObjectives_Edges_Node) GetControls() *GetAllControlObjectives_ControlObjectives_Edges_Node_Controls {
 	if t == nil {
 		t = &GetAllControlObjectives_ControlObjectives_Edges_Node{}
 	}
-	return t.Controls
+	return &t.Controls
 }
 func (t *GetAllControlObjectives_ControlObjectives_Edges_Node) GetCreatedAt() *time.Time {
 	if t == nil {
@@ -10509,11 +10707,11 @@ func (t *GetAllControlObjectives_ControlObjectives_Edges_Node) GetOwnerID() *str
 	}
 	return t.OwnerID
 }
-func (t *GetAllControlObjectives_ControlObjectives_Edges_Node) GetPrograms() []*GetAllControlObjectives_ControlObjectives_Edges_Node_Programs {
+func (t *GetAllControlObjectives_ControlObjectives_Edges_Node) GetPrograms() *GetAllControlObjectives_ControlObjectives_Edges_Node_Programs {
 	if t == nil {
 		t = &GetAllControlObjectives_ControlObjectives_Edges_Node{}
 	}
-	return t.Programs
+	return &t.Programs
 }
 func (t *GetAllControlObjectives_ControlObjectives_Edges_Node) GetRevision() *string {
 	if t == nil {
@@ -10586,61 +10784,105 @@ func (t *GetAllControlObjectives_ControlObjectives) GetEdges() []*GetAllControlO
 	return t.Edges
 }
 
-type GetControlObjectiveByID_ControlObjective_Controls struct {
+type GetControlObjectiveByID_ControlObjective_Controls_Edges_Node struct {
 	Description *string "json:\"description,omitempty\" graphql:\"description\""
 	DisplayID   string  "json:\"displayID\" graphql:\"displayID\""
 	ID          string  "json:\"id\" graphql:\"id\""
 	RefCode     string  "json:\"refCode\" graphql:\"refCode\""
 }
 
-func (t *GetControlObjectiveByID_ControlObjective_Controls) GetDescription() *string {
+func (t *GetControlObjectiveByID_ControlObjective_Controls_Edges_Node) GetDescription() *string {
 	if t == nil {
-		t = &GetControlObjectiveByID_ControlObjective_Controls{}
+		t = &GetControlObjectiveByID_ControlObjective_Controls_Edges_Node{}
 	}
 	return t.Description
 }
-func (t *GetControlObjectiveByID_ControlObjective_Controls) GetDisplayID() string {
+func (t *GetControlObjectiveByID_ControlObjective_Controls_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetControlObjectiveByID_ControlObjective_Controls{}
+		t = &GetControlObjectiveByID_ControlObjective_Controls_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetControlObjectiveByID_ControlObjective_Controls) GetID() string {
+func (t *GetControlObjectiveByID_ControlObjective_Controls_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetControlObjectiveByID_ControlObjective_Controls{}
+		t = &GetControlObjectiveByID_ControlObjective_Controls_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetControlObjectiveByID_ControlObjective_Controls) GetRefCode() string {
+func (t *GetControlObjectiveByID_ControlObjective_Controls_Edges_Node) GetRefCode() string {
 	if t == nil {
-		t = &GetControlObjectiveByID_ControlObjective_Controls{}
+		t = &GetControlObjectiveByID_ControlObjective_Controls_Edges_Node{}
 	}
 	return t.RefCode
 }
 
-type GetControlObjectiveByID_ControlObjective_Programs struct {
+type GetControlObjectiveByID_ControlObjective_Controls_Edges struct {
+	Node *GetControlObjectiveByID_ControlObjective_Controls_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetControlObjectiveByID_ControlObjective_Controls_Edges) GetNode() *GetControlObjectiveByID_ControlObjective_Controls_Edges_Node {
+	if t == nil {
+		t = &GetControlObjectiveByID_ControlObjective_Controls_Edges{}
+	}
+	return t.Node
+}
+
+type GetControlObjectiveByID_ControlObjective_Controls struct {
+	Edges []*GetControlObjectiveByID_ControlObjective_Controls_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetControlObjectiveByID_ControlObjective_Controls) GetEdges() []*GetControlObjectiveByID_ControlObjective_Controls_Edges {
+	if t == nil {
+		t = &GetControlObjectiveByID_ControlObjective_Controls{}
+	}
+	return t.Edges
+}
+
+type GetControlObjectiveByID_ControlObjective_Programs_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	Name      string "json:\"name\" graphql:\"name\""
 }
 
-func (t *GetControlObjectiveByID_ControlObjective_Programs) GetDisplayID() string {
+func (t *GetControlObjectiveByID_ControlObjective_Programs_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetControlObjectiveByID_ControlObjective_Programs{}
+		t = &GetControlObjectiveByID_ControlObjective_Programs_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetControlObjectiveByID_ControlObjective_Programs) GetID() string {
+func (t *GetControlObjectiveByID_ControlObjective_Programs_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetControlObjectiveByID_ControlObjective_Programs{}
+		t = &GetControlObjectiveByID_ControlObjective_Programs_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetControlObjectiveByID_ControlObjective_Programs) GetName() string {
+func (t *GetControlObjectiveByID_ControlObjective_Programs_Edges_Node) GetName() string {
+	if t == nil {
+		t = &GetControlObjectiveByID_ControlObjective_Programs_Edges_Node{}
+	}
+	return t.Name
+}
+
+type GetControlObjectiveByID_ControlObjective_Programs_Edges struct {
+	Node *GetControlObjectiveByID_ControlObjective_Programs_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetControlObjectiveByID_ControlObjective_Programs_Edges) GetNode() *GetControlObjectiveByID_ControlObjective_Programs_Edges_Node {
+	if t == nil {
+		t = &GetControlObjectiveByID_ControlObjective_Programs_Edges{}
+	}
+	return t.Node
+}
+
+type GetControlObjectiveByID_ControlObjective_Programs struct {
+	Edges []*GetControlObjectiveByID_ControlObjective_Programs_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetControlObjectiveByID_ControlObjective_Programs) GetEdges() []*GetControlObjectiveByID_ControlObjective_Programs_Edges {
 	if t == nil {
 		t = &GetControlObjectiveByID_ControlObjective_Programs{}
 	}
-	return t.Name
+	return t.Edges
 }
 
 type GetControlObjectiveByID_ControlObjective_Editors struct {
@@ -10701,7 +10943,7 @@ type GetControlObjectiveByID_ControlObjective struct {
 	BlockedGroups        []*GetControlObjectiveByID_ControlObjective_BlockedGroups "json:\"blockedGroups,omitempty\" graphql:\"blockedGroups\""
 	Category             *string                                                   "json:\"category,omitempty\" graphql:\"category\""
 	ControlObjectiveType *string                                                   "json:\"controlObjectiveType,omitempty\" graphql:\"controlObjectiveType\""
-	Controls             []*GetControlObjectiveByID_ControlObjective_Controls      "json:\"controls,omitempty\" graphql:\"controls\""
+	Controls             GetControlObjectiveByID_ControlObjective_Controls         "json:\"controls\" graphql:\"controls\""
 	CreatedAt            *time.Time                                                "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy            *string                                                   "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	DesiredOutcome       *string                                                   "json:\"desiredOutcome,omitempty\" graphql:\"desiredOutcome\""
@@ -10710,7 +10952,7 @@ type GetControlObjectiveByID_ControlObjective struct {
 	ID                   string                                                    "json:\"id\" graphql:\"id\""
 	Name                 string                                                    "json:\"name\" graphql:\"name\""
 	OwnerID              *string                                                   "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Programs             []*GetControlObjectiveByID_ControlObjective_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
+	Programs             GetControlObjectiveByID_ControlObjective_Programs         "json:\"programs\" graphql:\"programs\""
 	Revision             *string                                                   "json:\"revision,omitempty\" graphql:\"revision\""
 	Source               *enums.ControlSource                                      "json:\"source,omitempty\" graphql:\"source\""
 	Status               *string                                                   "json:\"status,omitempty\" graphql:\"status\""
@@ -10739,11 +10981,11 @@ func (t *GetControlObjectiveByID_ControlObjective) GetControlObjectiveType() *st
 	}
 	return t.ControlObjectiveType
 }
-func (t *GetControlObjectiveByID_ControlObjective) GetControls() []*GetControlObjectiveByID_ControlObjective_Controls {
+func (t *GetControlObjectiveByID_ControlObjective) GetControls() *GetControlObjectiveByID_ControlObjective_Controls {
 	if t == nil {
 		t = &GetControlObjectiveByID_ControlObjective{}
 	}
-	return t.Controls
+	return &t.Controls
 }
 func (t *GetControlObjectiveByID_ControlObjective) GetCreatedAt() *time.Time {
 	if t == nil {
@@ -10793,11 +11035,11 @@ func (t *GetControlObjectiveByID_ControlObjective) GetOwnerID() *string {
 	}
 	return t.OwnerID
 }
-func (t *GetControlObjectiveByID_ControlObjective) GetPrograms() []*GetControlObjectiveByID_ControlObjective_Programs {
+func (t *GetControlObjectiveByID_ControlObjective) GetPrograms() *GetControlObjectiveByID_ControlObjective_Programs {
 	if t == nil {
 		t = &GetControlObjectiveByID_ControlObjective{}
 	}
-	return t.Programs
+	return &t.Programs
 }
 func (t *GetControlObjectiveByID_ControlObjective) GetRevision() *string {
 	if t == nil {
@@ -10848,61 +11090,105 @@ func (t *GetControlObjectiveByID_ControlObjective) GetViewers() []*GetControlObj
 	return t.Viewers
 }
 
-type GetControlObjectives_ControlObjectives_Edges_Node_Controls struct {
+type GetControlObjectives_ControlObjectives_Edges_Node_Controls_Edges_Node struct {
 	Description *string "json:\"description,omitempty\" graphql:\"description\""
 	DisplayID   string  "json:\"displayID\" graphql:\"displayID\""
 	ID          string  "json:\"id\" graphql:\"id\""
 	RefCode     string  "json:\"refCode\" graphql:\"refCode\""
 }
 
-func (t *GetControlObjectives_ControlObjectives_Edges_Node_Controls) GetDescription() *string {
+func (t *GetControlObjectives_ControlObjectives_Edges_Node_Controls_Edges_Node) GetDescription() *string {
 	if t == nil {
-		t = &GetControlObjectives_ControlObjectives_Edges_Node_Controls{}
+		t = &GetControlObjectives_ControlObjectives_Edges_Node_Controls_Edges_Node{}
 	}
 	return t.Description
 }
-func (t *GetControlObjectives_ControlObjectives_Edges_Node_Controls) GetDisplayID() string {
+func (t *GetControlObjectives_ControlObjectives_Edges_Node_Controls_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetControlObjectives_ControlObjectives_Edges_Node_Controls{}
+		t = &GetControlObjectives_ControlObjectives_Edges_Node_Controls_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetControlObjectives_ControlObjectives_Edges_Node_Controls) GetID() string {
+func (t *GetControlObjectives_ControlObjectives_Edges_Node_Controls_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetControlObjectives_ControlObjectives_Edges_Node_Controls{}
+		t = &GetControlObjectives_ControlObjectives_Edges_Node_Controls_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetControlObjectives_ControlObjectives_Edges_Node_Controls) GetRefCode() string {
+func (t *GetControlObjectives_ControlObjectives_Edges_Node_Controls_Edges_Node) GetRefCode() string {
 	if t == nil {
-		t = &GetControlObjectives_ControlObjectives_Edges_Node_Controls{}
+		t = &GetControlObjectives_ControlObjectives_Edges_Node_Controls_Edges_Node{}
 	}
 	return t.RefCode
 }
 
-type GetControlObjectives_ControlObjectives_Edges_Node_Programs struct {
+type GetControlObjectives_ControlObjectives_Edges_Node_Controls_Edges struct {
+	Node *GetControlObjectives_ControlObjectives_Edges_Node_Controls_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetControlObjectives_ControlObjectives_Edges_Node_Controls_Edges) GetNode() *GetControlObjectives_ControlObjectives_Edges_Node_Controls_Edges_Node {
+	if t == nil {
+		t = &GetControlObjectives_ControlObjectives_Edges_Node_Controls_Edges{}
+	}
+	return t.Node
+}
+
+type GetControlObjectives_ControlObjectives_Edges_Node_Controls struct {
+	Edges []*GetControlObjectives_ControlObjectives_Edges_Node_Controls_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetControlObjectives_ControlObjectives_Edges_Node_Controls) GetEdges() []*GetControlObjectives_ControlObjectives_Edges_Node_Controls_Edges {
+	if t == nil {
+		t = &GetControlObjectives_ControlObjectives_Edges_Node_Controls{}
+	}
+	return t.Edges
+}
+
+type GetControlObjectives_ControlObjectives_Edges_Node_Programs_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	Name      string "json:\"name\" graphql:\"name\""
 }
 
-func (t *GetControlObjectives_ControlObjectives_Edges_Node_Programs) GetDisplayID() string {
+func (t *GetControlObjectives_ControlObjectives_Edges_Node_Programs_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetControlObjectives_ControlObjectives_Edges_Node_Programs{}
+		t = &GetControlObjectives_ControlObjectives_Edges_Node_Programs_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetControlObjectives_ControlObjectives_Edges_Node_Programs) GetID() string {
+func (t *GetControlObjectives_ControlObjectives_Edges_Node_Programs_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetControlObjectives_ControlObjectives_Edges_Node_Programs{}
+		t = &GetControlObjectives_ControlObjectives_Edges_Node_Programs_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetControlObjectives_ControlObjectives_Edges_Node_Programs) GetName() string {
+func (t *GetControlObjectives_ControlObjectives_Edges_Node_Programs_Edges_Node) GetName() string {
+	if t == nil {
+		t = &GetControlObjectives_ControlObjectives_Edges_Node_Programs_Edges_Node{}
+	}
+	return t.Name
+}
+
+type GetControlObjectives_ControlObjectives_Edges_Node_Programs_Edges struct {
+	Node *GetControlObjectives_ControlObjectives_Edges_Node_Programs_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetControlObjectives_ControlObjectives_Edges_Node_Programs_Edges) GetNode() *GetControlObjectives_ControlObjectives_Edges_Node_Programs_Edges_Node {
+	if t == nil {
+		t = &GetControlObjectives_ControlObjectives_Edges_Node_Programs_Edges{}
+	}
+	return t.Node
+}
+
+type GetControlObjectives_ControlObjectives_Edges_Node_Programs struct {
+	Edges []*GetControlObjectives_ControlObjectives_Edges_Node_Programs_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetControlObjectives_ControlObjectives_Edges_Node_Programs) GetEdges() []*GetControlObjectives_ControlObjectives_Edges_Node_Programs_Edges {
 	if t == nil {
 		t = &GetControlObjectives_ControlObjectives_Edges_Node_Programs{}
 	}
-	return t.Name
+	return t.Edges
 }
 
 type GetControlObjectives_ControlObjectives_Edges_Node_Editors struct {
@@ -10963,7 +11249,7 @@ type GetControlObjectives_ControlObjectives_Edges_Node struct {
 	BlockedGroups        []*GetControlObjectives_ControlObjectives_Edges_Node_BlockedGroups "json:\"blockedGroups,omitempty\" graphql:\"blockedGroups\""
 	Category             *string                                                            "json:\"category,omitempty\" graphql:\"category\""
 	ControlObjectiveType *string                                                            "json:\"controlObjectiveType,omitempty\" graphql:\"controlObjectiveType\""
-	Controls             []*GetControlObjectives_ControlObjectives_Edges_Node_Controls      "json:\"controls,omitempty\" graphql:\"controls\""
+	Controls             GetControlObjectives_ControlObjectives_Edges_Node_Controls         "json:\"controls\" graphql:\"controls\""
 	CreatedAt            *time.Time                                                         "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy            *string                                                            "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	DesiredOutcome       *string                                                            "json:\"desiredOutcome,omitempty\" graphql:\"desiredOutcome\""
@@ -10972,7 +11258,7 @@ type GetControlObjectives_ControlObjectives_Edges_Node struct {
 	ID                   string                                                             "json:\"id\" graphql:\"id\""
 	Name                 string                                                             "json:\"name\" graphql:\"name\""
 	OwnerID              *string                                                            "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Programs             []*GetControlObjectives_ControlObjectives_Edges_Node_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
+	Programs             GetControlObjectives_ControlObjectives_Edges_Node_Programs         "json:\"programs\" graphql:\"programs\""
 	Revision             *string                                                            "json:\"revision,omitempty\" graphql:\"revision\""
 	Source               *enums.ControlSource                                               "json:\"source,omitempty\" graphql:\"source\""
 	Status               *string                                                            "json:\"status,omitempty\" graphql:\"status\""
@@ -11001,11 +11287,11 @@ func (t *GetControlObjectives_ControlObjectives_Edges_Node) GetControlObjectiveT
 	}
 	return t.ControlObjectiveType
 }
-func (t *GetControlObjectives_ControlObjectives_Edges_Node) GetControls() []*GetControlObjectives_ControlObjectives_Edges_Node_Controls {
+func (t *GetControlObjectives_ControlObjectives_Edges_Node) GetControls() *GetControlObjectives_ControlObjectives_Edges_Node_Controls {
 	if t == nil {
 		t = &GetControlObjectives_ControlObjectives_Edges_Node{}
 	}
-	return t.Controls
+	return &t.Controls
 }
 func (t *GetControlObjectives_ControlObjectives_Edges_Node) GetCreatedAt() *time.Time {
 	if t == nil {
@@ -11055,11 +11341,11 @@ func (t *GetControlObjectives_ControlObjectives_Edges_Node) GetOwnerID() *string
 	}
 	return t.OwnerID
 }
-func (t *GetControlObjectives_ControlObjectives_Edges_Node) GetPrograms() []*GetControlObjectives_ControlObjectives_Edges_Node_Programs {
+func (t *GetControlObjectives_ControlObjectives_Edges_Node) GetPrograms() *GetControlObjectives_ControlObjectives_Edges_Node_Programs {
 	if t == nil {
 		t = &GetControlObjectives_ControlObjectives_Edges_Node{}
 	}
-	return t.Programs
+	return &t.Programs
 }
 func (t *GetControlObjectives_ControlObjectives_Edges_Node) GetRevision() *string {
 	if t == nil {
@@ -11132,61 +11418,105 @@ func (t *GetControlObjectives_ControlObjectives) GetEdges() []*GetControlObjecti
 	return t.Edges
 }
 
-type UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls struct {
+type UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls_Edges_Node struct {
 	Description *string "json:\"description,omitempty\" graphql:\"description\""
 	DisplayID   string  "json:\"displayID\" graphql:\"displayID\""
 	ID          string  "json:\"id\" graphql:\"id\""
 	RefCode     string  "json:\"refCode\" graphql:\"refCode\""
 }
 
-func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls) GetDescription() *string {
+func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls_Edges_Node) GetDescription() *string {
 	if t == nil {
-		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls{}
+		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls_Edges_Node{}
 	}
 	return t.Description
 }
-func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls) GetDisplayID() string {
+func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls{}
+		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls) GetID() string {
+func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls_Edges_Node) GetID() string {
 	if t == nil {
-		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls{}
+		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls) GetRefCode() string {
+func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls_Edges_Node) GetRefCode() string {
 	if t == nil {
-		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls{}
+		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls_Edges_Node{}
 	}
 	return t.RefCode
 }
 
-type UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs struct {
+type UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls_Edges struct {
+	Node *UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls_Edges) GetNode() *UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls_Edges_Node {
+	if t == nil {
+		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls_Edges{}
+	}
+	return t.Node
+}
+
+type UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls struct {
+	Edges []*UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls) GetEdges() []*UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls_Edges {
+	if t == nil {
+		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls{}
+	}
+	return t.Edges
+}
+
+type UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	Name      string "json:\"name\" graphql:\"name\""
 }
 
-func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs) GetDisplayID() string {
+func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs{}
+		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs) GetID() string {
+func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs_Edges_Node) GetID() string {
 	if t == nil {
-		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs{}
+		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs) GetName() string {
+func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs_Edges_Node) GetName() string {
+	if t == nil {
+		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs_Edges_Node{}
+	}
+	return t.Name
+}
+
+type UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs_Edges struct {
+	Node *UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs_Edges) GetNode() *UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs_Edges_Node {
+	if t == nil {
+		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs_Edges{}
+	}
+	return t.Node
+}
+
+type UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs struct {
+	Edges []*UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs) GetEdges() []*UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs_Edges {
 	if t == nil {
 		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs{}
 	}
-	return t.Name
+	return t.Edges
 }
 
 type UpdateControlObjective_UpdateControlObjective_ControlObjective_Editors struct {
@@ -11247,7 +11577,7 @@ type UpdateControlObjective_UpdateControlObjective_ControlObjective struct {
 	BlockedGroups        []*UpdateControlObjective_UpdateControlObjective_ControlObjective_BlockedGroups "json:\"blockedGroups,omitempty\" graphql:\"blockedGroups\""
 	Category             *string                                                                         "json:\"category,omitempty\" graphql:\"category\""
 	ControlObjectiveType *string                                                                         "json:\"controlObjectiveType,omitempty\" graphql:\"controlObjectiveType\""
-	Controls             []*UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls      "json:\"controls,omitempty\" graphql:\"controls\""
+	Controls             UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls         "json:\"controls\" graphql:\"controls\""
 	CreatedAt            *time.Time                                                                      "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy            *string                                                                         "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	DesiredOutcome       *string                                                                         "json:\"desiredOutcome,omitempty\" graphql:\"desiredOutcome\""
@@ -11256,7 +11586,7 @@ type UpdateControlObjective_UpdateControlObjective_ControlObjective struct {
 	ID                   string                                                                          "json:\"id\" graphql:\"id\""
 	Name                 string                                                                          "json:\"name\" graphql:\"name\""
 	OwnerID              *string                                                                         "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Programs             []*UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
+	Programs             UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs         "json:\"programs\" graphql:\"programs\""
 	Revision             *string                                                                         "json:\"revision,omitempty\" graphql:\"revision\""
 	Source               *enums.ControlSource                                                            "json:\"source,omitempty\" graphql:\"source\""
 	Status               *string                                                                         "json:\"status,omitempty\" graphql:\"status\""
@@ -11285,11 +11615,11 @@ func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective) GetCont
 	}
 	return t.ControlObjectiveType
 }
-func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective) GetControls() []*UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls {
+func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective) GetControls() *UpdateControlObjective_UpdateControlObjective_ControlObjective_Controls {
 	if t == nil {
 		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective{}
 	}
-	return t.Controls
+	return &t.Controls
 }
 func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective) GetCreatedAt() *time.Time {
 	if t == nil {
@@ -11339,11 +11669,11 @@ func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective) GetOwne
 	}
 	return t.OwnerID
 }
-func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective) GetPrograms() []*UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs {
+func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective) GetPrograms() *UpdateControlObjective_UpdateControlObjective_ControlObjective_Programs {
 	if t == nil {
 		t = &UpdateControlObjective_UpdateControlObjective_ControlObjective{}
 	}
-	return t.Programs
+	return &t.Programs
 }
 func (t *UpdateControlObjective_UpdateControlObjective_ControlObjective) GetRevision() *string {
 	if t == nil {
@@ -12135,29 +12465,51 @@ func (t *GetDocumentDataHistories_DocumentDataHistories) GetEdges() []*GetDocume
 	return t.Edges
 }
 
-type CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes struct {
+type CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes_Edges_Node struct {
 	Text      string     "json:\"text\" graphql:\"text\""
 	UpdatedAt *time.Time "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
 	UpdatedBy *string    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes) GetText() string {
+func (t *CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes_Edges_Node) GetText() string {
 	if t == nil {
-		t = &CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes{}
+		t = &CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes_Edges_Node{}
 	}
 	return t.Text
 }
-func (t *CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes) GetUpdatedAt() *time.Time {
+func (t *CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
-		t = &CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes{}
+		t = &CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes_Edges_Node{}
 	}
 	return t.UpdatedAt
 }
-func (t *CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes) GetUpdatedBy() *string {
+func (t *CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes_Edges_Node) GetUpdatedBy() *string {
+	if t == nil {
+		t = &CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes_Edges_Node{}
+	}
+	return t.UpdatedBy
+}
+
+type CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes_Edges struct {
+	Node *CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes_Edges) GetNode() *CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes_Edges_Node {
+	if t == nil {
+		t = &CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes_Edges{}
+	}
+	return t.Node
+}
+
+type CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes struct {
+	Edges []*CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes) GetEdges() []*CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes_Edges {
 	if t == nil {
 		t = &CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes{}
 	}
-	return t.UpdatedBy
+	return t.Edges
 }
 
 type CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_EntityType struct {
@@ -12180,7 +12532,7 @@ type CreateBulkCSVEntity_CreateBulkCSVEntity_Entities struct {
 	EntityType  *CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_EntityType "json:\"entityType,omitempty\" graphql:\"entityType\""
 	ID          string                                                       "json:\"id\" graphql:\"id\""
 	Name        *string                                                      "json:\"name,omitempty\" graphql:\"name\""
-	Notes       []*CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes    "json:\"notes,omitempty\" graphql:\"notes\""
+	Notes       CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes       "json:\"notes\" graphql:\"notes\""
 	OwnerID     *string                                                      "json:\"ownerID,omitempty\" graphql:\"ownerID\""
 	Status      *string                                                      "json:\"status,omitempty\" graphql:\"status\""
 	Tags        []string                                                     "json:\"tags,omitempty\" graphql:\"tags\""
@@ -12236,11 +12588,11 @@ func (t *CreateBulkCSVEntity_CreateBulkCSVEntity_Entities) GetName() *string {
 	}
 	return t.Name
 }
-func (t *CreateBulkCSVEntity_CreateBulkCSVEntity_Entities) GetNotes() []*CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes {
+func (t *CreateBulkCSVEntity_CreateBulkCSVEntity_Entities) GetNotes() *CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes {
 	if t == nil {
 		t = &CreateBulkCSVEntity_CreateBulkCSVEntity_Entities{}
 	}
-	return t.Notes
+	return &t.Notes
 }
 func (t *CreateBulkCSVEntity_CreateBulkCSVEntity_Entities) GetOwnerID() *string {
 	if t == nil {
@@ -12284,29 +12636,51 @@ func (t *CreateBulkCSVEntity_CreateBulkCSVEntity) GetEntities() []*CreateBulkCSV
 	return t.Entities
 }
 
-type CreateBulkEntity_CreateBulkEntity_Entities_Notes struct {
+type CreateBulkEntity_CreateBulkEntity_Entities_Notes_Edges_Node struct {
 	Text      string     "json:\"text\" graphql:\"text\""
 	UpdatedAt *time.Time "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
 	UpdatedBy *string    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *CreateBulkEntity_CreateBulkEntity_Entities_Notes) GetText() string {
+func (t *CreateBulkEntity_CreateBulkEntity_Entities_Notes_Edges_Node) GetText() string {
 	if t == nil {
-		t = &CreateBulkEntity_CreateBulkEntity_Entities_Notes{}
+		t = &CreateBulkEntity_CreateBulkEntity_Entities_Notes_Edges_Node{}
 	}
 	return t.Text
 }
-func (t *CreateBulkEntity_CreateBulkEntity_Entities_Notes) GetUpdatedAt() *time.Time {
+func (t *CreateBulkEntity_CreateBulkEntity_Entities_Notes_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
-		t = &CreateBulkEntity_CreateBulkEntity_Entities_Notes{}
+		t = &CreateBulkEntity_CreateBulkEntity_Entities_Notes_Edges_Node{}
 	}
 	return t.UpdatedAt
 }
-func (t *CreateBulkEntity_CreateBulkEntity_Entities_Notes) GetUpdatedBy() *string {
+func (t *CreateBulkEntity_CreateBulkEntity_Entities_Notes_Edges_Node) GetUpdatedBy() *string {
+	if t == nil {
+		t = &CreateBulkEntity_CreateBulkEntity_Entities_Notes_Edges_Node{}
+	}
+	return t.UpdatedBy
+}
+
+type CreateBulkEntity_CreateBulkEntity_Entities_Notes_Edges struct {
+	Node *CreateBulkEntity_CreateBulkEntity_Entities_Notes_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkEntity_CreateBulkEntity_Entities_Notes_Edges) GetNode() *CreateBulkEntity_CreateBulkEntity_Entities_Notes_Edges_Node {
+	if t == nil {
+		t = &CreateBulkEntity_CreateBulkEntity_Entities_Notes_Edges{}
+	}
+	return t.Node
+}
+
+type CreateBulkEntity_CreateBulkEntity_Entities_Notes struct {
+	Edges []*CreateBulkEntity_CreateBulkEntity_Entities_Notes_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateBulkEntity_CreateBulkEntity_Entities_Notes) GetEdges() []*CreateBulkEntity_CreateBulkEntity_Entities_Notes_Edges {
 	if t == nil {
 		t = &CreateBulkEntity_CreateBulkEntity_Entities_Notes{}
 	}
-	return t.UpdatedBy
+	return t.Edges
 }
 
 type CreateBulkEntity_CreateBulkEntity_Entities_EntityType struct {
@@ -12329,7 +12703,7 @@ type CreateBulkEntity_CreateBulkEntity_Entities struct {
 	EntityType  *CreateBulkEntity_CreateBulkEntity_Entities_EntityType "json:\"entityType,omitempty\" graphql:\"entityType\""
 	ID          string                                                 "json:\"id\" graphql:\"id\""
 	Name        *string                                                "json:\"name,omitempty\" graphql:\"name\""
-	Notes       []*CreateBulkEntity_CreateBulkEntity_Entities_Notes    "json:\"notes,omitempty\" graphql:\"notes\""
+	Notes       CreateBulkEntity_CreateBulkEntity_Entities_Notes       "json:\"notes\" graphql:\"notes\""
 	OwnerID     *string                                                "json:\"ownerID,omitempty\" graphql:\"ownerID\""
 	Status      *string                                                "json:\"status,omitempty\" graphql:\"status\""
 	Tags        []string                                               "json:\"tags,omitempty\" graphql:\"tags\""
@@ -12385,11 +12759,11 @@ func (t *CreateBulkEntity_CreateBulkEntity_Entities) GetName() *string {
 	}
 	return t.Name
 }
-func (t *CreateBulkEntity_CreateBulkEntity_Entities) GetNotes() []*CreateBulkEntity_CreateBulkEntity_Entities_Notes {
+func (t *CreateBulkEntity_CreateBulkEntity_Entities) GetNotes() *CreateBulkEntity_CreateBulkEntity_Entities_Notes {
 	if t == nil {
 		t = &CreateBulkEntity_CreateBulkEntity_Entities{}
 	}
-	return t.Notes
+	return &t.Notes
 }
 func (t *CreateBulkEntity_CreateBulkEntity_Entities) GetOwnerID() *string {
 	if t == nil {
@@ -12433,29 +12807,51 @@ func (t *CreateBulkEntity_CreateBulkEntity) GetEntities() []*CreateBulkEntity_Cr
 	return t.Entities
 }
 
-type CreateEntity_CreateEntity_Entity_Notes struct {
+type CreateEntity_CreateEntity_Entity_Notes_Edges_Node struct {
 	Text      string     "json:\"text\" graphql:\"text\""
 	UpdatedAt *time.Time "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
 	UpdatedBy *string    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *CreateEntity_CreateEntity_Entity_Notes) GetText() string {
+func (t *CreateEntity_CreateEntity_Entity_Notes_Edges_Node) GetText() string {
 	if t == nil {
-		t = &CreateEntity_CreateEntity_Entity_Notes{}
+		t = &CreateEntity_CreateEntity_Entity_Notes_Edges_Node{}
 	}
 	return t.Text
 }
-func (t *CreateEntity_CreateEntity_Entity_Notes) GetUpdatedAt() *time.Time {
+func (t *CreateEntity_CreateEntity_Entity_Notes_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
-		t = &CreateEntity_CreateEntity_Entity_Notes{}
+		t = &CreateEntity_CreateEntity_Entity_Notes_Edges_Node{}
 	}
 	return t.UpdatedAt
 }
-func (t *CreateEntity_CreateEntity_Entity_Notes) GetUpdatedBy() *string {
+func (t *CreateEntity_CreateEntity_Entity_Notes_Edges_Node) GetUpdatedBy() *string {
+	if t == nil {
+		t = &CreateEntity_CreateEntity_Entity_Notes_Edges_Node{}
+	}
+	return t.UpdatedBy
+}
+
+type CreateEntity_CreateEntity_Entity_Notes_Edges struct {
+	Node *CreateEntity_CreateEntity_Entity_Notes_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateEntity_CreateEntity_Entity_Notes_Edges) GetNode() *CreateEntity_CreateEntity_Entity_Notes_Edges_Node {
+	if t == nil {
+		t = &CreateEntity_CreateEntity_Entity_Notes_Edges{}
+	}
+	return t.Node
+}
+
+type CreateEntity_CreateEntity_Entity_Notes struct {
+	Edges []*CreateEntity_CreateEntity_Entity_Notes_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateEntity_CreateEntity_Entity_Notes) GetEdges() []*CreateEntity_CreateEntity_Entity_Notes_Edges {
 	if t == nil {
 		t = &CreateEntity_CreateEntity_Entity_Notes{}
 	}
-	return t.UpdatedBy
+	return t.Edges
 }
 
 type CreateEntity_CreateEntity_Entity_EntityType struct {
@@ -12478,7 +12874,7 @@ type CreateEntity_CreateEntity_Entity struct {
 	EntityType  *CreateEntity_CreateEntity_Entity_EntityType "json:\"entityType,omitempty\" graphql:\"entityType\""
 	ID          string                                       "json:\"id\" graphql:\"id\""
 	Name        *string                                      "json:\"name,omitempty\" graphql:\"name\""
-	Notes       []*CreateEntity_CreateEntity_Entity_Notes    "json:\"notes,omitempty\" graphql:\"notes\""
+	Notes       CreateEntity_CreateEntity_Entity_Notes       "json:\"notes\" graphql:\"notes\""
 	OwnerID     *string                                      "json:\"ownerID,omitempty\" graphql:\"ownerID\""
 	Status      *string                                      "json:\"status,omitempty\" graphql:\"status\""
 	Tags        []string                                     "json:\"tags,omitempty\" graphql:\"tags\""
@@ -12534,11 +12930,11 @@ func (t *CreateEntity_CreateEntity_Entity) GetName() *string {
 	}
 	return t.Name
 }
-func (t *CreateEntity_CreateEntity_Entity) GetNotes() []*CreateEntity_CreateEntity_Entity_Notes {
+func (t *CreateEntity_CreateEntity_Entity) GetNotes() *CreateEntity_CreateEntity_Entity_Notes {
 	if t == nil {
 		t = &CreateEntity_CreateEntity_Entity{}
 	}
-	return t.Notes
+	return &t.Notes
 }
 func (t *CreateEntity_CreateEntity_Entity) GetOwnerID() *string {
 	if t == nil {
@@ -12593,29 +12989,51 @@ func (t *DeleteEntity_DeleteEntity) GetDeletedID() string {
 	return t.DeletedID
 }
 
-type GetAllEntities_Entities_Edges_Node_Notes struct {
+type GetAllEntities_Entities_Edges_Node_Notes_Edges_Node struct {
 	Text      string     "json:\"text\" graphql:\"text\""
 	UpdatedAt *time.Time "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
 	UpdatedBy *string    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *GetAllEntities_Entities_Edges_Node_Notes) GetText() string {
+func (t *GetAllEntities_Entities_Edges_Node_Notes_Edges_Node) GetText() string {
 	if t == nil {
-		t = &GetAllEntities_Entities_Edges_Node_Notes{}
+		t = &GetAllEntities_Entities_Edges_Node_Notes_Edges_Node{}
 	}
 	return t.Text
 }
-func (t *GetAllEntities_Entities_Edges_Node_Notes) GetUpdatedAt() *time.Time {
+func (t *GetAllEntities_Entities_Edges_Node_Notes_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
-		t = &GetAllEntities_Entities_Edges_Node_Notes{}
+		t = &GetAllEntities_Entities_Edges_Node_Notes_Edges_Node{}
 	}
 	return t.UpdatedAt
 }
-func (t *GetAllEntities_Entities_Edges_Node_Notes) GetUpdatedBy() *string {
+func (t *GetAllEntities_Entities_Edges_Node_Notes_Edges_Node) GetUpdatedBy() *string {
+	if t == nil {
+		t = &GetAllEntities_Entities_Edges_Node_Notes_Edges_Node{}
+	}
+	return t.UpdatedBy
+}
+
+type GetAllEntities_Entities_Edges_Node_Notes_Edges struct {
+	Node *GetAllEntities_Entities_Edges_Node_Notes_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllEntities_Entities_Edges_Node_Notes_Edges) GetNode() *GetAllEntities_Entities_Edges_Node_Notes_Edges_Node {
+	if t == nil {
+		t = &GetAllEntities_Entities_Edges_Node_Notes_Edges{}
+	}
+	return t.Node
+}
+
+type GetAllEntities_Entities_Edges_Node_Notes struct {
+	Edges []*GetAllEntities_Entities_Edges_Node_Notes_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetAllEntities_Entities_Edges_Node_Notes) GetEdges() []*GetAllEntities_Entities_Edges_Node_Notes_Edges {
 	if t == nil {
 		t = &GetAllEntities_Entities_Edges_Node_Notes{}
 	}
-	return t.UpdatedBy
+	return t.Edges
 }
 
 type GetAllEntities_Entities_Edges_Node_EntityType struct {
@@ -12638,7 +13056,7 @@ type GetAllEntities_Entities_Edges_Node struct {
 	EntityType  *GetAllEntities_Entities_Edges_Node_EntityType "json:\"entityType,omitempty\" graphql:\"entityType\""
 	ID          string                                         "json:\"id\" graphql:\"id\""
 	Name        *string                                        "json:\"name,omitempty\" graphql:\"name\""
-	Notes       []*GetAllEntities_Entities_Edges_Node_Notes    "json:\"notes,omitempty\" graphql:\"notes\""
+	Notes       GetAllEntities_Entities_Edges_Node_Notes       "json:\"notes\" graphql:\"notes\""
 	OwnerID     *string                                        "json:\"ownerID,omitempty\" graphql:\"ownerID\""
 	Status      *string                                        "json:\"status,omitempty\" graphql:\"status\""
 	Tags        []string                                       "json:\"tags,omitempty\" graphql:\"tags\""
@@ -12694,11 +13112,11 @@ func (t *GetAllEntities_Entities_Edges_Node) GetName() *string {
 	}
 	return t.Name
 }
-func (t *GetAllEntities_Entities_Edges_Node) GetNotes() []*GetAllEntities_Entities_Edges_Node_Notes {
+func (t *GetAllEntities_Entities_Edges_Node) GetNotes() *GetAllEntities_Entities_Edges_Node_Notes {
 	if t == nil {
 		t = &GetAllEntities_Entities_Edges_Node{}
 	}
-	return t.Notes
+	return &t.Notes
 }
 func (t *GetAllEntities_Entities_Edges_Node) GetOwnerID() *string {
 	if t == nil {
@@ -12753,29 +13171,51 @@ func (t *GetAllEntities_Entities) GetEdges() []*GetAllEntities_Entities_Edges {
 	return t.Edges
 }
 
-type GetEntities_Entities_Edges_Node_Notes struct {
+type GetEntities_Entities_Edges_Node_Notes_Edges_Node struct {
 	Text      string     "json:\"text\" graphql:\"text\""
 	UpdatedAt *time.Time "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
 	UpdatedBy *string    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *GetEntities_Entities_Edges_Node_Notes) GetText() string {
+func (t *GetEntities_Entities_Edges_Node_Notes_Edges_Node) GetText() string {
 	if t == nil {
-		t = &GetEntities_Entities_Edges_Node_Notes{}
+		t = &GetEntities_Entities_Edges_Node_Notes_Edges_Node{}
 	}
 	return t.Text
 }
-func (t *GetEntities_Entities_Edges_Node_Notes) GetUpdatedAt() *time.Time {
+func (t *GetEntities_Entities_Edges_Node_Notes_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
-		t = &GetEntities_Entities_Edges_Node_Notes{}
+		t = &GetEntities_Entities_Edges_Node_Notes_Edges_Node{}
 	}
 	return t.UpdatedAt
 }
-func (t *GetEntities_Entities_Edges_Node_Notes) GetUpdatedBy() *string {
+func (t *GetEntities_Entities_Edges_Node_Notes_Edges_Node) GetUpdatedBy() *string {
+	if t == nil {
+		t = &GetEntities_Entities_Edges_Node_Notes_Edges_Node{}
+	}
+	return t.UpdatedBy
+}
+
+type GetEntities_Entities_Edges_Node_Notes_Edges struct {
+	Node *GetEntities_Entities_Edges_Node_Notes_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetEntities_Entities_Edges_Node_Notes_Edges) GetNode() *GetEntities_Entities_Edges_Node_Notes_Edges_Node {
+	if t == nil {
+		t = &GetEntities_Entities_Edges_Node_Notes_Edges{}
+	}
+	return t.Node
+}
+
+type GetEntities_Entities_Edges_Node_Notes struct {
+	Edges []*GetEntities_Entities_Edges_Node_Notes_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetEntities_Entities_Edges_Node_Notes) GetEdges() []*GetEntities_Entities_Edges_Node_Notes_Edges {
 	if t == nil {
 		t = &GetEntities_Entities_Edges_Node_Notes{}
 	}
-	return t.UpdatedBy
+	return t.Edges
 }
 
 type GetEntities_Entities_Edges_Node_EntityType struct {
@@ -12798,7 +13238,7 @@ type GetEntities_Entities_Edges_Node struct {
 	EntityType  *GetEntities_Entities_Edges_Node_EntityType "json:\"entityType,omitempty\" graphql:\"entityType\""
 	ID          string                                      "json:\"id\" graphql:\"id\""
 	Name        *string                                     "json:\"name,omitempty\" graphql:\"name\""
-	Notes       []*GetEntities_Entities_Edges_Node_Notes    "json:\"notes,omitempty\" graphql:\"notes\""
+	Notes       GetEntities_Entities_Edges_Node_Notes       "json:\"notes\" graphql:\"notes\""
 	OwnerID     *string                                     "json:\"ownerID,omitempty\" graphql:\"ownerID\""
 	Status      *string                                     "json:\"status,omitempty\" graphql:\"status\""
 	Tags        []string                                    "json:\"tags,omitempty\" graphql:\"tags\""
@@ -12854,11 +13294,11 @@ func (t *GetEntities_Entities_Edges_Node) GetName() *string {
 	}
 	return t.Name
 }
-func (t *GetEntities_Entities_Edges_Node) GetNotes() []*GetEntities_Entities_Edges_Node_Notes {
+func (t *GetEntities_Entities_Edges_Node) GetNotes() *GetEntities_Entities_Edges_Node_Notes {
 	if t == nil {
 		t = &GetEntities_Entities_Edges_Node{}
 	}
-	return t.Notes
+	return &t.Notes
 }
 func (t *GetEntities_Entities_Edges_Node) GetOwnerID() *string {
 	if t == nil {
@@ -12913,29 +13353,51 @@ func (t *GetEntities_Entities) GetEdges() []*GetEntities_Entities_Edges {
 	return t.Edges
 }
 
-type GetEntityByID_Entity_Notes struct {
+type GetEntityByID_Entity_Notes_Edges_Node struct {
 	Text      string     "json:\"text\" graphql:\"text\""
 	UpdatedAt *time.Time "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
 	UpdatedBy *string    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *GetEntityByID_Entity_Notes) GetText() string {
+func (t *GetEntityByID_Entity_Notes_Edges_Node) GetText() string {
 	if t == nil {
-		t = &GetEntityByID_Entity_Notes{}
+		t = &GetEntityByID_Entity_Notes_Edges_Node{}
 	}
 	return t.Text
 }
-func (t *GetEntityByID_Entity_Notes) GetUpdatedAt() *time.Time {
+func (t *GetEntityByID_Entity_Notes_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
-		t = &GetEntityByID_Entity_Notes{}
+		t = &GetEntityByID_Entity_Notes_Edges_Node{}
 	}
 	return t.UpdatedAt
 }
-func (t *GetEntityByID_Entity_Notes) GetUpdatedBy() *string {
+func (t *GetEntityByID_Entity_Notes_Edges_Node) GetUpdatedBy() *string {
+	if t == nil {
+		t = &GetEntityByID_Entity_Notes_Edges_Node{}
+	}
+	return t.UpdatedBy
+}
+
+type GetEntityByID_Entity_Notes_Edges struct {
+	Node *GetEntityByID_Entity_Notes_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetEntityByID_Entity_Notes_Edges) GetNode() *GetEntityByID_Entity_Notes_Edges_Node {
+	if t == nil {
+		t = &GetEntityByID_Entity_Notes_Edges{}
+	}
+	return t.Node
+}
+
+type GetEntityByID_Entity_Notes struct {
+	Edges []*GetEntityByID_Entity_Notes_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetEntityByID_Entity_Notes) GetEdges() []*GetEntityByID_Entity_Notes_Edges {
 	if t == nil {
 		t = &GetEntityByID_Entity_Notes{}
 	}
-	return t.UpdatedBy
+	return t.Edges
 }
 
 type GetEntityByID_Entity_EntityType struct {
@@ -12949,7 +13411,7 @@ func (t *GetEntityByID_Entity_EntityType) GetName() string {
 	return t.Name
 }
 
-type GetEntityByID_Entity_Contacts struct {
+type GetEntityByID_Entity_Contacts_Edges_Node struct {
 	Address     *string "json:\"address,omitempty\" graphql:\"address\""
 	Company     *string "json:\"company,omitempty\" graphql:\"company\""
 	Email       *string "json:\"email,omitempty\" graphql:\"email\""
@@ -12959,51 +13421,73 @@ type GetEntityByID_Entity_Contacts struct {
 	Title       *string "json:\"title,omitempty\" graphql:\"title\""
 }
 
-func (t *GetEntityByID_Entity_Contacts) GetAddress() *string {
+func (t *GetEntityByID_Entity_Contacts_Edges_Node) GetAddress() *string {
 	if t == nil {
-		t = &GetEntityByID_Entity_Contacts{}
+		t = &GetEntityByID_Entity_Contacts_Edges_Node{}
 	}
 	return t.Address
 }
-func (t *GetEntityByID_Entity_Contacts) GetCompany() *string {
+func (t *GetEntityByID_Entity_Contacts_Edges_Node) GetCompany() *string {
 	if t == nil {
-		t = &GetEntityByID_Entity_Contacts{}
+		t = &GetEntityByID_Entity_Contacts_Edges_Node{}
 	}
 	return t.Company
 }
-func (t *GetEntityByID_Entity_Contacts) GetEmail() *string {
+func (t *GetEntityByID_Entity_Contacts_Edges_Node) GetEmail() *string {
 	if t == nil {
-		t = &GetEntityByID_Entity_Contacts{}
+		t = &GetEntityByID_Entity_Contacts_Edges_Node{}
 	}
 	return t.Email
 }
-func (t *GetEntityByID_Entity_Contacts) GetFullName() string {
+func (t *GetEntityByID_Entity_Contacts_Edges_Node) GetFullName() string {
 	if t == nil {
-		t = &GetEntityByID_Entity_Contacts{}
+		t = &GetEntityByID_Entity_Contacts_Edges_Node{}
 	}
 	return t.FullName
 }
-func (t *GetEntityByID_Entity_Contacts) GetID() string {
+func (t *GetEntityByID_Entity_Contacts_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetEntityByID_Entity_Contacts{}
+		t = &GetEntityByID_Entity_Contacts_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetEntityByID_Entity_Contacts) GetPhoneNumber() *string {
+func (t *GetEntityByID_Entity_Contacts_Edges_Node) GetPhoneNumber() *string {
 	if t == nil {
-		t = &GetEntityByID_Entity_Contacts{}
+		t = &GetEntityByID_Entity_Contacts_Edges_Node{}
 	}
 	return t.PhoneNumber
 }
-func (t *GetEntityByID_Entity_Contacts) GetTitle() *string {
+func (t *GetEntityByID_Entity_Contacts_Edges_Node) GetTitle() *string {
 	if t == nil {
-		t = &GetEntityByID_Entity_Contacts{}
+		t = &GetEntityByID_Entity_Contacts_Edges_Node{}
 	}
 	return t.Title
 }
 
+type GetEntityByID_Entity_Contacts_Edges struct {
+	Node *GetEntityByID_Entity_Contacts_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetEntityByID_Entity_Contacts_Edges) GetNode() *GetEntityByID_Entity_Contacts_Edges_Node {
+	if t == nil {
+		t = &GetEntityByID_Entity_Contacts_Edges{}
+	}
+	return t.Node
+}
+
+type GetEntityByID_Entity_Contacts struct {
+	Edges []*GetEntityByID_Entity_Contacts_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetEntityByID_Entity_Contacts) GetEdges() []*GetEntityByID_Entity_Contacts_Edges {
+	if t == nil {
+		t = &GetEntityByID_Entity_Contacts{}
+	}
+	return t.Edges
+}
+
 type GetEntityByID_Entity struct {
-	Contacts    []*GetEntityByID_Entity_Contacts "json:\"contacts,omitempty\" graphql:\"contacts\""
+	Contacts    GetEntityByID_Entity_Contacts    "json:\"contacts\" graphql:\"contacts\""
 	CreatedAt   *time.Time                       "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy   *string                          "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	Description *string                          "json:\"description,omitempty\" graphql:\"description\""
@@ -13012,7 +13496,7 @@ type GetEntityByID_Entity struct {
 	EntityType  *GetEntityByID_Entity_EntityType "json:\"entityType,omitempty\" graphql:\"entityType\""
 	ID          string                           "json:\"id\" graphql:\"id\""
 	Name        *string                          "json:\"name,omitempty\" graphql:\"name\""
-	Notes       []*GetEntityByID_Entity_Notes    "json:\"notes,omitempty\" graphql:\"notes\""
+	Notes       GetEntityByID_Entity_Notes       "json:\"notes\" graphql:\"notes\""
 	OwnerID     *string                          "json:\"ownerID,omitempty\" graphql:\"ownerID\""
 	Status      *string                          "json:\"status,omitempty\" graphql:\"status\""
 	Tags        []string                         "json:\"tags,omitempty\" graphql:\"tags\""
@@ -13020,11 +13504,11 @@ type GetEntityByID_Entity struct {
 	UpdatedBy   *string                          "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *GetEntityByID_Entity) GetContacts() []*GetEntityByID_Entity_Contacts {
+func (t *GetEntityByID_Entity) GetContacts() *GetEntityByID_Entity_Contacts {
 	if t == nil {
 		t = &GetEntityByID_Entity{}
 	}
-	return t.Contacts
+	return &t.Contacts
 }
 func (t *GetEntityByID_Entity) GetCreatedAt() *time.Time {
 	if t == nil {
@@ -13074,11 +13558,11 @@ func (t *GetEntityByID_Entity) GetName() *string {
 	}
 	return t.Name
 }
-func (t *GetEntityByID_Entity) GetNotes() []*GetEntityByID_Entity_Notes {
+func (t *GetEntityByID_Entity) GetNotes() *GetEntityByID_Entity_Notes {
 	if t == nil {
 		t = &GetEntityByID_Entity{}
 	}
-	return t.Notes
+	return &t.Notes
 }
 func (t *GetEntityByID_Entity) GetOwnerID() *string {
 	if t == nil {
@@ -13111,29 +13595,51 @@ func (t *GetEntityByID_Entity) GetUpdatedBy() *string {
 	return t.UpdatedBy
 }
 
-type UpdateEntity_UpdateEntity_Entity_Notes struct {
+type UpdateEntity_UpdateEntity_Entity_Notes_Edges_Node struct {
 	Text      string     "json:\"text\" graphql:\"text\""
 	UpdatedAt *time.Time "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
 	UpdatedBy *string    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *UpdateEntity_UpdateEntity_Entity_Notes) GetText() string {
+func (t *UpdateEntity_UpdateEntity_Entity_Notes_Edges_Node) GetText() string {
 	if t == nil {
-		t = &UpdateEntity_UpdateEntity_Entity_Notes{}
+		t = &UpdateEntity_UpdateEntity_Entity_Notes_Edges_Node{}
 	}
 	return t.Text
 }
-func (t *UpdateEntity_UpdateEntity_Entity_Notes) GetUpdatedAt() *time.Time {
+func (t *UpdateEntity_UpdateEntity_Entity_Notes_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
-		t = &UpdateEntity_UpdateEntity_Entity_Notes{}
+		t = &UpdateEntity_UpdateEntity_Entity_Notes_Edges_Node{}
 	}
 	return t.UpdatedAt
 }
-func (t *UpdateEntity_UpdateEntity_Entity_Notes) GetUpdatedBy() *string {
+func (t *UpdateEntity_UpdateEntity_Entity_Notes_Edges_Node) GetUpdatedBy() *string {
+	if t == nil {
+		t = &UpdateEntity_UpdateEntity_Entity_Notes_Edges_Node{}
+	}
+	return t.UpdatedBy
+}
+
+type UpdateEntity_UpdateEntity_Entity_Notes_Edges struct {
+	Node *UpdateEntity_UpdateEntity_Entity_Notes_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateEntity_UpdateEntity_Entity_Notes_Edges) GetNode() *UpdateEntity_UpdateEntity_Entity_Notes_Edges_Node {
+	if t == nil {
+		t = &UpdateEntity_UpdateEntity_Entity_Notes_Edges{}
+	}
+	return t.Node
+}
+
+type UpdateEntity_UpdateEntity_Entity_Notes struct {
+	Edges []*UpdateEntity_UpdateEntity_Entity_Notes_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *UpdateEntity_UpdateEntity_Entity_Notes) GetEdges() []*UpdateEntity_UpdateEntity_Entity_Notes_Edges {
 	if t == nil {
 		t = &UpdateEntity_UpdateEntity_Entity_Notes{}
 	}
-	return t.UpdatedBy
+	return t.Edges
 }
 
 type UpdateEntity_UpdateEntity_Entity_EntityType struct {
@@ -13156,7 +13662,7 @@ type UpdateEntity_UpdateEntity_Entity struct {
 	EntityType  *UpdateEntity_UpdateEntity_Entity_EntityType "json:\"entityType,omitempty\" graphql:\"entityType\""
 	ID          string                                       "json:\"id\" graphql:\"id\""
 	Name        *string                                      "json:\"name,omitempty\" graphql:\"name\""
-	Notes       []*UpdateEntity_UpdateEntity_Entity_Notes    "json:\"notes,omitempty\" graphql:\"notes\""
+	Notes       UpdateEntity_UpdateEntity_Entity_Notes       "json:\"notes\" graphql:\"notes\""
 	OwnerID     *string                                      "json:\"ownerID,omitempty\" graphql:\"ownerID\""
 	Status      *string                                      "json:\"status,omitempty\" graphql:\"status\""
 	Tags        []string                                     "json:\"tags,omitempty\" graphql:\"tags\""
@@ -13212,11 +13718,11 @@ func (t *UpdateEntity_UpdateEntity_Entity) GetName() *string {
 	}
 	return t.Name
 }
-func (t *UpdateEntity_UpdateEntity_Entity) GetNotes() []*UpdateEntity_UpdateEntity_Entity_Notes {
+func (t *UpdateEntity_UpdateEntity_Entity) GetNotes() *UpdateEntity_UpdateEntity_Entity_Notes {
 	if t == nil {
 		t = &UpdateEntity_UpdateEntity_Entity{}
 	}
-	return t.Notes
+	return &t.Notes
 }
 func (t *UpdateEntity_UpdateEntity_Entity) GetOwnerID() *string {
 	if t == nil {
@@ -14261,120 +14767,318 @@ func (t *GetEntityTypeHistories_EntityTypeHistories) GetEdges() []*GetEntityType
 	return t.Edges
 }
 
-type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_User struct {
+type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_User_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_User) GetID() string {
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_User_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_User_Edges_Node{}
+	}
+	return t.ID
+}
+
+type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_User_Edges struct {
+	Node *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_User_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_User_Edges) GetNode() *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_User_Edges_Node {
+	if t == nil {
+		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_User_Edges{}
+	}
+	return t.Node
+}
+
+type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_User struct {
+	Edges []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_User_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_User) GetEdges() []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_User_Edges {
 	if t == nil {
 		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_User{}
 	}
+	return t.Edges
+}
+
+type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Group_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Group_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Group_Edges_Node{}
+	}
 	return t.ID
+}
+
+type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Group_Edges struct {
+	Node *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Group_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Group_Edges) GetNode() *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Group_Edges_Node {
+	if t == nil {
+		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Group_Edges{}
+	}
+	return t.Node
 }
 
 type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Group struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Group_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Group) GetID() string {
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Group) GetEdges() []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Group_Edges {
 	if t == nil {
 		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Group{}
 	}
+	return t.Edges
+}
+
+type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Integration_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Integration_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Integration_Edges_Node{}
+	}
 	return t.ID
+}
+
+type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Integration_Edges struct {
+	Node *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Integration_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Integration_Edges) GetNode() *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Integration_Edges_Node {
+	if t == nil {
+		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Integration_Edges{}
+	}
+	return t.Node
 }
 
 type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Integration struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Integration_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Integration) GetID() string {
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Integration) GetEdges() []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Integration_Edges {
 	if t == nil {
 		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Integration{}
 	}
+	return t.Edges
+}
+
+type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Organization_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Organization_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Organization_Edges_Node{}
+	}
 	return t.ID
+}
+
+type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Organization_Edges struct {
+	Node *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Organization_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Organization_Edges) GetNode() *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Organization_Edges_Node {
+	if t == nil {
+		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Organization_Edges{}
+	}
+	return t.Node
 }
 
 type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Organization struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Organization_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Organization) GetID() string {
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Organization) GetEdges() []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Organization_Edges {
 	if t == nil {
 		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Organization{}
 	}
+	return t.Edges
+}
+
+type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Invite_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Invite_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Invite_Edges_Node{}
+	}
 	return t.ID
+}
+
+type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Invite_Edges struct {
+	Node *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Invite_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Invite_Edges) GetNode() *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Invite_Edges_Node {
+	if t == nil {
+		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Invite_Edges{}
+	}
+	return t.Node
 }
 
 type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Invite struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Invite_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Invite) GetID() string {
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Invite) GetEdges() []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Invite_Edges {
 	if t == nil {
 		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Invite{}
 	}
+	return t.Edges
+}
+
+type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_PersonalAccessToken_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_PersonalAccessToken_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_PersonalAccessToken_Edges_Node{}
+	}
 	return t.ID
+}
+
+type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_PersonalAccessToken_Edges struct {
+	Node *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_PersonalAccessToken_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_PersonalAccessToken_Edges) GetNode() *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_PersonalAccessToken_Edges_Node {
+	if t == nil {
+		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_PersonalAccessToken_Edges{}
+	}
+	return t.Node
 }
 
 type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_PersonalAccessToken struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_PersonalAccessToken_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_PersonalAccessToken) GetID() string {
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_PersonalAccessToken) GetEdges() []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_PersonalAccessToken_Edges {
 	if t == nil {
 		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_PersonalAccessToken{}
 	}
+	return t.Edges
+}
+
+type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Hush_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Hush_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Hush_Edges_Node{}
+	}
 	return t.ID
+}
+
+type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Hush_Edges struct {
+	Node *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Hush_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Hush_Edges) GetNode() *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Hush_Edges_Node {
+	if t == nil {
+		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Hush_Edges{}
+	}
+	return t.Node
 }
 
 type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Hush struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Hush_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Hush) GetID() string {
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Hush) GetEdges() []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Hush_Edges {
 	if t == nil {
 		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Hush{}
 	}
+	return t.Edges
+}
+
+type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Orgmembership_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Orgmembership_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Orgmembership_Edges_Node{}
+	}
 	return t.ID
+}
+
+type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Orgmembership_Edges struct {
+	Node *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Orgmembership_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Orgmembership_Edges) GetNode() *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Orgmembership_Edges_Node {
+	if t == nil {
+		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Orgmembership_Edges{}
+	}
+	return t.Node
 }
 
 type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Orgmembership struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Orgmembership_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Orgmembership) GetID() string {
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Orgmembership) GetEdges() []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Orgmembership_Edges {
 	if t == nil {
 		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Orgmembership{}
 	}
-	return t.ID
+	return t.Edges
 }
 
-type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Groupmembership struct {
+type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Groupmembership_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Groupmembership) GetID() string {
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Groupmembership_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Groupmembership{}
+		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Groupmembership_Edges_Node{}
 	}
 	return t.ID
 }
 
+type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Groupmembership_Edges struct {
+	Node *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Groupmembership_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Groupmembership_Edges) GetNode() *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Groupmembership_Edges_Node {
+	if t == nil {
+		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Groupmembership_Edges{}
+	}
+	return t.Node
+}
+
+type CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Groupmembership struct {
+	Edges []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Groupmembership_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Groupmembership) GetEdges() []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Groupmembership_Edges {
+	if t == nil {
+		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Groupmembership{}
+	}
+	return t.Edges
+}
+
 type CreateBulkCSVEvent_CreateBulkCSVEvent_Events struct {
-	CorrelationID       *string                                                             "json:\"correlationID,omitempty\" graphql:\"correlationID\""
-	EventID             *string                                                             "json:\"eventID,omitempty\" graphql:\"eventID\""
-	EventType           string                                                              "json:\"eventType\" graphql:\"eventType\""
-	Group               []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Group               "json:\"group,omitempty\" graphql:\"group\""
-	Groupmembership     []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Groupmembership     "json:\"groupmembership,omitempty\" graphql:\"groupmembership\""
-	Hush                []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Hush                "json:\"hush,omitempty\" graphql:\"hush\""
-	ID                  string                                                              "json:\"id\" graphql:\"id\""
-	Integration         []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Integration         "json:\"integration,omitempty\" graphql:\"integration\""
-	Invite              []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Invite              "json:\"invite,omitempty\" graphql:\"invite\""
-	Metadata            map[string]any                                                      "json:\"metadata,omitempty\" graphql:\"metadata\""
-	Organization        []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Organization        "json:\"organization,omitempty\" graphql:\"organization\""
-	Orgmembership       []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Orgmembership       "json:\"orgmembership,omitempty\" graphql:\"orgmembership\""
-	PersonalAccessToken []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_PersonalAccessToken "json:\"personalAccessToken,omitempty\" graphql:\"personalAccessToken\""
-	User                []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_User                "json:\"user,omitempty\" graphql:\"user\""
+	CorrelationID       *string                                                          "json:\"correlationID,omitempty\" graphql:\"correlationID\""
+	EventID             *string                                                          "json:\"eventID,omitempty\" graphql:\"eventID\""
+	EventType           string                                                           "json:\"eventType\" graphql:\"eventType\""
+	Group               CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Group               "json:\"group\" graphql:\"group\""
+	Groupmembership     CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Groupmembership     "json:\"groupmembership\" graphql:\"groupmembership\""
+	Hush                CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Hush                "json:\"hush\" graphql:\"hush\""
+	ID                  string                                                           "json:\"id\" graphql:\"id\""
+	Integration         CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Integration         "json:\"integration\" graphql:\"integration\""
+	Invite              CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Invite              "json:\"invite\" graphql:\"invite\""
+	Metadata            map[string]any                                                   "json:\"metadata,omitempty\" graphql:\"metadata\""
+	Organization        CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Organization        "json:\"organization\" graphql:\"organization\""
+	Orgmembership       CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Orgmembership       "json:\"orgmembership\" graphql:\"orgmembership\""
+	PersonalAccessToken CreateBulkCSVEvent_CreateBulkCSVEvent_Events_PersonalAccessToken "json:\"personalAccessToken\" graphql:\"personalAccessToken\""
+	User                CreateBulkCSVEvent_CreateBulkCSVEvent_Events_User                "json:\"user\" graphql:\"user\""
 }
 
 func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events) GetCorrelationID() *string {
@@ -14395,23 +15099,23 @@ func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events) GetEventType() string {
 	}
 	return t.EventType
 }
-func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events) GetGroup() []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Group {
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events) GetGroup() *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Group {
 	if t == nil {
 		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events{}
 	}
-	return t.Group
+	return &t.Group
 }
-func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events) GetGroupmembership() []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Groupmembership {
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events) GetGroupmembership() *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Groupmembership {
 	if t == nil {
 		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events{}
 	}
-	return t.Groupmembership
+	return &t.Groupmembership
 }
-func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events) GetHush() []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Hush {
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events) GetHush() *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Hush {
 	if t == nil {
 		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events{}
 	}
-	return t.Hush
+	return &t.Hush
 }
 func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events) GetID() string {
 	if t == nil {
@@ -14419,17 +15123,17 @@ func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events) GetID() string {
 	}
 	return t.ID
 }
-func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events) GetIntegration() []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Integration {
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events) GetIntegration() *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Integration {
 	if t == nil {
 		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events{}
 	}
-	return t.Integration
+	return &t.Integration
 }
-func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events) GetInvite() []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Invite {
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events) GetInvite() *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Invite {
 	if t == nil {
 		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events{}
 	}
-	return t.Invite
+	return &t.Invite
 }
 func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events) GetMetadata() map[string]any {
 	if t == nil {
@@ -14437,29 +15141,29 @@ func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events) GetMetadata() map[string]
 	}
 	return t.Metadata
 }
-func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events) GetOrganization() []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Organization {
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events) GetOrganization() *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Organization {
 	if t == nil {
 		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events{}
 	}
-	return t.Organization
+	return &t.Organization
 }
-func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events) GetOrgmembership() []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Orgmembership {
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events) GetOrgmembership() *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_Orgmembership {
 	if t == nil {
 		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events{}
 	}
-	return t.Orgmembership
+	return &t.Orgmembership
 }
-func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events) GetPersonalAccessToken() []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_PersonalAccessToken {
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events) GetPersonalAccessToken() *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_PersonalAccessToken {
 	if t == nil {
 		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events{}
 	}
-	return t.PersonalAccessToken
+	return &t.PersonalAccessToken
 }
-func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events) GetUser() []*CreateBulkCSVEvent_CreateBulkCSVEvent_Events_User {
+func (t *CreateBulkCSVEvent_CreateBulkCSVEvent_Events) GetUser() *CreateBulkCSVEvent_CreateBulkCSVEvent_Events_User {
 	if t == nil {
 		t = &CreateBulkCSVEvent_CreateBulkCSVEvent_Events{}
 	}
-	return t.User
+	return &t.User
 }
 
 type CreateBulkCSVEvent_CreateBulkCSVEvent struct {
@@ -14473,120 +15177,318 @@ func (t *CreateBulkCSVEvent_CreateBulkCSVEvent) GetEvents() []*CreateBulkCSVEven
 	return t.Events
 }
 
-type CreateBulkEvent_CreateBulkEvent_Events_User struct {
+type CreateBulkEvent_CreateBulkEvent_Events_User_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *CreateBulkEvent_CreateBulkEvent_Events_User) GetID() string {
+func (t *CreateBulkEvent_CreateBulkEvent_Events_User_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateBulkEvent_CreateBulkEvent_Events_User_Edges_Node{}
+	}
+	return t.ID
+}
+
+type CreateBulkEvent_CreateBulkEvent_Events_User_Edges struct {
+	Node *CreateBulkEvent_CreateBulkEvent_Events_User_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkEvent_CreateBulkEvent_Events_User_Edges) GetNode() *CreateBulkEvent_CreateBulkEvent_Events_User_Edges_Node {
+	if t == nil {
+		t = &CreateBulkEvent_CreateBulkEvent_Events_User_Edges{}
+	}
+	return t.Node
+}
+
+type CreateBulkEvent_CreateBulkEvent_Events_User struct {
+	Edges []*CreateBulkEvent_CreateBulkEvent_Events_User_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateBulkEvent_CreateBulkEvent_Events_User) GetEdges() []*CreateBulkEvent_CreateBulkEvent_Events_User_Edges {
 	if t == nil {
 		t = &CreateBulkEvent_CreateBulkEvent_Events_User{}
 	}
+	return t.Edges
+}
+
+type CreateBulkEvent_CreateBulkEvent_Events_Group_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *CreateBulkEvent_CreateBulkEvent_Events_Group_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateBulkEvent_CreateBulkEvent_Events_Group_Edges_Node{}
+	}
 	return t.ID
+}
+
+type CreateBulkEvent_CreateBulkEvent_Events_Group_Edges struct {
+	Node *CreateBulkEvent_CreateBulkEvent_Events_Group_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkEvent_CreateBulkEvent_Events_Group_Edges) GetNode() *CreateBulkEvent_CreateBulkEvent_Events_Group_Edges_Node {
+	if t == nil {
+		t = &CreateBulkEvent_CreateBulkEvent_Events_Group_Edges{}
+	}
+	return t.Node
 }
 
 type CreateBulkEvent_CreateBulkEvent_Events_Group struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*CreateBulkEvent_CreateBulkEvent_Events_Group_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateBulkEvent_CreateBulkEvent_Events_Group) GetID() string {
+func (t *CreateBulkEvent_CreateBulkEvent_Events_Group) GetEdges() []*CreateBulkEvent_CreateBulkEvent_Events_Group_Edges {
 	if t == nil {
 		t = &CreateBulkEvent_CreateBulkEvent_Events_Group{}
 	}
+	return t.Edges
+}
+
+type CreateBulkEvent_CreateBulkEvent_Events_Integration_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *CreateBulkEvent_CreateBulkEvent_Events_Integration_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateBulkEvent_CreateBulkEvent_Events_Integration_Edges_Node{}
+	}
 	return t.ID
+}
+
+type CreateBulkEvent_CreateBulkEvent_Events_Integration_Edges struct {
+	Node *CreateBulkEvent_CreateBulkEvent_Events_Integration_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkEvent_CreateBulkEvent_Events_Integration_Edges) GetNode() *CreateBulkEvent_CreateBulkEvent_Events_Integration_Edges_Node {
+	if t == nil {
+		t = &CreateBulkEvent_CreateBulkEvent_Events_Integration_Edges{}
+	}
+	return t.Node
 }
 
 type CreateBulkEvent_CreateBulkEvent_Events_Integration struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*CreateBulkEvent_CreateBulkEvent_Events_Integration_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateBulkEvent_CreateBulkEvent_Events_Integration) GetID() string {
+func (t *CreateBulkEvent_CreateBulkEvent_Events_Integration) GetEdges() []*CreateBulkEvent_CreateBulkEvent_Events_Integration_Edges {
 	if t == nil {
 		t = &CreateBulkEvent_CreateBulkEvent_Events_Integration{}
 	}
+	return t.Edges
+}
+
+type CreateBulkEvent_CreateBulkEvent_Events_Organization_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *CreateBulkEvent_CreateBulkEvent_Events_Organization_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateBulkEvent_CreateBulkEvent_Events_Organization_Edges_Node{}
+	}
 	return t.ID
+}
+
+type CreateBulkEvent_CreateBulkEvent_Events_Organization_Edges struct {
+	Node *CreateBulkEvent_CreateBulkEvent_Events_Organization_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkEvent_CreateBulkEvent_Events_Organization_Edges) GetNode() *CreateBulkEvent_CreateBulkEvent_Events_Organization_Edges_Node {
+	if t == nil {
+		t = &CreateBulkEvent_CreateBulkEvent_Events_Organization_Edges{}
+	}
+	return t.Node
 }
 
 type CreateBulkEvent_CreateBulkEvent_Events_Organization struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*CreateBulkEvent_CreateBulkEvent_Events_Organization_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateBulkEvent_CreateBulkEvent_Events_Organization) GetID() string {
+func (t *CreateBulkEvent_CreateBulkEvent_Events_Organization) GetEdges() []*CreateBulkEvent_CreateBulkEvent_Events_Organization_Edges {
 	if t == nil {
 		t = &CreateBulkEvent_CreateBulkEvent_Events_Organization{}
 	}
+	return t.Edges
+}
+
+type CreateBulkEvent_CreateBulkEvent_Events_Invite_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *CreateBulkEvent_CreateBulkEvent_Events_Invite_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateBulkEvent_CreateBulkEvent_Events_Invite_Edges_Node{}
+	}
 	return t.ID
+}
+
+type CreateBulkEvent_CreateBulkEvent_Events_Invite_Edges struct {
+	Node *CreateBulkEvent_CreateBulkEvent_Events_Invite_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkEvent_CreateBulkEvent_Events_Invite_Edges) GetNode() *CreateBulkEvent_CreateBulkEvent_Events_Invite_Edges_Node {
+	if t == nil {
+		t = &CreateBulkEvent_CreateBulkEvent_Events_Invite_Edges{}
+	}
+	return t.Node
 }
 
 type CreateBulkEvent_CreateBulkEvent_Events_Invite struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*CreateBulkEvent_CreateBulkEvent_Events_Invite_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateBulkEvent_CreateBulkEvent_Events_Invite) GetID() string {
+func (t *CreateBulkEvent_CreateBulkEvent_Events_Invite) GetEdges() []*CreateBulkEvent_CreateBulkEvent_Events_Invite_Edges {
 	if t == nil {
 		t = &CreateBulkEvent_CreateBulkEvent_Events_Invite{}
 	}
+	return t.Edges
+}
+
+type CreateBulkEvent_CreateBulkEvent_Events_PersonalAccessToken_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *CreateBulkEvent_CreateBulkEvent_Events_PersonalAccessToken_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateBulkEvent_CreateBulkEvent_Events_PersonalAccessToken_Edges_Node{}
+	}
 	return t.ID
+}
+
+type CreateBulkEvent_CreateBulkEvent_Events_PersonalAccessToken_Edges struct {
+	Node *CreateBulkEvent_CreateBulkEvent_Events_PersonalAccessToken_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkEvent_CreateBulkEvent_Events_PersonalAccessToken_Edges) GetNode() *CreateBulkEvent_CreateBulkEvent_Events_PersonalAccessToken_Edges_Node {
+	if t == nil {
+		t = &CreateBulkEvent_CreateBulkEvent_Events_PersonalAccessToken_Edges{}
+	}
+	return t.Node
 }
 
 type CreateBulkEvent_CreateBulkEvent_Events_PersonalAccessToken struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*CreateBulkEvent_CreateBulkEvent_Events_PersonalAccessToken_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateBulkEvent_CreateBulkEvent_Events_PersonalAccessToken) GetID() string {
+func (t *CreateBulkEvent_CreateBulkEvent_Events_PersonalAccessToken) GetEdges() []*CreateBulkEvent_CreateBulkEvent_Events_PersonalAccessToken_Edges {
 	if t == nil {
 		t = &CreateBulkEvent_CreateBulkEvent_Events_PersonalAccessToken{}
 	}
+	return t.Edges
+}
+
+type CreateBulkEvent_CreateBulkEvent_Events_Hush_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *CreateBulkEvent_CreateBulkEvent_Events_Hush_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateBulkEvent_CreateBulkEvent_Events_Hush_Edges_Node{}
+	}
 	return t.ID
+}
+
+type CreateBulkEvent_CreateBulkEvent_Events_Hush_Edges struct {
+	Node *CreateBulkEvent_CreateBulkEvent_Events_Hush_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkEvent_CreateBulkEvent_Events_Hush_Edges) GetNode() *CreateBulkEvent_CreateBulkEvent_Events_Hush_Edges_Node {
+	if t == nil {
+		t = &CreateBulkEvent_CreateBulkEvent_Events_Hush_Edges{}
+	}
+	return t.Node
 }
 
 type CreateBulkEvent_CreateBulkEvent_Events_Hush struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*CreateBulkEvent_CreateBulkEvent_Events_Hush_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateBulkEvent_CreateBulkEvent_Events_Hush) GetID() string {
+func (t *CreateBulkEvent_CreateBulkEvent_Events_Hush) GetEdges() []*CreateBulkEvent_CreateBulkEvent_Events_Hush_Edges {
 	if t == nil {
 		t = &CreateBulkEvent_CreateBulkEvent_Events_Hush{}
 	}
+	return t.Edges
+}
+
+type CreateBulkEvent_CreateBulkEvent_Events_Orgmembership_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *CreateBulkEvent_CreateBulkEvent_Events_Orgmembership_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateBulkEvent_CreateBulkEvent_Events_Orgmembership_Edges_Node{}
+	}
 	return t.ID
+}
+
+type CreateBulkEvent_CreateBulkEvent_Events_Orgmembership_Edges struct {
+	Node *CreateBulkEvent_CreateBulkEvent_Events_Orgmembership_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkEvent_CreateBulkEvent_Events_Orgmembership_Edges) GetNode() *CreateBulkEvent_CreateBulkEvent_Events_Orgmembership_Edges_Node {
+	if t == nil {
+		t = &CreateBulkEvent_CreateBulkEvent_Events_Orgmembership_Edges{}
+	}
+	return t.Node
 }
 
 type CreateBulkEvent_CreateBulkEvent_Events_Orgmembership struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*CreateBulkEvent_CreateBulkEvent_Events_Orgmembership_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateBulkEvent_CreateBulkEvent_Events_Orgmembership) GetID() string {
+func (t *CreateBulkEvent_CreateBulkEvent_Events_Orgmembership) GetEdges() []*CreateBulkEvent_CreateBulkEvent_Events_Orgmembership_Edges {
 	if t == nil {
 		t = &CreateBulkEvent_CreateBulkEvent_Events_Orgmembership{}
 	}
-	return t.ID
+	return t.Edges
 }
 
-type CreateBulkEvent_CreateBulkEvent_Events_Groupmembership struct {
+type CreateBulkEvent_CreateBulkEvent_Events_Groupmembership_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *CreateBulkEvent_CreateBulkEvent_Events_Groupmembership) GetID() string {
+func (t *CreateBulkEvent_CreateBulkEvent_Events_Groupmembership_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateBulkEvent_CreateBulkEvent_Events_Groupmembership{}
+		t = &CreateBulkEvent_CreateBulkEvent_Events_Groupmembership_Edges_Node{}
 	}
 	return t.ID
 }
 
+type CreateBulkEvent_CreateBulkEvent_Events_Groupmembership_Edges struct {
+	Node *CreateBulkEvent_CreateBulkEvent_Events_Groupmembership_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkEvent_CreateBulkEvent_Events_Groupmembership_Edges) GetNode() *CreateBulkEvent_CreateBulkEvent_Events_Groupmembership_Edges_Node {
+	if t == nil {
+		t = &CreateBulkEvent_CreateBulkEvent_Events_Groupmembership_Edges{}
+	}
+	return t.Node
+}
+
+type CreateBulkEvent_CreateBulkEvent_Events_Groupmembership struct {
+	Edges []*CreateBulkEvent_CreateBulkEvent_Events_Groupmembership_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateBulkEvent_CreateBulkEvent_Events_Groupmembership) GetEdges() []*CreateBulkEvent_CreateBulkEvent_Events_Groupmembership_Edges {
+	if t == nil {
+		t = &CreateBulkEvent_CreateBulkEvent_Events_Groupmembership{}
+	}
+	return t.Edges
+}
+
 type CreateBulkEvent_CreateBulkEvent_Events struct {
-	CorrelationID       *string                                                       "json:\"correlationID,omitempty\" graphql:\"correlationID\""
-	EventID             *string                                                       "json:\"eventID,omitempty\" graphql:\"eventID\""
-	EventType           string                                                        "json:\"eventType\" graphql:\"eventType\""
-	Group               []*CreateBulkEvent_CreateBulkEvent_Events_Group               "json:\"group,omitempty\" graphql:\"group\""
-	Groupmembership     []*CreateBulkEvent_CreateBulkEvent_Events_Groupmembership     "json:\"groupmembership,omitempty\" graphql:\"groupmembership\""
-	Hush                []*CreateBulkEvent_CreateBulkEvent_Events_Hush                "json:\"hush,omitempty\" graphql:\"hush\""
-	ID                  string                                                        "json:\"id\" graphql:\"id\""
-	Integration         []*CreateBulkEvent_CreateBulkEvent_Events_Integration         "json:\"integration,omitempty\" graphql:\"integration\""
-	Invite              []*CreateBulkEvent_CreateBulkEvent_Events_Invite              "json:\"invite,omitempty\" graphql:\"invite\""
-	Metadata            map[string]any                                                "json:\"metadata,omitempty\" graphql:\"metadata\""
-	Organization        []*CreateBulkEvent_CreateBulkEvent_Events_Organization        "json:\"organization,omitempty\" graphql:\"organization\""
-	Orgmembership       []*CreateBulkEvent_CreateBulkEvent_Events_Orgmembership       "json:\"orgmembership,omitempty\" graphql:\"orgmembership\""
-	PersonalAccessToken []*CreateBulkEvent_CreateBulkEvent_Events_PersonalAccessToken "json:\"personalAccessToken,omitempty\" graphql:\"personalAccessToken\""
-	User                []*CreateBulkEvent_CreateBulkEvent_Events_User                "json:\"user,omitempty\" graphql:\"user\""
+	CorrelationID       *string                                                    "json:\"correlationID,omitempty\" graphql:\"correlationID\""
+	EventID             *string                                                    "json:\"eventID,omitempty\" graphql:\"eventID\""
+	EventType           string                                                     "json:\"eventType\" graphql:\"eventType\""
+	Group               CreateBulkEvent_CreateBulkEvent_Events_Group               "json:\"group\" graphql:\"group\""
+	Groupmembership     CreateBulkEvent_CreateBulkEvent_Events_Groupmembership     "json:\"groupmembership\" graphql:\"groupmembership\""
+	Hush                CreateBulkEvent_CreateBulkEvent_Events_Hush                "json:\"hush\" graphql:\"hush\""
+	ID                  string                                                     "json:\"id\" graphql:\"id\""
+	Integration         CreateBulkEvent_CreateBulkEvent_Events_Integration         "json:\"integration\" graphql:\"integration\""
+	Invite              CreateBulkEvent_CreateBulkEvent_Events_Invite              "json:\"invite\" graphql:\"invite\""
+	Metadata            map[string]any                                             "json:\"metadata,omitempty\" graphql:\"metadata\""
+	Organization        CreateBulkEvent_CreateBulkEvent_Events_Organization        "json:\"organization\" graphql:\"organization\""
+	Orgmembership       CreateBulkEvent_CreateBulkEvent_Events_Orgmembership       "json:\"orgmembership\" graphql:\"orgmembership\""
+	PersonalAccessToken CreateBulkEvent_CreateBulkEvent_Events_PersonalAccessToken "json:\"personalAccessToken\" graphql:\"personalAccessToken\""
+	User                CreateBulkEvent_CreateBulkEvent_Events_User                "json:\"user\" graphql:\"user\""
 }
 
 func (t *CreateBulkEvent_CreateBulkEvent_Events) GetCorrelationID() *string {
@@ -14607,23 +15509,23 @@ func (t *CreateBulkEvent_CreateBulkEvent_Events) GetEventType() string {
 	}
 	return t.EventType
 }
-func (t *CreateBulkEvent_CreateBulkEvent_Events) GetGroup() []*CreateBulkEvent_CreateBulkEvent_Events_Group {
+func (t *CreateBulkEvent_CreateBulkEvent_Events) GetGroup() *CreateBulkEvent_CreateBulkEvent_Events_Group {
 	if t == nil {
 		t = &CreateBulkEvent_CreateBulkEvent_Events{}
 	}
-	return t.Group
+	return &t.Group
 }
-func (t *CreateBulkEvent_CreateBulkEvent_Events) GetGroupmembership() []*CreateBulkEvent_CreateBulkEvent_Events_Groupmembership {
+func (t *CreateBulkEvent_CreateBulkEvent_Events) GetGroupmembership() *CreateBulkEvent_CreateBulkEvent_Events_Groupmembership {
 	if t == nil {
 		t = &CreateBulkEvent_CreateBulkEvent_Events{}
 	}
-	return t.Groupmembership
+	return &t.Groupmembership
 }
-func (t *CreateBulkEvent_CreateBulkEvent_Events) GetHush() []*CreateBulkEvent_CreateBulkEvent_Events_Hush {
+func (t *CreateBulkEvent_CreateBulkEvent_Events) GetHush() *CreateBulkEvent_CreateBulkEvent_Events_Hush {
 	if t == nil {
 		t = &CreateBulkEvent_CreateBulkEvent_Events{}
 	}
-	return t.Hush
+	return &t.Hush
 }
 func (t *CreateBulkEvent_CreateBulkEvent_Events) GetID() string {
 	if t == nil {
@@ -14631,17 +15533,17 @@ func (t *CreateBulkEvent_CreateBulkEvent_Events) GetID() string {
 	}
 	return t.ID
 }
-func (t *CreateBulkEvent_CreateBulkEvent_Events) GetIntegration() []*CreateBulkEvent_CreateBulkEvent_Events_Integration {
+func (t *CreateBulkEvent_CreateBulkEvent_Events) GetIntegration() *CreateBulkEvent_CreateBulkEvent_Events_Integration {
 	if t == nil {
 		t = &CreateBulkEvent_CreateBulkEvent_Events{}
 	}
-	return t.Integration
+	return &t.Integration
 }
-func (t *CreateBulkEvent_CreateBulkEvent_Events) GetInvite() []*CreateBulkEvent_CreateBulkEvent_Events_Invite {
+func (t *CreateBulkEvent_CreateBulkEvent_Events) GetInvite() *CreateBulkEvent_CreateBulkEvent_Events_Invite {
 	if t == nil {
 		t = &CreateBulkEvent_CreateBulkEvent_Events{}
 	}
-	return t.Invite
+	return &t.Invite
 }
 func (t *CreateBulkEvent_CreateBulkEvent_Events) GetMetadata() map[string]any {
 	if t == nil {
@@ -14649,29 +15551,29 @@ func (t *CreateBulkEvent_CreateBulkEvent_Events) GetMetadata() map[string]any {
 	}
 	return t.Metadata
 }
-func (t *CreateBulkEvent_CreateBulkEvent_Events) GetOrganization() []*CreateBulkEvent_CreateBulkEvent_Events_Organization {
+func (t *CreateBulkEvent_CreateBulkEvent_Events) GetOrganization() *CreateBulkEvent_CreateBulkEvent_Events_Organization {
 	if t == nil {
 		t = &CreateBulkEvent_CreateBulkEvent_Events{}
 	}
-	return t.Organization
+	return &t.Organization
 }
-func (t *CreateBulkEvent_CreateBulkEvent_Events) GetOrgmembership() []*CreateBulkEvent_CreateBulkEvent_Events_Orgmembership {
+func (t *CreateBulkEvent_CreateBulkEvent_Events) GetOrgmembership() *CreateBulkEvent_CreateBulkEvent_Events_Orgmembership {
 	if t == nil {
 		t = &CreateBulkEvent_CreateBulkEvent_Events{}
 	}
-	return t.Orgmembership
+	return &t.Orgmembership
 }
-func (t *CreateBulkEvent_CreateBulkEvent_Events) GetPersonalAccessToken() []*CreateBulkEvent_CreateBulkEvent_Events_PersonalAccessToken {
+func (t *CreateBulkEvent_CreateBulkEvent_Events) GetPersonalAccessToken() *CreateBulkEvent_CreateBulkEvent_Events_PersonalAccessToken {
 	if t == nil {
 		t = &CreateBulkEvent_CreateBulkEvent_Events{}
 	}
-	return t.PersonalAccessToken
+	return &t.PersonalAccessToken
 }
-func (t *CreateBulkEvent_CreateBulkEvent_Events) GetUser() []*CreateBulkEvent_CreateBulkEvent_Events_User {
+func (t *CreateBulkEvent_CreateBulkEvent_Events) GetUser() *CreateBulkEvent_CreateBulkEvent_Events_User {
 	if t == nil {
 		t = &CreateBulkEvent_CreateBulkEvent_Events{}
 	}
-	return t.User
+	return &t.User
 }
 
 type CreateBulkEvent_CreateBulkEvent struct {
@@ -14685,120 +15587,318 @@ func (t *CreateBulkEvent_CreateBulkEvent) GetEvents() []*CreateBulkEvent_CreateB
 	return t.Events
 }
 
-type CreateEvent_CreateEvent_Event_User struct {
+type CreateEvent_CreateEvent_Event_User_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *CreateEvent_CreateEvent_Event_User) GetID() string {
+func (t *CreateEvent_CreateEvent_Event_User_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateEvent_CreateEvent_Event_User_Edges_Node{}
+	}
+	return t.ID
+}
+
+type CreateEvent_CreateEvent_Event_User_Edges struct {
+	Node *CreateEvent_CreateEvent_Event_User_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateEvent_CreateEvent_Event_User_Edges) GetNode() *CreateEvent_CreateEvent_Event_User_Edges_Node {
+	if t == nil {
+		t = &CreateEvent_CreateEvent_Event_User_Edges{}
+	}
+	return t.Node
+}
+
+type CreateEvent_CreateEvent_Event_User struct {
+	Edges []*CreateEvent_CreateEvent_Event_User_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateEvent_CreateEvent_Event_User) GetEdges() []*CreateEvent_CreateEvent_Event_User_Edges {
 	if t == nil {
 		t = &CreateEvent_CreateEvent_Event_User{}
 	}
+	return t.Edges
+}
+
+type CreateEvent_CreateEvent_Event_Group_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *CreateEvent_CreateEvent_Event_Group_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateEvent_CreateEvent_Event_Group_Edges_Node{}
+	}
 	return t.ID
+}
+
+type CreateEvent_CreateEvent_Event_Group_Edges struct {
+	Node *CreateEvent_CreateEvent_Event_Group_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateEvent_CreateEvent_Event_Group_Edges) GetNode() *CreateEvent_CreateEvent_Event_Group_Edges_Node {
+	if t == nil {
+		t = &CreateEvent_CreateEvent_Event_Group_Edges{}
+	}
+	return t.Node
 }
 
 type CreateEvent_CreateEvent_Event_Group struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*CreateEvent_CreateEvent_Event_Group_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateEvent_CreateEvent_Event_Group) GetID() string {
+func (t *CreateEvent_CreateEvent_Event_Group) GetEdges() []*CreateEvent_CreateEvent_Event_Group_Edges {
 	if t == nil {
 		t = &CreateEvent_CreateEvent_Event_Group{}
 	}
+	return t.Edges
+}
+
+type CreateEvent_CreateEvent_Event_Integration_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *CreateEvent_CreateEvent_Event_Integration_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateEvent_CreateEvent_Event_Integration_Edges_Node{}
+	}
 	return t.ID
+}
+
+type CreateEvent_CreateEvent_Event_Integration_Edges struct {
+	Node *CreateEvent_CreateEvent_Event_Integration_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateEvent_CreateEvent_Event_Integration_Edges) GetNode() *CreateEvent_CreateEvent_Event_Integration_Edges_Node {
+	if t == nil {
+		t = &CreateEvent_CreateEvent_Event_Integration_Edges{}
+	}
+	return t.Node
 }
 
 type CreateEvent_CreateEvent_Event_Integration struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*CreateEvent_CreateEvent_Event_Integration_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateEvent_CreateEvent_Event_Integration) GetID() string {
+func (t *CreateEvent_CreateEvent_Event_Integration) GetEdges() []*CreateEvent_CreateEvent_Event_Integration_Edges {
 	if t == nil {
 		t = &CreateEvent_CreateEvent_Event_Integration{}
 	}
+	return t.Edges
+}
+
+type CreateEvent_CreateEvent_Event_Organization_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *CreateEvent_CreateEvent_Event_Organization_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateEvent_CreateEvent_Event_Organization_Edges_Node{}
+	}
 	return t.ID
+}
+
+type CreateEvent_CreateEvent_Event_Organization_Edges struct {
+	Node *CreateEvent_CreateEvent_Event_Organization_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateEvent_CreateEvent_Event_Organization_Edges) GetNode() *CreateEvent_CreateEvent_Event_Organization_Edges_Node {
+	if t == nil {
+		t = &CreateEvent_CreateEvent_Event_Organization_Edges{}
+	}
+	return t.Node
 }
 
 type CreateEvent_CreateEvent_Event_Organization struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*CreateEvent_CreateEvent_Event_Organization_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateEvent_CreateEvent_Event_Organization) GetID() string {
+func (t *CreateEvent_CreateEvent_Event_Organization) GetEdges() []*CreateEvent_CreateEvent_Event_Organization_Edges {
 	if t == nil {
 		t = &CreateEvent_CreateEvent_Event_Organization{}
 	}
+	return t.Edges
+}
+
+type CreateEvent_CreateEvent_Event_Invite_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *CreateEvent_CreateEvent_Event_Invite_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateEvent_CreateEvent_Event_Invite_Edges_Node{}
+	}
 	return t.ID
+}
+
+type CreateEvent_CreateEvent_Event_Invite_Edges struct {
+	Node *CreateEvent_CreateEvent_Event_Invite_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateEvent_CreateEvent_Event_Invite_Edges) GetNode() *CreateEvent_CreateEvent_Event_Invite_Edges_Node {
+	if t == nil {
+		t = &CreateEvent_CreateEvent_Event_Invite_Edges{}
+	}
+	return t.Node
 }
 
 type CreateEvent_CreateEvent_Event_Invite struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*CreateEvent_CreateEvent_Event_Invite_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateEvent_CreateEvent_Event_Invite) GetID() string {
+func (t *CreateEvent_CreateEvent_Event_Invite) GetEdges() []*CreateEvent_CreateEvent_Event_Invite_Edges {
 	if t == nil {
 		t = &CreateEvent_CreateEvent_Event_Invite{}
 	}
+	return t.Edges
+}
+
+type CreateEvent_CreateEvent_Event_PersonalAccessToken_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *CreateEvent_CreateEvent_Event_PersonalAccessToken_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateEvent_CreateEvent_Event_PersonalAccessToken_Edges_Node{}
+	}
 	return t.ID
+}
+
+type CreateEvent_CreateEvent_Event_PersonalAccessToken_Edges struct {
+	Node *CreateEvent_CreateEvent_Event_PersonalAccessToken_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateEvent_CreateEvent_Event_PersonalAccessToken_Edges) GetNode() *CreateEvent_CreateEvent_Event_PersonalAccessToken_Edges_Node {
+	if t == nil {
+		t = &CreateEvent_CreateEvent_Event_PersonalAccessToken_Edges{}
+	}
+	return t.Node
 }
 
 type CreateEvent_CreateEvent_Event_PersonalAccessToken struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*CreateEvent_CreateEvent_Event_PersonalAccessToken_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateEvent_CreateEvent_Event_PersonalAccessToken) GetID() string {
+func (t *CreateEvent_CreateEvent_Event_PersonalAccessToken) GetEdges() []*CreateEvent_CreateEvent_Event_PersonalAccessToken_Edges {
 	if t == nil {
 		t = &CreateEvent_CreateEvent_Event_PersonalAccessToken{}
 	}
+	return t.Edges
+}
+
+type CreateEvent_CreateEvent_Event_Hush_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *CreateEvent_CreateEvent_Event_Hush_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateEvent_CreateEvent_Event_Hush_Edges_Node{}
+	}
 	return t.ID
+}
+
+type CreateEvent_CreateEvent_Event_Hush_Edges struct {
+	Node *CreateEvent_CreateEvent_Event_Hush_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateEvent_CreateEvent_Event_Hush_Edges) GetNode() *CreateEvent_CreateEvent_Event_Hush_Edges_Node {
+	if t == nil {
+		t = &CreateEvent_CreateEvent_Event_Hush_Edges{}
+	}
+	return t.Node
 }
 
 type CreateEvent_CreateEvent_Event_Hush struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*CreateEvent_CreateEvent_Event_Hush_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateEvent_CreateEvent_Event_Hush) GetID() string {
+func (t *CreateEvent_CreateEvent_Event_Hush) GetEdges() []*CreateEvent_CreateEvent_Event_Hush_Edges {
 	if t == nil {
 		t = &CreateEvent_CreateEvent_Event_Hush{}
 	}
+	return t.Edges
+}
+
+type CreateEvent_CreateEvent_Event_Orgmembership_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *CreateEvent_CreateEvent_Event_Orgmembership_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateEvent_CreateEvent_Event_Orgmembership_Edges_Node{}
+	}
 	return t.ID
+}
+
+type CreateEvent_CreateEvent_Event_Orgmembership_Edges struct {
+	Node *CreateEvent_CreateEvent_Event_Orgmembership_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateEvent_CreateEvent_Event_Orgmembership_Edges) GetNode() *CreateEvent_CreateEvent_Event_Orgmembership_Edges_Node {
+	if t == nil {
+		t = &CreateEvent_CreateEvent_Event_Orgmembership_Edges{}
+	}
+	return t.Node
 }
 
 type CreateEvent_CreateEvent_Event_Orgmembership struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*CreateEvent_CreateEvent_Event_Orgmembership_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateEvent_CreateEvent_Event_Orgmembership) GetID() string {
+func (t *CreateEvent_CreateEvent_Event_Orgmembership) GetEdges() []*CreateEvent_CreateEvent_Event_Orgmembership_Edges {
 	if t == nil {
 		t = &CreateEvent_CreateEvent_Event_Orgmembership{}
 	}
-	return t.ID
+	return t.Edges
 }
 
-type CreateEvent_CreateEvent_Event_Groupmembership struct {
+type CreateEvent_CreateEvent_Event_Groupmembership_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *CreateEvent_CreateEvent_Event_Groupmembership) GetID() string {
+func (t *CreateEvent_CreateEvent_Event_Groupmembership_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateEvent_CreateEvent_Event_Groupmembership{}
+		t = &CreateEvent_CreateEvent_Event_Groupmembership_Edges_Node{}
 	}
 	return t.ID
 }
 
+type CreateEvent_CreateEvent_Event_Groupmembership_Edges struct {
+	Node *CreateEvent_CreateEvent_Event_Groupmembership_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateEvent_CreateEvent_Event_Groupmembership_Edges) GetNode() *CreateEvent_CreateEvent_Event_Groupmembership_Edges_Node {
+	if t == nil {
+		t = &CreateEvent_CreateEvent_Event_Groupmembership_Edges{}
+	}
+	return t.Node
+}
+
+type CreateEvent_CreateEvent_Event_Groupmembership struct {
+	Edges []*CreateEvent_CreateEvent_Event_Groupmembership_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateEvent_CreateEvent_Event_Groupmembership) GetEdges() []*CreateEvent_CreateEvent_Event_Groupmembership_Edges {
+	if t == nil {
+		t = &CreateEvent_CreateEvent_Event_Groupmembership{}
+	}
+	return t.Edges
+}
+
 type CreateEvent_CreateEvent_Event struct {
-	CorrelationID       *string                                              "json:\"correlationID,omitempty\" graphql:\"correlationID\""
-	EventID             *string                                              "json:\"eventID,omitempty\" graphql:\"eventID\""
-	EventType           string                                               "json:\"eventType\" graphql:\"eventType\""
-	Group               []*CreateEvent_CreateEvent_Event_Group               "json:\"group,omitempty\" graphql:\"group\""
-	Groupmembership     []*CreateEvent_CreateEvent_Event_Groupmembership     "json:\"groupmembership,omitempty\" graphql:\"groupmembership\""
-	Hush                []*CreateEvent_CreateEvent_Event_Hush                "json:\"hush,omitempty\" graphql:\"hush\""
-	ID                  string                                               "json:\"id\" graphql:\"id\""
-	Integration         []*CreateEvent_CreateEvent_Event_Integration         "json:\"integration,omitempty\" graphql:\"integration\""
-	Invite              []*CreateEvent_CreateEvent_Event_Invite              "json:\"invite,omitempty\" graphql:\"invite\""
-	Metadata            map[string]any                                       "json:\"metadata,omitempty\" graphql:\"metadata\""
-	Organization        []*CreateEvent_CreateEvent_Event_Organization        "json:\"organization,omitempty\" graphql:\"organization\""
-	Orgmembership       []*CreateEvent_CreateEvent_Event_Orgmembership       "json:\"orgmembership,omitempty\" graphql:\"orgmembership\""
-	PersonalAccessToken []*CreateEvent_CreateEvent_Event_PersonalAccessToken "json:\"personalAccessToken,omitempty\" graphql:\"personalAccessToken\""
-	User                []*CreateEvent_CreateEvent_Event_User                "json:\"user,omitempty\" graphql:\"user\""
+	CorrelationID       *string                                           "json:\"correlationID,omitempty\" graphql:\"correlationID\""
+	EventID             *string                                           "json:\"eventID,omitempty\" graphql:\"eventID\""
+	EventType           string                                            "json:\"eventType\" graphql:\"eventType\""
+	Group               CreateEvent_CreateEvent_Event_Group               "json:\"group\" graphql:\"group\""
+	Groupmembership     CreateEvent_CreateEvent_Event_Groupmembership     "json:\"groupmembership\" graphql:\"groupmembership\""
+	Hush                CreateEvent_CreateEvent_Event_Hush                "json:\"hush\" graphql:\"hush\""
+	ID                  string                                            "json:\"id\" graphql:\"id\""
+	Integration         CreateEvent_CreateEvent_Event_Integration         "json:\"integration\" graphql:\"integration\""
+	Invite              CreateEvent_CreateEvent_Event_Invite              "json:\"invite\" graphql:\"invite\""
+	Metadata            map[string]any                                    "json:\"metadata,omitempty\" graphql:\"metadata\""
+	Organization        CreateEvent_CreateEvent_Event_Organization        "json:\"organization\" graphql:\"organization\""
+	Orgmembership       CreateEvent_CreateEvent_Event_Orgmembership       "json:\"orgmembership\" graphql:\"orgmembership\""
+	PersonalAccessToken CreateEvent_CreateEvent_Event_PersonalAccessToken "json:\"personalAccessToken\" graphql:\"personalAccessToken\""
+	User                CreateEvent_CreateEvent_Event_User                "json:\"user\" graphql:\"user\""
 }
 
 func (t *CreateEvent_CreateEvent_Event) GetCorrelationID() *string {
@@ -14819,23 +15919,23 @@ func (t *CreateEvent_CreateEvent_Event) GetEventType() string {
 	}
 	return t.EventType
 }
-func (t *CreateEvent_CreateEvent_Event) GetGroup() []*CreateEvent_CreateEvent_Event_Group {
+func (t *CreateEvent_CreateEvent_Event) GetGroup() *CreateEvent_CreateEvent_Event_Group {
 	if t == nil {
 		t = &CreateEvent_CreateEvent_Event{}
 	}
-	return t.Group
+	return &t.Group
 }
-func (t *CreateEvent_CreateEvent_Event) GetGroupmembership() []*CreateEvent_CreateEvent_Event_Groupmembership {
+func (t *CreateEvent_CreateEvent_Event) GetGroupmembership() *CreateEvent_CreateEvent_Event_Groupmembership {
 	if t == nil {
 		t = &CreateEvent_CreateEvent_Event{}
 	}
-	return t.Groupmembership
+	return &t.Groupmembership
 }
-func (t *CreateEvent_CreateEvent_Event) GetHush() []*CreateEvent_CreateEvent_Event_Hush {
+func (t *CreateEvent_CreateEvent_Event) GetHush() *CreateEvent_CreateEvent_Event_Hush {
 	if t == nil {
 		t = &CreateEvent_CreateEvent_Event{}
 	}
-	return t.Hush
+	return &t.Hush
 }
 func (t *CreateEvent_CreateEvent_Event) GetID() string {
 	if t == nil {
@@ -14843,17 +15943,17 @@ func (t *CreateEvent_CreateEvent_Event) GetID() string {
 	}
 	return t.ID
 }
-func (t *CreateEvent_CreateEvent_Event) GetIntegration() []*CreateEvent_CreateEvent_Event_Integration {
+func (t *CreateEvent_CreateEvent_Event) GetIntegration() *CreateEvent_CreateEvent_Event_Integration {
 	if t == nil {
 		t = &CreateEvent_CreateEvent_Event{}
 	}
-	return t.Integration
+	return &t.Integration
 }
-func (t *CreateEvent_CreateEvent_Event) GetInvite() []*CreateEvent_CreateEvent_Event_Invite {
+func (t *CreateEvent_CreateEvent_Event) GetInvite() *CreateEvent_CreateEvent_Event_Invite {
 	if t == nil {
 		t = &CreateEvent_CreateEvent_Event{}
 	}
-	return t.Invite
+	return &t.Invite
 }
 func (t *CreateEvent_CreateEvent_Event) GetMetadata() map[string]any {
 	if t == nil {
@@ -14861,29 +15961,29 @@ func (t *CreateEvent_CreateEvent_Event) GetMetadata() map[string]any {
 	}
 	return t.Metadata
 }
-func (t *CreateEvent_CreateEvent_Event) GetOrganization() []*CreateEvent_CreateEvent_Event_Organization {
+func (t *CreateEvent_CreateEvent_Event) GetOrganization() *CreateEvent_CreateEvent_Event_Organization {
 	if t == nil {
 		t = &CreateEvent_CreateEvent_Event{}
 	}
-	return t.Organization
+	return &t.Organization
 }
-func (t *CreateEvent_CreateEvent_Event) GetOrgmembership() []*CreateEvent_CreateEvent_Event_Orgmembership {
+func (t *CreateEvent_CreateEvent_Event) GetOrgmembership() *CreateEvent_CreateEvent_Event_Orgmembership {
 	if t == nil {
 		t = &CreateEvent_CreateEvent_Event{}
 	}
-	return t.Orgmembership
+	return &t.Orgmembership
 }
-func (t *CreateEvent_CreateEvent_Event) GetPersonalAccessToken() []*CreateEvent_CreateEvent_Event_PersonalAccessToken {
+func (t *CreateEvent_CreateEvent_Event) GetPersonalAccessToken() *CreateEvent_CreateEvent_Event_PersonalAccessToken {
 	if t == nil {
 		t = &CreateEvent_CreateEvent_Event{}
 	}
-	return t.PersonalAccessToken
+	return &t.PersonalAccessToken
 }
-func (t *CreateEvent_CreateEvent_Event) GetUser() []*CreateEvent_CreateEvent_Event_User {
+func (t *CreateEvent_CreateEvent_Event) GetUser() *CreateEvent_CreateEvent_Event_User {
 	if t == nil {
 		t = &CreateEvent_CreateEvent_Event{}
 	}
-	return t.User
+	return &t.User
 }
 
 type CreateEvent_CreateEvent struct {
@@ -14908,124 +16008,322 @@ func (t *DeleteEvent_DeleteEvent) GetDeletedID() string {
 	return t.DeletedID
 }
 
-type GetAllEvents_Events_Edges_Node_User struct {
+type GetAllEvents_Events_Edges_Node_User_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *GetAllEvents_Events_Edges_Node_User) GetID() string {
+func (t *GetAllEvents_Events_Edges_Node_User_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetAllEvents_Events_Edges_Node_User_Edges_Node{}
+	}
+	return t.ID
+}
+
+type GetAllEvents_Events_Edges_Node_User_Edges struct {
+	Node *GetAllEvents_Events_Edges_Node_User_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllEvents_Events_Edges_Node_User_Edges) GetNode() *GetAllEvents_Events_Edges_Node_User_Edges_Node {
+	if t == nil {
+		t = &GetAllEvents_Events_Edges_Node_User_Edges{}
+	}
+	return t.Node
+}
+
+type GetAllEvents_Events_Edges_Node_User struct {
+	Edges []*GetAllEvents_Events_Edges_Node_User_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetAllEvents_Events_Edges_Node_User) GetEdges() []*GetAllEvents_Events_Edges_Node_User_Edges {
 	if t == nil {
 		t = &GetAllEvents_Events_Edges_Node_User{}
 	}
+	return t.Edges
+}
+
+type GetAllEvents_Events_Edges_Node_Group_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *GetAllEvents_Events_Edges_Node_Group_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetAllEvents_Events_Edges_Node_Group_Edges_Node{}
+	}
 	return t.ID
+}
+
+type GetAllEvents_Events_Edges_Node_Group_Edges struct {
+	Node *GetAllEvents_Events_Edges_Node_Group_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllEvents_Events_Edges_Node_Group_Edges) GetNode() *GetAllEvents_Events_Edges_Node_Group_Edges_Node {
+	if t == nil {
+		t = &GetAllEvents_Events_Edges_Node_Group_Edges{}
+	}
+	return t.Node
 }
 
 type GetAllEvents_Events_Edges_Node_Group struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*GetAllEvents_Events_Edges_Node_Group_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *GetAllEvents_Events_Edges_Node_Group) GetID() string {
+func (t *GetAllEvents_Events_Edges_Node_Group) GetEdges() []*GetAllEvents_Events_Edges_Node_Group_Edges {
 	if t == nil {
 		t = &GetAllEvents_Events_Edges_Node_Group{}
 	}
+	return t.Edges
+}
+
+type GetAllEvents_Events_Edges_Node_Integration_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *GetAllEvents_Events_Edges_Node_Integration_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetAllEvents_Events_Edges_Node_Integration_Edges_Node{}
+	}
 	return t.ID
+}
+
+type GetAllEvents_Events_Edges_Node_Integration_Edges struct {
+	Node *GetAllEvents_Events_Edges_Node_Integration_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllEvents_Events_Edges_Node_Integration_Edges) GetNode() *GetAllEvents_Events_Edges_Node_Integration_Edges_Node {
+	if t == nil {
+		t = &GetAllEvents_Events_Edges_Node_Integration_Edges{}
+	}
+	return t.Node
 }
 
 type GetAllEvents_Events_Edges_Node_Integration struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*GetAllEvents_Events_Edges_Node_Integration_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *GetAllEvents_Events_Edges_Node_Integration) GetID() string {
+func (t *GetAllEvents_Events_Edges_Node_Integration) GetEdges() []*GetAllEvents_Events_Edges_Node_Integration_Edges {
 	if t == nil {
 		t = &GetAllEvents_Events_Edges_Node_Integration{}
 	}
+	return t.Edges
+}
+
+type GetAllEvents_Events_Edges_Node_Organization_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *GetAllEvents_Events_Edges_Node_Organization_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetAllEvents_Events_Edges_Node_Organization_Edges_Node{}
+	}
 	return t.ID
+}
+
+type GetAllEvents_Events_Edges_Node_Organization_Edges struct {
+	Node *GetAllEvents_Events_Edges_Node_Organization_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllEvents_Events_Edges_Node_Organization_Edges) GetNode() *GetAllEvents_Events_Edges_Node_Organization_Edges_Node {
+	if t == nil {
+		t = &GetAllEvents_Events_Edges_Node_Organization_Edges{}
+	}
+	return t.Node
 }
 
 type GetAllEvents_Events_Edges_Node_Organization struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*GetAllEvents_Events_Edges_Node_Organization_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *GetAllEvents_Events_Edges_Node_Organization) GetID() string {
+func (t *GetAllEvents_Events_Edges_Node_Organization) GetEdges() []*GetAllEvents_Events_Edges_Node_Organization_Edges {
 	if t == nil {
 		t = &GetAllEvents_Events_Edges_Node_Organization{}
 	}
+	return t.Edges
+}
+
+type GetAllEvents_Events_Edges_Node_Invite_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *GetAllEvents_Events_Edges_Node_Invite_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetAllEvents_Events_Edges_Node_Invite_Edges_Node{}
+	}
 	return t.ID
+}
+
+type GetAllEvents_Events_Edges_Node_Invite_Edges struct {
+	Node *GetAllEvents_Events_Edges_Node_Invite_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllEvents_Events_Edges_Node_Invite_Edges) GetNode() *GetAllEvents_Events_Edges_Node_Invite_Edges_Node {
+	if t == nil {
+		t = &GetAllEvents_Events_Edges_Node_Invite_Edges{}
+	}
+	return t.Node
 }
 
 type GetAllEvents_Events_Edges_Node_Invite struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*GetAllEvents_Events_Edges_Node_Invite_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *GetAllEvents_Events_Edges_Node_Invite) GetID() string {
+func (t *GetAllEvents_Events_Edges_Node_Invite) GetEdges() []*GetAllEvents_Events_Edges_Node_Invite_Edges {
 	if t == nil {
 		t = &GetAllEvents_Events_Edges_Node_Invite{}
 	}
+	return t.Edges
+}
+
+type GetAllEvents_Events_Edges_Node_PersonalAccessToken_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *GetAllEvents_Events_Edges_Node_PersonalAccessToken_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetAllEvents_Events_Edges_Node_PersonalAccessToken_Edges_Node{}
+	}
 	return t.ID
+}
+
+type GetAllEvents_Events_Edges_Node_PersonalAccessToken_Edges struct {
+	Node *GetAllEvents_Events_Edges_Node_PersonalAccessToken_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllEvents_Events_Edges_Node_PersonalAccessToken_Edges) GetNode() *GetAllEvents_Events_Edges_Node_PersonalAccessToken_Edges_Node {
+	if t == nil {
+		t = &GetAllEvents_Events_Edges_Node_PersonalAccessToken_Edges{}
+	}
+	return t.Node
 }
 
 type GetAllEvents_Events_Edges_Node_PersonalAccessToken struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*GetAllEvents_Events_Edges_Node_PersonalAccessToken_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *GetAllEvents_Events_Edges_Node_PersonalAccessToken) GetID() string {
+func (t *GetAllEvents_Events_Edges_Node_PersonalAccessToken) GetEdges() []*GetAllEvents_Events_Edges_Node_PersonalAccessToken_Edges {
 	if t == nil {
 		t = &GetAllEvents_Events_Edges_Node_PersonalAccessToken{}
 	}
+	return t.Edges
+}
+
+type GetAllEvents_Events_Edges_Node_Hush_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *GetAllEvents_Events_Edges_Node_Hush_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetAllEvents_Events_Edges_Node_Hush_Edges_Node{}
+	}
 	return t.ID
+}
+
+type GetAllEvents_Events_Edges_Node_Hush_Edges struct {
+	Node *GetAllEvents_Events_Edges_Node_Hush_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllEvents_Events_Edges_Node_Hush_Edges) GetNode() *GetAllEvents_Events_Edges_Node_Hush_Edges_Node {
+	if t == nil {
+		t = &GetAllEvents_Events_Edges_Node_Hush_Edges{}
+	}
+	return t.Node
 }
 
 type GetAllEvents_Events_Edges_Node_Hush struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*GetAllEvents_Events_Edges_Node_Hush_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *GetAllEvents_Events_Edges_Node_Hush) GetID() string {
+func (t *GetAllEvents_Events_Edges_Node_Hush) GetEdges() []*GetAllEvents_Events_Edges_Node_Hush_Edges {
 	if t == nil {
 		t = &GetAllEvents_Events_Edges_Node_Hush{}
 	}
+	return t.Edges
+}
+
+type GetAllEvents_Events_Edges_Node_Orgmembership_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *GetAllEvents_Events_Edges_Node_Orgmembership_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetAllEvents_Events_Edges_Node_Orgmembership_Edges_Node{}
+	}
 	return t.ID
+}
+
+type GetAllEvents_Events_Edges_Node_Orgmembership_Edges struct {
+	Node *GetAllEvents_Events_Edges_Node_Orgmembership_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllEvents_Events_Edges_Node_Orgmembership_Edges) GetNode() *GetAllEvents_Events_Edges_Node_Orgmembership_Edges_Node {
+	if t == nil {
+		t = &GetAllEvents_Events_Edges_Node_Orgmembership_Edges{}
+	}
+	return t.Node
 }
 
 type GetAllEvents_Events_Edges_Node_Orgmembership struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*GetAllEvents_Events_Edges_Node_Orgmembership_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *GetAllEvents_Events_Edges_Node_Orgmembership) GetID() string {
+func (t *GetAllEvents_Events_Edges_Node_Orgmembership) GetEdges() []*GetAllEvents_Events_Edges_Node_Orgmembership_Edges {
 	if t == nil {
 		t = &GetAllEvents_Events_Edges_Node_Orgmembership{}
 	}
-	return t.ID
+	return t.Edges
 }
 
-type GetAllEvents_Events_Edges_Node_Groupmembership struct {
+type GetAllEvents_Events_Edges_Node_Groupmembership_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *GetAllEvents_Events_Edges_Node_Groupmembership) GetID() string {
+func (t *GetAllEvents_Events_Edges_Node_Groupmembership_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetAllEvents_Events_Edges_Node_Groupmembership{}
+		t = &GetAllEvents_Events_Edges_Node_Groupmembership_Edges_Node{}
 	}
 	return t.ID
 }
 
+type GetAllEvents_Events_Edges_Node_Groupmembership_Edges struct {
+	Node *GetAllEvents_Events_Edges_Node_Groupmembership_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllEvents_Events_Edges_Node_Groupmembership_Edges) GetNode() *GetAllEvents_Events_Edges_Node_Groupmembership_Edges_Node {
+	if t == nil {
+		t = &GetAllEvents_Events_Edges_Node_Groupmembership_Edges{}
+	}
+	return t.Node
+}
+
+type GetAllEvents_Events_Edges_Node_Groupmembership struct {
+	Edges []*GetAllEvents_Events_Edges_Node_Groupmembership_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetAllEvents_Events_Edges_Node_Groupmembership) GetEdges() []*GetAllEvents_Events_Edges_Node_Groupmembership_Edges {
+	if t == nil {
+		t = &GetAllEvents_Events_Edges_Node_Groupmembership{}
+	}
+	return t.Edges
+}
+
 type GetAllEvents_Events_Edges_Node struct {
-	CorrelationID       *string                                               "json:\"correlationID,omitempty\" graphql:\"correlationID\""
-	CreatedAt           *time.Time                                            "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy           *string                                               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	EventID             *string                                               "json:\"eventID,omitempty\" graphql:\"eventID\""
-	EventType           string                                                "json:\"eventType\" graphql:\"eventType\""
-	Group               []*GetAllEvents_Events_Edges_Node_Group               "json:\"group,omitempty\" graphql:\"group\""
-	Groupmembership     []*GetAllEvents_Events_Edges_Node_Groupmembership     "json:\"groupmembership,omitempty\" graphql:\"groupmembership\""
-	Hush                []*GetAllEvents_Events_Edges_Node_Hush                "json:\"hush,omitempty\" graphql:\"hush\""
-	ID                  string                                                "json:\"id\" graphql:\"id\""
-	Integration         []*GetAllEvents_Events_Edges_Node_Integration         "json:\"integration,omitempty\" graphql:\"integration\""
-	Invite              []*GetAllEvents_Events_Edges_Node_Invite              "json:\"invite,omitempty\" graphql:\"invite\""
-	Metadata            map[string]any                                        "json:\"metadata,omitempty\" graphql:\"metadata\""
-	Organization        []*GetAllEvents_Events_Edges_Node_Organization        "json:\"organization,omitempty\" graphql:\"organization\""
-	Orgmembership       []*GetAllEvents_Events_Edges_Node_Orgmembership       "json:\"orgmembership,omitempty\" graphql:\"orgmembership\""
-	PersonalAccessToken []*GetAllEvents_Events_Edges_Node_PersonalAccessToken "json:\"personalAccessToken,omitempty\" graphql:\"personalAccessToken\""
-	UpdatedAt           *time.Time                                            "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy           *string                                               "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
-	User                []*GetAllEvents_Events_Edges_Node_User                "json:\"user,omitempty\" graphql:\"user\""
+	CorrelationID       *string                                            "json:\"correlationID,omitempty\" graphql:\"correlationID\""
+	CreatedAt           *time.Time                                         "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy           *string                                            "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	EventID             *string                                            "json:\"eventID,omitempty\" graphql:\"eventID\""
+	EventType           string                                             "json:\"eventType\" graphql:\"eventType\""
+	Group               GetAllEvents_Events_Edges_Node_Group               "json:\"group\" graphql:\"group\""
+	Groupmembership     GetAllEvents_Events_Edges_Node_Groupmembership     "json:\"groupmembership\" graphql:\"groupmembership\""
+	Hush                GetAllEvents_Events_Edges_Node_Hush                "json:\"hush\" graphql:\"hush\""
+	ID                  string                                             "json:\"id\" graphql:\"id\""
+	Integration         GetAllEvents_Events_Edges_Node_Integration         "json:\"integration\" graphql:\"integration\""
+	Invite              GetAllEvents_Events_Edges_Node_Invite              "json:\"invite\" graphql:\"invite\""
+	Metadata            map[string]any                                     "json:\"metadata,omitempty\" graphql:\"metadata\""
+	Organization        GetAllEvents_Events_Edges_Node_Organization        "json:\"organization\" graphql:\"organization\""
+	Orgmembership       GetAllEvents_Events_Edges_Node_Orgmembership       "json:\"orgmembership\" graphql:\"orgmembership\""
+	PersonalAccessToken GetAllEvents_Events_Edges_Node_PersonalAccessToken "json:\"personalAccessToken\" graphql:\"personalAccessToken\""
+	UpdatedAt           *time.Time                                         "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy           *string                                            "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	User                GetAllEvents_Events_Edges_Node_User                "json:\"user\" graphql:\"user\""
 }
 
 func (t *GetAllEvents_Events_Edges_Node) GetCorrelationID() *string {
@@ -15058,23 +16356,23 @@ func (t *GetAllEvents_Events_Edges_Node) GetEventType() string {
 	}
 	return t.EventType
 }
-func (t *GetAllEvents_Events_Edges_Node) GetGroup() []*GetAllEvents_Events_Edges_Node_Group {
+func (t *GetAllEvents_Events_Edges_Node) GetGroup() *GetAllEvents_Events_Edges_Node_Group {
 	if t == nil {
 		t = &GetAllEvents_Events_Edges_Node{}
 	}
-	return t.Group
+	return &t.Group
 }
-func (t *GetAllEvents_Events_Edges_Node) GetGroupmembership() []*GetAllEvents_Events_Edges_Node_Groupmembership {
+func (t *GetAllEvents_Events_Edges_Node) GetGroupmembership() *GetAllEvents_Events_Edges_Node_Groupmembership {
 	if t == nil {
 		t = &GetAllEvents_Events_Edges_Node{}
 	}
-	return t.Groupmembership
+	return &t.Groupmembership
 }
-func (t *GetAllEvents_Events_Edges_Node) GetHush() []*GetAllEvents_Events_Edges_Node_Hush {
+func (t *GetAllEvents_Events_Edges_Node) GetHush() *GetAllEvents_Events_Edges_Node_Hush {
 	if t == nil {
 		t = &GetAllEvents_Events_Edges_Node{}
 	}
-	return t.Hush
+	return &t.Hush
 }
 func (t *GetAllEvents_Events_Edges_Node) GetID() string {
 	if t == nil {
@@ -15082,17 +16380,17 @@ func (t *GetAllEvents_Events_Edges_Node) GetID() string {
 	}
 	return t.ID
 }
-func (t *GetAllEvents_Events_Edges_Node) GetIntegration() []*GetAllEvents_Events_Edges_Node_Integration {
+func (t *GetAllEvents_Events_Edges_Node) GetIntegration() *GetAllEvents_Events_Edges_Node_Integration {
 	if t == nil {
 		t = &GetAllEvents_Events_Edges_Node{}
 	}
-	return t.Integration
+	return &t.Integration
 }
-func (t *GetAllEvents_Events_Edges_Node) GetInvite() []*GetAllEvents_Events_Edges_Node_Invite {
+func (t *GetAllEvents_Events_Edges_Node) GetInvite() *GetAllEvents_Events_Edges_Node_Invite {
 	if t == nil {
 		t = &GetAllEvents_Events_Edges_Node{}
 	}
-	return t.Invite
+	return &t.Invite
 }
 func (t *GetAllEvents_Events_Edges_Node) GetMetadata() map[string]any {
 	if t == nil {
@@ -15100,23 +16398,23 @@ func (t *GetAllEvents_Events_Edges_Node) GetMetadata() map[string]any {
 	}
 	return t.Metadata
 }
-func (t *GetAllEvents_Events_Edges_Node) GetOrganization() []*GetAllEvents_Events_Edges_Node_Organization {
+func (t *GetAllEvents_Events_Edges_Node) GetOrganization() *GetAllEvents_Events_Edges_Node_Organization {
 	if t == nil {
 		t = &GetAllEvents_Events_Edges_Node{}
 	}
-	return t.Organization
+	return &t.Organization
 }
-func (t *GetAllEvents_Events_Edges_Node) GetOrgmembership() []*GetAllEvents_Events_Edges_Node_Orgmembership {
+func (t *GetAllEvents_Events_Edges_Node) GetOrgmembership() *GetAllEvents_Events_Edges_Node_Orgmembership {
 	if t == nil {
 		t = &GetAllEvents_Events_Edges_Node{}
 	}
-	return t.Orgmembership
+	return &t.Orgmembership
 }
-func (t *GetAllEvents_Events_Edges_Node) GetPersonalAccessToken() []*GetAllEvents_Events_Edges_Node_PersonalAccessToken {
+func (t *GetAllEvents_Events_Edges_Node) GetPersonalAccessToken() *GetAllEvents_Events_Edges_Node_PersonalAccessToken {
 	if t == nil {
 		t = &GetAllEvents_Events_Edges_Node{}
 	}
-	return t.PersonalAccessToken
+	return &t.PersonalAccessToken
 }
 func (t *GetAllEvents_Events_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
@@ -15130,11 +16428,11 @@ func (t *GetAllEvents_Events_Edges_Node) GetUpdatedBy() *string {
 	}
 	return t.UpdatedBy
 }
-func (t *GetAllEvents_Events_Edges_Node) GetUser() []*GetAllEvents_Events_Edges_Node_User {
+func (t *GetAllEvents_Events_Edges_Node) GetUser() *GetAllEvents_Events_Edges_Node_User {
 	if t == nil {
 		t = &GetAllEvents_Events_Edges_Node{}
 	}
-	return t.User
+	return &t.User
 }
 
 type GetAllEvents_Events_Edges struct {
@@ -15159,124 +16457,322 @@ func (t *GetAllEvents_Events) GetEdges() []*GetAllEvents_Events_Edges {
 	return t.Edges
 }
 
-type GetEventByID_Event_User struct {
+type GetEventByID_Event_User_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *GetEventByID_Event_User) GetID() string {
+func (t *GetEventByID_Event_User_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetEventByID_Event_User_Edges_Node{}
+	}
+	return t.ID
+}
+
+type GetEventByID_Event_User_Edges struct {
+	Node *GetEventByID_Event_User_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetEventByID_Event_User_Edges) GetNode() *GetEventByID_Event_User_Edges_Node {
+	if t == nil {
+		t = &GetEventByID_Event_User_Edges{}
+	}
+	return t.Node
+}
+
+type GetEventByID_Event_User struct {
+	Edges []*GetEventByID_Event_User_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetEventByID_Event_User) GetEdges() []*GetEventByID_Event_User_Edges {
 	if t == nil {
 		t = &GetEventByID_Event_User{}
 	}
+	return t.Edges
+}
+
+type GetEventByID_Event_Group_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *GetEventByID_Event_Group_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetEventByID_Event_Group_Edges_Node{}
+	}
 	return t.ID
+}
+
+type GetEventByID_Event_Group_Edges struct {
+	Node *GetEventByID_Event_Group_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetEventByID_Event_Group_Edges) GetNode() *GetEventByID_Event_Group_Edges_Node {
+	if t == nil {
+		t = &GetEventByID_Event_Group_Edges{}
+	}
+	return t.Node
 }
 
 type GetEventByID_Event_Group struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*GetEventByID_Event_Group_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *GetEventByID_Event_Group) GetID() string {
+func (t *GetEventByID_Event_Group) GetEdges() []*GetEventByID_Event_Group_Edges {
 	if t == nil {
 		t = &GetEventByID_Event_Group{}
 	}
+	return t.Edges
+}
+
+type GetEventByID_Event_Integration_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *GetEventByID_Event_Integration_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetEventByID_Event_Integration_Edges_Node{}
+	}
 	return t.ID
+}
+
+type GetEventByID_Event_Integration_Edges struct {
+	Node *GetEventByID_Event_Integration_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetEventByID_Event_Integration_Edges) GetNode() *GetEventByID_Event_Integration_Edges_Node {
+	if t == nil {
+		t = &GetEventByID_Event_Integration_Edges{}
+	}
+	return t.Node
 }
 
 type GetEventByID_Event_Integration struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*GetEventByID_Event_Integration_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *GetEventByID_Event_Integration) GetID() string {
+func (t *GetEventByID_Event_Integration) GetEdges() []*GetEventByID_Event_Integration_Edges {
 	if t == nil {
 		t = &GetEventByID_Event_Integration{}
 	}
+	return t.Edges
+}
+
+type GetEventByID_Event_Organization_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *GetEventByID_Event_Organization_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetEventByID_Event_Organization_Edges_Node{}
+	}
 	return t.ID
+}
+
+type GetEventByID_Event_Organization_Edges struct {
+	Node *GetEventByID_Event_Organization_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetEventByID_Event_Organization_Edges) GetNode() *GetEventByID_Event_Organization_Edges_Node {
+	if t == nil {
+		t = &GetEventByID_Event_Organization_Edges{}
+	}
+	return t.Node
 }
 
 type GetEventByID_Event_Organization struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*GetEventByID_Event_Organization_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *GetEventByID_Event_Organization) GetID() string {
+func (t *GetEventByID_Event_Organization) GetEdges() []*GetEventByID_Event_Organization_Edges {
 	if t == nil {
 		t = &GetEventByID_Event_Organization{}
 	}
+	return t.Edges
+}
+
+type GetEventByID_Event_Invite_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *GetEventByID_Event_Invite_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetEventByID_Event_Invite_Edges_Node{}
+	}
 	return t.ID
+}
+
+type GetEventByID_Event_Invite_Edges struct {
+	Node *GetEventByID_Event_Invite_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetEventByID_Event_Invite_Edges) GetNode() *GetEventByID_Event_Invite_Edges_Node {
+	if t == nil {
+		t = &GetEventByID_Event_Invite_Edges{}
+	}
+	return t.Node
 }
 
 type GetEventByID_Event_Invite struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*GetEventByID_Event_Invite_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *GetEventByID_Event_Invite) GetID() string {
+func (t *GetEventByID_Event_Invite) GetEdges() []*GetEventByID_Event_Invite_Edges {
 	if t == nil {
 		t = &GetEventByID_Event_Invite{}
 	}
+	return t.Edges
+}
+
+type GetEventByID_Event_PersonalAccessToken_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *GetEventByID_Event_PersonalAccessToken_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetEventByID_Event_PersonalAccessToken_Edges_Node{}
+	}
 	return t.ID
+}
+
+type GetEventByID_Event_PersonalAccessToken_Edges struct {
+	Node *GetEventByID_Event_PersonalAccessToken_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetEventByID_Event_PersonalAccessToken_Edges) GetNode() *GetEventByID_Event_PersonalAccessToken_Edges_Node {
+	if t == nil {
+		t = &GetEventByID_Event_PersonalAccessToken_Edges{}
+	}
+	return t.Node
 }
 
 type GetEventByID_Event_PersonalAccessToken struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*GetEventByID_Event_PersonalAccessToken_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *GetEventByID_Event_PersonalAccessToken) GetID() string {
+func (t *GetEventByID_Event_PersonalAccessToken) GetEdges() []*GetEventByID_Event_PersonalAccessToken_Edges {
 	if t == nil {
 		t = &GetEventByID_Event_PersonalAccessToken{}
 	}
+	return t.Edges
+}
+
+type GetEventByID_Event_Hush_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *GetEventByID_Event_Hush_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetEventByID_Event_Hush_Edges_Node{}
+	}
 	return t.ID
+}
+
+type GetEventByID_Event_Hush_Edges struct {
+	Node *GetEventByID_Event_Hush_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetEventByID_Event_Hush_Edges) GetNode() *GetEventByID_Event_Hush_Edges_Node {
+	if t == nil {
+		t = &GetEventByID_Event_Hush_Edges{}
+	}
+	return t.Node
 }
 
 type GetEventByID_Event_Hush struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*GetEventByID_Event_Hush_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *GetEventByID_Event_Hush) GetID() string {
+func (t *GetEventByID_Event_Hush) GetEdges() []*GetEventByID_Event_Hush_Edges {
 	if t == nil {
 		t = &GetEventByID_Event_Hush{}
 	}
+	return t.Edges
+}
+
+type GetEventByID_Event_Orgmembership_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *GetEventByID_Event_Orgmembership_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetEventByID_Event_Orgmembership_Edges_Node{}
+	}
 	return t.ID
+}
+
+type GetEventByID_Event_Orgmembership_Edges struct {
+	Node *GetEventByID_Event_Orgmembership_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetEventByID_Event_Orgmembership_Edges) GetNode() *GetEventByID_Event_Orgmembership_Edges_Node {
+	if t == nil {
+		t = &GetEventByID_Event_Orgmembership_Edges{}
+	}
+	return t.Node
 }
 
 type GetEventByID_Event_Orgmembership struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*GetEventByID_Event_Orgmembership_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *GetEventByID_Event_Orgmembership) GetID() string {
+func (t *GetEventByID_Event_Orgmembership) GetEdges() []*GetEventByID_Event_Orgmembership_Edges {
 	if t == nil {
 		t = &GetEventByID_Event_Orgmembership{}
 	}
-	return t.ID
+	return t.Edges
 }
 
-type GetEventByID_Event_Groupmembership struct {
+type GetEventByID_Event_Groupmembership_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *GetEventByID_Event_Groupmembership) GetID() string {
+func (t *GetEventByID_Event_Groupmembership_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetEventByID_Event_Groupmembership{}
+		t = &GetEventByID_Event_Groupmembership_Edges_Node{}
 	}
 	return t.ID
 }
 
+type GetEventByID_Event_Groupmembership_Edges struct {
+	Node *GetEventByID_Event_Groupmembership_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetEventByID_Event_Groupmembership_Edges) GetNode() *GetEventByID_Event_Groupmembership_Edges_Node {
+	if t == nil {
+		t = &GetEventByID_Event_Groupmembership_Edges{}
+	}
+	return t.Node
+}
+
+type GetEventByID_Event_Groupmembership struct {
+	Edges []*GetEventByID_Event_Groupmembership_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetEventByID_Event_Groupmembership) GetEdges() []*GetEventByID_Event_Groupmembership_Edges {
+	if t == nil {
+		t = &GetEventByID_Event_Groupmembership{}
+	}
+	return t.Edges
+}
+
 type GetEventByID_Event struct {
-	CorrelationID       *string                                   "json:\"correlationID,omitempty\" graphql:\"correlationID\""
-	CreatedAt           *time.Time                                "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy           *string                                   "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	EventID             *string                                   "json:\"eventID,omitempty\" graphql:\"eventID\""
-	EventType           string                                    "json:\"eventType\" graphql:\"eventType\""
-	Group               []*GetEventByID_Event_Group               "json:\"group,omitempty\" graphql:\"group\""
-	Groupmembership     []*GetEventByID_Event_Groupmembership     "json:\"groupmembership,omitempty\" graphql:\"groupmembership\""
-	Hush                []*GetEventByID_Event_Hush                "json:\"hush,omitempty\" graphql:\"hush\""
-	ID                  string                                    "json:\"id\" graphql:\"id\""
-	Integration         []*GetEventByID_Event_Integration         "json:\"integration,omitempty\" graphql:\"integration\""
-	Invite              []*GetEventByID_Event_Invite              "json:\"invite,omitempty\" graphql:\"invite\""
-	Metadata            map[string]any                            "json:\"metadata,omitempty\" graphql:\"metadata\""
-	Organization        []*GetEventByID_Event_Organization        "json:\"organization,omitempty\" graphql:\"organization\""
-	Orgmembership       []*GetEventByID_Event_Orgmembership       "json:\"orgmembership,omitempty\" graphql:\"orgmembership\""
-	PersonalAccessToken []*GetEventByID_Event_PersonalAccessToken "json:\"personalAccessToken,omitempty\" graphql:\"personalAccessToken\""
-	UpdatedAt           *time.Time                                "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy           *string                                   "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
-	User                []*GetEventByID_Event_User                "json:\"user,omitempty\" graphql:\"user\""
+	CorrelationID       *string                                "json:\"correlationID,omitempty\" graphql:\"correlationID\""
+	CreatedAt           *time.Time                             "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy           *string                                "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	EventID             *string                                "json:\"eventID,omitempty\" graphql:\"eventID\""
+	EventType           string                                 "json:\"eventType\" graphql:\"eventType\""
+	Group               GetEventByID_Event_Group               "json:\"group\" graphql:\"group\""
+	Groupmembership     GetEventByID_Event_Groupmembership     "json:\"groupmembership\" graphql:\"groupmembership\""
+	Hush                GetEventByID_Event_Hush                "json:\"hush\" graphql:\"hush\""
+	ID                  string                                 "json:\"id\" graphql:\"id\""
+	Integration         GetEventByID_Event_Integration         "json:\"integration\" graphql:\"integration\""
+	Invite              GetEventByID_Event_Invite              "json:\"invite\" graphql:\"invite\""
+	Metadata            map[string]any                         "json:\"metadata,omitempty\" graphql:\"metadata\""
+	Organization        GetEventByID_Event_Organization        "json:\"organization\" graphql:\"organization\""
+	Orgmembership       GetEventByID_Event_Orgmembership       "json:\"orgmembership\" graphql:\"orgmembership\""
+	PersonalAccessToken GetEventByID_Event_PersonalAccessToken "json:\"personalAccessToken\" graphql:\"personalAccessToken\""
+	UpdatedAt           *time.Time                             "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy           *string                                "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	User                GetEventByID_Event_User                "json:\"user\" graphql:\"user\""
 }
 
 func (t *GetEventByID_Event) GetCorrelationID() *string {
@@ -15309,23 +16805,23 @@ func (t *GetEventByID_Event) GetEventType() string {
 	}
 	return t.EventType
 }
-func (t *GetEventByID_Event) GetGroup() []*GetEventByID_Event_Group {
+func (t *GetEventByID_Event) GetGroup() *GetEventByID_Event_Group {
 	if t == nil {
 		t = &GetEventByID_Event{}
 	}
-	return t.Group
+	return &t.Group
 }
-func (t *GetEventByID_Event) GetGroupmembership() []*GetEventByID_Event_Groupmembership {
+func (t *GetEventByID_Event) GetGroupmembership() *GetEventByID_Event_Groupmembership {
 	if t == nil {
 		t = &GetEventByID_Event{}
 	}
-	return t.Groupmembership
+	return &t.Groupmembership
 }
-func (t *GetEventByID_Event) GetHush() []*GetEventByID_Event_Hush {
+func (t *GetEventByID_Event) GetHush() *GetEventByID_Event_Hush {
 	if t == nil {
 		t = &GetEventByID_Event{}
 	}
-	return t.Hush
+	return &t.Hush
 }
 func (t *GetEventByID_Event) GetID() string {
 	if t == nil {
@@ -15333,17 +16829,17 @@ func (t *GetEventByID_Event) GetID() string {
 	}
 	return t.ID
 }
-func (t *GetEventByID_Event) GetIntegration() []*GetEventByID_Event_Integration {
+func (t *GetEventByID_Event) GetIntegration() *GetEventByID_Event_Integration {
 	if t == nil {
 		t = &GetEventByID_Event{}
 	}
-	return t.Integration
+	return &t.Integration
 }
-func (t *GetEventByID_Event) GetInvite() []*GetEventByID_Event_Invite {
+func (t *GetEventByID_Event) GetInvite() *GetEventByID_Event_Invite {
 	if t == nil {
 		t = &GetEventByID_Event{}
 	}
-	return t.Invite
+	return &t.Invite
 }
 func (t *GetEventByID_Event) GetMetadata() map[string]any {
 	if t == nil {
@@ -15351,23 +16847,23 @@ func (t *GetEventByID_Event) GetMetadata() map[string]any {
 	}
 	return t.Metadata
 }
-func (t *GetEventByID_Event) GetOrganization() []*GetEventByID_Event_Organization {
+func (t *GetEventByID_Event) GetOrganization() *GetEventByID_Event_Organization {
 	if t == nil {
 		t = &GetEventByID_Event{}
 	}
-	return t.Organization
+	return &t.Organization
 }
-func (t *GetEventByID_Event) GetOrgmembership() []*GetEventByID_Event_Orgmembership {
+func (t *GetEventByID_Event) GetOrgmembership() *GetEventByID_Event_Orgmembership {
 	if t == nil {
 		t = &GetEventByID_Event{}
 	}
-	return t.Orgmembership
+	return &t.Orgmembership
 }
-func (t *GetEventByID_Event) GetPersonalAccessToken() []*GetEventByID_Event_PersonalAccessToken {
+func (t *GetEventByID_Event) GetPersonalAccessToken() *GetEventByID_Event_PersonalAccessToken {
 	if t == nil {
 		t = &GetEventByID_Event{}
 	}
-	return t.PersonalAccessToken
+	return &t.PersonalAccessToken
 }
 func (t *GetEventByID_Event) GetUpdatedAt() *time.Time {
 	if t == nil {
@@ -15381,11 +16877,11 @@ func (t *GetEventByID_Event) GetUpdatedBy() *string {
 	}
 	return t.UpdatedBy
 }
-func (t *GetEventByID_Event) GetUser() []*GetEventByID_Event_User {
+func (t *GetEventByID_Event) GetUser() *GetEventByID_Event_User {
 	if t == nil {
 		t = &GetEventByID_Event{}
 	}
-	return t.User
+	return &t.User
 }
 
 type GetEvents_Events_Edges_Node struct {
@@ -15449,124 +16945,322 @@ func (t *GetEvents_Events) GetEdges() []*GetEvents_Events_Edges {
 	return t.Edges
 }
 
-type UpdateEvent_UpdateEvent_Event_User struct {
+type UpdateEvent_UpdateEvent_Event_User_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *UpdateEvent_UpdateEvent_Event_User) GetID() string {
+func (t *UpdateEvent_UpdateEvent_Event_User_Edges_Node) GetID() string {
+	if t == nil {
+		t = &UpdateEvent_UpdateEvent_Event_User_Edges_Node{}
+	}
+	return t.ID
+}
+
+type UpdateEvent_UpdateEvent_Event_User_Edges struct {
+	Node *UpdateEvent_UpdateEvent_Event_User_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateEvent_UpdateEvent_Event_User_Edges) GetNode() *UpdateEvent_UpdateEvent_Event_User_Edges_Node {
+	if t == nil {
+		t = &UpdateEvent_UpdateEvent_Event_User_Edges{}
+	}
+	return t.Node
+}
+
+type UpdateEvent_UpdateEvent_Event_User struct {
+	Edges []*UpdateEvent_UpdateEvent_Event_User_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *UpdateEvent_UpdateEvent_Event_User) GetEdges() []*UpdateEvent_UpdateEvent_Event_User_Edges {
 	if t == nil {
 		t = &UpdateEvent_UpdateEvent_Event_User{}
 	}
+	return t.Edges
+}
+
+type UpdateEvent_UpdateEvent_Event_Group_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *UpdateEvent_UpdateEvent_Event_Group_Edges_Node) GetID() string {
+	if t == nil {
+		t = &UpdateEvent_UpdateEvent_Event_Group_Edges_Node{}
+	}
 	return t.ID
+}
+
+type UpdateEvent_UpdateEvent_Event_Group_Edges struct {
+	Node *UpdateEvent_UpdateEvent_Event_Group_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateEvent_UpdateEvent_Event_Group_Edges) GetNode() *UpdateEvent_UpdateEvent_Event_Group_Edges_Node {
+	if t == nil {
+		t = &UpdateEvent_UpdateEvent_Event_Group_Edges{}
+	}
+	return t.Node
 }
 
 type UpdateEvent_UpdateEvent_Event_Group struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*UpdateEvent_UpdateEvent_Event_Group_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *UpdateEvent_UpdateEvent_Event_Group) GetID() string {
+func (t *UpdateEvent_UpdateEvent_Event_Group) GetEdges() []*UpdateEvent_UpdateEvent_Event_Group_Edges {
 	if t == nil {
 		t = &UpdateEvent_UpdateEvent_Event_Group{}
 	}
+	return t.Edges
+}
+
+type UpdateEvent_UpdateEvent_Event_Integration_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *UpdateEvent_UpdateEvent_Event_Integration_Edges_Node) GetID() string {
+	if t == nil {
+		t = &UpdateEvent_UpdateEvent_Event_Integration_Edges_Node{}
+	}
 	return t.ID
+}
+
+type UpdateEvent_UpdateEvent_Event_Integration_Edges struct {
+	Node *UpdateEvent_UpdateEvent_Event_Integration_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateEvent_UpdateEvent_Event_Integration_Edges) GetNode() *UpdateEvent_UpdateEvent_Event_Integration_Edges_Node {
+	if t == nil {
+		t = &UpdateEvent_UpdateEvent_Event_Integration_Edges{}
+	}
+	return t.Node
 }
 
 type UpdateEvent_UpdateEvent_Event_Integration struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*UpdateEvent_UpdateEvent_Event_Integration_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *UpdateEvent_UpdateEvent_Event_Integration) GetID() string {
+func (t *UpdateEvent_UpdateEvent_Event_Integration) GetEdges() []*UpdateEvent_UpdateEvent_Event_Integration_Edges {
 	if t == nil {
 		t = &UpdateEvent_UpdateEvent_Event_Integration{}
 	}
+	return t.Edges
+}
+
+type UpdateEvent_UpdateEvent_Event_Organization_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *UpdateEvent_UpdateEvent_Event_Organization_Edges_Node) GetID() string {
+	if t == nil {
+		t = &UpdateEvent_UpdateEvent_Event_Organization_Edges_Node{}
+	}
 	return t.ID
+}
+
+type UpdateEvent_UpdateEvent_Event_Organization_Edges struct {
+	Node *UpdateEvent_UpdateEvent_Event_Organization_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateEvent_UpdateEvent_Event_Organization_Edges) GetNode() *UpdateEvent_UpdateEvent_Event_Organization_Edges_Node {
+	if t == nil {
+		t = &UpdateEvent_UpdateEvent_Event_Organization_Edges{}
+	}
+	return t.Node
 }
 
 type UpdateEvent_UpdateEvent_Event_Organization struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*UpdateEvent_UpdateEvent_Event_Organization_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *UpdateEvent_UpdateEvent_Event_Organization) GetID() string {
+func (t *UpdateEvent_UpdateEvent_Event_Organization) GetEdges() []*UpdateEvent_UpdateEvent_Event_Organization_Edges {
 	if t == nil {
 		t = &UpdateEvent_UpdateEvent_Event_Organization{}
 	}
+	return t.Edges
+}
+
+type UpdateEvent_UpdateEvent_Event_Invite_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *UpdateEvent_UpdateEvent_Event_Invite_Edges_Node) GetID() string {
+	if t == nil {
+		t = &UpdateEvent_UpdateEvent_Event_Invite_Edges_Node{}
+	}
 	return t.ID
+}
+
+type UpdateEvent_UpdateEvent_Event_Invite_Edges struct {
+	Node *UpdateEvent_UpdateEvent_Event_Invite_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateEvent_UpdateEvent_Event_Invite_Edges) GetNode() *UpdateEvent_UpdateEvent_Event_Invite_Edges_Node {
+	if t == nil {
+		t = &UpdateEvent_UpdateEvent_Event_Invite_Edges{}
+	}
+	return t.Node
 }
 
 type UpdateEvent_UpdateEvent_Event_Invite struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*UpdateEvent_UpdateEvent_Event_Invite_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *UpdateEvent_UpdateEvent_Event_Invite) GetID() string {
+func (t *UpdateEvent_UpdateEvent_Event_Invite) GetEdges() []*UpdateEvent_UpdateEvent_Event_Invite_Edges {
 	if t == nil {
 		t = &UpdateEvent_UpdateEvent_Event_Invite{}
 	}
+	return t.Edges
+}
+
+type UpdateEvent_UpdateEvent_Event_PersonalAccessToken_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *UpdateEvent_UpdateEvent_Event_PersonalAccessToken_Edges_Node) GetID() string {
+	if t == nil {
+		t = &UpdateEvent_UpdateEvent_Event_PersonalAccessToken_Edges_Node{}
+	}
 	return t.ID
+}
+
+type UpdateEvent_UpdateEvent_Event_PersonalAccessToken_Edges struct {
+	Node *UpdateEvent_UpdateEvent_Event_PersonalAccessToken_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateEvent_UpdateEvent_Event_PersonalAccessToken_Edges) GetNode() *UpdateEvent_UpdateEvent_Event_PersonalAccessToken_Edges_Node {
+	if t == nil {
+		t = &UpdateEvent_UpdateEvent_Event_PersonalAccessToken_Edges{}
+	}
+	return t.Node
 }
 
 type UpdateEvent_UpdateEvent_Event_PersonalAccessToken struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*UpdateEvent_UpdateEvent_Event_PersonalAccessToken_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *UpdateEvent_UpdateEvent_Event_PersonalAccessToken) GetID() string {
+func (t *UpdateEvent_UpdateEvent_Event_PersonalAccessToken) GetEdges() []*UpdateEvent_UpdateEvent_Event_PersonalAccessToken_Edges {
 	if t == nil {
 		t = &UpdateEvent_UpdateEvent_Event_PersonalAccessToken{}
 	}
+	return t.Edges
+}
+
+type UpdateEvent_UpdateEvent_Event_Hush_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *UpdateEvent_UpdateEvent_Event_Hush_Edges_Node) GetID() string {
+	if t == nil {
+		t = &UpdateEvent_UpdateEvent_Event_Hush_Edges_Node{}
+	}
 	return t.ID
+}
+
+type UpdateEvent_UpdateEvent_Event_Hush_Edges struct {
+	Node *UpdateEvent_UpdateEvent_Event_Hush_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateEvent_UpdateEvent_Event_Hush_Edges) GetNode() *UpdateEvent_UpdateEvent_Event_Hush_Edges_Node {
+	if t == nil {
+		t = &UpdateEvent_UpdateEvent_Event_Hush_Edges{}
+	}
+	return t.Node
 }
 
 type UpdateEvent_UpdateEvent_Event_Hush struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*UpdateEvent_UpdateEvent_Event_Hush_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *UpdateEvent_UpdateEvent_Event_Hush) GetID() string {
+func (t *UpdateEvent_UpdateEvent_Event_Hush) GetEdges() []*UpdateEvent_UpdateEvent_Event_Hush_Edges {
 	if t == nil {
 		t = &UpdateEvent_UpdateEvent_Event_Hush{}
 	}
+	return t.Edges
+}
+
+type UpdateEvent_UpdateEvent_Event_Orgmembership_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *UpdateEvent_UpdateEvent_Event_Orgmembership_Edges_Node) GetID() string {
+	if t == nil {
+		t = &UpdateEvent_UpdateEvent_Event_Orgmembership_Edges_Node{}
+	}
 	return t.ID
+}
+
+type UpdateEvent_UpdateEvent_Event_Orgmembership_Edges struct {
+	Node *UpdateEvent_UpdateEvent_Event_Orgmembership_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateEvent_UpdateEvent_Event_Orgmembership_Edges) GetNode() *UpdateEvent_UpdateEvent_Event_Orgmembership_Edges_Node {
+	if t == nil {
+		t = &UpdateEvent_UpdateEvent_Event_Orgmembership_Edges{}
+	}
+	return t.Node
 }
 
 type UpdateEvent_UpdateEvent_Event_Orgmembership struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*UpdateEvent_UpdateEvent_Event_Orgmembership_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *UpdateEvent_UpdateEvent_Event_Orgmembership) GetID() string {
+func (t *UpdateEvent_UpdateEvent_Event_Orgmembership) GetEdges() []*UpdateEvent_UpdateEvent_Event_Orgmembership_Edges {
 	if t == nil {
 		t = &UpdateEvent_UpdateEvent_Event_Orgmembership{}
 	}
-	return t.ID
+	return t.Edges
 }
 
-type UpdateEvent_UpdateEvent_Event_Groupmembership struct {
+type UpdateEvent_UpdateEvent_Event_Groupmembership_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *UpdateEvent_UpdateEvent_Event_Groupmembership) GetID() string {
+func (t *UpdateEvent_UpdateEvent_Event_Groupmembership_Edges_Node) GetID() string {
 	if t == nil {
-		t = &UpdateEvent_UpdateEvent_Event_Groupmembership{}
+		t = &UpdateEvent_UpdateEvent_Event_Groupmembership_Edges_Node{}
 	}
 	return t.ID
 }
 
+type UpdateEvent_UpdateEvent_Event_Groupmembership_Edges struct {
+	Node *UpdateEvent_UpdateEvent_Event_Groupmembership_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateEvent_UpdateEvent_Event_Groupmembership_Edges) GetNode() *UpdateEvent_UpdateEvent_Event_Groupmembership_Edges_Node {
+	if t == nil {
+		t = &UpdateEvent_UpdateEvent_Event_Groupmembership_Edges{}
+	}
+	return t.Node
+}
+
+type UpdateEvent_UpdateEvent_Event_Groupmembership struct {
+	Edges []*UpdateEvent_UpdateEvent_Event_Groupmembership_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *UpdateEvent_UpdateEvent_Event_Groupmembership) GetEdges() []*UpdateEvent_UpdateEvent_Event_Groupmembership_Edges {
+	if t == nil {
+		t = &UpdateEvent_UpdateEvent_Event_Groupmembership{}
+	}
+	return t.Edges
+}
+
 type UpdateEvent_UpdateEvent_Event struct {
-	CorrelationID       *string                                              "json:\"correlationID,omitempty\" graphql:\"correlationID\""
-	CreatedAt           *time.Time                                           "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy           *string                                              "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	EventID             *string                                              "json:\"eventID,omitempty\" graphql:\"eventID\""
-	EventType           string                                               "json:\"eventType\" graphql:\"eventType\""
-	Group               []*UpdateEvent_UpdateEvent_Event_Group               "json:\"group,omitempty\" graphql:\"group\""
-	Groupmembership     []*UpdateEvent_UpdateEvent_Event_Groupmembership     "json:\"groupmembership,omitempty\" graphql:\"groupmembership\""
-	Hush                []*UpdateEvent_UpdateEvent_Event_Hush                "json:\"hush,omitempty\" graphql:\"hush\""
-	ID                  string                                               "json:\"id\" graphql:\"id\""
-	Integration         []*UpdateEvent_UpdateEvent_Event_Integration         "json:\"integration,omitempty\" graphql:\"integration\""
-	Invite              []*UpdateEvent_UpdateEvent_Event_Invite              "json:\"invite,omitempty\" graphql:\"invite\""
-	Metadata            map[string]any                                       "json:\"metadata,omitempty\" graphql:\"metadata\""
-	Organization        []*UpdateEvent_UpdateEvent_Event_Organization        "json:\"organization,omitempty\" graphql:\"organization\""
-	Orgmembership       []*UpdateEvent_UpdateEvent_Event_Orgmembership       "json:\"orgmembership,omitempty\" graphql:\"orgmembership\""
-	PersonalAccessToken []*UpdateEvent_UpdateEvent_Event_PersonalAccessToken "json:\"personalAccessToken,omitempty\" graphql:\"personalAccessToken\""
-	UpdatedAt           *time.Time                                           "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy           *string                                              "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
-	User                []*UpdateEvent_UpdateEvent_Event_User                "json:\"user,omitempty\" graphql:\"user\""
+	CorrelationID       *string                                           "json:\"correlationID,omitempty\" graphql:\"correlationID\""
+	CreatedAt           *time.Time                                        "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy           *string                                           "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	EventID             *string                                           "json:\"eventID,omitempty\" graphql:\"eventID\""
+	EventType           string                                            "json:\"eventType\" graphql:\"eventType\""
+	Group               UpdateEvent_UpdateEvent_Event_Group               "json:\"group\" graphql:\"group\""
+	Groupmembership     UpdateEvent_UpdateEvent_Event_Groupmembership     "json:\"groupmembership\" graphql:\"groupmembership\""
+	Hush                UpdateEvent_UpdateEvent_Event_Hush                "json:\"hush\" graphql:\"hush\""
+	ID                  string                                            "json:\"id\" graphql:\"id\""
+	Integration         UpdateEvent_UpdateEvent_Event_Integration         "json:\"integration\" graphql:\"integration\""
+	Invite              UpdateEvent_UpdateEvent_Event_Invite              "json:\"invite\" graphql:\"invite\""
+	Metadata            map[string]any                                    "json:\"metadata,omitempty\" graphql:\"metadata\""
+	Organization        UpdateEvent_UpdateEvent_Event_Organization        "json:\"organization\" graphql:\"organization\""
+	Orgmembership       UpdateEvent_UpdateEvent_Event_Orgmembership       "json:\"orgmembership\" graphql:\"orgmembership\""
+	PersonalAccessToken UpdateEvent_UpdateEvent_Event_PersonalAccessToken "json:\"personalAccessToken\" graphql:\"personalAccessToken\""
+	UpdatedAt           *time.Time                                        "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy           *string                                           "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	User                UpdateEvent_UpdateEvent_Event_User                "json:\"user\" graphql:\"user\""
 }
 
 func (t *UpdateEvent_UpdateEvent_Event) GetCorrelationID() *string {
@@ -15599,23 +17293,23 @@ func (t *UpdateEvent_UpdateEvent_Event) GetEventType() string {
 	}
 	return t.EventType
 }
-func (t *UpdateEvent_UpdateEvent_Event) GetGroup() []*UpdateEvent_UpdateEvent_Event_Group {
+func (t *UpdateEvent_UpdateEvent_Event) GetGroup() *UpdateEvent_UpdateEvent_Event_Group {
 	if t == nil {
 		t = &UpdateEvent_UpdateEvent_Event{}
 	}
-	return t.Group
+	return &t.Group
 }
-func (t *UpdateEvent_UpdateEvent_Event) GetGroupmembership() []*UpdateEvent_UpdateEvent_Event_Groupmembership {
+func (t *UpdateEvent_UpdateEvent_Event) GetGroupmembership() *UpdateEvent_UpdateEvent_Event_Groupmembership {
 	if t == nil {
 		t = &UpdateEvent_UpdateEvent_Event{}
 	}
-	return t.Groupmembership
+	return &t.Groupmembership
 }
-func (t *UpdateEvent_UpdateEvent_Event) GetHush() []*UpdateEvent_UpdateEvent_Event_Hush {
+func (t *UpdateEvent_UpdateEvent_Event) GetHush() *UpdateEvent_UpdateEvent_Event_Hush {
 	if t == nil {
 		t = &UpdateEvent_UpdateEvent_Event{}
 	}
-	return t.Hush
+	return &t.Hush
 }
 func (t *UpdateEvent_UpdateEvent_Event) GetID() string {
 	if t == nil {
@@ -15623,17 +17317,17 @@ func (t *UpdateEvent_UpdateEvent_Event) GetID() string {
 	}
 	return t.ID
 }
-func (t *UpdateEvent_UpdateEvent_Event) GetIntegration() []*UpdateEvent_UpdateEvent_Event_Integration {
+func (t *UpdateEvent_UpdateEvent_Event) GetIntegration() *UpdateEvent_UpdateEvent_Event_Integration {
 	if t == nil {
 		t = &UpdateEvent_UpdateEvent_Event{}
 	}
-	return t.Integration
+	return &t.Integration
 }
-func (t *UpdateEvent_UpdateEvent_Event) GetInvite() []*UpdateEvent_UpdateEvent_Event_Invite {
+func (t *UpdateEvent_UpdateEvent_Event) GetInvite() *UpdateEvent_UpdateEvent_Event_Invite {
 	if t == nil {
 		t = &UpdateEvent_UpdateEvent_Event{}
 	}
-	return t.Invite
+	return &t.Invite
 }
 func (t *UpdateEvent_UpdateEvent_Event) GetMetadata() map[string]any {
 	if t == nil {
@@ -15641,23 +17335,23 @@ func (t *UpdateEvent_UpdateEvent_Event) GetMetadata() map[string]any {
 	}
 	return t.Metadata
 }
-func (t *UpdateEvent_UpdateEvent_Event) GetOrganization() []*UpdateEvent_UpdateEvent_Event_Organization {
+func (t *UpdateEvent_UpdateEvent_Event) GetOrganization() *UpdateEvent_UpdateEvent_Event_Organization {
 	if t == nil {
 		t = &UpdateEvent_UpdateEvent_Event{}
 	}
-	return t.Organization
+	return &t.Organization
 }
-func (t *UpdateEvent_UpdateEvent_Event) GetOrgmembership() []*UpdateEvent_UpdateEvent_Event_Orgmembership {
+func (t *UpdateEvent_UpdateEvent_Event) GetOrgmembership() *UpdateEvent_UpdateEvent_Event_Orgmembership {
 	if t == nil {
 		t = &UpdateEvent_UpdateEvent_Event{}
 	}
-	return t.Orgmembership
+	return &t.Orgmembership
 }
-func (t *UpdateEvent_UpdateEvent_Event) GetPersonalAccessToken() []*UpdateEvent_UpdateEvent_Event_PersonalAccessToken {
+func (t *UpdateEvent_UpdateEvent_Event) GetPersonalAccessToken() *UpdateEvent_UpdateEvent_Event_PersonalAccessToken {
 	if t == nil {
 		t = &UpdateEvent_UpdateEvent_Event{}
 	}
-	return t.PersonalAccessToken
+	return &t.PersonalAccessToken
 }
 func (t *UpdateEvent_UpdateEvent_Event) GetUpdatedAt() *time.Time {
 	if t == nil {
@@ -15671,11 +17365,11 @@ func (t *UpdateEvent_UpdateEvent_Event) GetUpdatedBy() *string {
 	}
 	return t.UpdatedBy
 }
-func (t *UpdateEvent_UpdateEvent_Event) GetUser() []*UpdateEvent_UpdateEvent_Event_User {
+func (t *UpdateEvent_UpdateEvent_Event) GetUser() *UpdateEvent_UpdateEvent_Event_User {
 	if t == nil {
 		t = &UpdateEvent_UpdateEvent_Event{}
 	}
-	return t.User
+	return &t.User
 }
 
 type UpdateEvent_UpdateEvent struct {
@@ -15923,166 +17617,298 @@ func (t *GetEventHistories_EventHistories) GetEdges() []*GetEventHistories_Event
 	return t.Edges
 }
 
-type CreateEvidence_CreateEvidence_Evidence_Files struct {
+type CreateEvidence_CreateEvidence_Evidence_Files_Edges_Node struct {
 	ID           string  "json:\"id\" graphql:\"id\""
 	PresignedURL *string "json:\"presignedURL,omitempty\" graphql:\"presignedURL\""
 }
 
-func (t *CreateEvidence_CreateEvidence_Evidence_Files) GetID() string {
+func (t *CreateEvidence_CreateEvidence_Evidence_Files_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateEvidence_CreateEvidence_Evidence_Files{}
+		t = &CreateEvidence_CreateEvidence_Evidence_Files_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *CreateEvidence_CreateEvidence_Evidence_Files) GetPresignedURL() *string {
+func (t *CreateEvidence_CreateEvidence_Evidence_Files_Edges_Node) GetPresignedURL() *string {
 	if t == nil {
-		t = &CreateEvidence_CreateEvidence_Evidence_Files{}
+		t = &CreateEvidence_CreateEvidence_Evidence_Files_Edges_Node{}
 	}
 	return t.PresignedURL
 }
 
-type CreateEvidence_CreateEvidence_Evidence_Programs struct {
+type CreateEvidence_CreateEvidence_Evidence_Files_Edges struct {
+	Node *CreateEvidence_CreateEvidence_Evidence_Files_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateEvidence_CreateEvidence_Evidence_Files_Edges) GetNode() *CreateEvidence_CreateEvidence_Evidence_Files_Edges_Node {
+	if t == nil {
+		t = &CreateEvidence_CreateEvidence_Evidence_Files_Edges{}
+	}
+	return t.Node
+}
+
+type CreateEvidence_CreateEvidence_Evidence_Files struct {
+	Edges []*CreateEvidence_CreateEvidence_Evidence_Files_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateEvidence_CreateEvidence_Evidence_Files) GetEdges() []*CreateEvidence_CreateEvidence_Evidence_Files_Edges {
+	if t == nil {
+		t = &CreateEvidence_CreateEvidence_Evidence_Files{}
+	}
+	return t.Edges
+}
+
+type CreateEvidence_CreateEvidence_Evidence_Programs_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	Name      string "json:\"name\" graphql:\"name\""
 }
 
-func (t *CreateEvidence_CreateEvidence_Evidence_Programs) GetDisplayID() string {
+func (t *CreateEvidence_CreateEvidence_Evidence_Programs_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &CreateEvidence_CreateEvidence_Evidence_Programs{}
+		t = &CreateEvidence_CreateEvidence_Evidence_Programs_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *CreateEvidence_CreateEvidence_Evidence_Programs) GetID() string {
+func (t *CreateEvidence_CreateEvidence_Evidence_Programs_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateEvidence_CreateEvidence_Evidence_Programs{}
+		t = &CreateEvidence_CreateEvidence_Evidence_Programs_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *CreateEvidence_CreateEvidence_Evidence_Programs) GetName() string {
+func (t *CreateEvidence_CreateEvidence_Evidence_Programs_Edges_Node) GetName() string {
+	if t == nil {
+		t = &CreateEvidence_CreateEvidence_Evidence_Programs_Edges_Node{}
+	}
+	return t.Name
+}
+
+type CreateEvidence_CreateEvidence_Evidence_Programs_Edges struct {
+	Node *CreateEvidence_CreateEvidence_Evidence_Programs_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateEvidence_CreateEvidence_Evidence_Programs_Edges) GetNode() *CreateEvidence_CreateEvidence_Evidence_Programs_Edges_Node {
+	if t == nil {
+		t = &CreateEvidence_CreateEvidence_Evidence_Programs_Edges{}
+	}
+	return t.Node
+}
+
+type CreateEvidence_CreateEvidence_Evidence_Programs struct {
+	Edges []*CreateEvidence_CreateEvidence_Evidence_Programs_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateEvidence_CreateEvidence_Evidence_Programs) GetEdges() []*CreateEvidence_CreateEvidence_Evidence_Programs_Edges {
 	if t == nil {
 		t = &CreateEvidence_CreateEvidence_Evidence_Programs{}
 	}
-	return t.Name
+	return t.Edges
+}
+
+type CreateEvidence_CreateEvidence_Evidence_Tasks_Edges_Node struct {
+	DisplayID string "json:\"displayID\" graphql:\"displayID\""
+	ID        string "json:\"id\" graphql:\"id\""
+}
+
+func (t *CreateEvidence_CreateEvidence_Evidence_Tasks_Edges_Node) GetDisplayID() string {
+	if t == nil {
+		t = &CreateEvidence_CreateEvidence_Evidence_Tasks_Edges_Node{}
+	}
+	return t.DisplayID
+}
+func (t *CreateEvidence_CreateEvidence_Evidence_Tasks_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateEvidence_CreateEvidence_Evidence_Tasks_Edges_Node{}
+	}
+	return t.ID
+}
+
+type CreateEvidence_CreateEvidence_Evidence_Tasks_Edges struct {
+	Node *CreateEvidence_CreateEvidence_Evidence_Tasks_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateEvidence_CreateEvidence_Evidence_Tasks_Edges) GetNode() *CreateEvidence_CreateEvidence_Evidence_Tasks_Edges_Node {
+	if t == nil {
+		t = &CreateEvidence_CreateEvidence_Evidence_Tasks_Edges{}
+	}
+	return t.Node
 }
 
 type CreateEvidence_CreateEvidence_Evidence_Tasks struct {
-	DisplayID string "json:\"displayID\" graphql:\"displayID\""
-	ID        string "json:\"id\" graphql:\"id\""
+	Edges []*CreateEvidence_CreateEvidence_Evidence_Tasks_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateEvidence_CreateEvidence_Evidence_Tasks) GetDisplayID() string {
+func (t *CreateEvidence_CreateEvidence_Evidence_Tasks) GetEdges() []*CreateEvidence_CreateEvidence_Evidence_Tasks_Edges {
 	if t == nil {
 		t = &CreateEvidence_CreateEvidence_Evidence_Tasks{}
+	}
+	return t.Edges
+}
+
+type CreateEvidence_CreateEvidence_Evidence_Controls_Edges_Node struct {
+	DisplayID string "json:\"displayID\" graphql:\"displayID\""
+	ID        string "json:\"id\" graphql:\"id\""
+	RefCode   string "json:\"refCode\" graphql:\"refCode\""
+}
+
+func (t *CreateEvidence_CreateEvidence_Evidence_Controls_Edges_Node) GetDisplayID() string {
+	if t == nil {
+		t = &CreateEvidence_CreateEvidence_Evidence_Controls_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *CreateEvidence_CreateEvidence_Evidence_Tasks) GetID() string {
+func (t *CreateEvidence_CreateEvidence_Evidence_Controls_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateEvidence_CreateEvidence_Evidence_Tasks{}
+		t = &CreateEvidence_CreateEvidence_Evidence_Controls_Edges_Node{}
 	}
 	return t.ID
+}
+func (t *CreateEvidence_CreateEvidence_Evidence_Controls_Edges_Node) GetRefCode() string {
+	if t == nil {
+		t = &CreateEvidence_CreateEvidence_Evidence_Controls_Edges_Node{}
+	}
+	return t.RefCode
+}
+
+type CreateEvidence_CreateEvidence_Evidence_Controls_Edges struct {
+	Node *CreateEvidence_CreateEvidence_Evidence_Controls_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateEvidence_CreateEvidence_Evidence_Controls_Edges) GetNode() *CreateEvidence_CreateEvidence_Evidence_Controls_Edges_Node {
+	if t == nil {
+		t = &CreateEvidence_CreateEvidence_Evidence_Controls_Edges{}
+	}
+	return t.Node
 }
 
 type CreateEvidence_CreateEvidence_Evidence_Controls struct {
+	Edges []*CreateEvidence_CreateEvidence_Evidence_Controls_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateEvidence_CreateEvidence_Evidence_Controls) GetEdges() []*CreateEvidence_CreateEvidence_Evidence_Controls_Edges {
+	if t == nil {
+		t = &CreateEvidence_CreateEvidence_Evidence_Controls{}
+	}
+	return t.Edges
+}
+
+type CreateEvidence_CreateEvidence_Evidence_Subcontrols_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	RefCode   string "json:\"refCode\" graphql:\"refCode\""
 }
 
-func (t *CreateEvidence_CreateEvidence_Evidence_Controls) GetDisplayID() string {
+func (t *CreateEvidence_CreateEvidence_Evidence_Subcontrols_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &CreateEvidence_CreateEvidence_Evidence_Controls{}
+		t = &CreateEvidence_CreateEvidence_Evidence_Subcontrols_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *CreateEvidence_CreateEvidence_Evidence_Controls) GetID() string {
+func (t *CreateEvidence_CreateEvidence_Evidence_Subcontrols_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateEvidence_CreateEvidence_Evidence_Controls{}
+		t = &CreateEvidence_CreateEvidence_Evidence_Subcontrols_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *CreateEvidence_CreateEvidence_Evidence_Controls) GetRefCode() string {
+func (t *CreateEvidence_CreateEvidence_Evidence_Subcontrols_Edges_Node) GetRefCode() string {
 	if t == nil {
-		t = &CreateEvidence_CreateEvidence_Evidence_Controls{}
+		t = &CreateEvidence_CreateEvidence_Evidence_Subcontrols_Edges_Node{}
 	}
 	return t.RefCode
+}
+
+type CreateEvidence_CreateEvidence_Evidence_Subcontrols_Edges struct {
+	Node *CreateEvidence_CreateEvidence_Evidence_Subcontrols_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateEvidence_CreateEvidence_Evidence_Subcontrols_Edges) GetNode() *CreateEvidence_CreateEvidence_Evidence_Subcontrols_Edges_Node {
+	if t == nil {
+		t = &CreateEvidence_CreateEvidence_Evidence_Subcontrols_Edges{}
+	}
+	return t.Node
 }
 
 type CreateEvidence_CreateEvidence_Evidence_Subcontrols struct {
-	DisplayID string "json:\"displayID\" graphql:\"displayID\""
-	ID        string "json:\"id\" graphql:\"id\""
-	RefCode   string "json:\"refCode\" graphql:\"refCode\""
+	Edges []*CreateEvidence_CreateEvidence_Evidence_Subcontrols_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateEvidence_CreateEvidence_Evidence_Subcontrols) GetDisplayID() string {
+func (t *CreateEvidence_CreateEvidence_Evidence_Subcontrols) GetEdges() []*CreateEvidence_CreateEvidence_Evidence_Subcontrols_Edges {
 	if t == nil {
 		t = &CreateEvidence_CreateEvidence_Evidence_Subcontrols{}
 	}
-	return t.DisplayID
-}
-func (t *CreateEvidence_CreateEvidence_Evidence_Subcontrols) GetID() string {
-	if t == nil {
-		t = &CreateEvidence_CreateEvidence_Evidence_Subcontrols{}
-	}
-	return t.ID
-}
-func (t *CreateEvidence_CreateEvidence_Evidence_Subcontrols) GetRefCode() string {
-	if t == nil {
-		t = &CreateEvidence_CreateEvidence_Evidence_Subcontrols{}
-	}
-	return t.RefCode
+	return t.Edges
 }
 
-type CreateEvidence_CreateEvidence_Evidence_ControlObjectives struct {
+type CreateEvidence_CreateEvidence_Evidence_ControlObjectives_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	Name      string "json:\"name\" graphql:\"name\""
 }
 
-func (t *CreateEvidence_CreateEvidence_Evidence_ControlObjectives) GetDisplayID() string {
+func (t *CreateEvidence_CreateEvidence_Evidence_ControlObjectives_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &CreateEvidence_CreateEvidence_Evidence_ControlObjectives{}
+		t = &CreateEvidence_CreateEvidence_Evidence_ControlObjectives_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *CreateEvidence_CreateEvidence_Evidence_ControlObjectives) GetID() string {
+func (t *CreateEvidence_CreateEvidence_Evidence_ControlObjectives_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateEvidence_CreateEvidence_Evidence_ControlObjectives{}
+		t = &CreateEvidence_CreateEvidence_Evidence_ControlObjectives_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *CreateEvidence_CreateEvidence_Evidence_ControlObjectives) GetName() string {
+func (t *CreateEvidence_CreateEvidence_Evidence_ControlObjectives_Edges_Node) GetName() string {
 	if t == nil {
-		t = &CreateEvidence_CreateEvidence_Evidence_ControlObjectives{}
+		t = &CreateEvidence_CreateEvidence_Evidence_ControlObjectives_Edges_Node{}
 	}
 	return t.Name
 }
 
+type CreateEvidence_CreateEvidence_Evidence_ControlObjectives_Edges struct {
+	Node *CreateEvidence_CreateEvidence_Evidence_ControlObjectives_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateEvidence_CreateEvidence_Evidence_ControlObjectives_Edges) GetNode() *CreateEvidence_CreateEvidence_Evidence_ControlObjectives_Edges_Node {
+	if t == nil {
+		t = &CreateEvidence_CreateEvidence_Evidence_ControlObjectives_Edges{}
+	}
+	return t.Node
+}
+
+type CreateEvidence_CreateEvidence_Evidence_ControlObjectives struct {
+	Edges []*CreateEvidence_CreateEvidence_Evidence_ControlObjectives_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateEvidence_CreateEvidence_Evidence_ControlObjectives) GetEdges() []*CreateEvidence_CreateEvidence_Evidence_ControlObjectives_Edges {
+	if t == nil {
+		t = &CreateEvidence_CreateEvidence_Evidence_ControlObjectives{}
+	}
+	return t.Edges
+}
+
 type CreateEvidence_CreateEvidence_Evidence struct {
-	CollectionProcedure *string                                                     "json:\"collectionProcedure,omitempty\" graphql:\"collectionProcedure\""
-	ControlObjectives   []*CreateEvidence_CreateEvidence_Evidence_ControlObjectives "json:\"controlObjectives,omitempty\" graphql:\"controlObjectives\""
-	Controls            []*CreateEvidence_CreateEvidence_Evidence_Controls          "json:\"controls,omitempty\" graphql:\"controls\""
-	CreatedAt           *time.Time                                                  "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy           *string                                                     "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	CreationDate        time.Time                                                   "json:\"creationDate\" graphql:\"creationDate\""
-	Description         *string                                                     "json:\"description,omitempty\" graphql:\"description\""
-	DisplayID           string                                                      "json:\"displayID\" graphql:\"displayID\""
-	Files               []*CreateEvidence_CreateEvidence_Evidence_Files             "json:\"files,omitempty\" graphql:\"files\""
-	ID                  string                                                      "json:\"id\" graphql:\"id\""
-	IsAutomated         *bool                                                       "json:\"isAutomated,omitempty\" graphql:\"isAutomated\""
-	Name                string                                                      "json:\"name\" graphql:\"name\""
-	OwnerID             *string                                                     "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Programs            []*CreateEvidence_CreateEvidence_Evidence_Programs          "json:\"programs,omitempty\" graphql:\"programs\""
-	RenewalDate         *time.Time                                                  "json:\"renewalDate,omitempty\" graphql:\"renewalDate\""
-	Source              *string                                                     "json:\"source,omitempty\" graphql:\"source\""
-	Status              *enums.EvidenceStatus                                       "json:\"status,omitempty\" graphql:\"status\""
-	Subcontrols         []*CreateEvidence_CreateEvidence_Evidence_Subcontrols       "json:\"subcontrols,omitempty\" graphql:\"subcontrols\""
-	Tags                []string                                                    "json:\"tags,omitempty\" graphql:\"tags\""
-	Tasks               []*CreateEvidence_CreateEvidence_Evidence_Tasks             "json:\"tasks,omitempty\" graphql:\"tasks\""
-	UpdatedAt           *time.Time                                                  "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy           *string                                                     "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
-	URL                 *string                                                     "json:\"url,omitempty\" graphql:\"url\""
+	CollectionProcedure *string                                                  "json:\"collectionProcedure,omitempty\" graphql:\"collectionProcedure\""
+	ControlObjectives   CreateEvidence_CreateEvidence_Evidence_ControlObjectives "json:\"controlObjectives\" graphql:\"controlObjectives\""
+	Controls            CreateEvidence_CreateEvidence_Evidence_Controls          "json:\"controls\" graphql:\"controls\""
+	CreatedAt           *time.Time                                               "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy           *string                                                  "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	CreationDate        time.Time                                                "json:\"creationDate\" graphql:\"creationDate\""
+	Description         *string                                                  "json:\"description,omitempty\" graphql:\"description\""
+	DisplayID           string                                                   "json:\"displayID\" graphql:\"displayID\""
+	Files               CreateEvidence_CreateEvidence_Evidence_Files             "json:\"files\" graphql:\"files\""
+	ID                  string                                                   "json:\"id\" graphql:\"id\""
+	IsAutomated         *bool                                                    "json:\"isAutomated,omitempty\" graphql:\"isAutomated\""
+	Name                string                                                   "json:\"name\" graphql:\"name\""
+	OwnerID             *string                                                  "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	Programs            CreateEvidence_CreateEvidence_Evidence_Programs          "json:\"programs\" graphql:\"programs\""
+	RenewalDate         *time.Time                                               "json:\"renewalDate,omitempty\" graphql:\"renewalDate\""
+	Source              *string                                                  "json:\"source,omitempty\" graphql:\"source\""
+	Status              *enums.EvidenceStatus                                    "json:\"status,omitempty\" graphql:\"status\""
+	Subcontrols         CreateEvidence_CreateEvidence_Evidence_Subcontrols       "json:\"subcontrols\" graphql:\"subcontrols\""
+	Tags                []string                                                 "json:\"tags,omitempty\" graphql:\"tags\""
+	Tasks               CreateEvidence_CreateEvidence_Evidence_Tasks             "json:\"tasks\" graphql:\"tasks\""
+	UpdatedAt           *time.Time                                               "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy           *string                                                  "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	URL                 *string                                                  "json:\"url,omitempty\" graphql:\"url\""
 }
 
 func (t *CreateEvidence_CreateEvidence_Evidence) GetCollectionProcedure() *string {
@@ -16091,17 +17917,17 @@ func (t *CreateEvidence_CreateEvidence_Evidence) GetCollectionProcedure() *strin
 	}
 	return t.CollectionProcedure
 }
-func (t *CreateEvidence_CreateEvidence_Evidence) GetControlObjectives() []*CreateEvidence_CreateEvidence_Evidence_ControlObjectives {
+func (t *CreateEvidence_CreateEvidence_Evidence) GetControlObjectives() *CreateEvidence_CreateEvidence_Evidence_ControlObjectives {
 	if t == nil {
 		t = &CreateEvidence_CreateEvidence_Evidence{}
 	}
-	return t.ControlObjectives
+	return &t.ControlObjectives
 }
-func (t *CreateEvidence_CreateEvidence_Evidence) GetControls() []*CreateEvidence_CreateEvidence_Evidence_Controls {
+func (t *CreateEvidence_CreateEvidence_Evidence) GetControls() *CreateEvidence_CreateEvidence_Evidence_Controls {
 	if t == nil {
 		t = &CreateEvidence_CreateEvidence_Evidence{}
 	}
-	return t.Controls
+	return &t.Controls
 }
 func (t *CreateEvidence_CreateEvidence_Evidence) GetCreatedAt() *time.Time {
 	if t == nil {
@@ -16133,11 +17959,11 @@ func (t *CreateEvidence_CreateEvidence_Evidence) GetDisplayID() string {
 	}
 	return t.DisplayID
 }
-func (t *CreateEvidence_CreateEvidence_Evidence) GetFiles() []*CreateEvidence_CreateEvidence_Evidence_Files {
+func (t *CreateEvidence_CreateEvidence_Evidence) GetFiles() *CreateEvidence_CreateEvidence_Evidence_Files {
 	if t == nil {
 		t = &CreateEvidence_CreateEvidence_Evidence{}
 	}
-	return t.Files
+	return &t.Files
 }
 func (t *CreateEvidence_CreateEvidence_Evidence) GetID() string {
 	if t == nil {
@@ -16163,11 +17989,11 @@ func (t *CreateEvidence_CreateEvidence_Evidence) GetOwnerID() *string {
 	}
 	return t.OwnerID
 }
-func (t *CreateEvidence_CreateEvidence_Evidence) GetPrograms() []*CreateEvidence_CreateEvidence_Evidence_Programs {
+func (t *CreateEvidence_CreateEvidence_Evidence) GetPrograms() *CreateEvidence_CreateEvidence_Evidence_Programs {
 	if t == nil {
 		t = &CreateEvidence_CreateEvidence_Evidence{}
 	}
-	return t.Programs
+	return &t.Programs
 }
 func (t *CreateEvidence_CreateEvidence_Evidence) GetRenewalDate() *time.Time {
 	if t == nil {
@@ -16187,11 +18013,11 @@ func (t *CreateEvidence_CreateEvidence_Evidence) GetStatus() *enums.EvidenceStat
 	}
 	return t.Status
 }
-func (t *CreateEvidence_CreateEvidence_Evidence) GetSubcontrols() []*CreateEvidence_CreateEvidence_Evidence_Subcontrols {
+func (t *CreateEvidence_CreateEvidence_Evidence) GetSubcontrols() *CreateEvidence_CreateEvidence_Evidence_Subcontrols {
 	if t == nil {
 		t = &CreateEvidence_CreateEvidence_Evidence{}
 	}
-	return t.Subcontrols
+	return &t.Subcontrols
 }
 func (t *CreateEvidence_CreateEvidence_Evidence) GetTags() []string {
 	if t == nil {
@@ -16199,11 +18025,11 @@ func (t *CreateEvidence_CreateEvidence_Evidence) GetTags() []string {
 	}
 	return t.Tags
 }
-func (t *CreateEvidence_CreateEvidence_Evidence) GetTasks() []*CreateEvidence_CreateEvidence_Evidence_Tasks {
+func (t *CreateEvidence_CreateEvidence_Evidence) GetTasks() *CreateEvidence_CreateEvidence_Evidence_Tasks {
 	if t == nil {
 		t = &CreateEvidence_CreateEvidence_Evidence{}
 	}
-	return t.Tasks
+	return &t.Tasks
 }
 func (t *CreateEvidence_CreateEvidence_Evidence) GetUpdatedAt() *time.Time {
 	if t == nil {
@@ -16246,166 +18072,298 @@ func (t *DeleteEvidence_DeleteEvidence) GetDeletedID() string {
 	return t.DeletedID
 }
 
-type GetAllEvidences_Evidences_Edges_Node_Files struct {
+type GetAllEvidences_Evidences_Edges_Node_Files_Edges_Node struct {
 	ID           string  "json:\"id\" graphql:\"id\""
 	PresignedURL *string "json:\"presignedURL,omitempty\" graphql:\"presignedURL\""
 }
 
-func (t *GetAllEvidences_Evidences_Edges_Node_Files) GetID() string {
+func (t *GetAllEvidences_Evidences_Edges_Node_Files_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetAllEvidences_Evidences_Edges_Node_Files{}
+		t = &GetAllEvidences_Evidences_Edges_Node_Files_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetAllEvidences_Evidences_Edges_Node_Files) GetPresignedURL() *string {
+func (t *GetAllEvidences_Evidences_Edges_Node_Files_Edges_Node) GetPresignedURL() *string {
 	if t == nil {
-		t = &GetAllEvidences_Evidences_Edges_Node_Files{}
+		t = &GetAllEvidences_Evidences_Edges_Node_Files_Edges_Node{}
 	}
 	return t.PresignedURL
 }
 
-type GetAllEvidences_Evidences_Edges_Node_Programs struct {
+type GetAllEvidences_Evidences_Edges_Node_Files_Edges struct {
+	Node *GetAllEvidences_Evidences_Edges_Node_Files_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllEvidences_Evidences_Edges_Node_Files_Edges) GetNode() *GetAllEvidences_Evidences_Edges_Node_Files_Edges_Node {
+	if t == nil {
+		t = &GetAllEvidences_Evidences_Edges_Node_Files_Edges{}
+	}
+	return t.Node
+}
+
+type GetAllEvidences_Evidences_Edges_Node_Files struct {
+	Edges []*GetAllEvidences_Evidences_Edges_Node_Files_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetAllEvidences_Evidences_Edges_Node_Files) GetEdges() []*GetAllEvidences_Evidences_Edges_Node_Files_Edges {
+	if t == nil {
+		t = &GetAllEvidences_Evidences_Edges_Node_Files{}
+	}
+	return t.Edges
+}
+
+type GetAllEvidences_Evidences_Edges_Node_Programs_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	Name      string "json:\"name\" graphql:\"name\""
 }
 
-func (t *GetAllEvidences_Evidences_Edges_Node_Programs) GetDisplayID() string {
+func (t *GetAllEvidences_Evidences_Edges_Node_Programs_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetAllEvidences_Evidences_Edges_Node_Programs{}
+		t = &GetAllEvidences_Evidences_Edges_Node_Programs_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetAllEvidences_Evidences_Edges_Node_Programs) GetID() string {
+func (t *GetAllEvidences_Evidences_Edges_Node_Programs_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetAllEvidences_Evidences_Edges_Node_Programs{}
+		t = &GetAllEvidences_Evidences_Edges_Node_Programs_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetAllEvidences_Evidences_Edges_Node_Programs) GetName() string {
+func (t *GetAllEvidences_Evidences_Edges_Node_Programs_Edges_Node) GetName() string {
+	if t == nil {
+		t = &GetAllEvidences_Evidences_Edges_Node_Programs_Edges_Node{}
+	}
+	return t.Name
+}
+
+type GetAllEvidences_Evidences_Edges_Node_Programs_Edges struct {
+	Node *GetAllEvidences_Evidences_Edges_Node_Programs_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllEvidences_Evidences_Edges_Node_Programs_Edges) GetNode() *GetAllEvidences_Evidences_Edges_Node_Programs_Edges_Node {
+	if t == nil {
+		t = &GetAllEvidences_Evidences_Edges_Node_Programs_Edges{}
+	}
+	return t.Node
+}
+
+type GetAllEvidences_Evidences_Edges_Node_Programs struct {
+	Edges []*GetAllEvidences_Evidences_Edges_Node_Programs_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetAllEvidences_Evidences_Edges_Node_Programs) GetEdges() []*GetAllEvidences_Evidences_Edges_Node_Programs_Edges {
 	if t == nil {
 		t = &GetAllEvidences_Evidences_Edges_Node_Programs{}
 	}
-	return t.Name
+	return t.Edges
+}
+
+type GetAllEvidences_Evidences_Edges_Node_Tasks_Edges_Node struct {
+	DisplayID string "json:\"displayID\" graphql:\"displayID\""
+	ID        string "json:\"id\" graphql:\"id\""
+}
+
+func (t *GetAllEvidences_Evidences_Edges_Node_Tasks_Edges_Node) GetDisplayID() string {
+	if t == nil {
+		t = &GetAllEvidences_Evidences_Edges_Node_Tasks_Edges_Node{}
+	}
+	return t.DisplayID
+}
+func (t *GetAllEvidences_Evidences_Edges_Node_Tasks_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetAllEvidences_Evidences_Edges_Node_Tasks_Edges_Node{}
+	}
+	return t.ID
+}
+
+type GetAllEvidences_Evidences_Edges_Node_Tasks_Edges struct {
+	Node *GetAllEvidences_Evidences_Edges_Node_Tasks_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllEvidences_Evidences_Edges_Node_Tasks_Edges) GetNode() *GetAllEvidences_Evidences_Edges_Node_Tasks_Edges_Node {
+	if t == nil {
+		t = &GetAllEvidences_Evidences_Edges_Node_Tasks_Edges{}
+	}
+	return t.Node
 }
 
 type GetAllEvidences_Evidences_Edges_Node_Tasks struct {
-	DisplayID string "json:\"displayID\" graphql:\"displayID\""
-	ID        string "json:\"id\" graphql:\"id\""
+	Edges []*GetAllEvidences_Evidences_Edges_Node_Tasks_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *GetAllEvidences_Evidences_Edges_Node_Tasks) GetDisplayID() string {
+func (t *GetAllEvidences_Evidences_Edges_Node_Tasks) GetEdges() []*GetAllEvidences_Evidences_Edges_Node_Tasks_Edges {
 	if t == nil {
 		t = &GetAllEvidences_Evidences_Edges_Node_Tasks{}
+	}
+	return t.Edges
+}
+
+type GetAllEvidences_Evidences_Edges_Node_Controls_Edges_Node struct {
+	DisplayID string "json:\"displayID\" graphql:\"displayID\""
+	ID        string "json:\"id\" graphql:\"id\""
+	RefCode   string "json:\"refCode\" graphql:\"refCode\""
+}
+
+func (t *GetAllEvidences_Evidences_Edges_Node_Controls_Edges_Node) GetDisplayID() string {
+	if t == nil {
+		t = &GetAllEvidences_Evidences_Edges_Node_Controls_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetAllEvidences_Evidences_Edges_Node_Tasks) GetID() string {
+func (t *GetAllEvidences_Evidences_Edges_Node_Controls_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetAllEvidences_Evidences_Edges_Node_Tasks{}
+		t = &GetAllEvidences_Evidences_Edges_Node_Controls_Edges_Node{}
 	}
 	return t.ID
+}
+func (t *GetAllEvidences_Evidences_Edges_Node_Controls_Edges_Node) GetRefCode() string {
+	if t == nil {
+		t = &GetAllEvidences_Evidences_Edges_Node_Controls_Edges_Node{}
+	}
+	return t.RefCode
+}
+
+type GetAllEvidences_Evidences_Edges_Node_Controls_Edges struct {
+	Node *GetAllEvidences_Evidences_Edges_Node_Controls_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllEvidences_Evidences_Edges_Node_Controls_Edges) GetNode() *GetAllEvidences_Evidences_Edges_Node_Controls_Edges_Node {
+	if t == nil {
+		t = &GetAllEvidences_Evidences_Edges_Node_Controls_Edges{}
+	}
+	return t.Node
 }
 
 type GetAllEvidences_Evidences_Edges_Node_Controls struct {
+	Edges []*GetAllEvidences_Evidences_Edges_Node_Controls_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetAllEvidences_Evidences_Edges_Node_Controls) GetEdges() []*GetAllEvidences_Evidences_Edges_Node_Controls_Edges {
+	if t == nil {
+		t = &GetAllEvidences_Evidences_Edges_Node_Controls{}
+	}
+	return t.Edges
+}
+
+type GetAllEvidences_Evidences_Edges_Node_Subcontrols_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	RefCode   string "json:\"refCode\" graphql:\"refCode\""
 }
 
-func (t *GetAllEvidences_Evidences_Edges_Node_Controls) GetDisplayID() string {
+func (t *GetAllEvidences_Evidences_Edges_Node_Subcontrols_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetAllEvidences_Evidences_Edges_Node_Controls{}
+		t = &GetAllEvidences_Evidences_Edges_Node_Subcontrols_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetAllEvidences_Evidences_Edges_Node_Controls) GetID() string {
+func (t *GetAllEvidences_Evidences_Edges_Node_Subcontrols_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetAllEvidences_Evidences_Edges_Node_Controls{}
+		t = &GetAllEvidences_Evidences_Edges_Node_Subcontrols_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetAllEvidences_Evidences_Edges_Node_Controls) GetRefCode() string {
+func (t *GetAllEvidences_Evidences_Edges_Node_Subcontrols_Edges_Node) GetRefCode() string {
 	if t == nil {
-		t = &GetAllEvidences_Evidences_Edges_Node_Controls{}
+		t = &GetAllEvidences_Evidences_Edges_Node_Subcontrols_Edges_Node{}
 	}
 	return t.RefCode
+}
+
+type GetAllEvidences_Evidences_Edges_Node_Subcontrols_Edges struct {
+	Node *GetAllEvidences_Evidences_Edges_Node_Subcontrols_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllEvidences_Evidences_Edges_Node_Subcontrols_Edges) GetNode() *GetAllEvidences_Evidences_Edges_Node_Subcontrols_Edges_Node {
+	if t == nil {
+		t = &GetAllEvidences_Evidences_Edges_Node_Subcontrols_Edges{}
+	}
+	return t.Node
 }
 
 type GetAllEvidences_Evidences_Edges_Node_Subcontrols struct {
-	DisplayID string "json:\"displayID\" graphql:\"displayID\""
-	ID        string "json:\"id\" graphql:\"id\""
-	RefCode   string "json:\"refCode\" graphql:\"refCode\""
+	Edges []*GetAllEvidences_Evidences_Edges_Node_Subcontrols_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *GetAllEvidences_Evidences_Edges_Node_Subcontrols) GetDisplayID() string {
+func (t *GetAllEvidences_Evidences_Edges_Node_Subcontrols) GetEdges() []*GetAllEvidences_Evidences_Edges_Node_Subcontrols_Edges {
 	if t == nil {
 		t = &GetAllEvidences_Evidences_Edges_Node_Subcontrols{}
 	}
-	return t.DisplayID
-}
-func (t *GetAllEvidences_Evidences_Edges_Node_Subcontrols) GetID() string {
-	if t == nil {
-		t = &GetAllEvidences_Evidences_Edges_Node_Subcontrols{}
-	}
-	return t.ID
-}
-func (t *GetAllEvidences_Evidences_Edges_Node_Subcontrols) GetRefCode() string {
-	if t == nil {
-		t = &GetAllEvidences_Evidences_Edges_Node_Subcontrols{}
-	}
-	return t.RefCode
+	return t.Edges
 }
 
-type GetAllEvidences_Evidences_Edges_Node_ControlObjectives struct {
+type GetAllEvidences_Evidences_Edges_Node_ControlObjectives_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	Name      string "json:\"name\" graphql:\"name\""
 }
 
-func (t *GetAllEvidences_Evidences_Edges_Node_ControlObjectives) GetDisplayID() string {
+func (t *GetAllEvidences_Evidences_Edges_Node_ControlObjectives_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetAllEvidences_Evidences_Edges_Node_ControlObjectives{}
+		t = &GetAllEvidences_Evidences_Edges_Node_ControlObjectives_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetAllEvidences_Evidences_Edges_Node_ControlObjectives) GetID() string {
+func (t *GetAllEvidences_Evidences_Edges_Node_ControlObjectives_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetAllEvidences_Evidences_Edges_Node_ControlObjectives{}
+		t = &GetAllEvidences_Evidences_Edges_Node_ControlObjectives_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetAllEvidences_Evidences_Edges_Node_ControlObjectives) GetName() string {
+func (t *GetAllEvidences_Evidences_Edges_Node_ControlObjectives_Edges_Node) GetName() string {
 	if t == nil {
-		t = &GetAllEvidences_Evidences_Edges_Node_ControlObjectives{}
+		t = &GetAllEvidences_Evidences_Edges_Node_ControlObjectives_Edges_Node{}
 	}
 	return t.Name
 }
 
+type GetAllEvidences_Evidences_Edges_Node_ControlObjectives_Edges struct {
+	Node *GetAllEvidences_Evidences_Edges_Node_ControlObjectives_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllEvidences_Evidences_Edges_Node_ControlObjectives_Edges) GetNode() *GetAllEvidences_Evidences_Edges_Node_ControlObjectives_Edges_Node {
+	if t == nil {
+		t = &GetAllEvidences_Evidences_Edges_Node_ControlObjectives_Edges{}
+	}
+	return t.Node
+}
+
+type GetAllEvidences_Evidences_Edges_Node_ControlObjectives struct {
+	Edges []*GetAllEvidences_Evidences_Edges_Node_ControlObjectives_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetAllEvidences_Evidences_Edges_Node_ControlObjectives) GetEdges() []*GetAllEvidences_Evidences_Edges_Node_ControlObjectives_Edges {
+	if t == nil {
+		t = &GetAllEvidences_Evidences_Edges_Node_ControlObjectives{}
+	}
+	return t.Edges
+}
+
 type GetAllEvidences_Evidences_Edges_Node struct {
-	CollectionProcedure *string                                                   "json:\"collectionProcedure,omitempty\" graphql:\"collectionProcedure\""
-	ControlObjectives   []*GetAllEvidences_Evidences_Edges_Node_ControlObjectives "json:\"controlObjectives,omitempty\" graphql:\"controlObjectives\""
-	Controls            []*GetAllEvidences_Evidences_Edges_Node_Controls          "json:\"controls,omitempty\" graphql:\"controls\""
-	CreatedAt           *time.Time                                                "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy           *string                                                   "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	CreationDate        time.Time                                                 "json:\"creationDate\" graphql:\"creationDate\""
-	Description         *string                                                   "json:\"description,omitempty\" graphql:\"description\""
-	DisplayID           string                                                    "json:\"displayID\" graphql:\"displayID\""
-	Files               []*GetAllEvidences_Evidences_Edges_Node_Files             "json:\"files,omitempty\" graphql:\"files\""
-	ID                  string                                                    "json:\"id\" graphql:\"id\""
-	IsAutomated         *bool                                                     "json:\"isAutomated,omitempty\" graphql:\"isAutomated\""
-	Name                string                                                    "json:\"name\" graphql:\"name\""
-	OwnerID             *string                                                   "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Programs            []*GetAllEvidences_Evidences_Edges_Node_Programs          "json:\"programs,omitempty\" graphql:\"programs\""
-	RenewalDate         *time.Time                                                "json:\"renewalDate,omitempty\" graphql:\"renewalDate\""
-	Source              *string                                                   "json:\"source,omitempty\" graphql:\"source\""
-	Status              *enums.EvidenceStatus                                     "json:\"status,omitempty\" graphql:\"status\""
-	Subcontrols         []*GetAllEvidences_Evidences_Edges_Node_Subcontrols       "json:\"subcontrols,omitempty\" graphql:\"subcontrols\""
-	Tags                []string                                                  "json:\"tags,omitempty\" graphql:\"tags\""
-	Tasks               []*GetAllEvidences_Evidences_Edges_Node_Tasks             "json:\"tasks,omitempty\" graphql:\"tasks\""
-	UpdatedAt           *time.Time                                                "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy           *string                                                   "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
-	URL                 *string                                                   "json:\"url,omitempty\" graphql:\"url\""
+	CollectionProcedure *string                                                "json:\"collectionProcedure,omitempty\" graphql:\"collectionProcedure\""
+	ControlObjectives   GetAllEvidences_Evidences_Edges_Node_ControlObjectives "json:\"controlObjectives\" graphql:\"controlObjectives\""
+	Controls            GetAllEvidences_Evidences_Edges_Node_Controls          "json:\"controls\" graphql:\"controls\""
+	CreatedAt           *time.Time                                             "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy           *string                                                "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	CreationDate        time.Time                                              "json:\"creationDate\" graphql:\"creationDate\""
+	Description         *string                                                "json:\"description,omitempty\" graphql:\"description\""
+	DisplayID           string                                                 "json:\"displayID\" graphql:\"displayID\""
+	Files               GetAllEvidences_Evidences_Edges_Node_Files             "json:\"files\" graphql:\"files\""
+	ID                  string                                                 "json:\"id\" graphql:\"id\""
+	IsAutomated         *bool                                                  "json:\"isAutomated,omitempty\" graphql:\"isAutomated\""
+	Name                string                                                 "json:\"name\" graphql:\"name\""
+	OwnerID             *string                                                "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	Programs            GetAllEvidences_Evidences_Edges_Node_Programs          "json:\"programs\" graphql:\"programs\""
+	RenewalDate         *time.Time                                             "json:\"renewalDate,omitempty\" graphql:\"renewalDate\""
+	Source              *string                                                "json:\"source,omitempty\" graphql:\"source\""
+	Status              *enums.EvidenceStatus                                  "json:\"status,omitempty\" graphql:\"status\""
+	Subcontrols         GetAllEvidences_Evidences_Edges_Node_Subcontrols       "json:\"subcontrols\" graphql:\"subcontrols\""
+	Tags                []string                                               "json:\"tags,omitempty\" graphql:\"tags\""
+	Tasks               GetAllEvidences_Evidences_Edges_Node_Tasks             "json:\"tasks\" graphql:\"tasks\""
+	UpdatedAt           *time.Time                                             "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy           *string                                                "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	URL                 *string                                                "json:\"url,omitempty\" graphql:\"url\""
 }
 
 func (t *GetAllEvidences_Evidences_Edges_Node) GetCollectionProcedure() *string {
@@ -16414,17 +18372,17 @@ func (t *GetAllEvidences_Evidences_Edges_Node) GetCollectionProcedure() *string 
 	}
 	return t.CollectionProcedure
 }
-func (t *GetAllEvidences_Evidences_Edges_Node) GetControlObjectives() []*GetAllEvidences_Evidences_Edges_Node_ControlObjectives {
+func (t *GetAllEvidences_Evidences_Edges_Node) GetControlObjectives() *GetAllEvidences_Evidences_Edges_Node_ControlObjectives {
 	if t == nil {
 		t = &GetAllEvidences_Evidences_Edges_Node{}
 	}
-	return t.ControlObjectives
+	return &t.ControlObjectives
 }
-func (t *GetAllEvidences_Evidences_Edges_Node) GetControls() []*GetAllEvidences_Evidences_Edges_Node_Controls {
+func (t *GetAllEvidences_Evidences_Edges_Node) GetControls() *GetAllEvidences_Evidences_Edges_Node_Controls {
 	if t == nil {
 		t = &GetAllEvidences_Evidences_Edges_Node{}
 	}
-	return t.Controls
+	return &t.Controls
 }
 func (t *GetAllEvidences_Evidences_Edges_Node) GetCreatedAt() *time.Time {
 	if t == nil {
@@ -16456,11 +18414,11 @@ func (t *GetAllEvidences_Evidences_Edges_Node) GetDisplayID() string {
 	}
 	return t.DisplayID
 }
-func (t *GetAllEvidences_Evidences_Edges_Node) GetFiles() []*GetAllEvidences_Evidences_Edges_Node_Files {
+func (t *GetAllEvidences_Evidences_Edges_Node) GetFiles() *GetAllEvidences_Evidences_Edges_Node_Files {
 	if t == nil {
 		t = &GetAllEvidences_Evidences_Edges_Node{}
 	}
-	return t.Files
+	return &t.Files
 }
 func (t *GetAllEvidences_Evidences_Edges_Node) GetID() string {
 	if t == nil {
@@ -16486,11 +18444,11 @@ func (t *GetAllEvidences_Evidences_Edges_Node) GetOwnerID() *string {
 	}
 	return t.OwnerID
 }
-func (t *GetAllEvidences_Evidences_Edges_Node) GetPrograms() []*GetAllEvidences_Evidences_Edges_Node_Programs {
+func (t *GetAllEvidences_Evidences_Edges_Node) GetPrograms() *GetAllEvidences_Evidences_Edges_Node_Programs {
 	if t == nil {
 		t = &GetAllEvidences_Evidences_Edges_Node{}
 	}
-	return t.Programs
+	return &t.Programs
 }
 func (t *GetAllEvidences_Evidences_Edges_Node) GetRenewalDate() *time.Time {
 	if t == nil {
@@ -16510,11 +18468,11 @@ func (t *GetAllEvidences_Evidences_Edges_Node) GetStatus() *enums.EvidenceStatus
 	}
 	return t.Status
 }
-func (t *GetAllEvidences_Evidences_Edges_Node) GetSubcontrols() []*GetAllEvidences_Evidences_Edges_Node_Subcontrols {
+func (t *GetAllEvidences_Evidences_Edges_Node) GetSubcontrols() *GetAllEvidences_Evidences_Edges_Node_Subcontrols {
 	if t == nil {
 		t = &GetAllEvidences_Evidences_Edges_Node{}
 	}
-	return t.Subcontrols
+	return &t.Subcontrols
 }
 func (t *GetAllEvidences_Evidences_Edges_Node) GetTags() []string {
 	if t == nil {
@@ -16522,11 +18480,11 @@ func (t *GetAllEvidences_Evidences_Edges_Node) GetTags() []string {
 	}
 	return t.Tags
 }
-func (t *GetAllEvidences_Evidences_Edges_Node) GetTasks() []*GetAllEvidences_Evidences_Edges_Node_Tasks {
+func (t *GetAllEvidences_Evidences_Edges_Node) GetTasks() *GetAllEvidences_Evidences_Edges_Node_Tasks {
 	if t == nil {
 		t = &GetAllEvidences_Evidences_Edges_Node{}
 	}
-	return t.Tasks
+	return &t.Tasks
 }
 func (t *GetAllEvidences_Evidences_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
@@ -16569,166 +18527,298 @@ func (t *GetAllEvidences_Evidences) GetEdges() []*GetAllEvidences_Evidences_Edge
 	return t.Edges
 }
 
-type GetEvidenceByID_Evidence_Files struct {
+type GetEvidenceByID_Evidence_Files_Edges_Node struct {
 	ID           string  "json:\"id\" graphql:\"id\""
 	PresignedURL *string "json:\"presignedURL,omitempty\" graphql:\"presignedURL\""
 }
 
-func (t *GetEvidenceByID_Evidence_Files) GetID() string {
+func (t *GetEvidenceByID_Evidence_Files_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetEvidenceByID_Evidence_Files{}
+		t = &GetEvidenceByID_Evidence_Files_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetEvidenceByID_Evidence_Files) GetPresignedURL() *string {
+func (t *GetEvidenceByID_Evidence_Files_Edges_Node) GetPresignedURL() *string {
 	if t == nil {
-		t = &GetEvidenceByID_Evidence_Files{}
+		t = &GetEvidenceByID_Evidence_Files_Edges_Node{}
 	}
 	return t.PresignedURL
 }
 
-type GetEvidenceByID_Evidence_Programs struct {
+type GetEvidenceByID_Evidence_Files_Edges struct {
+	Node *GetEvidenceByID_Evidence_Files_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetEvidenceByID_Evidence_Files_Edges) GetNode() *GetEvidenceByID_Evidence_Files_Edges_Node {
+	if t == nil {
+		t = &GetEvidenceByID_Evidence_Files_Edges{}
+	}
+	return t.Node
+}
+
+type GetEvidenceByID_Evidence_Files struct {
+	Edges []*GetEvidenceByID_Evidence_Files_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetEvidenceByID_Evidence_Files) GetEdges() []*GetEvidenceByID_Evidence_Files_Edges {
+	if t == nil {
+		t = &GetEvidenceByID_Evidence_Files{}
+	}
+	return t.Edges
+}
+
+type GetEvidenceByID_Evidence_Programs_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	Name      string "json:\"name\" graphql:\"name\""
 }
 
-func (t *GetEvidenceByID_Evidence_Programs) GetDisplayID() string {
+func (t *GetEvidenceByID_Evidence_Programs_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetEvidenceByID_Evidence_Programs{}
+		t = &GetEvidenceByID_Evidence_Programs_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetEvidenceByID_Evidence_Programs) GetID() string {
+func (t *GetEvidenceByID_Evidence_Programs_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetEvidenceByID_Evidence_Programs{}
+		t = &GetEvidenceByID_Evidence_Programs_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetEvidenceByID_Evidence_Programs) GetName() string {
+func (t *GetEvidenceByID_Evidence_Programs_Edges_Node) GetName() string {
+	if t == nil {
+		t = &GetEvidenceByID_Evidence_Programs_Edges_Node{}
+	}
+	return t.Name
+}
+
+type GetEvidenceByID_Evidence_Programs_Edges struct {
+	Node *GetEvidenceByID_Evidence_Programs_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetEvidenceByID_Evidence_Programs_Edges) GetNode() *GetEvidenceByID_Evidence_Programs_Edges_Node {
+	if t == nil {
+		t = &GetEvidenceByID_Evidence_Programs_Edges{}
+	}
+	return t.Node
+}
+
+type GetEvidenceByID_Evidence_Programs struct {
+	Edges []*GetEvidenceByID_Evidence_Programs_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetEvidenceByID_Evidence_Programs) GetEdges() []*GetEvidenceByID_Evidence_Programs_Edges {
 	if t == nil {
 		t = &GetEvidenceByID_Evidence_Programs{}
 	}
-	return t.Name
+	return t.Edges
+}
+
+type GetEvidenceByID_Evidence_Tasks_Edges_Node struct {
+	DisplayID string "json:\"displayID\" graphql:\"displayID\""
+	ID        string "json:\"id\" graphql:\"id\""
+}
+
+func (t *GetEvidenceByID_Evidence_Tasks_Edges_Node) GetDisplayID() string {
+	if t == nil {
+		t = &GetEvidenceByID_Evidence_Tasks_Edges_Node{}
+	}
+	return t.DisplayID
+}
+func (t *GetEvidenceByID_Evidence_Tasks_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetEvidenceByID_Evidence_Tasks_Edges_Node{}
+	}
+	return t.ID
+}
+
+type GetEvidenceByID_Evidence_Tasks_Edges struct {
+	Node *GetEvidenceByID_Evidence_Tasks_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetEvidenceByID_Evidence_Tasks_Edges) GetNode() *GetEvidenceByID_Evidence_Tasks_Edges_Node {
+	if t == nil {
+		t = &GetEvidenceByID_Evidence_Tasks_Edges{}
+	}
+	return t.Node
 }
 
 type GetEvidenceByID_Evidence_Tasks struct {
-	DisplayID string "json:\"displayID\" graphql:\"displayID\""
-	ID        string "json:\"id\" graphql:\"id\""
+	Edges []*GetEvidenceByID_Evidence_Tasks_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *GetEvidenceByID_Evidence_Tasks) GetDisplayID() string {
+func (t *GetEvidenceByID_Evidence_Tasks) GetEdges() []*GetEvidenceByID_Evidence_Tasks_Edges {
 	if t == nil {
 		t = &GetEvidenceByID_Evidence_Tasks{}
+	}
+	return t.Edges
+}
+
+type GetEvidenceByID_Evidence_Controls_Edges_Node struct {
+	DisplayID string "json:\"displayID\" graphql:\"displayID\""
+	ID        string "json:\"id\" graphql:\"id\""
+	RefCode   string "json:\"refCode\" graphql:\"refCode\""
+}
+
+func (t *GetEvidenceByID_Evidence_Controls_Edges_Node) GetDisplayID() string {
+	if t == nil {
+		t = &GetEvidenceByID_Evidence_Controls_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetEvidenceByID_Evidence_Tasks) GetID() string {
+func (t *GetEvidenceByID_Evidence_Controls_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetEvidenceByID_Evidence_Tasks{}
+		t = &GetEvidenceByID_Evidence_Controls_Edges_Node{}
 	}
 	return t.ID
+}
+func (t *GetEvidenceByID_Evidence_Controls_Edges_Node) GetRefCode() string {
+	if t == nil {
+		t = &GetEvidenceByID_Evidence_Controls_Edges_Node{}
+	}
+	return t.RefCode
+}
+
+type GetEvidenceByID_Evidence_Controls_Edges struct {
+	Node *GetEvidenceByID_Evidence_Controls_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetEvidenceByID_Evidence_Controls_Edges) GetNode() *GetEvidenceByID_Evidence_Controls_Edges_Node {
+	if t == nil {
+		t = &GetEvidenceByID_Evidence_Controls_Edges{}
+	}
+	return t.Node
 }
 
 type GetEvidenceByID_Evidence_Controls struct {
+	Edges []*GetEvidenceByID_Evidence_Controls_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetEvidenceByID_Evidence_Controls) GetEdges() []*GetEvidenceByID_Evidence_Controls_Edges {
+	if t == nil {
+		t = &GetEvidenceByID_Evidence_Controls{}
+	}
+	return t.Edges
+}
+
+type GetEvidenceByID_Evidence_Subcontrols_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	RefCode   string "json:\"refCode\" graphql:\"refCode\""
 }
 
-func (t *GetEvidenceByID_Evidence_Controls) GetDisplayID() string {
+func (t *GetEvidenceByID_Evidence_Subcontrols_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetEvidenceByID_Evidence_Controls{}
+		t = &GetEvidenceByID_Evidence_Subcontrols_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetEvidenceByID_Evidence_Controls) GetID() string {
+func (t *GetEvidenceByID_Evidence_Subcontrols_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetEvidenceByID_Evidence_Controls{}
+		t = &GetEvidenceByID_Evidence_Subcontrols_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetEvidenceByID_Evidence_Controls) GetRefCode() string {
+func (t *GetEvidenceByID_Evidence_Subcontrols_Edges_Node) GetRefCode() string {
 	if t == nil {
-		t = &GetEvidenceByID_Evidence_Controls{}
+		t = &GetEvidenceByID_Evidence_Subcontrols_Edges_Node{}
 	}
 	return t.RefCode
+}
+
+type GetEvidenceByID_Evidence_Subcontrols_Edges struct {
+	Node *GetEvidenceByID_Evidence_Subcontrols_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetEvidenceByID_Evidence_Subcontrols_Edges) GetNode() *GetEvidenceByID_Evidence_Subcontrols_Edges_Node {
+	if t == nil {
+		t = &GetEvidenceByID_Evidence_Subcontrols_Edges{}
+	}
+	return t.Node
 }
 
 type GetEvidenceByID_Evidence_Subcontrols struct {
-	DisplayID string "json:\"displayID\" graphql:\"displayID\""
-	ID        string "json:\"id\" graphql:\"id\""
-	RefCode   string "json:\"refCode\" graphql:\"refCode\""
+	Edges []*GetEvidenceByID_Evidence_Subcontrols_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *GetEvidenceByID_Evidence_Subcontrols) GetDisplayID() string {
+func (t *GetEvidenceByID_Evidence_Subcontrols) GetEdges() []*GetEvidenceByID_Evidence_Subcontrols_Edges {
 	if t == nil {
 		t = &GetEvidenceByID_Evidence_Subcontrols{}
 	}
-	return t.DisplayID
-}
-func (t *GetEvidenceByID_Evidence_Subcontrols) GetID() string {
-	if t == nil {
-		t = &GetEvidenceByID_Evidence_Subcontrols{}
-	}
-	return t.ID
-}
-func (t *GetEvidenceByID_Evidence_Subcontrols) GetRefCode() string {
-	if t == nil {
-		t = &GetEvidenceByID_Evidence_Subcontrols{}
-	}
-	return t.RefCode
+	return t.Edges
 }
 
-type GetEvidenceByID_Evidence_ControlObjectives struct {
+type GetEvidenceByID_Evidence_ControlObjectives_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	Name      string "json:\"name\" graphql:\"name\""
 }
 
-func (t *GetEvidenceByID_Evidence_ControlObjectives) GetDisplayID() string {
+func (t *GetEvidenceByID_Evidence_ControlObjectives_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetEvidenceByID_Evidence_ControlObjectives{}
+		t = &GetEvidenceByID_Evidence_ControlObjectives_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetEvidenceByID_Evidence_ControlObjectives) GetID() string {
+func (t *GetEvidenceByID_Evidence_ControlObjectives_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetEvidenceByID_Evidence_ControlObjectives{}
+		t = &GetEvidenceByID_Evidence_ControlObjectives_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetEvidenceByID_Evidence_ControlObjectives) GetName() string {
+func (t *GetEvidenceByID_Evidence_ControlObjectives_Edges_Node) GetName() string {
 	if t == nil {
-		t = &GetEvidenceByID_Evidence_ControlObjectives{}
+		t = &GetEvidenceByID_Evidence_ControlObjectives_Edges_Node{}
 	}
 	return t.Name
 }
 
+type GetEvidenceByID_Evidence_ControlObjectives_Edges struct {
+	Node *GetEvidenceByID_Evidence_ControlObjectives_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetEvidenceByID_Evidence_ControlObjectives_Edges) GetNode() *GetEvidenceByID_Evidence_ControlObjectives_Edges_Node {
+	if t == nil {
+		t = &GetEvidenceByID_Evidence_ControlObjectives_Edges{}
+	}
+	return t.Node
+}
+
+type GetEvidenceByID_Evidence_ControlObjectives struct {
+	Edges []*GetEvidenceByID_Evidence_ControlObjectives_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetEvidenceByID_Evidence_ControlObjectives) GetEdges() []*GetEvidenceByID_Evidence_ControlObjectives_Edges {
+	if t == nil {
+		t = &GetEvidenceByID_Evidence_ControlObjectives{}
+	}
+	return t.Edges
+}
+
 type GetEvidenceByID_Evidence struct {
-	CollectionProcedure *string                                       "json:\"collectionProcedure,omitempty\" graphql:\"collectionProcedure\""
-	ControlObjectives   []*GetEvidenceByID_Evidence_ControlObjectives "json:\"controlObjectives,omitempty\" graphql:\"controlObjectives\""
-	Controls            []*GetEvidenceByID_Evidence_Controls          "json:\"controls,omitempty\" graphql:\"controls\""
-	CreatedAt           *time.Time                                    "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy           *string                                       "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	CreationDate        time.Time                                     "json:\"creationDate\" graphql:\"creationDate\""
-	Description         *string                                       "json:\"description,omitempty\" graphql:\"description\""
-	DisplayID           string                                        "json:\"displayID\" graphql:\"displayID\""
-	Files               []*GetEvidenceByID_Evidence_Files             "json:\"files,omitempty\" graphql:\"files\""
-	ID                  string                                        "json:\"id\" graphql:\"id\""
-	IsAutomated         *bool                                         "json:\"isAutomated,omitempty\" graphql:\"isAutomated\""
-	Name                string                                        "json:\"name\" graphql:\"name\""
-	OwnerID             *string                                       "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Programs            []*GetEvidenceByID_Evidence_Programs          "json:\"programs,omitempty\" graphql:\"programs\""
-	RenewalDate         *time.Time                                    "json:\"renewalDate,omitempty\" graphql:\"renewalDate\""
-	Source              *string                                       "json:\"source,omitempty\" graphql:\"source\""
-	Status              *enums.EvidenceStatus                         "json:\"status,omitempty\" graphql:\"status\""
-	Subcontrols         []*GetEvidenceByID_Evidence_Subcontrols       "json:\"subcontrols,omitempty\" graphql:\"subcontrols\""
-	Tags                []string                                      "json:\"tags,omitempty\" graphql:\"tags\""
-	Tasks               []*GetEvidenceByID_Evidence_Tasks             "json:\"tasks,omitempty\" graphql:\"tasks\""
-	UpdatedAt           *time.Time                                    "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy           *string                                       "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
-	URL                 *string                                       "json:\"url,omitempty\" graphql:\"url\""
+	CollectionProcedure *string                                    "json:\"collectionProcedure,omitempty\" graphql:\"collectionProcedure\""
+	ControlObjectives   GetEvidenceByID_Evidence_ControlObjectives "json:\"controlObjectives\" graphql:\"controlObjectives\""
+	Controls            GetEvidenceByID_Evidence_Controls          "json:\"controls\" graphql:\"controls\""
+	CreatedAt           *time.Time                                 "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy           *string                                    "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	CreationDate        time.Time                                  "json:\"creationDate\" graphql:\"creationDate\""
+	Description         *string                                    "json:\"description,omitempty\" graphql:\"description\""
+	DisplayID           string                                     "json:\"displayID\" graphql:\"displayID\""
+	Files               GetEvidenceByID_Evidence_Files             "json:\"files\" graphql:\"files\""
+	ID                  string                                     "json:\"id\" graphql:\"id\""
+	IsAutomated         *bool                                      "json:\"isAutomated,omitempty\" graphql:\"isAutomated\""
+	Name                string                                     "json:\"name\" graphql:\"name\""
+	OwnerID             *string                                    "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	Programs            GetEvidenceByID_Evidence_Programs          "json:\"programs\" graphql:\"programs\""
+	RenewalDate         *time.Time                                 "json:\"renewalDate,omitempty\" graphql:\"renewalDate\""
+	Source              *string                                    "json:\"source,omitempty\" graphql:\"source\""
+	Status              *enums.EvidenceStatus                      "json:\"status,omitempty\" graphql:\"status\""
+	Subcontrols         GetEvidenceByID_Evidence_Subcontrols       "json:\"subcontrols\" graphql:\"subcontrols\""
+	Tags                []string                                   "json:\"tags,omitempty\" graphql:\"tags\""
+	Tasks               GetEvidenceByID_Evidence_Tasks             "json:\"tasks\" graphql:\"tasks\""
+	UpdatedAt           *time.Time                                 "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy           *string                                    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	URL                 *string                                    "json:\"url,omitempty\" graphql:\"url\""
 }
 
 func (t *GetEvidenceByID_Evidence) GetCollectionProcedure() *string {
@@ -16737,17 +18827,17 @@ func (t *GetEvidenceByID_Evidence) GetCollectionProcedure() *string {
 	}
 	return t.CollectionProcedure
 }
-func (t *GetEvidenceByID_Evidence) GetControlObjectives() []*GetEvidenceByID_Evidence_ControlObjectives {
+func (t *GetEvidenceByID_Evidence) GetControlObjectives() *GetEvidenceByID_Evidence_ControlObjectives {
 	if t == nil {
 		t = &GetEvidenceByID_Evidence{}
 	}
-	return t.ControlObjectives
+	return &t.ControlObjectives
 }
-func (t *GetEvidenceByID_Evidence) GetControls() []*GetEvidenceByID_Evidence_Controls {
+func (t *GetEvidenceByID_Evidence) GetControls() *GetEvidenceByID_Evidence_Controls {
 	if t == nil {
 		t = &GetEvidenceByID_Evidence{}
 	}
-	return t.Controls
+	return &t.Controls
 }
 func (t *GetEvidenceByID_Evidence) GetCreatedAt() *time.Time {
 	if t == nil {
@@ -16779,11 +18869,11 @@ func (t *GetEvidenceByID_Evidence) GetDisplayID() string {
 	}
 	return t.DisplayID
 }
-func (t *GetEvidenceByID_Evidence) GetFiles() []*GetEvidenceByID_Evidence_Files {
+func (t *GetEvidenceByID_Evidence) GetFiles() *GetEvidenceByID_Evidence_Files {
 	if t == nil {
 		t = &GetEvidenceByID_Evidence{}
 	}
-	return t.Files
+	return &t.Files
 }
 func (t *GetEvidenceByID_Evidence) GetID() string {
 	if t == nil {
@@ -16809,11 +18899,11 @@ func (t *GetEvidenceByID_Evidence) GetOwnerID() *string {
 	}
 	return t.OwnerID
 }
-func (t *GetEvidenceByID_Evidence) GetPrograms() []*GetEvidenceByID_Evidence_Programs {
+func (t *GetEvidenceByID_Evidence) GetPrograms() *GetEvidenceByID_Evidence_Programs {
 	if t == nil {
 		t = &GetEvidenceByID_Evidence{}
 	}
-	return t.Programs
+	return &t.Programs
 }
 func (t *GetEvidenceByID_Evidence) GetRenewalDate() *time.Time {
 	if t == nil {
@@ -16833,11 +18923,11 @@ func (t *GetEvidenceByID_Evidence) GetStatus() *enums.EvidenceStatus {
 	}
 	return t.Status
 }
-func (t *GetEvidenceByID_Evidence) GetSubcontrols() []*GetEvidenceByID_Evidence_Subcontrols {
+func (t *GetEvidenceByID_Evidence) GetSubcontrols() *GetEvidenceByID_Evidence_Subcontrols {
 	if t == nil {
 		t = &GetEvidenceByID_Evidence{}
 	}
-	return t.Subcontrols
+	return &t.Subcontrols
 }
 func (t *GetEvidenceByID_Evidence) GetTags() []string {
 	if t == nil {
@@ -16845,11 +18935,11 @@ func (t *GetEvidenceByID_Evidence) GetTags() []string {
 	}
 	return t.Tags
 }
-func (t *GetEvidenceByID_Evidence) GetTasks() []*GetEvidenceByID_Evidence_Tasks {
+func (t *GetEvidenceByID_Evidence) GetTasks() *GetEvidenceByID_Evidence_Tasks {
 	if t == nil {
 		t = &GetEvidenceByID_Evidence{}
 	}
-	return t.Tasks
+	return &t.Tasks
 }
 func (t *GetEvidenceByID_Evidence) GetUpdatedAt() *time.Time {
 	if t == nil {
@@ -16870,166 +18960,298 @@ func (t *GetEvidenceByID_Evidence) GetURL() *string {
 	return t.URL
 }
 
-type GetEvidences_Evidences_Edges_Node_Files struct {
+type GetEvidences_Evidences_Edges_Node_Files_Edges_Node struct {
 	ID           string  "json:\"id\" graphql:\"id\""
 	PresignedURL *string "json:\"presignedURL,omitempty\" graphql:\"presignedURL\""
 }
 
-func (t *GetEvidences_Evidences_Edges_Node_Files) GetID() string {
+func (t *GetEvidences_Evidences_Edges_Node_Files_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetEvidences_Evidences_Edges_Node_Files{}
+		t = &GetEvidences_Evidences_Edges_Node_Files_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetEvidences_Evidences_Edges_Node_Files) GetPresignedURL() *string {
+func (t *GetEvidences_Evidences_Edges_Node_Files_Edges_Node) GetPresignedURL() *string {
 	if t == nil {
-		t = &GetEvidences_Evidences_Edges_Node_Files{}
+		t = &GetEvidences_Evidences_Edges_Node_Files_Edges_Node{}
 	}
 	return t.PresignedURL
 }
 
-type GetEvidences_Evidences_Edges_Node_Programs struct {
+type GetEvidences_Evidences_Edges_Node_Files_Edges struct {
+	Node *GetEvidences_Evidences_Edges_Node_Files_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetEvidences_Evidences_Edges_Node_Files_Edges) GetNode() *GetEvidences_Evidences_Edges_Node_Files_Edges_Node {
+	if t == nil {
+		t = &GetEvidences_Evidences_Edges_Node_Files_Edges{}
+	}
+	return t.Node
+}
+
+type GetEvidences_Evidences_Edges_Node_Files struct {
+	Edges []*GetEvidences_Evidences_Edges_Node_Files_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetEvidences_Evidences_Edges_Node_Files) GetEdges() []*GetEvidences_Evidences_Edges_Node_Files_Edges {
+	if t == nil {
+		t = &GetEvidences_Evidences_Edges_Node_Files{}
+	}
+	return t.Edges
+}
+
+type GetEvidences_Evidences_Edges_Node_Programs_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	Name      string "json:\"name\" graphql:\"name\""
 }
 
-func (t *GetEvidences_Evidences_Edges_Node_Programs) GetDisplayID() string {
+func (t *GetEvidences_Evidences_Edges_Node_Programs_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetEvidences_Evidences_Edges_Node_Programs{}
+		t = &GetEvidences_Evidences_Edges_Node_Programs_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetEvidences_Evidences_Edges_Node_Programs) GetID() string {
+func (t *GetEvidences_Evidences_Edges_Node_Programs_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetEvidences_Evidences_Edges_Node_Programs{}
+		t = &GetEvidences_Evidences_Edges_Node_Programs_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetEvidences_Evidences_Edges_Node_Programs) GetName() string {
+func (t *GetEvidences_Evidences_Edges_Node_Programs_Edges_Node) GetName() string {
+	if t == nil {
+		t = &GetEvidences_Evidences_Edges_Node_Programs_Edges_Node{}
+	}
+	return t.Name
+}
+
+type GetEvidences_Evidences_Edges_Node_Programs_Edges struct {
+	Node *GetEvidences_Evidences_Edges_Node_Programs_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetEvidences_Evidences_Edges_Node_Programs_Edges) GetNode() *GetEvidences_Evidences_Edges_Node_Programs_Edges_Node {
+	if t == nil {
+		t = &GetEvidences_Evidences_Edges_Node_Programs_Edges{}
+	}
+	return t.Node
+}
+
+type GetEvidences_Evidences_Edges_Node_Programs struct {
+	Edges []*GetEvidences_Evidences_Edges_Node_Programs_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetEvidences_Evidences_Edges_Node_Programs) GetEdges() []*GetEvidences_Evidences_Edges_Node_Programs_Edges {
 	if t == nil {
 		t = &GetEvidences_Evidences_Edges_Node_Programs{}
 	}
-	return t.Name
+	return t.Edges
+}
+
+type GetEvidences_Evidences_Edges_Node_Tasks_Edges_Node struct {
+	DisplayID string "json:\"displayID\" graphql:\"displayID\""
+	ID        string "json:\"id\" graphql:\"id\""
+}
+
+func (t *GetEvidences_Evidences_Edges_Node_Tasks_Edges_Node) GetDisplayID() string {
+	if t == nil {
+		t = &GetEvidences_Evidences_Edges_Node_Tasks_Edges_Node{}
+	}
+	return t.DisplayID
+}
+func (t *GetEvidences_Evidences_Edges_Node_Tasks_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetEvidences_Evidences_Edges_Node_Tasks_Edges_Node{}
+	}
+	return t.ID
+}
+
+type GetEvidences_Evidences_Edges_Node_Tasks_Edges struct {
+	Node *GetEvidences_Evidences_Edges_Node_Tasks_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetEvidences_Evidences_Edges_Node_Tasks_Edges) GetNode() *GetEvidences_Evidences_Edges_Node_Tasks_Edges_Node {
+	if t == nil {
+		t = &GetEvidences_Evidences_Edges_Node_Tasks_Edges{}
+	}
+	return t.Node
 }
 
 type GetEvidences_Evidences_Edges_Node_Tasks struct {
-	DisplayID string "json:\"displayID\" graphql:\"displayID\""
-	ID        string "json:\"id\" graphql:\"id\""
+	Edges []*GetEvidences_Evidences_Edges_Node_Tasks_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *GetEvidences_Evidences_Edges_Node_Tasks) GetDisplayID() string {
+func (t *GetEvidences_Evidences_Edges_Node_Tasks) GetEdges() []*GetEvidences_Evidences_Edges_Node_Tasks_Edges {
 	if t == nil {
 		t = &GetEvidences_Evidences_Edges_Node_Tasks{}
+	}
+	return t.Edges
+}
+
+type GetEvidences_Evidences_Edges_Node_Controls_Edges_Node struct {
+	DisplayID string "json:\"displayID\" graphql:\"displayID\""
+	ID        string "json:\"id\" graphql:\"id\""
+	RefCode   string "json:\"refCode\" graphql:\"refCode\""
+}
+
+func (t *GetEvidences_Evidences_Edges_Node_Controls_Edges_Node) GetDisplayID() string {
+	if t == nil {
+		t = &GetEvidences_Evidences_Edges_Node_Controls_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetEvidences_Evidences_Edges_Node_Tasks) GetID() string {
+func (t *GetEvidences_Evidences_Edges_Node_Controls_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetEvidences_Evidences_Edges_Node_Tasks{}
+		t = &GetEvidences_Evidences_Edges_Node_Controls_Edges_Node{}
 	}
 	return t.ID
+}
+func (t *GetEvidences_Evidences_Edges_Node_Controls_Edges_Node) GetRefCode() string {
+	if t == nil {
+		t = &GetEvidences_Evidences_Edges_Node_Controls_Edges_Node{}
+	}
+	return t.RefCode
+}
+
+type GetEvidences_Evidences_Edges_Node_Controls_Edges struct {
+	Node *GetEvidences_Evidences_Edges_Node_Controls_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetEvidences_Evidences_Edges_Node_Controls_Edges) GetNode() *GetEvidences_Evidences_Edges_Node_Controls_Edges_Node {
+	if t == nil {
+		t = &GetEvidences_Evidences_Edges_Node_Controls_Edges{}
+	}
+	return t.Node
 }
 
 type GetEvidences_Evidences_Edges_Node_Controls struct {
+	Edges []*GetEvidences_Evidences_Edges_Node_Controls_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetEvidences_Evidences_Edges_Node_Controls) GetEdges() []*GetEvidences_Evidences_Edges_Node_Controls_Edges {
+	if t == nil {
+		t = &GetEvidences_Evidences_Edges_Node_Controls{}
+	}
+	return t.Edges
+}
+
+type GetEvidences_Evidences_Edges_Node_Subcontrols_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	RefCode   string "json:\"refCode\" graphql:\"refCode\""
 }
 
-func (t *GetEvidences_Evidences_Edges_Node_Controls) GetDisplayID() string {
+func (t *GetEvidences_Evidences_Edges_Node_Subcontrols_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetEvidences_Evidences_Edges_Node_Controls{}
+		t = &GetEvidences_Evidences_Edges_Node_Subcontrols_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetEvidences_Evidences_Edges_Node_Controls) GetID() string {
+func (t *GetEvidences_Evidences_Edges_Node_Subcontrols_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetEvidences_Evidences_Edges_Node_Controls{}
+		t = &GetEvidences_Evidences_Edges_Node_Subcontrols_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetEvidences_Evidences_Edges_Node_Controls) GetRefCode() string {
+func (t *GetEvidences_Evidences_Edges_Node_Subcontrols_Edges_Node) GetRefCode() string {
 	if t == nil {
-		t = &GetEvidences_Evidences_Edges_Node_Controls{}
+		t = &GetEvidences_Evidences_Edges_Node_Subcontrols_Edges_Node{}
 	}
 	return t.RefCode
+}
+
+type GetEvidences_Evidences_Edges_Node_Subcontrols_Edges struct {
+	Node *GetEvidences_Evidences_Edges_Node_Subcontrols_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetEvidences_Evidences_Edges_Node_Subcontrols_Edges) GetNode() *GetEvidences_Evidences_Edges_Node_Subcontrols_Edges_Node {
+	if t == nil {
+		t = &GetEvidences_Evidences_Edges_Node_Subcontrols_Edges{}
+	}
+	return t.Node
 }
 
 type GetEvidences_Evidences_Edges_Node_Subcontrols struct {
-	DisplayID string "json:\"displayID\" graphql:\"displayID\""
-	ID        string "json:\"id\" graphql:\"id\""
-	RefCode   string "json:\"refCode\" graphql:\"refCode\""
+	Edges []*GetEvidences_Evidences_Edges_Node_Subcontrols_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *GetEvidences_Evidences_Edges_Node_Subcontrols) GetDisplayID() string {
+func (t *GetEvidences_Evidences_Edges_Node_Subcontrols) GetEdges() []*GetEvidences_Evidences_Edges_Node_Subcontrols_Edges {
 	if t == nil {
 		t = &GetEvidences_Evidences_Edges_Node_Subcontrols{}
 	}
-	return t.DisplayID
-}
-func (t *GetEvidences_Evidences_Edges_Node_Subcontrols) GetID() string {
-	if t == nil {
-		t = &GetEvidences_Evidences_Edges_Node_Subcontrols{}
-	}
-	return t.ID
-}
-func (t *GetEvidences_Evidences_Edges_Node_Subcontrols) GetRefCode() string {
-	if t == nil {
-		t = &GetEvidences_Evidences_Edges_Node_Subcontrols{}
-	}
-	return t.RefCode
+	return t.Edges
 }
 
-type GetEvidences_Evidences_Edges_Node_ControlObjectives struct {
+type GetEvidences_Evidences_Edges_Node_ControlObjectives_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	Name      string "json:\"name\" graphql:\"name\""
 }
 
-func (t *GetEvidences_Evidences_Edges_Node_ControlObjectives) GetDisplayID() string {
+func (t *GetEvidences_Evidences_Edges_Node_ControlObjectives_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetEvidences_Evidences_Edges_Node_ControlObjectives{}
+		t = &GetEvidences_Evidences_Edges_Node_ControlObjectives_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetEvidences_Evidences_Edges_Node_ControlObjectives) GetID() string {
+func (t *GetEvidences_Evidences_Edges_Node_ControlObjectives_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetEvidences_Evidences_Edges_Node_ControlObjectives{}
+		t = &GetEvidences_Evidences_Edges_Node_ControlObjectives_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetEvidences_Evidences_Edges_Node_ControlObjectives) GetName() string {
+func (t *GetEvidences_Evidences_Edges_Node_ControlObjectives_Edges_Node) GetName() string {
 	if t == nil {
-		t = &GetEvidences_Evidences_Edges_Node_ControlObjectives{}
+		t = &GetEvidences_Evidences_Edges_Node_ControlObjectives_Edges_Node{}
 	}
 	return t.Name
 }
 
+type GetEvidences_Evidences_Edges_Node_ControlObjectives_Edges struct {
+	Node *GetEvidences_Evidences_Edges_Node_ControlObjectives_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetEvidences_Evidences_Edges_Node_ControlObjectives_Edges) GetNode() *GetEvidences_Evidences_Edges_Node_ControlObjectives_Edges_Node {
+	if t == nil {
+		t = &GetEvidences_Evidences_Edges_Node_ControlObjectives_Edges{}
+	}
+	return t.Node
+}
+
+type GetEvidences_Evidences_Edges_Node_ControlObjectives struct {
+	Edges []*GetEvidences_Evidences_Edges_Node_ControlObjectives_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetEvidences_Evidences_Edges_Node_ControlObjectives) GetEdges() []*GetEvidences_Evidences_Edges_Node_ControlObjectives_Edges {
+	if t == nil {
+		t = &GetEvidences_Evidences_Edges_Node_ControlObjectives{}
+	}
+	return t.Edges
+}
+
 type GetEvidences_Evidences_Edges_Node struct {
-	CollectionProcedure *string                                                "json:\"collectionProcedure,omitempty\" graphql:\"collectionProcedure\""
-	ControlObjectives   []*GetEvidences_Evidences_Edges_Node_ControlObjectives "json:\"controlObjectives,omitempty\" graphql:\"controlObjectives\""
-	Controls            []*GetEvidences_Evidences_Edges_Node_Controls          "json:\"controls,omitempty\" graphql:\"controls\""
-	CreatedAt           *time.Time                                             "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy           *string                                                "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	CreationDate        time.Time                                              "json:\"creationDate\" graphql:\"creationDate\""
-	Description         *string                                                "json:\"description,omitempty\" graphql:\"description\""
-	DisplayID           string                                                 "json:\"displayID\" graphql:\"displayID\""
-	Files               []*GetEvidences_Evidences_Edges_Node_Files             "json:\"files,omitempty\" graphql:\"files\""
-	ID                  string                                                 "json:\"id\" graphql:\"id\""
-	IsAutomated         *bool                                                  "json:\"isAutomated,omitempty\" graphql:\"isAutomated\""
-	Name                string                                                 "json:\"name\" graphql:\"name\""
-	OwnerID             *string                                                "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Programs            []*GetEvidences_Evidences_Edges_Node_Programs          "json:\"programs,omitempty\" graphql:\"programs\""
-	RenewalDate         *time.Time                                             "json:\"renewalDate,omitempty\" graphql:\"renewalDate\""
-	Source              *string                                                "json:\"source,omitempty\" graphql:\"source\""
-	Status              *enums.EvidenceStatus                                  "json:\"status,omitempty\" graphql:\"status\""
-	Subcontrols         []*GetEvidences_Evidences_Edges_Node_Subcontrols       "json:\"subcontrols,omitempty\" graphql:\"subcontrols\""
-	Tags                []string                                               "json:\"tags,omitempty\" graphql:\"tags\""
-	Tasks               []*GetEvidences_Evidences_Edges_Node_Tasks             "json:\"tasks,omitempty\" graphql:\"tasks\""
-	UpdatedAt           *time.Time                                             "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy           *string                                                "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
-	URL                 *string                                                "json:\"url,omitempty\" graphql:\"url\""
+	CollectionProcedure *string                                             "json:\"collectionProcedure,omitempty\" graphql:\"collectionProcedure\""
+	ControlObjectives   GetEvidences_Evidences_Edges_Node_ControlObjectives "json:\"controlObjectives\" graphql:\"controlObjectives\""
+	Controls            GetEvidences_Evidences_Edges_Node_Controls          "json:\"controls\" graphql:\"controls\""
+	CreatedAt           *time.Time                                          "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy           *string                                             "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	CreationDate        time.Time                                           "json:\"creationDate\" graphql:\"creationDate\""
+	Description         *string                                             "json:\"description,omitempty\" graphql:\"description\""
+	DisplayID           string                                              "json:\"displayID\" graphql:\"displayID\""
+	Files               GetEvidences_Evidences_Edges_Node_Files             "json:\"files\" graphql:\"files\""
+	ID                  string                                              "json:\"id\" graphql:\"id\""
+	IsAutomated         *bool                                               "json:\"isAutomated,omitempty\" graphql:\"isAutomated\""
+	Name                string                                              "json:\"name\" graphql:\"name\""
+	OwnerID             *string                                             "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	Programs            GetEvidences_Evidences_Edges_Node_Programs          "json:\"programs\" graphql:\"programs\""
+	RenewalDate         *time.Time                                          "json:\"renewalDate,omitempty\" graphql:\"renewalDate\""
+	Source              *string                                             "json:\"source,omitempty\" graphql:\"source\""
+	Status              *enums.EvidenceStatus                               "json:\"status,omitempty\" graphql:\"status\""
+	Subcontrols         GetEvidences_Evidences_Edges_Node_Subcontrols       "json:\"subcontrols\" graphql:\"subcontrols\""
+	Tags                []string                                            "json:\"tags,omitempty\" graphql:\"tags\""
+	Tasks               GetEvidences_Evidences_Edges_Node_Tasks             "json:\"tasks\" graphql:\"tasks\""
+	UpdatedAt           *time.Time                                          "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy           *string                                             "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	URL                 *string                                             "json:\"url,omitempty\" graphql:\"url\""
 }
 
 func (t *GetEvidences_Evidences_Edges_Node) GetCollectionProcedure() *string {
@@ -17038,17 +19260,17 @@ func (t *GetEvidences_Evidences_Edges_Node) GetCollectionProcedure() *string {
 	}
 	return t.CollectionProcedure
 }
-func (t *GetEvidences_Evidences_Edges_Node) GetControlObjectives() []*GetEvidences_Evidences_Edges_Node_ControlObjectives {
+func (t *GetEvidences_Evidences_Edges_Node) GetControlObjectives() *GetEvidences_Evidences_Edges_Node_ControlObjectives {
 	if t == nil {
 		t = &GetEvidences_Evidences_Edges_Node{}
 	}
-	return t.ControlObjectives
+	return &t.ControlObjectives
 }
-func (t *GetEvidences_Evidences_Edges_Node) GetControls() []*GetEvidences_Evidences_Edges_Node_Controls {
+func (t *GetEvidences_Evidences_Edges_Node) GetControls() *GetEvidences_Evidences_Edges_Node_Controls {
 	if t == nil {
 		t = &GetEvidences_Evidences_Edges_Node{}
 	}
-	return t.Controls
+	return &t.Controls
 }
 func (t *GetEvidences_Evidences_Edges_Node) GetCreatedAt() *time.Time {
 	if t == nil {
@@ -17080,11 +19302,11 @@ func (t *GetEvidences_Evidences_Edges_Node) GetDisplayID() string {
 	}
 	return t.DisplayID
 }
-func (t *GetEvidences_Evidences_Edges_Node) GetFiles() []*GetEvidences_Evidences_Edges_Node_Files {
+func (t *GetEvidences_Evidences_Edges_Node) GetFiles() *GetEvidences_Evidences_Edges_Node_Files {
 	if t == nil {
 		t = &GetEvidences_Evidences_Edges_Node{}
 	}
-	return t.Files
+	return &t.Files
 }
 func (t *GetEvidences_Evidences_Edges_Node) GetID() string {
 	if t == nil {
@@ -17110,11 +19332,11 @@ func (t *GetEvidences_Evidences_Edges_Node) GetOwnerID() *string {
 	}
 	return t.OwnerID
 }
-func (t *GetEvidences_Evidences_Edges_Node) GetPrograms() []*GetEvidences_Evidences_Edges_Node_Programs {
+func (t *GetEvidences_Evidences_Edges_Node) GetPrograms() *GetEvidences_Evidences_Edges_Node_Programs {
 	if t == nil {
 		t = &GetEvidences_Evidences_Edges_Node{}
 	}
-	return t.Programs
+	return &t.Programs
 }
 func (t *GetEvidences_Evidences_Edges_Node) GetRenewalDate() *time.Time {
 	if t == nil {
@@ -17134,11 +19356,11 @@ func (t *GetEvidences_Evidences_Edges_Node) GetStatus() *enums.EvidenceStatus {
 	}
 	return t.Status
 }
-func (t *GetEvidences_Evidences_Edges_Node) GetSubcontrols() []*GetEvidences_Evidences_Edges_Node_Subcontrols {
+func (t *GetEvidences_Evidences_Edges_Node) GetSubcontrols() *GetEvidences_Evidences_Edges_Node_Subcontrols {
 	if t == nil {
 		t = &GetEvidences_Evidences_Edges_Node{}
 	}
-	return t.Subcontrols
+	return &t.Subcontrols
 }
 func (t *GetEvidences_Evidences_Edges_Node) GetTags() []string {
 	if t == nil {
@@ -17146,11 +19368,11 @@ func (t *GetEvidences_Evidences_Edges_Node) GetTags() []string {
 	}
 	return t.Tags
 }
-func (t *GetEvidences_Evidences_Edges_Node) GetTasks() []*GetEvidences_Evidences_Edges_Node_Tasks {
+func (t *GetEvidences_Evidences_Edges_Node) GetTasks() *GetEvidences_Evidences_Edges_Node_Tasks {
 	if t == nil {
 		t = &GetEvidences_Evidences_Edges_Node{}
 	}
-	return t.Tasks
+	return &t.Tasks
 }
 func (t *GetEvidences_Evidences_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
@@ -17193,166 +19415,298 @@ func (t *GetEvidences_Evidences) GetEdges() []*GetEvidences_Evidences_Edges {
 	return t.Edges
 }
 
-type UpdateEvidence_UpdateEvidence_Evidence_Files struct {
+type UpdateEvidence_UpdateEvidence_Evidence_Files_Edges_Node struct {
 	ID           string  "json:\"id\" graphql:\"id\""
 	PresignedURL *string "json:\"presignedURL,omitempty\" graphql:\"presignedURL\""
 }
 
-func (t *UpdateEvidence_UpdateEvidence_Evidence_Files) GetID() string {
+func (t *UpdateEvidence_UpdateEvidence_Evidence_Files_Edges_Node) GetID() string {
 	if t == nil {
-		t = &UpdateEvidence_UpdateEvidence_Evidence_Files{}
+		t = &UpdateEvidence_UpdateEvidence_Evidence_Files_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *UpdateEvidence_UpdateEvidence_Evidence_Files) GetPresignedURL() *string {
+func (t *UpdateEvidence_UpdateEvidence_Evidence_Files_Edges_Node) GetPresignedURL() *string {
 	if t == nil {
-		t = &UpdateEvidence_UpdateEvidence_Evidence_Files{}
+		t = &UpdateEvidence_UpdateEvidence_Evidence_Files_Edges_Node{}
 	}
 	return t.PresignedURL
 }
 
-type UpdateEvidence_UpdateEvidence_Evidence_Programs struct {
+type UpdateEvidence_UpdateEvidence_Evidence_Files_Edges struct {
+	Node *UpdateEvidence_UpdateEvidence_Evidence_Files_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateEvidence_UpdateEvidence_Evidence_Files_Edges) GetNode() *UpdateEvidence_UpdateEvidence_Evidence_Files_Edges_Node {
+	if t == nil {
+		t = &UpdateEvidence_UpdateEvidence_Evidence_Files_Edges{}
+	}
+	return t.Node
+}
+
+type UpdateEvidence_UpdateEvidence_Evidence_Files struct {
+	Edges []*UpdateEvidence_UpdateEvidence_Evidence_Files_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *UpdateEvidence_UpdateEvidence_Evidence_Files) GetEdges() []*UpdateEvidence_UpdateEvidence_Evidence_Files_Edges {
+	if t == nil {
+		t = &UpdateEvidence_UpdateEvidence_Evidence_Files{}
+	}
+	return t.Edges
+}
+
+type UpdateEvidence_UpdateEvidence_Evidence_Programs_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	Name      string "json:\"name\" graphql:\"name\""
 }
 
-func (t *UpdateEvidence_UpdateEvidence_Evidence_Programs) GetDisplayID() string {
+func (t *UpdateEvidence_UpdateEvidence_Evidence_Programs_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &UpdateEvidence_UpdateEvidence_Evidence_Programs{}
+		t = &UpdateEvidence_UpdateEvidence_Evidence_Programs_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *UpdateEvidence_UpdateEvidence_Evidence_Programs) GetID() string {
+func (t *UpdateEvidence_UpdateEvidence_Evidence_Programs_Edges_Node) GetID() string {
 	if t == nil {
-		t = &UpdateEvidence_UpdateEvidence_Evidence_Programs{}
+		t = &UpdateEvidence_UpdateEvidence_Evidence_Programs_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *UpdateEvidence_UpdateEvidence_Evidence_Programs) GetName() string {
+func (t *UpdateEvidence_UpdateEvidence_Evidence_Programs_Edges_Node) GetName() string {
+	if t == nil {
+		t = &UpdateEvidence_UpdateEvidence_Evidence_Programs_Edges_Node{}
+	}
+	return t.Name
+}
+
+type UpdateEvidence_UpdateEvidence_Evidence_Programs_Edges struct {
+	Node *UpdateEvidence_UpdateEvidence_Evidence_Programs_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateEvidence_UpdateEvidence_Evidence_Programs_Edges) GetNode() *UpdateEvidence_UpdateEvidence_Evidence_Programs_Edges_Node {
+	if t == nil {
+		t = &UpdateEvidence_UpdateEvidence_Evidence_Programs_Edges{}
+	}
+	return t.Node
+}
+
+type UpdateEvidence_UpdateEvidence_Evidence_Programs struct {
+	Edges []*UpdateEvidence_UpdateEvidence_Evidence_Programs_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *UpdateEvidence_UpdateEvidence_Evidence_Programs) GetEdges() []*UpdateEvidence_UpdateEvidence_Evidence_Programs_Edges {
 	if t == nil {
 		t = &UpdateEvidence_UpdateEvidence_Evidence_Programs{}
 	}
-	return t.Name
+	return t.Edges
+}
+
+type UpdateEvidence_UpdateEvidence_Evidence_Tasks_Edges_Node struct {
+	DisplayID string "json:\"displayID\" graphql:\"displayID\""
+	ID        string "json:\"id\" graphql:\"id\""
+}
+
+func (t *UpdateEvidence_UpdateEvidence_Evidence_Tasks_Edges_Node) GetDisplayID() string {
+	if t == nil {
+		t = &UpdateEvidence_UpdateEvidence_Evidence_Tasks_Edges_Node{}
+	}
+	return t.DisplayID
+}
+func (t *UpdateEvidence_UpdateEvidence_Evidence_Tasks_Edges_Node) GetID() string {
+	if t == nil {
+		t = &UpdateEvidence_UpdateEvidence_Evidence_Tasks_Edges_Node{}
+	}
+	return t.ID
+}
+
+type UpdateEvidence_UpdateEvidence_Evidence_Tasks_Edges struct {
+	Node *UpdateEvidence_UpdateEvidence_Evidence_Tasks_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateEvidence_UpdateEvidence_Evidence_Tasks_Edges) GetNode() *UpdateEvidence_UpdateEvidence_Evidence_Tasks_Edges_Node {
+	if t == nil {
+		t = &UpdateEvidence_UpdateEvidence_Evidence_Tasks_Edges{}
+	}
+	return t.Node
 }
 
 type UpdateEvidence_UpdateEvidence_Evidence_Tasks struct {
-	DisplayID string "json:\"displayID\" graphql:\"displayID\""
-	ID        string "json:\"id\" graphql:\"id\""
+	Edges []*UpdateEvidence_UpdateEvidence_Evidence_Tasks_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *UpdateEvidence_UpdateEvidence_Evidence_Tasks) GetDisplayID() string {
+func (t *UpdateEvidence_UpdateEvidence_Evidence_Tasks) GetEdges() []*UpdateEvidence_UpdateEvidence_Evidence_Tasks_Edges {
 	if t == nil {
 		t = &UpdateEvidence_UpdateEvidence_Evidence_Tasks{}
+	}
+	return t.Edges
+}
+
+type UpdateEvidence_UpdateEvidence_Evidence_Controls_Edges_Node struct {
+	DisplayID string "json:\"displayID\" graphql:\"displayID\""
+	ID        string "json:\"id\" graphql:\"id\""
+	RefCode   string "json:\"refCode\" graphql:\"refCode\""
+}
+
+func (t *UpdateEvidence_UpdateEvidence_Evidence_Controls_Edges_Node) GetDisplayID() string {
+	if t == nil {
+		t = &UpdateEvidence_UpdateEvidence_Evidence_Controls_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *UpdateEvidence_UpdateEvidence_Evidence_Tasks) GetID() string {
+func (t *UpdateEvidence_UpdateEvidence_Evidence_Controls_Edges_Node) GetID() string {
 	if t == nil {
-		t = &UpdateEvidence_UpdateEvidence_Evidence_Tasks{}
+		t = &UpdateEvidence_UpdateEvidence_Evidence_Controls_Edges_Node{}
 	}
 	return t.ID
+}
+func (t *UpdateEvidence_UpdateEvidence_Evidence_Controls_Edges_Node) GetRefCode() string {
+	if t == nil {
+		t = &UpdateEvidence_UpdateEvidence_Evidence_Controls_Edges_Node{}
+	}
+	return t.RefCode
+}
+
+type UpdateEvidence_UpdateEvidence_Evidence_Controls_Edges struct {
+	Node *UpdateEvidence_UpdateEvidence_Evidence_Controls_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateEvidence_UpdateEvidence_Evidence_Controls_Edges) GetNode() *UpdateEvidence_UpdateEvidence_Evidence_Controls_Edges_Node {
+	if t == nil {
+		t = &UpdateEvidence_UpdateEvidence_Evidence_Controls_Edges{}
+	}
+	return t.Node
 }
 
 type UpdateEvidence_UpdateEvidence_Evidence_Controls struct {
+	Edges []*UpdateEvidence_UpdateEvidence_Evidence_Controls_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *UpdateEvidence_UpdateEvidence_Evidence_Controls) GetEdges() []*UpdateEvidence_UpdateEvidence_Evidence_Controls_Edges {
+	if t == nil {
+		t = &UpdateEvidence_UpdateEvidence_Evidence_Controls{}
+	}
+	return t.Edges
+}
+
+type UpdateEvidence_UpdateEvidence_Evidence_Subcontrols_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	RefCode   string "json:\"refCode\" graphql:\"refCode\""
 }
 
-func (t *UpdateEvidence_UpdateEvidence_Evidence_Controls) GetDisplayID() string {
+func (t *UpdateEvidence_UpdateEvidence_Evidence_Subcontrols_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &UpdateEvidence_UpdateEvidence_Evidence_Controls{}
+		t = &UpdateEvidence_UpdateEvidence_Evidence_Subcontrols_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *UpdateEvidence_UpdateEvidence_Evidence_Controls) GetID() string {
+func (t *UpdateEvidence_UpdateEvidence_Evidence_Subcontrols_Edges_Node) GetID() string {
 	if t == nil {
-		t = &UpdateEvidence_UpdateEvidence_Evidence_Controls{}
+		t = &UpdateEvidence_UpdateEvidence_Evidence_Subcontrols_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *UpdateEvidence_UpdateEvidence_Evidence_Controls) GetRefCode() string {
+func (t *UpdateEvidence_UpdateEvidence_Evidence_Subcontrols_Edges_Node) GetRefCode() string {
 	if t == nil {
-		t = &UpdateEvidence_UpdateEvidence_Evidence_Controls{}
+		t = &UpdateEvidence_UpdateEvidence_Evidence_Subcontrols_Edges_Node{}
 	}
 	return t.RefCode
+}
+
+type UpdateEvidence_UpdateEvidence_Evidence_Subcontrols_Edges struct {
+	Node *UpdateEvidence_UpdateEvidence_Evidence_Subcontrols_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateEvidence_UpdateEvidence_Evidence_Subcontrols_Edges) GetNode() *UpdateEvidence_UpdateEvidence_Evidence_Subcontrols_Edges_Node {
+	if t == nil {
+		t = &UpdateEvidence_UpdateEvidence_Evidence_Subcontrols_Edges{}
+	}
+	return t.Node
 }
 
 type UpdateEvidence_UpdateEvidence_Evidence_Subcontrols struct {
-	DisplayID string "json:\"displayID\" graphql:\"displayID\""
-	ID        string "json:\"id\" graphql:\"id\""
-	RefCode   string "json:\"refCode\" graphql:\"refCode\""
+	Edges []*UpdateEvidence_UpdateEvidence_Evidence_Subcontrols_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *UpdateEvidence_UpdateEvidence_Evidence_Subcontrols) GetDisplayID() string {
+func (t *UpdateEvidence_UpdateEvidence_Evidence_Subcontrols) GetEdges() []*UpdateEvidence_UpdateEvidence_Evidence_Subcontrols_Edges {
 	if t == nil {
 		t = &UpdateEvidence_UpdateEvidence_Evidence_Subcontrols{}
 	}
-	return t.DisplayID
-}
-func (t *UpdateEvidence_UpdateEvidence_Evidence_Subcontrols) GetID() string {
-	if t == nil {
-		t = &UpdateEvidence_UpdateEvidence_Evidence_Subcontrols{}
-	}
-	return t.ID
-}
-func (t *UpdateEvidence_UpdateEvidence_Evidence_Subcontrols) GetRefCode() string {
-	if t == nil {
-		t = &UpdateEvidence_UpdateEvidence_Evidence_Subcontrols{}
-	}
-	return t.RefCode
+	return t.Edges
 }
 
-type UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives struct {
+type UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	Name      string "json:\"name\" graphql:\"name\""
 }
 
-func (t *UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives) GetDisplayID() string {
+func (t *UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives{}
+		t = &UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives) GetID() string {
+func (t *UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives_Edges_Node) GetID() string {
 	if t == nil {
-		t = &UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives{}
+		t = &UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives) GetName() string {
+func (t *UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives_Edges_Node) GetName() string {
 	if t == nil {
-		t = &UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives{}
+		t = &UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives_Edges_Node{}
 	}
 	return t.Name
 }
 
+type UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives_Edges struct {
+	Node *UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives_Edges) GetNode() *UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives_Edges_Node {
+	if t == nil {
+		t = &UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives_Edges{}
+	}
+	return t.Node
+}
+
+type UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives struct {
+	Edges []*UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives) GetEdges() []*UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives_Edges {
+	if t == nil {
+		t = &UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives{}
+	}
+	return t.Edges
+}
+
 type UpdateEvidence_UpdateEvidence_Evidence struct {
-	CollectionProcedure *string                                                     "json:\"collectionProcedure,omitempty\" graphql:\"collectionProcedure\""
-	ControlObjectives   []*UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives "json:\"controlObjectives,omitempty\" graphql:\"controlObjectives\""
-	Controls            []*UpdateEvidence_UpdateEvidence_Evidence_Controls          "json:\"controls,omitempty\" graphql:\"controls\""
-	CreatedAt           *time.Time                                                  "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy           *string                                                     "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	CreationDate        time.Time                                                   "json:\"creationDate\" graphql:\"creationDate\""
-	Description         *string                                                     "json:\"description,omitempty\" graphql:\"description\""
-	DisplayID           string                                                      "json:\"displayID\" graphql:\"displayID\""
-	Files               []*UpdateEvidence_UpdateEvidence_Evidence_Files             "json:\"files,omitempty\" graphql:\"files\""
-	ID                  string                                                      "json:\"id\" graphql:\"id\""
-	IsAutomated         *bool                                                       "json:\"isAutomated,omitempty\" graphql:\"isAutomated\""
-	Name                string                                                      "json:\"name\" graphql:\"name\""
-	OwnerID             *string                                                     "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Programs            []*UpdateEvidence_UpdateEvidence_Evidence_Programs          "json:\"programs,omitempty\" graphql:\"programs\""
-	RenewalDate         *time.Time                                                  "json:\"renewalDate,omitempty\" graphql:\"renewalDate\""
-	Source              *string                                                     "json:\"source,omitempty\" graphql:\"source\""
-	Status              *enums.EvidenceStatus                                       "json:\"status,omitempty\" graphql:\"status\""
-	Subcontrols         []*UpdateEvidence_UpdateEvidence_Evidence_Subcontrols       "json:\"subcontrols,omitempty\" graphql:\"subcontrols\""
-	Tags                []string                                                    "json:\"tags,omitempty\" graphql:\"tags\""
-	Tasks               []*UpdateEvidence_UpdateEvidence_Evidence_Tasks             "json:\"tasks,omitempty\" graphql:\"tasks\""
-	UpdatedAt           *time.Time                                                  "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy           *string                                                     "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
-	URL                 *string                                                     "json:\"url,omitempty\" graphql:\"url\""
+	CollectionProcedure *string                                                  "json:\"collectionProcedure,omitempty\" graphql:\"collectionProcedure\""
+	ControlObjectives   UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives "json:\"controlObjectives\" graphql:\"controlObjectives\""
+	Controls            UpdateEvidence_UpdateEvidence_Evidence_Controls          "json:\"controls\" graphql:\"controls\""
+	CreatedAt           *time.Time                                               "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy           *string                                                  "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	CreationDate        time.Time                                                "json:\"creationDate\" graphql:\"creationDate\""
+	Description         *string                                                  "json:\"description,omitempty\" graphql:\"description\""
+	DisplayID           string                                                   "json:\"displayID\" graphql:\"displayID\""
+	Files               UpdateEvidence_UpdateEvidence_Evidence_Files             "json:\"files\" graphql:\"files\""
+	ID                  string                                                   "json:\"id\" graphql:\"id\""
+	IsAutomated         *bool                                                    "json:\"isAutomated,omitempty\" graphql:\"isAutomated\""
+	Name                string                                                   "json:\"name\" graphql:\"name\""
+	OwnerID             *string                                                  "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	Programs            UpdateEvidence_UpdateEvidence_Evidence_Programs          "json:\"programs\" graphql:\"programs\""
+	RenewalDate         *time.Time                                               "json:\"renewalDate,omitempty\" graphql:\"renewalDate\""
+	Source              *string                                                  "json:\"source,omitempty\" graphql:\"source\""
+	Status              *enums.EvidenceStatus                                    "json:\"status,omitempty\" graphql:\"status\""
+	Subcontrols         UpdateEvidence_UpdateEvidence_Evidence_Subcontrols       "json:\"subcontrols\" graphql:\"subcontrols\""
+	Tags                []string                                                 "json:\"tags,omitempty\" graphql:\"tags\""
+	Tasks               UpdateEvidence_UpdateEvidence_Evidence_Tasks             "json:\"tasks\" graphql:\"tasks\""
+	UpdatedAt           *time.Time                                               "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy           *string                                                  "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	URL                 *string                                                  "json:\"url,omitempty\" graphql:\"url\""
 }
 
 func (t *UpdateEvidence_UpdateEvidence_Evidence) GetCollectionProcedure() *string {
@@ -17361,17 +19715,17 @@ func (t *UpdateEvidence_UpdateEvidence_Evidence) GetCollectionProcedure() *strin
 	}
 	return t.CollectionProcedure
 }
-func (t *UpdateEvidence_UpdateEvidence_Evidence) GetControlObjectives() []*UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives {
+func (t *UpdateEvidence_UpdateEvidence_Evidence) GetControlObjectives() *UpdateEvidence_UpdateEvidence_Evidence_ControlObjectives {
 	if t == nil {
 		t = &UpdateEvidence_UpdateEvidence_Evidence{}
 	}
-	return t.ControlObjectives
+	return &t.ControlObjectives
 }
-func (t *UpdateEvidence_UpdateEvidence_Evidence) GetControls() []*UpdateEvidence_UpdateEvidence_Evidence_Controls {
+func (t *UpdateEvidence_UpdateEvidence_Evidence) GetControls() *UpdateEvidence_UpdateEvidence_Evidence_Controls {
 	if t == nil {
 		t = &UpdateEvidence_UpdateEvidence_Evidence{}
 	}
-	return t.Controls
+	return &t.Controls
 }
 func (t *UpdateEvidence_UpdateEvidence_Evidence) GetCreatedAt() *time.Time {
 	if t == nil {
@@ -17403,11 +19757,11 @@ func (t *UpdateEvidence_UpdateEvidence_Evidence) GetDisplayID() string {
 	}
 	return t.DisplayID
 }
-func (t *UpdateEvidence_UpdateEvidence_Evidence) GetFiles() []*UpdateEvidence_UpdateEvidence_Evidence_Files {
+func (t *UpdateEvidence_UpdateEvidence_Evidence) GetFiles() *UpdateEvidence_UpdateEvidence_Evidence_Files {
 	if t == nil {
 		t = &UpdateEvidence_UpdateEvidence_Evidence{}
 	}
-	return t.Files
+	return &t.Files
 }
 func (t *UpdateEvidence_UpdateEvidence_Evidence) GetID() string {
 	if t == nil {
@@ -17433,11 +19787,11 @@ func (t *UpdateEvidence_UpdateEvidence_Evidence) GetOwnerID() *string {
 	}
 	return t.OwnerID
 }
-func (t *UpdateEvidence_UpdateEvidence_Evidence) GetPrograms() []*UpdateEvidence_UpdateEvidence_Evidence_Programs {
+func (t *UpdateEvidence_UpdateEvidence_Evidence) GetPrograms() *UpdateEvidence_UpdateEvidence_Evidence_Programs {
 	if t == nil {
 		t = &UpdateEvidence_UpdateEvidence_Evidence{}
 	}
-	return t.Programs
+	return &t.Programs
 }
 func (t *UpdateEvidence_UpdateEvidence_Evidence) GetRenewalDate() *time.Time {
 	if t == nil {
@@ -17457,11 +19811,11 @@ func (t *UpdateEvidence_UpdateEvidence_Evidence) GetStatus() *enums.EvidenceStat
 	}
 	return t.Status
 }
-func (t *UpdateEvidence_UpdateEvidence_Evidence) GetSubcontrols() []*UpdateEvidence_UpdateEvidence_Evidence_Subcontrols {
+func (t *UpdateEvidence_UpdateEvidence_Evidence) GetSubcontrols() *UpdateEvidence_UpdateEvidence_Evidence_Subcontrols {
 	if t == nil {
 		t = &UpdateEvidence_UpdateEvidence_Evidence{}
 	}
-	return t.Subcontrols
+	return &t.Subcontrols
 }
 func (t *UpdateEvidence_UpdateEvidence_Evidence) GetTags() []string {
 	if t == nil {
@@ -17469,11 +19823,11 @@ func (t *UpdateEvidence_UpdateEvidence_Evidence) GetTags() []string {
 	}
 	return t.Tags
 }
-func (t *UpdateEvidence_UpdateEvidence_Evidence) GetTasks() []*UpdateEvidence_UpdateEvidence_Evidence_Tasks {
+func (t *UpdateEvidence_UpdateEvidence_Evidence) GetTasks() *UpdateEvidence_UpdateEvidence_Evidence_Tasks {
 	if t == nil {
 		t = &UpdateEvidence_UpdateEvidence_Evidence{}
 	}
-	return t.Tasks
+	return &t.Tasks
 }
 func (t *UpdateEvidence_UpdateEvidence_Evidence) GetUpdatedAt() *time.Time {
 	if t == nil {
@@ -22313,48 +24667,114 @@ func (t *GetGroupSettingHistories_GroupSettingHistories) GetEdges() []*GetGroupS
 	return t.Edges
 }
 
-type CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Integrations struct {
+type CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Integrations_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Integrations) GetID() string {
+func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Integrations_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Integrations_Edges_Node{}
+	}
+	return t.ID
+}
+
+type CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Integrations_Edges struct {
+	Node *CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Integrations_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Integrations_Edges) GetNode() *CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Integrations_Edges_Node {
+	if t == nil {
+		t = &CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Integrations_Edges{}
+	}
+	return t.Node
+}
+
+type CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Integrations struct {
+	Edges []*CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Integrations_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Integrations) GetEdges() []*CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Integrations_Edges {
 	if t == nil {
 		t = &CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Integrations{}
 	}
+	return t.Edges
+}
+
+type CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Organization_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Organization_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Organization_Edges_Node{}
+	}
 	return t.ID
+}
+
+type CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Organization_Edges struct {
+	Node *CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Organization_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Organization_Edges) GetNode() *CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Organization_Edges_Node {
+	if t == nil {
+		t = &CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Organization_Edges{}
+	}
+	return t.Node
 }
 
 type CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Organization struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Organization_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Organization) GetID() string {
+func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Organization) GetEdges() []*CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Organization_Edges {
 	if t == nil {
 		t = &CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Organization{}
 	}
-	return t.ID
+	return t.Edges
 }
 
-type CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Events struct {
+type CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Events_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Events) GetID() string {
+func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Events_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Events{}
+		t = &CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Events_Edges_Node{}
 	}
 	return t.ID
 }
 
+type CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Events_Edges struct {
+	Node *CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Events_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Events_Edges) GetNode() *CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Events_Edges_Node {
+	if t == nil {
+		t = &CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Events_Edges{}
+	}
+	return t.Node
+}
+
+type CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Events struct {
+	Edges []*CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Events_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Events) GetEdges() []*CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Events_Edges {
+	if t == nil {
+		t = &CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Events{}
+	}
+	return t.Edges
+}
+
 type CreateBulkCSVHush_CreateBulkCSVHush_Hushes struct {
-	Description  *string                                                    "json:\"description,omitempty\" graphql:\"description\""
-	Events       []*CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Events       "json:\"events,omitempty\" graphql:\"events\""
-	ID           string                                                     "json:\"id\" graphql:\"id\""
-	Integrations []*CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Integrations "json:\"integrations,omitempty\" graphql:\"integrations\""
-	Kind         *string                                                    "json:\"kind,omitempty\" graphql:\"kind\""
-	Name         string                                                     "json:\"name\" graphql:\"name\""
-	Organization []*CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Organization "json:\"organization,omitempty\" graphql:\"organization\""
-	SecretName   *string                                                    "json:\"secretName,omitempty\" graphql:\"secretName\""
+	Description  *string                                                 "json:\"description,omitempty\" graphql:\"description\""
+	Events       CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Events       "json:\"events\" graphql:\"events\""
+	ID           string                                                  "json:\"id\" graphql:\"id\""
+	Integrations CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Integrations "json:\"integrations\" graphql:\"integrations\""
+	Kind         *string                                                 "json:\"kind,omitempty\" graphql:\"kind\""
+	Name         string                                                  "json:\"name\" graphql:\"name\""
+	Organization CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Organization "json:\"organization\" graphql:\"organization\""
+	SecretName   *string                                                 "json:\"secretName,omitempty\" graphql:\"secretName\""
 }
 
 func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes) GetDescription() *string {
@@ -22363,11 +24783,11 @@ func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes) GetDescription() *string {
 	}
 	return t.Description
 }
-func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes) GetEvents() []*CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Events {
+func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes) GetEvents() *CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Events {
 	if t == nil {
 		t = &CreateBulkCSVHush_CreateBulkCSVHush_Hushes{}
 	}
-	return t.Events
+	return &t.Events
 }
 func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes) GetID() string {
 	if t == nil {
@@ -22375,11 +24795,11 @@ func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes) GetID() string {
 	}
 	return t.ID
 }
-func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes) GetIntegrations() []*CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Integrations {
+func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes) GetIntegrations() *CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Integrations {
 	if t == nil {
 		t = &CreateBulkCSVHush_CreateBulkCSVHush_Hushes{}
 	}
-	return t.Integrations
+	return &t.Integrations
 }
 func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes) GetKind() *string {
 	if t == nil {
@@ -22393,11 +24813,11 @@ func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes) GetName() string {
 	}
 	return t.Name
 }
-func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes) GetOrganization() []*CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Organization {
+func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes) GetOrganization() *CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Organization {
 	if t == nil {
 		t = &CreateBulkCSVHush_CreateBulkCSVHush_Hushes{}
 	}
-	return t.Organization
+	return &t.Organization
 }
 func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes) GetSecretName() *string {
 	if t == nil {
@@ -22417,48 +24837,114 @@ func (t *CreateBulkCSVHush_CreateBulkCSVHush) GetHushes() []*CreateBulkCSVHush_C
 	return t.Hushes
 }
 
-type CreateBulkHush_CreateBulkHush_Hushes_Integrations struct {
+type CreateBulkHush_CreateBulkHush_Hushes_Integrations_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *CreateBulkHush_CreateBulkHush_Hushes_Integrations) GetID() string {
+func (t *CreateBulkHush_CreateBulkHush_Hushes_Integrations_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateBulkHush_CreateBulkHush_Hushes_Integrations_Edges_Node{}
+	}
+	return t.ID
+}
+
+type CreateBulkHush_CreateBulkHush_Hushes_Integrations_Edges struct {
+	Node *CreateBulkHush_CreateBulkHush_Hushes_Integrations_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkHush_CreateBulkHush_Hushes_Integrations_Edges) GetNode() *CreateBulkHush_CreateBulkHush_Hushes_Integrations_Edges_Node {
+	if t == nil {
+		t = &CreateBulkHush_CreateBulkHush_Hushes_Integrations_Edges{}
+	}
+	return t.Node
+}
+
+type CreateBulkHush_CreateBulkHush_Hushes_Integrations struct {
+	Edges []*CreateBulkHush_CreateBulkHush_Hushes_Integrations_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateBulkHush_CreateBulkHush_Hushes_Integrations) GetEdges() []*CreateBulkHush_CreateBulkHush_Hushes_Integrations_Edges {
 	if t == nil {
 		t = &CreateBulkHush_CreateBulkHush_Hushes_Integrations{}
 	}
+	return t.Edges
+}
+
+type CreateBulkHush_CreateBulkHush_Hushes_Organization_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *CreateBulkHush_CreateBulkHush_Hushes_Organization_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateBulkHush_CreateBulkHush_Hushes_Organization_Edges_Node{}
+	}
 	return t.ID
+}
+
+type CreateBulkHush_CreateBulkHush_Hushes_Organization_Edges struct {
+	Node *CreateBulkHush_CreateBulkHush_Hushes_Organization_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkHush_CreateBulkHush_Hushes_Organization_Edges) GetNode() *CreateBulkHush_CreateBulkHush_Hushes_Organization_Edges_Node {
+	if t == nil {
+		t = &CreateBulkHush_CreateBulkHush_Hushes_Organization_Edges{}
+	}
+	return t.Node
 }
 
 type CreateBulkHush_CreateBulkHush_Hushes_Organization struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*CreateBulkHush_CreateBulkHush_Hushes_Organization_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateBulkHush_CreateBulkHush_Hushes_Organization) GetID() string {
+func (t *CreateBulkHush_CreateBulkHush_Hushes_Organization) GetEdges() []*CreateBulkHush_CreateBulkHush_Hushes_Organization_Edges {
 	if t == nil {
 		t = &CreateBulkHush_CreateBulkHush_Hushes_Organization{}
 	}
-	return t.ID
+	return t.Edges
 }
 
-type CreateBulkHush_CreateBulkHush_Hushes_Events struct {
+type CreateBulkHush_CreateBulkHush_Hushes_Events_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *CreateBulkHush_CreateBulkHush_Hushes_Events) GetID() string {
+func (t *CreateBulkHush_CreateBulkHush_Hushes_Events_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateBulkHush_CreateBulkHush_Hushes_Events{}
+		t = &CreateBulkHush_CreateBulkHush_Hushes_Events_Edges_Node{}
 	}
 	return t.ID
 }
 
+type CreateBulkHush_CreateBulkHush_Hushes_Events_Edges struct {
+	Node *CreateBulkHush_CreateBulkHush_Hushes_Events_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkHush_CreateBulkHush_Hushes_Events_Edges) GetNode() *CreateBulkHush_CreateBulkHush_Hushes_Events_Edges_Node {
+	if t == nil {
+		t = &CreateBulkHush_CreateBulkHush_Hushes_Events_Edges{}
+	}
+	return t.Node
+}
+
+type CreateBulkHush_CreateBulkHush_Hushes_Events struct {
+	Edges []*CreateBulkHush_CreateBulkHush_Hushes_Events_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateBulkHush_CreateBulkHush_Hushes_Events) GetEdges() []*CreateBulkHush_CreateBulkHush_Hushes_Events_Edges {
+	if t == nil {
+		t = &CreateBulkHush_CreateBulkHush_Hushes_Events{}
+	}
+	return t.Edges
+}
+
 type CreateBulkHush_CreateBulkHush_Hushes struct {
-	Description  *string                                              "json:\"description,omitempty\" graphql:\"description\""
-	Events       []*CreateBulkHush_CreateBulkHush_Hushes_Events       "json:\"events,omitempty\" graphql:\"events\""
-	ID           string                                               "json:\"id\" graphql:\"id\""
-	Integrations []*CreateBulkHush_CreateBulkHush_Hushes_Integrations "json:\"integrations,omitempty\" graphql:\"integrations\""
-	Kind         *string                                              "json:\"kind,omitempty\" graphql:\"kind\""
-	Name         string                                               "json:\"name\" graphql:\"name\""
-	Organization []*CreateBulkHush_CreateBulkHush_Hushes_Organization "json:\"organization,omitempty\" graphql:\"organization\""
-	SecretName   *string                                              "json:\"secretName,omitempty\" graphql:\"secretName\""
+	Description  *string                                           "json:\"description,omitempty\" graphql:\"description\""
+	Events       CreateBulkHush_CreateBulkHush_Hushes_Events       "json:\"events\" graphql:\"events\""
+	ID           string                                            "json:\"id\" graphql:\"id\""
+	Integrations CreateBulkHush_CreateBulkHush_Hushes_Integrations "json:\"integrations\" graphql:\"integrations\""
+	Kind         *string                                           "json:\"kind,omitempty\" graphql:\"kind\""
+	Name         string                                            "json:\"name\" graphql:\"name\""
+	Organization CreateBulkHush_CreateBulkHush_Hushes_Organization "json:\"organization\" graphql:\"organization\""
+	SecretName   *string                                           "json:\"secretName,omitempty\" graphql:\"secretName\""
 }
 
 func (t *CreateBulkHush_CreateBulkHush_Hushes) GetDescription() *string {
@@ -22467,11 +24953,11 @@ func (t *CreateBulkHush_CreateBulkHush_Hushes) GetDescription() *string {
 	}
 	return t.Description
 }
-func (t *CreateBulkHush_CreateBulkHush_Hushes) GetEvents() []*CreateBulkHush_CreateBulkHush_Hushes_Events {
+func (t *CreateBulkHush_CreateBulkHush_Hushes) GetEvents() *CreateBulkHush_CreateBulkHush_Hushes_Events {
 	if t == nil {
 		t = &CreateBulkHush_CreateBulkHush_Hushes{}
 	}
-	return t.Events
+	return &t.Events
 }
 func (t *CreateBulkHush_CreateBulkHush_Hushes) GetID() string {
 	if t == nil {
@@ -22479,11 +24965,11 @@ func (t *CreateBulkHush_CreateBulkHush_Hushes) GetID() string {
 	}
 	return t.ID
 }
-func (t *CreateBulkHush_CreateBulkHush_Hushes) GetIntegrations() []*CreateBulkHush_CreateBulkHush_Hushes_Integrations {
+func (t *CreateBulkHush_CreateBulkHush_Hushes) GetIntegrations() *CreateBulkHush_CreateBulkHush_Hushes_Integrations {
 	if t == nil {
 		t = &CreateBulkHush_CreateBulkHush_Hushes{}
 	}
-	return t.Integrations
+	return &t.Integrations
 }
 func (t *CreateBulkHush_CreateBulkHush_Hushes) GetKind() *string {
 	if t == nil {
@@ -22497,11 +24983,11 @@ func (t *CreateBulkHush_CreateBulkHush_Hushes) GetName() string {
 	}
 	return t.Name
 }
-func (t *CreateBulkHush_CreateBulkHush_Hushes) GetOrganization() []*CreateBulkHush_CreateBulkHush_Hushes_Organization {
+func (t *CreateBulkHush_CreateBulkHush_Hushes) GetOrganization() *CreateBulkHush_CreateBulkHush_Hushes_Organization {
 	if t == nil {
 		t = &CreateBulkHush_CreateBulkHush_Hushes{}
 	}
-	return t.Organization
+	return &t.Organization
 }
 func (t *CreateBulkHush_CreateBulkHush_Hushes) GetSecretName() *string {
 	if t == nil {
@@ -22521,48 +25007,114 @@ func (t *CreateBulkHush_CreateBulkHush) GetHushes() []*CreateBulkHush_CreateBulk
 	return t.Hushes
 }
 
-type CreateHush_CreateHush_Hush_Integrations struct {
+type CreateHush_CreateHush_Hush_Integrations_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *CreateHush_CreateHush_Hush_Integrations) GetID() string {
+func (t *CreateHush_CreateHush_Hush_Integrations_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateHush_CreateHush_Hush_Integrations_Edges_Node{}
+	}
+	return t.ID
+}
+
+type CreateHush_CreateHush_Hush_Integrations_Edges struct {
+	Node *CreateHush_CreateHush_Hush_Integrations_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateHush_CreateHush_Hush_Integrations_Edges) GetNode() *CreateHush_CreateHush_Hush_Integrations_Edges_Node {
+	if t == nil {
+		t = &CreateHush_CreateHush_Hush_Integrations_Edges{}
+	}
+	return t.Node
+}
+
+type CreateHush_CreateHush_Hush_Integrations struct {
+	Edges []*CreateHush_CreateHush_Hush_Integrations_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateHush_CreateHush_Hush_Integrations) GetEdges() []*CreateHush_CreateHush_Hush_Integrations_Edges {
 	if t == nil {
 		t = &CreateHush_CreateHush_Hush_Integrations{}
 	}
+	return t.Edges
+}
+
+type CreateHush_CreateHush_Hush_Organization_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *CreateHush_CreateHush_Hush_Organization_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateHush_CreateHush_Hush_Organization_Edges_Node{}
+	}
 	return t.ID
+}
+
+type CreateHush_CreateHush_Hush_Organization_Edges struct {
+	Node *CreateHush_CreateHush_Hush_Organization_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateHush_CreateHush_Hush_Organization_Edges) GetNode() *CreateHush_CreateHush_Hush_Organization_Edges_Node {
+	if t == nil {
+		t = &CreateHush_CreateHush_Hush_Organization_Edges{}
+	}
+	return t.Node
 }
 
 type CreateHush_CreateHush_Hush_Organization struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*CreateHush_CreateHush_Hush_Organization_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateHush_CreateHush_Hush_Organization) GetID() string {
+func (t *CreateHush_CreateHush_Hush_Organization) GetEdges() []*CreateHush_CreateHush_Hush_Organization_Edges {
 	if t == nil {
 		t = &CreateHush_CreateHush_Hush_Organization{}
 	}
-	return t.ID
+	return t.Edges
 }
 
-type CreateHush_CreateHush_Hush_Events struct {
+type CreateHush_CreateHush_Hush_Events_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *CreateHush_CreateHush_Hush_Events) GetID() string {
+func (t *CreateHush_CreateHush_Hush_Events_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateHush_CreateHush_Hush_Events{}
+		t = &CreateHush_CreateHush_Hush_Events_Edges_Node{}
 	}
 	return t.ID
 }
 
+type CreateHush_CreateHush_Hush_Events_Edges struct {
+	Node *CreateHush_CreateHush_Hush_Events_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateHush_CreateHush_Hush_Events_Edges) GetNode() *CreateHush_CreateHush_Hush_Events_Edges_Node {
+	if t == nil {
+		t = &CreateHush_CreateHush_Hush_Events_Edges{}
+	}
+	return t.Node
+}
+
+type CreateHush_CreateHush_Hush_Events struct {
+	Edges []*CreateHush_CreateHush_Hush_Events_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateHush_CreateHush_Hush_Events) GetEdges() []*CreateHush_CreateHush_Hush_Events_Edges {
+	if t == nil {
+		t = &CreateHush_CreateHush_Hush_Events{}
+	}
+	return t.Edges
+}
+
 type CreateHush_CreateHush_Hush struct {
-	Description  *string                                    "json:\"description,omitempty\" graphql:\"description\""
-	Events       []*CreateHush_CreateHush_Hush_Events       "json:\"events,omitempty\" graphql:\"events\""
-	ID           string                                     "json:\"id\" graphql:\"id\""
-	Integrations []*CreateHush_CreateHush_Hush_Integrations "json:\"integrations,omitempty\" graphql:\"integrations\""
-	Kind         *string                                    "json:\"kind,omitempty\" graphql:\"kind\""
-	Name         string                                     "json:\"name\" graphql:\"name\""
-	Organization []*CreateHush_CreateHush_Hush_Organization "json:\"organization,omitempty\" graphql:\"organization\""
-	SecretName   *string                                    "json:\"secretName,omitempty\" graphql:\"secretName\""
+	Description  *string                                 "json:\"description,omitempty\" graphql:\"description\""
+	Events       CreateHush_CreateHush_Hush_Events       "json:\"events\" graphql:\"events\""
+	ID           string                                  "json:\"id\" graphql:\"id\""
+	Integrations CreateHush_CreateHush_Hush_Integrations "json:\"integrations\" graphql:\"integrations\""
+	Kind         *string                                 "json:\"kind,omitempty\" graphql:\"kind\""
+	Name         string                                  "json:\"name\" graphql:\"name\""
+	Organization CreateHush_CreateHush_Hush_Organization "json:\"organization\" graphql:\"organization\""
+	SecretName   *string                                 "json:\"secretName,omitempty\" graphql:\"secretName\""
 }
 
 func (t *CreateHush_CreateHush_Hush) GetDescription() *string {
@@ -22571,11 +25123,11 @@ func (t *CreateHush_CreateHush_Hush) GetDescription() *string {
 	}
 	return t.Description
 }
-func (t *CreateHush_CreateHush_Hush) GetEvents() []*CreateHush_CreateHush_Hush_Events {
+func (t *CreateHush_CreateHush_Hush) GetEvents() *CreateHush_CreateHush_Hush_Events {
 	if t == nil {
 		t = &CreateHush_CreateHush_Hush{}
 	}
-	return t.Events
+	return &t.Events
 }
 func (t *CreateHush_CreateHush_Hush) GetID() string {
 	if t == nil {
@@ -22583,11 +25135,11 @@ func (t *CreateHush_CreateHush_Hush) GetID() string {
 	}
 	return t.ID
 }
-func (t *CreateHush_CreateHush_Hush) GetIntegrations() []*CreateHush_CreateHush_Hush_Integrations {
+func (t *CreateHush_CreateHush_Hush) GetIntegrations() *CreateHush_CreateHush_Hush_Integrations {
 	if t == nil {
 		t = &CreateHush_CreateHush_Hush{}
 	}
-	return t.Integrations
+	return &t.Integrations
 }
 func (t *CreateHush_CreateHush_Hush) GetKind() *string {
 	if t == nil {
@@ -22601,11 +25153,11 @@ func (t *CreateHush_CreateHush_Hush) GetName() string {
 	}
 	return t.Name
 }
-func (t *CreateHush_CreateHush_Hush) GetOrganization() []*CreateHush_CreateHush_Hush_Organization {
+func (t *CreateHush_CreateHush_Hush) GetOrganization() *CreateHush_CreateHush_Hush_Organization {
 	if t == nil {
 		t = &CreateHush_CreateHush_Hush{}
 	}
-	return t.Organization
+	return &t.Organization
 }
 func (t *CreateHush_CreateHush_Hush) GetSecretName() *string {
 	if t == nil {
@@ -22625,52 +25177,118 @@ func (t *CreateHush_CreateHush) GetHush() *CreateHush_CreateHush_Hush {
 	return &t.Hush
 }
 
-type GetAllHushes_Hushes_Edges_Node_Integrations struct {
+type GetAllHushes_Hushes_Edges_Node_Integrations_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *GetAllHushes_Hushes_Edges_Node_Integrations) GetID() string {
+func (t *GetAllHushes_Hushes_Edges_Node_Integrations_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetAllHushes_Hushes_Edges_Node_Integrations_Edges_Node{}
+	}
+	return t.ID
+}
+
+type GetAllHushes_Hushes_Edges_Node_Integrations_Edges struct {
+	Node *GetAllHushes_Hushes_Edges_Node_Integrations_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllHushes_Hushes_Edges_Node_Integrations_Edges) GetNode() *GetAllHushes_Hushes_Edges_Node_Integrations_Edges_Node {
+	if t == nil {
+		t = &GetAllHushes_Hushes_Edges_Node_Integrations_Edges{}
+	}
+	return t.Node
+}
+
+type GetAllHushes_Hushes_Edges_Node_Integrations struct {
+	Edges []*GetAllHushes_Hushes_Edges_Node_Integrations_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetAllHushes_Hushes_Edges_Node_Integrations) GetEdges() []*GetAllHushes_Hushes_Edges_Node_Integrations_Edges {
 	if t == nil {
 		t = &GetAllHushes_Hushes_Edges_Node_Integrations{}
 	}
+	return t.Edges
+}
+
+type GetAllHushes_Hushes_Edges_Node_Organization_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *GetAllHushes_Hushes_Edges_Node_Organization_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetAllHushes_Hushes_Edges_Node_Organization_Edges_Node{}
+	}
 	return t.ID
+}
+
+type GetAllHushes_Hushes_Edges_Node_Organization_Edges struct {
+	Node *GetAllHushes_Hushes_Edges_Node_Organization_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllHushes_Hushes_Edges_Node_Organization_Edges) GetNode() *GetAllHushes_Hushes_Edges_Node_Organization_Edges_Node {
+	if t == nil {
+		t = &GetAllHushes_Hushes_Edges_Node_Organization_Edges{}
+	}
+	return t.Node
 }
 
 type GetAllHushes_Hushes_Edges_Node_Organization struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*GetAllHushes_Hushes_Edges_Node_Organization_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *GetAllHushes_Hushes_Edges_Node_Organization) GetID() string {
+func (t *GetAllHushes_Hushes_Edges_Node_Organization) GetEdges() []*GetAllHushes_Hushes_Edges_Node_Organization_Edges {
 	if t == nil {
 		t = &GetAllHushes_Hushes_Edges_Node_Organization{}
 	}
-	return t.ID
+	return t.Edges
 }
 
-type GetAllHushes_Hushes_Edges_Node_Events struct {
+type GetAllHushes_Hushes_Edges_Node_Events_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *GetAllHushes_Hushes_Edges_Node_Events) GetID() string {
+func (t *GetAllHushes_Hushes_Edges_Node_Events_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetAllHushes_Hushes_Edges_Node_Events{}
+		t = &GetAllHushes_Hushes_Edges_Node_Events_Edges_Node{}
 	}
 	return t.ID
 }
 
+type GetAllHushes_Hushes_Edges_Node_Events_Edges struct {
+	Node *GetAllHushes_Hushes_Edges_Node_Events_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllHushes_Hushes_Edges_Node_Events_Edges) GetNode() *GetAllHushes_Hushes_Edges_Node_Events_Edges_Node {
+	if t == nil {
+		t = &GetAllHushes_Hushes_Edges_Node_Events_Edges{}
+	}
+	return t.Node
+}
+
+type GetAllHushes_Hushes_Edges_Node_Events struct {
+	Edges []*GetAllHushes_Hushes_Edges_Node_Events_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetAllHushes_Hushes_Edges_Node_Events) GetEdges() []*GetAllHushes_Hushes_Edges_Node_Events_Edges {
+	if t == nil {
+		t = &GetAllHushes_Hushes_Edges_Node_Events{}
+	}
+	return t.Edges
+}
+
 type GetAllHushes_Hushes_Edges_Node struct {
-	CreatedAt    *time.Time                                     "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy    *string                                        "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description  *string                                        "json:\"description,omitempty\" graphql:\"description\""
-	Events       []*GetAllHushes_Hushes_Edges_Node_Events       "json:\"events,omitempty\" graphql:\"events\""
-	ID           string                                         "json:\"id\" graphql:\"id\""
-	Integrations []*GetAllHushes_Hushes_Edges_Node_Integrations "json:\"integrations,omitempty\" graphql:\"integrations\""
-	Kind         *string                                        "json:\"kind,omitempty\" graphql:\"kind\""
-	Name         string                                         "json:\"name\" graphql:\"name\""
-	Organization []*GetAllHushes_Hushes_Edges_Node_Organization "json:\"organization,omitempty\" graphql:\"organization\""
-	SecretName   *string                                        "json:\"secretName,omitempty\" graphql:\"secretName\""
-	UpdatedAt    *time.Time                                     "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy    *string                                        "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	CreatedAt    *time.Time                                  "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy    *string                                     "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description  *string                                     "json:\"description,omitempty\" graphql:\"description\""
+	Events       GetAllHushes_Hushes_Edges_Node_Events       "json:\"events\" graphql:\"events\""
+	ID           string                                      "json:\"id\" graphql:\"id\""
+	Integrations GetAllHushes_Hushes_Edges_Node_Integrations "json:\"integrations\" graphql:\"integrations\""
+	Kind         *string                                     "json:\"kind,omitempty\" graphql:\"kind\""
+	Name         string                                      "json:\"name\" graphql:\"name\""
+	Organization GetAllHushes_Hushes_Edges_Node_Organization "json:\"organization\" graphql:\"organization\""
+	SecretName   *string                                     "json:\"secretName,omitempty\" graphql:\"secretName\""
+	UpdatedAt    *time.Time                                  "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy    *string                                     "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *GetAllHushes_Hushes_Edges_Node) GetCreatedAt() *time.Time {
@@ -22691,11 +25309,11 @@ func (t *GetAllHushes_Hushes_Edges_Node) GetDescription() *string {
 	}
 	return t.Description
 }
-func (t *GetAllHushes_Hushes_Edges_Node) GetEvents() []*GetAllHushes_Hushes_Edges_Node_Events {
+func (t *GetAllHushes_Hushes_Edges_Node) GetEvents() *GetAllHushes_Hushes_Edges_Node_Events {
 	if t == nil {
 		t = &GetAllHushes_Hushes_Edges_Node{}
 	}
-	return t.Events
+	return &t.Events
 }
 func (t *GetAllHushes_Hushes_Edges_Node) GetID() string {
 	if t == nil {
@@ -22703,11 +25321,11 @@ func (t *GetAllHushes_Hushes_Edges_Node) GetID() string {
 	}
 	return t.ID
 }
-func (t *GetAllHushes_Hushes_Edges_Node) GetIntegrations() []*GetAllHushes_Hushes_Edges_Node_Integrations {
+func (t *GetAllHushes_Hushes_Edges_Node) GetIntegrations() *GetAllHushes_Hushes_Edges_Node_Integrations {
 	if t == nil {
 		t = &GetAllHushes_Hushes_Edges_Node{}
 	}
-	return t.Integrations
+	return &t.Integrations
 }
 func (t *GetAllHushes_Hushes_Edges_Node) GetKind() *string {
 	if t == nil {
@@ -22721,11 +25339,11 @@ func (t *GetAllHushes_Hushes_Edges_Node) GetName() string {
 	}
 	return t.Name
 }
-func (t *GetAllHushes_Hushes_Edges_Node) GetOrganization() []*GetAllHushes_Hushes_Edges_Node_Organization {
+func (t *GetAllHushes_Hushes_Edges_Node) GetOrganization() *GetAllHushes_Hushes_Edges_Node_Organization {
 	if t == nil {
 		t = &GetAllHushes_Hushes_Edges_Node{}
 	}
-	return t.Organization
+	return &t.Organization
 }
 func (t *GetAllHushes_Hushes_Edges_Node) GetSecretName() *string {
 	if t == nil {
@@ -22768,52 +25386,118 @@ func (t *GetAllHushes_Hushes) GetEdges() []*GetAllHushes_Hushes_Edges {
 	return t.Edges
 }
 
-type GetHushByID_Hush_Integrations struct {
+type GetHushByID_Hush_Integrations_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *GetHushByID_Hush_Integrations) GetID() string {
+func (t *GetHushByID_Hush_Integrations_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetHushByID_Hush_Integrations_Edges_Node{}
+	}
+	return t.ID
+}
+
+type GetHushByID_Hush_Integrations_Edges struct {
+	Node *GetHushByID_Hush_Integrations_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetHushByID_Hush_Integrations_Edges) GetNode() *GetHushByID_Hush_Integrations_Edges_Node {
+	if t == nil {
+		t = &GetHushByID_Hush_Integrations_Edges{}
+	}
+	return t.Node
+}
+
+type GetHushByID_Hush_Integrations struct {
+	Edges []*GetHushByID_Hush_Integrations_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetHushByID_Hush_Integrations) GetEdges() []*GetHushByID_Hush_Integrations_Edges {
 	if t == nil {
 		t = &GetHushByID_Hush_Integrations{}
 	}
+	return t.Edges
+}
+
+type GetHushByID_Hush_Organization_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *GetHushByID_Hush_Organization_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetHushByID_Hush_Organization_Edges_Node{}
+	}
 	return t.ID
+}
+
+type GetHushByID_Hush_Organization_Edges struct {
+	Node *GetHushByID_Hush_Organization_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetHushByID_Hush_Organization_Edges) GetNode() *GetHushByID_Hush_Organization_Edges_Node {
+	if t == nil {
+		t = &GetHushByID_Hush_Organization_Edges{}
+	}
+	return t.Node
 }
 
 type GetHushByID_Hush_Organization struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*GetHushByID_Hush_Organization_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *GetHushByID_Hush_Organization) GetID() string {
+func (t *GetHushByID_Hush_Organization) GetEdges() []*GetHushByID_Hush_Organization_Edges {
 	if t == nil {
 		t = &GetHushByID_Hush_Organization{}
 	}
-	return t.ID
+	return t.Edges
 }
 
-type GetHushByID_Hush_Events struct {
+type GetHushByID_Hush_Events_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *GetHushByID_Hush_Events) GetID() string {
+func (t *GetHushByID_Hush_Events_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetHushByID_Hush_Events{}
+		t = &GetHushByID_Hush_Events_Edges_Node{}
 	}
 	return t.ID
 }
 
+type GetHushByID_Hush_Events_Edges struct {
+	Node *GetHushByID_Hush_Events_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetHushByID_Hush_Events_Edges) GetNode() *GetHushByID_Hush_Events_Edges_Node {
+	if t == nil {
+		t = &GetHushByID_Hush_Events_Edges{}
+	}
+	return t.Node
+}
+
+type GetHushByID_Hush_Events struct {
+	Edges []*GetHushByID_Hush_Events_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetHushByID_Hush_Events) GetEdges() []*GetHushByID_Hush_Events_Edges {
+	if t == nil {
+		t = &GetHushByID_Hush_Events{}
+	}
+	return t.Edges
+}
+
 type GetHushByID_Hush struct {
-	CreatedAt    *time.Time                       "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy    *string                          "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description  *string                          "json:\"description,omitempty\" graphql:\"description\""
-	Events       []*GetHushByID_Hush_Events       "json:\"events,omitempty\" graphql:\"events\""
-	ID           string                           "json:\"id\" graphql:\"id\""
-	Integrations []*GetHushByID_Hush_Integrations "json:\"integrations,omitempty\" graphql:\"integrations\""
-	Kind         *string                          "json:\"kind,omitempty\" graphql:\"kind\""
-	Name         string                           "json:\"name\" graphql:\"name\""
-	Organization []*GetHushByID_Hush_Organization "json:\"organization,omitempty\" graphql:\"organization\""
-	SecretName   *string                          "json:\"secretName,omitempty\" graphql:\"secretName\""
-	UpdatedAt    *time.Time                       "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy    *string                          "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	CreatedAt    *time.Time                    "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy    *string                       "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description  *string                       "json:\"description,omitempty\" graphql:\"description\""
+	Events       GetHushByID_Hush_Events       "json:\"events\" graphql:\"events\""
+	ID           string                        "json:\"id\" graphql:\"id\""
+	Integrations GetHushByID_Hush_Integrations "json:\"integrations\" graphql:\"integrations\""
+	Kind         *string                       "json:\"kind,omitempty\" graphql:\"kind\""
+	Name         string                        "json:\"name\" graphql:\"name\""
+	Organization GetHushByID_Hush_Organization "json:\"organization\" graphql:\"organization\""
+	SecretName   *string                       "json:\"secretName,omitempty\" graphql:\"secretName\""
+	UpdatedAt    *time.Time                    "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy    *string                       "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *GetHushByID_Hush) GetCreatedAt() *time.Time {
@@ -22834,11 +25518,11 @@ func (t *GetHushByID_Hush) GetDescription() *string {
 	}
 	return t.Description
 }
-func (t *GetHushByID_Hush) GetEvents() []*GetHushByID_Hush_Events {
+func (t *GetHushByID_Hush) GetEvents() *GetHushByID_Hush_Events {
 	if t == nil {
 		t = &GetHushByID_Hush{}
 	}
-	return t.Events
+	return &t.Events
 }
 func (t *GetHushByID_Hush) GetID() string {
 	if t == nil {
@@ -22846,11 +25530,11 @@ func (t *GetHushByID_Hush) GetID() string {
 	}
 	return t.ID
 }
-func (t *GetHushByID_Hush) GetIntegrations() []*GetHushByID_Hush_Integrations {
+func (t *GetHushByID_Hush) GetIntegrations() *GetHushByID_Hush_Integrations {
 	if t == nil {
 		t = &GetHushByID_Hush{}
 	}
-	return t.Integrations
+	return &t.Integrations
 }
 func (t *GetHushByID_Hush) GetKind() *string {
 	if t == nil {
@@ -22864,11 +25548,11 @@ func (t *GetHushByID_Hush) GetName() string {
 	}
 	return t.Name
 }
-func (t *GetHushByID_Hush) GetOrganization() []*GetHushByID_Hush_Organization {
+func (t *GetHushByID_Hush) GetOrganization() *GetHushByID_Hush_Organization {
 	if t == nil {
 		t = &GetHushByID_Hush{}
 	}
-	return t.Organization
+	return &t.Organization
 }
 func (t *GetHushByID_Hush) GetSecretName() *string {
 	if t == nil {
@@ -22889,52 +25573,118 @@ func (t *GetHushByID_Hush) GetUpdatedBy() *string {
 	return t.UpdatedBy
 }
 
-type GetHushes_Hushes_Edges_Node_Integrations struct {
+type GetHushes_Hushes_Edges_Node_Integrations_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *GetHushes_Hushes_Edges_Node_Integrations) GetID() string {
+func (t *GetHushes_Hushes_Edges_Node_Integrations_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetHushes_Hushes_Edges_Node_Integrations_Edges_Node{}
+	}
+	return t.ID
+}
+
+type GetHushes_Hushes_Edges_Node_Integrations_Edges struct {
+	Node *GetHushes_Hushes_Edges_Node_Integrations_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetHushes_Hushes_Edges_Node_Integrations_Edges) GetNode() *GetHushes_Hushes_Edges_Node_Integrations_Edges_Node {
+	if t == nil {
+		t = &GetHushes_Hushes_Edges_Node_Integrations_Edges{}
+	}
+	return t.Node
+}
+
+type GetHushes_Hushes_Edges_Node_Integrations struct {
+	Edges []*GetHushes_Hushes_Edges_Node_Integrations_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetHushes_Hushes_Edges_Node_Integrations) GetEdges() []*GetHushes_Hushes_Edges_Node_Integrations_Edges {
 	if t == nil {
 		t = &GetHushes_Hushes_Edges_Node_Integrations{}
 	}
+	return t.Edges
+}
+
+type GetHushes_Hushes_Edges_Node_Organization_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *GetHushes_Hushes_Edges_Node_Organization_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetHushes_Hushes_Edges_Node_Organization_Edges_Node{}
+	}
 	return t.ID
+}
+
+type GetHushes_Hushes_Edges_Node_Organization_Edges struct {
+	Node *GetHushes_Hushes_Edges_Node_Organization_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetHushes_Hushes_Edges_Node_Organization_Edges) GetNode() *GetHushes_Hushes_Edges_Node_Organization_Edges_Node {
+	if t == nil {
+		t = &GetHushes_Hushes_Edges_Node_Organization_Edges{}
+	}
+	return t.Node
 }
 
 type GetHushes_Hushes_Edges_Node_Organization struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*GetHushes_Hushes_Edges_Node_Organization_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *GetHushes_Hushes_Edges_Node_Organization) GetID() string {
+func (t *GetHushes_Hushes_Edges_Node_Organization) GetEdges() []*GetHushes_Hushes_Edges_Node_Organization_Edges {
 	if t == nil {
 		t = &GetHushes_Hushes_Edges_Node_Organization{}
 	}
-	return t.ID
+	return t.Edges
 }
 
-type GetHushes_Hushes_Edges_Node_Events struct {
+type GetHushes_Hushes_Edges_Node_Events_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *GetHushes_Hushes_Edges_Node_Events) GetID() string {
+func (t *GetHushes_Hushes_Edges_Node_Events_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetHushes_Hushes_Edges_Node_Events{}
+		t = &GetHushes_Hushes_Edges_Node_Events_Edges_Node{}
 	}
 	return t.ID
 }
 
+type GetHushes_Hushes_Edges_Node_Events_Edges struct {
+	Node *GetHushes_Hushes_Edges_Node_Events_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetHushes_Hushes_Edges_Node_Events_Edges) GetNode() *GetHushes_Hushes_Edges_Node_Events_Edges_Node {
+	if t == nil {
+		t = &GetHushes_Hushes_Edges_Node_Events_Edges{}
+	}
+	return t.Node
+}
+
+type GetHushes_Hushes_Edges_Node_Events struct {
+	Edges []*GetHushes_Hushes_Edges_Node_Events_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetHushes_Hushes_Edges_Node_Events) GetEdges() []*GetHushes_Hushes_Edges_Node_Events_Edges {
+	if t == nil {
+		t = &GetHushes_Hushes_Edges_Node_Events{}
+	}
+	return t.Edges
+}
+
 type GetHushes_Hushes_Edges_Node struct {
-	CreatedAt    *time.Time                                  "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy    *string                                     "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description  *string                                     "json:\"description,omitempty\" graphql:\"description\""
-	Events       []*GetHushes_Hushes_Edges_Node_Events       "json:\"events,omitempty\" graphql:\"events\""
-	ID           string                                      "json:\"id\" graphql:\"id\""
-	Integrations []*GetHushes_Hushes_Edges_Node_Integrations "json:\"integrations,omitempty\" graphql:\"integrations\""
-	Kind         *string                                     "json:\"kind,omitempty\" graphql:\"kind\""
-	Name         string                                      "json:\"name\" graphql:\"name\""
-	Organization []*GetHushes_Hushes_Edges_Node_Organization "json:\"organization,omitempty\" graphql:\"organization\""
-	SecretName   *string                                     "json:\"secretName,omitempty\" graphql:\"secretName\""
-	UpdatedAt    *time.Time                                  "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy    *string                                     "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	CreatedAt    *time.Time                               "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy    *string                                  "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description  *string                                  "json:\"description,omitempty\" graphql:\"description\""
+	Events       GetHushes_Hushes_Edges_Node_Events       "json:\"events\" graphql:\"events\""
+	ID           string                                   "json:\"id\" graphql:\"id\""
+	Integrations GetHushes_Hushes_Edges_Node_Integrations "json:\"integrations\" graphql:\"integrations\""
+	Kind         *string                                  "json:\"kind,omitempty\" graphql:\"kind\""
+	Name         string                                   "json:\"name\" graphql:\"name\""
+	Organization GetHushes_Hushes_Edges_Node_Organization "json:\"organization\" graphql:\"organization\""
+	SecretName   *string                                  "json:\"secretName,omitempty\" graphql:\"secretName\""
+	UpdatedAt    *time.Time                               "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy    *string                                  "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *GetHushes_Hushes_Edges_Node) GetCreatedAt() *time.Time {
@@ -22955,11 +25705,11 @@ func (t *GetHushes_Hushes_Edges_Node) GetDescription() *string {
 	}
 	return t.Description
 }
-func (t *GetHushes_Hushes_Edges_Node) GetEvents() []*GetHushes_Hushes_Edges_Node_Events {
+func (t *GetHushes_Hushes_Edges_Node) GetEvents() *GetHushes_Hushes_Edges_Node_Events {
 	if t == nil {
 		t = &GetHushes_Hushes_Edges_Node{}
 	}
-	return t.Events
+	return &t.Events
 }
 func (t *GetHushes_Hushes_Edges_Node) GetID() string {
 	if t == nil {
@@ -22967,11 +25717,11 @@ func (t *GetHushes_Hushes_Edges_Node) GetID() string {
 	}
 	return t.ID
 }
-func (t *GetHushes_Hushes_Edges_Node) GetIntegrations() []*GetHushes_Hushes_Edges_Node_Integrations {
+func (t *GetHushes_Hushes_Edges_Node) GetIntegrations() *GetHushes_Hushes_Edges_Node_Integrations {
 	if t == nil {
 		t = &GetHushes_Hushes_Edges_Node{}
 	}
-	return t.Integrations
+	return &t.Integrations
 }
 func (t *GetHushes_Hushes_Edges_Node) GetKind() *string {
 	if t == nil {
@@ -22985,11 +25735,11 @@ func (t *GetHushes_Hushes_Edges_Node) GetName() string {
 	}
 	return t.Name
 }
-func (t *GetHushes_Hushes_Edges_Node) GetOrganization() []*GetHushes_Hushes_Edges_Node_Organization {
+func (t *GetHushes_Hushes_Edges_Node) GetOrganization() *GetHushes_Hushes_Edges_Node_Organization {
 	if t == nil {
 		t = &GetHushes_Hushes_Edges_Node{}
 	}
-	return t.Organization
+	return &t.Organization
 }
 func (t *GetHushes_Hushes_Edges_Node) GetSecretName() *string {
 	if t == nil {
@@ -23032,48 +25782,114 @@ func (t *GetHushes_Hushes) GetEdges() []*GetHushes_Hushes_Edges {
 	return t.Edges
 }
 
-type UpdateHush_UpdateHush_Hush_Integrations struct {
+type UpdateHush_UpdateHush_Hush_Integrations_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *UpdateHush_UpdateHush_Hush_Integrations) GetID() string {
+func (t *UpdateHush_UpdateHush_Hush_Integrations_Edges_Node) GetID() string {
+	if t == nil {
+		t = &UpdateHush_UpdateHush_Hush_Integrations_Edges_Node{}
+	}
+	return t.ID
+}
+
+type UpdateHush_UpdateHush_Hush_Integrations_Edges struct {
+	Node *UpdateHush_UpdateHush_Hush_Integrations_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateHush_UpdateHush_Hush_Integrations_Edges) GetNode() *UpdateHush_UpdateHush_Hush_Integrations_Edges_Node {
+	if t == nil {
+		t = &UpdateHush_UpdateHush_Hush_Integrations_Edges{}
+	}
+	return t.Node
+}
+
+type UpdateHush_UpdateHush_Hush_Integrations struct {
+	Edges []*UpdateHush_UpdateHush_Hush_Integrations_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *UpdateHush_UpdateHush_Hush_Integrations) GetEdges() []*UpdateHush_UpdateHush_Hush_Integrations_Edges {
 	if t == nil {
 		t = &UpdateHush_UpdateHush_Hush_Integrations{}
 	}
+	return t.Edges
+}
+
+type UpdateHush_UpdateHush_Hush_Organization_Edges_Node struct {
+	ID string "json:\"id\" graphql:\"id\""
+}
+
+func (t *UpdateHush_UpdateHush_Hush_Organization_Edges_Node) GetID() string {
+	if t == nil {
+		t = &UpdateHush_UpdateHush_Hush_Organization_Edges_Node{}
+	}
 	return t.ID
+}
+
+type UpdateHush_UpdateHush_Hush_Organization_Edges struct {
+	Node *UpdateHush_UpdateHush_Hush_Organization_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateHush_UpdateHush_Hush_Organization_Edges) GetNode() *UpdateHush_UpdateHush_Hush_Organization_Edges_Node {
+	if t == nil {
+		t = &UpdateHush_UpdateHush_Hush_Organization_Edges{}
+	}
+	return t.Node
 }
 
 type UpdateHush_UpdateHush_Hush_Organization struct {
-	ID string "json:\"id\" graphql:\"id\""
+	Edges []*UpdateHush_UpdateHush_Hush_Organization_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *UpdateHush_UpdateHush_Hush_Organization) GetID() string {
+func (t *UpdateHush_UpdateHush_Hush_Organization) GetEdges() []*UpdateHush_UpdateHush_Hush_Organization_Edges {
 	if t == nil {
 		t = &UpdateHush_UpdateHush_Hush_Organization{}
 	}
-	return t.ID
+	return t.Edges
 }
 
-type UpdateHush_UpdateHush_Hush_Events struct {
+type UpdateHush_UpdateHush_Hush_Events_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *UpdateHush_UpdateHush_Hush_Events) GetID() string {
+func (t *UpdateHush_UpdateHush_Hush_Events_Edges_Node) GetID() string {
 	if t == nil {
-		t = &UpdateHush_UpdateHush_Hush_Events{}
+		t = &UpdateHush_UpdateHush_Hush_Events_Edges_Node{}
 	}
 	return t.ID
 }
 
+type UpdateHush_UpdateHush_Hush_Events_Edges struct {
+	Node *UpdateHush_UpdateHush_Hush_Events_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateHush_UpdateHush_Hush_Events_Edges) GetNode() *UpdateHush_UpdateHush_Hush_Events_Edges_Node {
+	if t == nil {
+		t = &UpdateHush_UpdateHush_Hush_Events_Edges{}
+	}
+	return t.Node
+}
+
+type UpdateHush_UpdateHush_Hush_Events struct {
+	Edges []*UpdateHush_UpdateHush_Hush_Events_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *UpdateHush_UpdateHush_Hush_Events) GetEdges() []*UpdateHush_UpdateHush_Hush_Events_Edges {
+	if t == nil {
+		t = &UpdateHush_UpdateHush_Hush_Events{}
+	}
+	return t.Edges
+}
+
 type UpdateHush_UpdateHush_Hush struct {
-	Description  *string                                    "json:\"description,omitempty\" graphql:\"description\""
-	Events       []*UpdateHush_UpdateHush_Hush_Events       "json:\"events,omitempty\" graphql:\"events\""
-	ID           string                                     "json:\"id\" graphql:\"id\""
-	Integrations []*UpdateHush_UpdateHush_Hush_Integrations "json:\"integrations,omitempty\" graphql:\"integrations\""
-	Kind         *string                                    "json:\"kind,omitempty\" graphql:\"kind\""
-	Name         string                                     "json:\"name\" graphql:\"name\""
-	Organization []*UpdateHush_UpdateHush_Hush_Organization "json:\"organization,omitempty\" graphql:\"organization\""
-	SecretName   *string                                    "json:\"secretName,omitempty\" graphql:\"secretName\""
+	Description  *string                                 "json:\"description,omitempty\" graphql:\"description\""
+	Events       UpdateHush_UpdateHush_Hush_Events       "json:\"events\" graphql:\"events\""
+	ID           string                                  "json:\"id\" graphql:\"id\""
+	Integrations UpdateHush_UpdateHush_Hush_Integrations "json:\"integrations\" graphql:\"integrations\""
+	Kind         *string                                 "json:\"kind,omitempty\" graphql:\"kind\""
+	Name         string                                  "json:\"name\" graphql:\"name\""
+	Organization UpdateHush_UpdateHush_Hush_Organization "json:\"organization\" graphql:\"organization\""
+	SecretName   *string                                 "json:\"secretName,omitempty\" graphql:\"secretName\""
 }
 
 func (t *UpdateHush_UpdateHush_Hush) GetDescription() *string {
@@ -23082,11 +25898,11 @@ func (t *UpdateHush_UpdateHush_Hush) GetDescription() *string {
 	}
 	return t.Description
 }
-func (t *UpdateHush_UpdateHush_Hush) GetEvents() []*UpdateHush_UpdateHush_Hush_Events {
+func (t *UpdateHush_UpdateHush_Hush) GetEvents() *UpdateHush_UpdateHush_Hush_Events {
 	if t == nil {
 		t = &UpdateHush_UpdateHush_Hush{}
 	}
-	return t.Events
+	return &t.Events
 }
 func (t *UpdateHush_UpdateHush_Hush) GetID() string {
 	if t == nil {
@@ -23094,11 +25910,11 @@ func (t *UpdateHush_UpdateHush_Hush) GetID() string {
 	}
 	return t.ID
 }
-func (t *UpdateHush_UpdateHush_Hush) GetIntegrations() []*UpdateHush_UpdateHush_Hush_Integrations {
+func (t *UpdateHush_UpdateHush_Hush) GetIntegrations() *UpdateHush_UpdateHush_Hush_Integrations {
 	if t == nil {
 		t = &UpdateHush_UpdateHush_Hush{}
 	}
-	return t.Integrations
+	return &t.Integrations
 }
 func (t *UpdateHush_UpdateHush_Hush) GetKind() *string {
 	if t == nil {
@@ -23112,11 +25928,11 @@ func (t *UpdateHush_UpdateHush_Hush) GetName() string {
 	}
 	return t.Name
 }
-func (t *UpdateHush_UpdateHush_Hush) GetOrganization() []*UpdateHush_UpdateHush_Hush_Organization {
+func (t *UpdateHush_UpdateHush_Hush) GetOrganization() *UpdateHush_UpdateHush_Hush_Organization {
 	if t == nil {
 		t = &UpdateHush_UpdateHush_Hush{}
 	}
-	return t.Organization
+	return &t.Organization
 }
 func (t *UpdateHush_UpdateHush_Hush) GetSecretName() *string {
 	if t == nil {
@@ -23367,37 +26183,81 @@ func (t *CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Owner) G
 	return t.ID
 }
 
-type CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Secrets struct {
+type CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Secrets_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Secrets) GetID() string {
+func (t *CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Secrets_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Secrets_Edges_Node{}
+	}
+	return t.ID
+}
+
+type CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Secrets_Edges struct {
+	Node *CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Secrets_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Secrets_Edges) GetNode() *CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Secrets_Edges_Node {
+	if t == nil {
+		t = &CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Secrets_Edges{}
+	}
+	return t.Node
+}
+
+type CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Secrets struct {
+	Edges []*CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Secrets_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Secrets) GetEdges() []*CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Secrets_Edges {
 	if t == nil {
 		t = &CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Secrets{}
 	}
-	return t.ID
+	return t.Edges
 }
 
-type CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Events struct {
+type CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Events_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Events) GetID() string {
+func (t *CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Events_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Events{}
+		t = &CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Events_Edges_Node{}
 	}
 	return t.ID
 }
 
+type CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Events_Edges struct {
+	Node *CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Events_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Events_Edges) GetNode() *CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Events_Edges_Node {
+	if t == nil {
+		t = &CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Events_Edges{}
+	}
+	return t.Node
+}
+
+type CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Events struct {
+	Edges []*CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Events_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Events) GetEdges() []*CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Events_Edges {
+	if t == nil {
+		t = &CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Events{}
+	}
+	return t.Edges
+}
+
 type CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations struct {
-	Description *string                                                                   "json:\"description,omitempty\" graphql:\"description\""
-	Events      []*CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Events  "json:\"events,omitempty\" graphql:\"events\""
-	ID          string                                                                    "json:\"id\" graphql:\"id\""
-	Kind        *string                                                                   "json:\"kind,omitempty\" graphql:\"kind\""
-	Name        string                                                                    "json:\"name\" graphql:\"name\""
-	Owner       *CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Owner     "json:\"owner,omitempty\" graphql:\"owner\""
-	OwnerID     *string                                                                   "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Secrets     []*CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Secrets "json:\"secrets,omitempty\" graphql:\"secrets\""
+	Description *string                                                                "json:\"description,omitempty\" graphql:\"description\""
+	Events      CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Events  "json:\"events\" graphql:\"events\""
+	ID          string                                                                 "json:\"id\" graphql:\"id\""
+	Kind        *string                                                                "json:\"kind,omitempty\" graphql:\"kind\""
+	Name        string                                                                 "json:\"name\" graphql:\"name\""
+	Owner       *CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Owner  "json:\"owner,omitempty\" graphql:\"owner\""
+	OwnerID     *string                                                                "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	Secrets     CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Secrets "json:\"secrets\" graphql:\"secrets\""
 }
 
 func (t *CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations) GetDescription() *string {
@@ -23406,11 +26266,11 @@ func (t *CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations) GetDesc
 	}
 	return t.Description
 }
-func (t *CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations) GetEvents() []*CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Events {
+func (t *CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations) GetEvents() *CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Events {
 	if t == nil {
 		t = &CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations{}
 	}
-	return t.Events
+	return &t.Events
 }
 func (t *CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations) GetID() string {
 	if t == nil {
@@ -23442,11 +26302,11 @@ func (t *CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations) GetOwne
 	}
 	return t.OwnerID
 }
-func (t *CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations) GetSecrets() []*CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Secrets {
+func (t *CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations) GetSecrets() *CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations_Secrets {
 	if t == nil {
 		t = &CreateBulkCSVIntegration_CreateBulkCSVIntegration_Integrations{}
 	}
-	return t.Secrets
+	return &t.Secrets
 }
 
 type CreateBulkCSVIntegration_CreateBulkCSVIntegration struct {
@@ -23471,37 +26331,81 @@ func (t *CreateBulkIntegration_CreateBulkIntegration_Integrations_Owner) GetID()
 	return t.ID
 }
 
-type CreateBulkIntegration_CreateBulkIntegration_Integrations_Secrets struct {
+type CreateBulkIntegration_CreateBulkIntegration_Integrations_Secrets_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *CreateBulkIntegration_CreateBulkIntegration_Integrations_Secrets) GetID() string {
+func (t *CreateBulkIntegration_CreateBulkIntegration_Integrations_Secrets_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateBulkIntegration_CreateBulkIntegration_Integrations_Secrets_Edges_Node{}
+	}
+	return t.ID
+}
+
+type CreateBulkIntegration_CreateBulkIntegration_Integrations_Secrets_Edges struct {
+	Node *CreateBulkIntegration_CreateBulkIntegration_Integrations_Secrets_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkIntegration_CreateBulkIntegration_Integrations_Secrets_Edges) GetNode() *CreateBulkIntegration_CreateBulkIntegration_Integrations_Secrets_Edges_Node {
+	if t == nil {
+		t = &CreateBulkIntegration_CreateBulkIntegration_Integrations_Secrets_Edges{}
+	}
+	return t.Node
+}
+
+type CreateBulkIntegration_CreateBulkIntegration_Integrations_Secrets struct {
+	Edges []*CreateBulkIntegration_CreateBulkIntegration_Integrations_Secrets_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateBulkIntegration_CreateBulkIntegration_Integrations_Secrets) GetEdges() []*CreateBulkIntegration_CreateBulkIntegration_Integrations_Secrets_Edges {
 	if t == nil {
 		t = &CreateBulkIntegration_CreateBulkIntegration_Integrations_Secrets{}
 	}
-	return t.ID
+	return t.Edges
 }
 
-type CreateBulkIntegration_CreateBulkIntegration_Integrations_Events struct {
+type CreateBulkIntegration_CreateBulkIntegration_Integrations_Events_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *CreateBulkIntegration_CreateBulkIntegration_Integrations_Events) GetID() string {
+func (t *CreateBulkIntegration_CreateBulkIntegration_Integrations_Events_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateBulkIntegration_CreateBulkIntegration_Integrations_Events{}
+		t = &CreateBulkIntegration_CreateBulkIntegration_Integrations_Events_Edges_Node{}
 	}
 	return t.ID
 }
 
+type CreateBulkIntegration_CreateBulkIntegration_Integrations_Events_Edges struct {
+	Node *CreateBulkIntegration_CreateBulkIntegration_Integrations_Events_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkIntegration_CreateBulkIntegration_Integrations_Events_Edges) GetNode() *CreateBulkIntegration_CreateBulkIntegration_Integrations_Events_Edges_Node {
+	if t == nil {
+		t = &CreateBulkIntegration_CreateBulkIntegration_Integrations_Events_Edges{}
+	}
+	return t.Node
+}
+
+type CreateBulkIntegration_CreateBulkIntegration_Integrations_Events struct {
+	Edges []*CreateBulkIntegration_CreateBulkIntegration_Integrations_Events_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateBulkIntegration_CreateBulkIntegration_Integrations_Events) GetEdges() []*CreateBulkIntegration_CreateBulkIntegration_Integrations_Events_Edges {
+	if t == nil {
+		t = &CreateBulkIntegration_CreateBulkIntegration_Integrations_Events{}
+	}
+	return t.Edges
+}
+
 type CreateBulkIntegration_CreateBulkIntegration_Integrations struct {
-	Description *string                                                             "json:\"description,omitempty\" graphql:\"description\""
-	Events      []*CreateBulkIntegration_CreateBulkIntegration_Integrations_Events  "json:\"events,omitempty\" graphql:\"events\""
-	ID          string                                                              "json:\"id\" graphql:\"id\""
-	Kind        *string                                                             "json:\"kind,omitempty\" graphql:\"kind\""
-	Name        string                                                              "json:\"name\" graphql:\"name\""
-	Owner       *CreateBulkIntegration_CreateBulkIntegration_Integrations_Owner     "json:\"owner,omitempty\" graphql:\"owner\""
-	OwnerID     *string                                                             "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Secrets     []*CreateBulkIntegration_CreateBulkIntegration_Integrations_Secrets "json:\"secrets,omitempty\" graphql:\"secrets\""
+	Description *string                                                          "json:\"description,omitempty\" graphql:\"description\""
+	Events      CreateBulkIntegration_CreateBulkIntegration_Integrations_Events  "json:\"events\" graphql:\"events\""
+	ID          string                                                           "json:\"id\" graphql:\"id\""
+	Kind        *string                                                          "json:\"kind,omitempty\" graphql:\"kind\""
+	Name        string                                                           "json:\"name\" graphql:\"name\""
+	Owner       *CreateBulkIntegration_CreateBulkIntegration_Integrations_Owner  "json:\"owner,omitempty\" graphql:\"owner\""
+	OwnerID     *string                                                          "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	Secrets     CreateBulkIntegration_CreateBulkIntegration_Integrations_Secrets "json:\"secrets\" graphql:\"secrets\""
 }
 
 func (t *CreateBulkIntegration_CreateBulkIntegration_Integrations) GetDescription() *string {
@@ -23510,11 +26414,11 @@ func (t *CreateBulkIntegration_CreateBulkIntegration_Integrations) GetDescriptio
 	}
 	return t.Description
 }
-func (t *CreateBulkIntegration_CreateBulkIntegration_Integrations) GetEvents() []*CreateBulkIntegration_CreateBulkIntegration_Integrations_Events {
+func (t *CreateBulkIntegration_CreateBulkIntegration_Integrations) GetEvents() *CreateBulkIntegration_CreateBulkIntegration_Integrations_Events {
 	if t == nil {
 		t = &CreateBulkIntegration_CreateBulkIntegration_Integrations{}
 	}
-	return t.Events
+	return &t.Events
 }
 func (t *CreateBulkIntegration_CreateBulkIntegration_Integrations) GetID() string {
 	if t == nil {
@@ -23546,11 +26450,11 @@ func (t *CreateBulkIntegration_CreateBulkIntegration_Integrations) GetOwnerID() 
 	}
 	return t.OwnerID
 }
-func (t *CreateBulkIntegration_CreateBulkIntegration_Integrations) GetSecrets() []*CreateBulkIntegration_CreateBulkIntegration_Integrations_Secrets {
+func (t *CreateBulkIntegration_CreateBulkIntegration_Integrations) GetSecrets() *CreateBulkIntegration_CreateBulkIntegration_Integrations_Secrets {
 	if t == nil {
 		t = &CreateBulkIntegration_CreateBulkIntegration_Integrations{}
 	}
-	return t.Secrets
+	return &t.Secrets
 }
 
 type CreateBulkIntegration_CreateBulkIntegration struct {
@@ -23575,37 +26479,81 @@ func (t *CreateIntegration_CreateIntegration_Integration_Owner) GetID() string {
 	return t.ID
 }
 
-type CreateIntegration_CreateIntegration_Integration_Secrets struct {
+type CreateIntegration_CreateIntegration_Integration_Secrets_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *CreateIntegration_CreateIntegration_Integration_Secrets) GetID() string {
+func (t *CreateIntegration_CreateIntegration_Integration_Secrets_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateIntegration_CreateIntegration_Integration_Secrets_Edges_Node{}
+	}
+	return t.ID
+}
+
+type CreateIntegration_CreateIntegration_Integration_Secrets_Edges struct {
+	Node *CreateIntegration_CreateIntegration_Integration_Secrets_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateIntegration_CreateIntegration_Integration_Secrets_Edges) GetNode() *CreateIntegration_CreateIntegration_Integration_Secrets_Edges_Node {
+	if t == nil {
+		t = &CreateIntegration_CreateIntegration_Integration_Secrets_Edges{}
+	}
+	return t.Node
+}
+
+type CreateIntegration_CreateIntegration_Integration_Secrets struct {
+	Edges []*CreateIntegration_CreateIntegration_Integration_Secrets_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateIntegration_CreateIntegration_Integration_Secrets) GetEdges() []*CreateIntegration_CreateIntegration_Integration_Secrets_Edges {
 	if t == nil {
 		t = &CreateIntegration_CreateIntegration_Integration_Secrets{}
 	}
-	return t.ID
+	return t.Edges
 }
 
-type CreateIntegration_CreateIntegration_Integration_Events struct {
+type CreateIntegration_CreateIntegration_Integration_Events_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *CreateIntegration_CreateIntegration_Integration_Events) GetID() string {
+func (t *CreateIntegration_CreateIntegration_Integration_Events_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateIntegration_CreateIntegration_Integration_Events{}
+		t = &CreateIntegration_CreateIntegration_Integration_Events_Edges_Node{}
 	}
 	return t.ID
 }
 
+type CreateIntegration_CreateIntegration_Integration_Events_Edges struct {
+	Node *CreateIntegration_CreateIntegration_Integration_Events_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateIntegration_CreateIntegration_Integration_Events_Edges) GetNode() *CreateIntegration_CreateIntegration_Integration_Events_Edges_Node {
+	if t == nil {
+		t = &CreateIntegration_CreateIntegration_Integration_Events_Edges{}
+	}
+	return t.Node
+}
+
+type CreateIntegration_CreateIntegration_Integration_Events struct {
+	Edges []*CreateIntegration_CreateIntegration_Integration_Events_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateIntegration_CreateIntegration_Integration_Events) GetEdges() []*CreateIntegration_CreateIntegration_Integration_Events_Edges {
+	if t == nil {
+		t = &CreateIntegration_CreateIntegration_Integration_Events{}
+	}
+	return t.Edges
+}
+
 type CreateIntegration_CreateIntegration_Integration struct {
-	Description *string                                                    "json:\"description,omitempty\" graphql:\"description\""
-	Events      []*CreateIntegration_CreateIntegration_Integration_Events  "json:\"events,omitempty\" graphql:\"events\""
-	ID          string                                                     "json:\"id\" graphql:\"id\""
-	Kind        *string                                                    "json:\"kind,omitempty\" graphql:\"kind\""
-	Name        string                                                     "json:\"name\" graphql:\"name\""
-	Owner       *CreateIntegration_CreateIntegration_Integration_Owner     "json:\"owner,omitempty\" graphql:\"owner\""
-	OwnerID     *string                                                    "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Secrets     []*CreateIntegration_CreateIntegration_Integration_Secrets "json:\"secrets,omitempty\" graphql:\"secrets\""
+	Description *string                                                 "json:\"description,omitempty\" graphql:\"description\""
+	Events      CreateIntegration_CreateIntegration_Integration_Events  "json:\"events\" graphql:\"events\""
+	ID          string                                                  "json:\"id\" graphql:\"id\""
+	Kind        *string                                                 "json:\"kind,omitempty\" graphql:\"kind\""
+	Name        string                                                  "json:\"name\" graphql:\"name\""
+	Owner       *CreateIntegration_CreateIntegration_Integration_Owner  "json:\"owner,omitempty\" graphql:\"owner\""
+	OwnerID     *string                                                 "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	Secrets     CreateIntegration_CreateIntegration_Integration_Secrets "json:\"secrets\" graphql:\"secrets\""
 }
 
 func (t *CreateIntegration_CreateIntegration_Integration) GetDescription() *string {
@@ -23614,11 +26562,11 @@ func (t *CreateIntegration_CreateIntegration_Integration) GetDescription() *stri
 	}
 	return t.Description
 }
-func (t *CreateIntegration_CreateIntegration_Integration) GetEvents() []*CreateIntegration_CreateIntegration_Integration_Events {
+func (t *CreateIntegration_CreateIntegration_Integration) GetEvents() *CreateIntegration_CreateIntegration_Integration_Events {
 	if t == nil {
 		t = &CreateIntegration_CreateIntegration_Integration{}
 	}
-	return t.Events
+	return &t.Events
 }
 func (t *CreateIntegration_CreateIntegration_Integration) GetID() string {
 	if t == nil {
@@ -23650,11 +26598,11 @@ func (t *CreateIntegration_CreateIntegration_Integration) GetOwnerID() *string {
 	}
 	return t.OwnerID
 }
-func (t *CreateIntegration_CreateIntegration_Integration) GetSecrets() []*CreateIntegration_CreateIntegration_Integration_Secrets {
+func (t *CreateIntegration_CreateIntegration_Integration) GetSecrets() *CreateIntegration_CreateIntegration_Integration_Secrets {
 	if t == nil {
 		t = &CreateIntegration_CreateIntegration_Integration{}
 	}
-	return t.Secrets
+	return &t.Secrets
 }
 
 type CreateIntegration_CreateIntegration struct {
@@ -23690,41 +26638,85 @@ func (t *GetAllIntegrations_Integrations_Edges_Node_Owner) GetID() string {
 	return t.ID
 }
 
-type GetAllIntegrations_Integrations_Edges_Node_Secrets struct {
+type GetAllIntegrations_Integrations_Edges_Node_Secrets_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *GetAllIntegrations_Integrations_Edges_Node_Secrets) GetID() string {
+func (t *GetAllIntegrations_Integrations_Edges_Node_Secrets_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetAllIntegrations_Integrations_Edges_Node_Secrets_Edges_Node{}
+	}
+	return t.ID
+}
+
+type GetAllIntegrations_Integrations_Edges_Node_Secrets_Edges struct {
+	Node *GetAllIntegrations_Integrations_Edges_Node_Secrets_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllIntegrations_Integrations_Edges_Node_Secrets_Edges) GetNode() *GetAllIntegrations_Integrations_Edges_Node_Secrets_Edges_Node {
+	if t == nil {
+		t = &GetAllIntegrations_Integrations_Edges_Node_Secrets_Edges{}
+	}
+	return t.Node
+}
+
+type GetAllIntegrations_Integrations_Edges_Node_Secrets struct {
+	Edges []*GetAllIntegrations_Integrations_Edges_Node_Secrets_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetAllIntegrations_Integrations_Edges_Node_Secrets) GetEdges() []*GetAllIntegrations_Integrations_Edges_Node_Secrets_Edges {
 	if t == nil {
 		t = &GetAllIntegrations_Integrations_Edges_Node_Secrets{}
 	}
-	return t.ID
+	return t.Edges
 }
 
-type GetAllIntegrations_Integrations_Edges_Node_Events struct {
+type GetAllIntegrations_Integrations_Edges_Node_Events_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *GetAllIntegrations_Integrations_Edges_Node_Events) GetID() string {
+func (t *GetAllIntegrations_Integrations_Edges_Node_Events_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetAllIntegrations_Integrations_Edges_Node_Events{}
+		t = &GetAllIntegrations_Integrations_Edges_Node_Events_Edges_Node{}
 	}
 	return t.ID
 }
 
+type GetAllIntegrations_Integrations_Edges_Node_Events_Edges struct {
+	Node *GetAllIntegrations_Integrations_Edges_Node_Events_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllIntegrations_Integrations_Edges_Node_Events_Edges) GetNode() *GetAllIntegrations_Integrations_Edges_Node_Events_Edges_Node {
+	if t == nil {
+		t = &GetAllIntegrations_Integrations_Edges_Node_Events_Edges{}
+	}
+	return t.Node
+}
+
+type GetAllIntegrations_Integrations_Edges_Node_Events struct {
+	Edges []*GetAllIntegrations_Integrations_Edges_Node_Events_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetAllIntegrations_Integrations_Edges_Node_Events) GetEdges() []*GetAllIntegrations_Integrations_Edges_Node_Events_Edges {
+	if t == nil {
+		t = &GetAllIntegrations_Integrations_Edges_Node_Events{}
+	}
+	return t.Edges
+}
+
 type GetAllIntegrations_Integrations_Edges_Node struct {
-	CreatedAt   *time.Time                                            "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy   *string                                               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description *string                                               "json:\"description,omitempty\" graphql:\"description\""
-	Events      []*GetAllIntegrations_Integrations_Edges_Node_Events  "json:\"events,omitempty\" graphql:\"events\""
-	ID          string                                                "json:\"id\" graphql:\"id\""
-	Kind        *string                                               "json:\"kind,omitempty\" graphql:\"kind\""
-	Name        string                                                "json:\"name\" graphql:\"name\""
-	Owner       *GetAllIntegrations_Integrations_Edges_Node_Owner     "json:\"owner,omitempty\" graphql:\"owner\""
-	OwnerID     *string                                               "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Secrets     []*GetAllIntegrations_Integrations_Edges_Node_Secrets "json:\"secrets,omitempty\" graphql:\"secrets\""
-	UpdatedAt   *time.Time                                            "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy   *string                                               "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	CreatedAt   *time.Time                                         "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy   *string                                            "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description *string                                            "json:\"description,omitempty\" graphql:\"description\""
+	Events      GetAllIntegrations_Integrations_Edges_Node_Events  "json:\"events\" graphql:\"events\""
+	ID          string                                             "json:\"id\" graphql:\"id\""
+	Kind        *string                                            "json:\"kind,omitempty\" graphql:\"kind\""
+	Name        string                                             "json:\"name\" graphql:\"name\""
+	Owner       *GetAllIntegrations_Integrations_Edges_Node_Owner  "json:\"owner,omitempty\" graphql:\"owner\""
+	OwnerID     *string                                            "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	Secrets     GetAllIntegrations_Integrations_Edges_Node_Secrets "json:\"secrets\" graphql:\"secrets\""
+	UpdatedAt   *time.Time                                         "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy   *string                                            "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *GetAllIntegrations_Integrations_Edges_Node) GetCreatedAt() *time.Time {
@@ -23745,11 +26737,11 @@ func (t *GetAllIntegrations_Integrations_Edges_Node) GetDescription() *string {
 	}
 	return t.Description
 }
-func (t *GetAllIntegrations_Integrations_Edges_Node) GetEvents() []*GetAllIntegrations_Integrations_Edges_Node_Events {
+func (t *GetAllIntegrations_Integrations_Edges_Node) GetEvents() *GetAllIntegrations_Integrations_Edges_Node_Events {
 	if t == nil {
 		t = &GetAllIntegrations_Integrations_Edges_Node{}
 	}
-	return t.Events
+	return &t.Events
 }
 func (t *GetAllIntegrations_Integrations_Edges_Node) GetID() string {
 	if t == nil {
@@ -23781,11 +26773,11 @@ func (t *GetAllIntegrations_Integrations_Edges_Node) GetOwnerID() *string {
 	}
 	return t.OwnerID
 }
-func (t *GetAllIntegrations_Integrations_Edges_Node) GetSecrets() []*GetAllIntegrations_Integrations_Edges_Node_Secrets {
+func (t *GetAllIntegrations_Integrations_Edges_Node) GetSecrets() *GetAllIntegrations_Integrations_Edges_Node_Secrets {
 	if t == nil {
 		t = &GetAllIntegrations_Integrations_Edges_Node{}
 	}
-	return t.Secrets
+	return &t.Secrets
 }
 func (t *GetAllIntegrations_Integrations_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
@@ -23833,41 +26825,85 @@ func (t *GetIntegrationByID_Integration_Owner) GetID() string {
 	return t.ID
 }
 
-type GetIntegrationByID_Integration_Secrets struct {
+type GetIntegrationByID_Integration_Secrets_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *GetIntegrationByID_Integration_Secrets) GetID() string {
+func (t *GetIntegrationByID_Integration_Secrets_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetIntegrationByID_Integration_Secrets_Edges_Node{}
+	}
+	return t.ID
+}
+
+type GetIntegrationByID_Integration_Secrets_Edges struct {
+	Node *GetIntegrationByID_Integration_Secrets_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetIntegrationByID_Integration_Secrets_Edges) GetNode() *GetIntegrationByID_Integration_Secrets_Edges_Node {
+	if t == nil {
+		t = &GetIntegrationByID_Integration_Secrets_Edges{}
+	}
+	return t.Node
+}
+
+type GetIntegrationByID_Integration_Secrets struct {
+	Edges []*GetIntegrationByID_Integration_Secrets_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetIntegrationByID_Integration_Secrets) GetEdges() []*GetIntegrationByID_Integration_Secrets_Edges {
 	if t == nil {
 		t = &GetIntegrationByID_Integration_Secrets{}
 	}
-	return t.ID
+	return t.Edges
 }
 
-type GetIntegrationByID_Integration_Events struct {
+type GetIntegrationByID_Integration_Events_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *GetIntegrationByID_Integration_Events) GetID() string {
+func (t *GetIntegrationByID_Integration_Events_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetIntegrationByID_Integration_Events{}
+		t = &GetIntegrationByID_Integration_Events_Edges_Node{}
 	}
 	return t.ID
 }
 
+type GetIntegrationByID_Integration_Events_Edges struct {
+	Node *GetIntegrationByID_Integration_Events_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetIntegrationByID_Integration_Events_Edges) GetNode() *GetIntegrationByID_Integration_Events_Edges_Node {
+	if t == nil {
+		t = &GetIntegrationByID_Integration_Events_Edges{}
+	}
+	return t.Node
+}
+
+type GetIntegrationByID_Integration_Events struct {
+	Edges []*GetIntegrationByID_Integration_Events_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetIntegrationByID_Integration_Events) GetEdges() []*GetIntegrationByID_Integration_Events_Edges {
+	if t == nil {
+		t = &GetIntegrationByID_Integration_Events{}
+	}
+	return t.Edges
+}
+
 type GetIntegrationByID_Integration struct {
-	CreatedAt   *time.Time                                "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy   *string                                   "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description *string                                   "json:\"description,omitempty\" graphql:\"description\""
-	Events      []*GetIntegrationByID_Integration_Events  "json:\"events,omitempty\" graphql:\"events\""
-	ID          string                                    "json:\"id\" graphql:\"id\""
-	Kind        *string                                   "json:\"kind,omitempty\" graphql:\"kind\""
-	Name        string                                    "json:\"name\" graphql:\"name\""
-	Owner       *GetIntegrationByID_Integration_Owner     "json:\"owner,omitempty\" graphql:\"owner\""
-	OwnerID     *string                                   "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Secrets     []*GetIntegrationByID_Integration_Secrets "json:\"secrets,omitempty\" graphql:\"secrets\""
-	UpdatedAt   *time.Time                                "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy   *string                                   "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	CreatedAt   *time.Time                             "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy   *string                                "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description *string                                "json:\"description,omitempty\" graphql:\"description\""
+	Events      GetIntegrationByID_Integration_Events  "json:\"events\" graphql:\"events\""
+	ID          string                                 "json:\"id\" graphql:\"id\""
+	Kind        *string                                "json:\"kind,omitempty\" graphql:\"kind\""
+	Name        string                                 "json:\"name\" graphql:\"name\""
+	Owner       *GetIntegrationByID_Integration_Owner  "json:\"owner,omitempty\" graphql:\"owner\""
+	OwnerID     *string                                "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	Secrets     GetIntegrationByID_Integration_Secrets "json:\"secrets\" graphql:\"secrets\""
+	UpdatedAt   *time.Time                             "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy   *string                                "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *GetIntegrationByID_Integration) GetCreatedAt() *time.Time {
@@ -23888,11 +26924,11 @@ func (t *GetIntegrationByID_Integration) GetDescription() *string {
 	}
 	return t.Description
 }
-func (t *GetIntegrationByID_Integration) GetEvents() []*GetIntegrationByID_Integration_Events {
+func (t *GetIntegrationByID_Integration) GetEvents() *GetIntegrationByID_Integration_Events {
 	if t == nil {
 		t = &GetIntegrationByID_Integration{}
 	}
-	return t.Events
+	return &t.Events
 }
 func (t *GetIntegrationByID_Integration) GetID() string {
 	if t == nil {
@@ -23924,11 +26960,11 @@ func (t *GetIntegrationByID_Integration) GetOwnerID() *string {
 	}
 	return t.OwnerID
 }
-func (t *GetIntegrationByID_Integration) GetSecrets() []*GetIntegrationByID_Integration_Secrets {
+func (t *GetIntegrationByID_Integration) GetSecrets() *GetIntegrationByID_Integration_Secrets {
 	if t == nil {
 		t = &GetIntegrationByID_Integration{}
 	}
-	return t.Secrets
+	return &t.Secrets
 }
 func (t *GetIntegrationByID_Integration) GetUpdatedAt() *time.Time {
 	if t == nil {
@@ -23954,41 +26990,85 @@ func (t *GetIntegrations_Integrations_Edges_Node_Owner) GetID() string {
 	return t.ID
 }
 
-type GetIntegrations_Integrations_Edges_Node_Secrets struct {
+type GetIntegrations_Integrations_Edges_Node_Secrets_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *GetIntegrations_Integrations_Edges_Node_Secrets) GetID() string {
+func (t *GetIntegrations_Integrations_Edges_Node_Secrets_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetIntegrations_Integrations_Edges_Node_Secrets_Edges_Node{}
+	}
+	return t.ID
+}
+
+type GetIntegrations_Integrations_Edges_Node_Secrets_Edges struct {
+	Node *GetIntegrations_Integrations_Edges_Node_Secrets_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetIntegrations_Integrations_Edges_Node_Secrets_Edges) GetNode() *GetIntegrations_Integrations_Edges_Node_Secrets_Edges_Node {
+	if t == nil {
+		t = &GetIntegrations_Integrations_Edges_Node_Secrets_Edges{}
+	}
+	return t.Node
+}
+
+type GetIntegrations_Integrations_Edges_Node_Secrets struct {
+	Edges []*GetIntegrations_Integrations_Edges_Node_Secrets_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetIntegrations_Integrations_Edges_Node_Secrets) GetEdges() []*GetIntegrations_Integrations_Edges_Node_Secrets_Edges {
 	if t == nil {
 		t = &GetIntegrations_Integrations_Edges_Node_Secrets{}
 	}
-	return t.ID
+	return t.Edges
 }
 
-type GetIntegrations_Integrations_Edges_Node_Events struct {
+type GetIntegrations_Integrations_Edges_Node_Events_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *GetIntegrations_Integrations_Edges_Node_Events) GetID() string {
+func (t *GetIntegrations_Integrations_Edges_Node_Events_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetIntegrations_Integrations_Edges_Node_Events{}
+		t = &GetIntegrations_Integrations_Edges_Node_Events_Edges_Node{}
 	}
 	return t.ID
 }
 
+type GetIntegrations_Integrations_Edges_Node_Events_Edges struct {
+	Node *GetIntegrations_Integrations_Edges_Node_Events_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetIntegrations_Integrations_Edges_Node_Events_Edges) GetNode() *GetIntegrations_Integrations_Edges_Node_Events_Edges_Node {
+	if t == nil {
+		t = &GetIntegrations_Integrations_Edges_Node_Events_Edges{}
+	}
+	return t.Node
+}
+
+type GetIntegrations_Integrations_Edges_Node_Events struct {
+	Edges []*GetIntegrations_Integrations_Edges_Node_Events_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetIntegrations_Integrations_Edges_Node_Events) GetEdges() []*GetIntegrations_Integrations_Edges_Node_Events_Edges {
+	if t == nil {
+		t = &GetIntegrations_Integrations_Edges_Node_Events{}
+	}
+	return t.Edges
+}
+
 type GetIntegrations_Integrations_Edges_Node struct {
-	CreatedAt   *time.Time                                         "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy   *string                                            "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description *string                                            "json:\"description,omitempty\" graphql:\"description\""
-	Events      []*GetIntegrations_Integrations_Edges_Node_Events  "json:\"events,omitempty\" graphql:\"events\""
-	ID          string                                             "json:\"id\" graphql:\"id\""
-	Kind        *string                                            "json:\"kind,omitempty\" graphql:\"kind\""
-	Name        string                                             "json:\"name\" graphql:\"name\""
-	Owner       *GetIntegrations_Integrations_Edges_Node_Owner     "json:\"owner,omitempty\" graphql:\"owner\""
-	OwnerID     *string                                            "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Secrets     []*GetIntegrations_Integrations_Edges_Node_Secrets "json:\"secrets,omitempty\" graphql:\"secrets\""
-	UpdatedAt   *time.Time                                         "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy   *string                                            "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	CreatedAt   *time.Time                                      "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy   *string                                         "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description *string                                         "json:\"description,omitempty\" graphql:\"description\""
+	Events      GetIntegrations_Integrations_Edges_Node_Events  "json:\"events\" graphql:\"events\""
+	ID          string                                          "json:\"id\" graphql:\"id\""
+	Kind        *string                                         "json:\"kind,omitempty\" graphql:\"kind\""
+	Name        string                                          "json:\"name\" graphql:\"name\""
+	Owner       *GetIntegrations_Integrations_Edges_Node_Owner  "json:\"owner,omitempty\" graphql:\"owner\""
+	OwnerID     *string                                         "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	Secrets     GetIntegrations_Integrations_Edges_Node_Secrets "json:\"secrets\" graphql:\"secrets\""
+	UpdatedAt   *time.Time                                      "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy   *string                                         "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *GetIntegrations_Integrations_Edges_Node) GetCreatedAt() *time.Time {
@@ -24009,11 +27089,11 @@ func (t *GetIntegrations_Integrations_Edges_Node) GetDescription() *string {
 	}
 	return t.Description
 }
-func (t *GetIntegrations_Integrations_Edges_Node) GetEvents() []*GetIntegrations_Integrations_Edges_Node_Events {
+func (t *GetIntegrations_Integrations_Edges_Node) GetEvents() *GetIntegrations_Integrations_Edges_Node_Events {
 	if t == nil {
 		t = &GetIntegrations_Integrations_Edges_Node{}
 	}
-	return t.Events
+	return &t.Events
 }
 func (t *GetIntegrations_Integrations_Edges_Node) GetID() string {
 	if t == nil {
@@ -24045,11 +27125,11 @@ func (t *GetIntegrations_Integrations_Edges_Node) GetOwnerID() *string {
 	}
 	return t.OwnerID
 }
-func (t *GetIntegrations_Integrations_Edges_Node) GetSecrets() []*GetIntegrations_Integrations_Edges_Node_Secrets {
+func (t *GetIntegrations_Integrations_Edges_Node) GetSecrets() *GetIntegrations_Integrations_Edges_Node_Secrets {
 	if t == nil {
 		t = &GetIntegrations_Integrations_Edges_Node{}
 	}
-	return t.Secrets
+	return &t.Secrets
 }
 func (t *GetIntegrations_Integrations_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
@@ -24097,37 +27177,81 @@ func (t *UpdateIntegration_UpdateIntegration_Integration_Owner) GetID() string {
 	return t.ID
 }
 
-type UpdateIntegration_UpdateIntegration_Integration_Secrets struct {
+type UpdateIntegration_UpdateIntegration_Integration_Secrets_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *UpdateIntegration_UpdateIntegration_Integration_Secrets) GetID() string {
+func (t *UpdateIntegration_UpdateIntegration_Integration_Secrets_Edges_Node) GetID() string {
+	if t == nil {
+		t = &UpdateIntegration_UpdateIntegration_Integration_Secrets_Edges_Node{}
+	}
+	return t.ID
+}
+
+type UpdateIntegration_UpdateIntegration_Integration_Secrets_Edges struct {
+	Node *UpdateIntegration_UpdateIntegration_Integration_Secrets_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateIntegration_UpdateIntegration_Integration_Secrets_Edges) GetNode() *UpdateIntegration_UpdateIntegration_Integration_Secrets_Edges_Node {
+	if t == nil {
+		t = &UpdateIntegration_UpdateIntegration_Integration_Secrets_Edges{}
+	}
+	return t.Node
+}
+
+type UpdateIntegration_UpdateIntegration_Integration_Secrets struct {
+	Edges []*UpdateIntegration_UpdateIntegration_Integration_Secrets_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *UpdateIntegration_UpdateIntegration_Integration_Secrets) GetEdges() []*UpdateIntegration_UpdateIntegration_Integration_Secrets_Edges {
 	if t == nil {
 		t = &UpdateIntegration_UpdateIntegration_Integration_Secrets{}
 	}
-	return t.ID
+	return t.Edges
 }
 
-type UpdateIntegration_UpdateIntegration_Integration_Events struct {
+type UpdateIntegration_UpdateIntegration_Integration_Events_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *UpdateIntegration_UpdateIntegration_Integration_Events) GetID() string {
+func (t *UpdateIntegration_UpdateIntegration_Integration_Events_Edges_Node) GetID() string {
 	if t == nil {
-		t = &UpdateIntegration_UpdateIntegration_Integration_Events{}
+		t = &UpdateIntegration_UpdateIntegration_Integration_Events_Edges_Node{}
 	}
 	return t.ID
 }
 
+type UpdateIntegration_UpdateIntegration_Integration_Events_Edges struct {
+	Node *UpdateIntegration_UpdateIntegration_Integration_Events_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateIntegration_UpdateIntegration_Integration_Events_Edges) GetNode() *UpdateIntegration_UpdateIntegration_Integration_Events_Edges_Node {
+	if t == nil {
+		t = &UpdateIntegration_UpdateIntegration_Integration_Events_Edges{}
+	}
+	return t.Node
+}
+
+type UpdateIntegration_UpdateIntegration_Integration_Events struct {
+	Edges []*UpdateIntegration_UpdateIntegration_Integration_Events_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *UpdateIntegration_UpdateIntegration_Integration_Events) GetEdges() []*UpdateIntegration_UpdateIntegration_Integration_Events_Edges {
+	if t == nil {
+		t = &UpdateIntegration_UpdateIntegration_Integration_Events{}
+	}
+	return t.Edges
+}
+
 type UpdateIntegration_UpdateIntegration_Integration struct {
-	Description *string                                                    "json:\"description,omitempty\" graphql:\"description\""
-	Events      []*UpdateIntegration_UpdateIntegration_Integration_Events  "json:\"events,omitempty\" graphql:\"events\""
-	ID          string                                                     "json:\"id\" graphql:\"id\""
-	Kind        *string                                                    "json:\"kind,omitempty\" graphql:\"kind\""
-	Name        string                                                     "json:\"name\" graphql:\"name\""
-	Owner       *UpdateIntegration_UpdateIntegration_Integration_Owner     "json:\"owner,omitempty\" graphql:\"owner\""
-	OwnerID     *string                                                    "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Secrets     []*UpdateIntegration_UpdateIntegration_Integration_Secrets "json:\"secrets,omitempty\" graphql:\"secrets\""
+	Description *string                                                 "json:\"description,omitempty\" graphql:\"description\""
+	Events      UpdateIntegration_UpdateIntegration_Integration_Events  "json:\"events\" graphql:\"events\""
+	ID          string                                                  "json:\"id\" graphql:\"id\""
+	Kind        *string                                                 "json:\"kind,omitempty\" graphql:\"kind\""
+	Name        string                                                  "json:\"name\" graphql:\"name\""
+	Owner       *UpdateIntegration_UpdateIntegration_Integration_Owner  "json:\"owner,omitempty\" graphql:\"owner\""
+	OwnerID     *string                                                 "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	Secrets     UpdateIntegration_UpdateIntegration_Integration_Secrets "json:\"secrets\" graphql:\"secrets\""
 }
 
 func (t *UpdateIntegration_UpdateIntegration_Integration) GetDescription() *string {
@@ -24136,11 +27260,11 @@ func (t *UpdateIntegration_UpdateIntegration_Integration) GetDescription() *stri
 	}
 	return t.Description
 }
-func (t *UpdateIntegration_UpdateIntegration_Integration) GetEvents() []*UpdateIntegration_UpdateIntegration_Integration_Events {
+func (t *UpdateIntegration_UpdateIntegration_Integration) GetEvents() *UpdateIntegration_UpdateIntegration_Integration_Events {
 	if t == nil {
 		t = &UpdateIntegration_UpdateIntegration_Integration{}
 	}
-	return t.Events
+	return &t.Events
 }
 func (t *UpdateIntegration_UpdateIntegration_Integration) GetID() string {
 	if t == nil {
@@ -24172,11 +27296,11 @@ func (t *UpdateIntegration_UpdateIntegration_Integration) GetOwnerID() *string {
 	}
 	return t.OwnerID
 }
-func (t *UpdateIntegration_UpdateIntegration_Integration) GetSecrets() []*UpdateIntegration_UpdateIntegration_Integration_Secrets {
+func (t *UpdateIntegration_UpdateIntegration_Integration) GetSecrets() *UpdateIntegration_UpdateIntegration_Integration_Secrets {
 	if t == nil {
 		t = &UpdateIntegration_UpdateIntegration_Integration{}
 	}
-	return t.Secrets
+	return &t.Secrets
 }
 
 type UpdateIntegration_UpdateIntegration struct {
@@ -26277,7 +29401,7 @@ func (t *GetInviteByID_Invite) GetUpdatedBy() *string {
 	return t.UpdatedBy
 }
 
-type InvitesByOrgID_Invites_Edges_Node_Owner_Invites struct {
+type InvitesByOrgID_Invites_Edges_Node_Owner_Invites_Edges_Node struct {
 	Recipient    string             "json:\"recipient\" graphql:\"recipient\""
 	RequestorID  *string            "json:\"requestorID,omitempty\" graphql:\"requestorID\""
 	Role         enums.Role         "json:\"role\" graphql:\"role\""
@@ -26285,40 +29409,62 @@ type InvitesByOrgID_Invites_Edges_Node_Owner_Invites struct {
 	Status       enums.InviteStatus "json:\"status\" graphql:\"status\""
 }
 
-func (t *InvitesByOrgID_Invites_Edges_Node_Owner_Invites) GetRecipient() string {
+func (t *InvitesByOrgID_Invites_Edges_Node_Owner_Invites_Edges_Node) GetRecipient() string {
 	if t == nil {
-		t = &InvitesByOrgID_Invites_Edges_Node_Owner_Invites{}
+		t = &InvitesByOrgID_Invites_Edges_Node_Owner_Invites_Edges_Node{}
 	}
 	return t.Recipient
 }
-func (t *InvitesByOrgID_Invites_Edges_Node_Owner_Invites) GetRequestorID() *string {
+func (t *InvitesByOrgID_Invites_Edges_Node_Owner_Invites_Edges_Node) GetRequestorID() *string {
 	if t == nil {
-		t = &InvitesByOrgID_Invites_Edges_Node_Owner_Invites{}
+		t = &InvitesByOrgID_Invites_Edges_Node_Owner_Invites_Edges_Node{}
 	}
 	return t.RequestorID
 }
-func (t *InvitesByOrgID_Invites_Edges_Node_Owner_Invites) GetRole() *enums.Role {
+func (t *InvitesByOrgID_Invites_Edges_Node_Owner_Invites_Edges_Node) GetRole() *enums.Role {
 	if t == nil {
-		t = &InvitesByOrgID_Invites_Edges_Node_Owner_Invites{}
+		t = &InvitesByOrgID_Invites_Edges_Node_Owner_Invites_Edges_Node{}
 	}
 	return &t.Role
 }
-func (t *InvitesByOrgID_Invites_Edges_Node_Owner_Invites) GetSendAttempts() int64 {
+func (t *InvitesByOrgID_Invites_Edges_Node_Owner_Invites_Edges_Node) GetSendAttempts() int64 {
 	if t == nil {
-		t = &InvitesByOrgID_Invites_Edges_Node_Owner_Invites{}
+		t = &InvitesByOrgID_Invites_Edges_Node_Owner_Invites_Edges_Node{}
 	}
 	return t.SendAttempts
 }
-func (t *InvitesByOrgID_Invites_Edges_Node_Owner_Invites) GetStatus() *enums.InviteStatus {
+func (t *InvitesByOrgID_Invites_Edges_Node_Owner_Invites_Edges_Node) GetStatus() *enums.InviteStatus {
 	if t == nil {
-		t = &InvitesByOrgID_Invites_Edges_Node_Owner_Invites{}
+		t = &InvitesByOrgID_Invites_Edges_Node_Owner_Invites_Edges_Node{}
 	}
 	return &t.Status
 }
 
+type InvitesByOrgID_Invites_Edges_Node_Owner_Invites_Edges struct {
+	Node *InvitesByOrgID_Invites_Edges_Node_Owner_Invites_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *InvitesByOrgID_Invites_Edges_Node_Owner_Invites_Edges) GetNode() *InvitesByOrgID_Invites_Edges_Node_Owner_Invites_Edges_Node {
+	if t == nil {
+		t = &InvitesByOrgID_Invites_Edges_Node_Owner_Invites_Edges{}
+	}
+	return t.Node
+}
+
+type InvitesByOrgID_Invites_Edges_Node_Owner_Invites struct {
+	Edges []*InvitesByOrgID_Invites_Edges_Node_Owner_Invites_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *InvitesByOrgID_Invites_Edges_Node_Owner_Invites) GetEdges() []*InvitesByOrgID_Invites_Edges_Node_Owner_Invites_Edges {
+	if t == nil {
+		t = &InvitesByOrgID_Invites_Edges_Node_Owner_Invites{}
+	}
+	return t.Edges
+}
+
 type InvitesByOrgID_Invites_Edges_Node_Owner struct {
-	ID      string                                             "json:\"id\" graphql:\"id\""
-	Invites []*InvitesByOrgID_Invites_Edges_Node_Owner_Invites "json:\"invites,omitempty\" graphql:\"invites\""
+	ID      string                                          "json:\"id\" graphql:\"id\""
+	Invites InvitesByOrgID_Invites_Edges_Node_Owner_Invites "json:\"invites\" graphql:\"invites\""
 }
 
 func (t *InvitesByOrgID_Invites_Edges_Node_Owner) GetID() string {
@@ -26327,11 +29473,11 @@ func (t *InvitesByOrgID_Invites_Edges_Node_Owner) GetID() string {
 	}
 	return t.ID
 }
-func (t *InvitesByOrgID_Invites_Edges_Node_Owner) GetInvites() []*InvitesByOrgID_Invites_Edges_Node_Owner_Invites {
+func (t *InvitesByOrgID_Invites_Edges_Node_Owner) GetInvites() *InvitesByOrgID_Invites_Edges_Node_Owner_Invites {
 	if t == nil {
 		t = &InvitesByOrgID_Invites_Edges_Node_Owner{}
 	}
-	return t.Invites
+	return &t.Invites
 }
 
 type InvitesByOrgID_Invites_Edges_Node struct {
@@ -26367,74 +29513,118 @@ func (t *InvitesByOrgID_Invites) GetEdges() []*InvitesByOrgID_Invites_Edges {
 	return t.Edges
 }
 
-type CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls struct {
+type CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls_Edges_Node struct {
 	Description *string "json:\"description,omitempty\" graphql:\"description\""
 	ID          string  "json:\"id\" graphql:\"id\""
 	RefCode     string  "json:\"refCode\" graphql:\"refCode\""
 }
 
-func (t *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls) GetDescription() *string {
+func (t *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls_Edges_Node) GetDescription() *string {
 	if t == nil {
-		t = &CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls{}
+		t = &CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls_Edges_Node{}
 	}
 	return t.Description
 }
-func (t *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls) GetID() string {
+func (t *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls{}
+		t = &CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls) GetRefCode() string {
+func (t *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls_Edges_Node) GetRefCode() string {
+	if t == nil {
+		t = &CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls_Edges_Node{}
+	}
+	return t.RefCode
+}
+
+type CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls_Edges struct {
+	Node *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls_Edges) GetNode() *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls_Edges_Node {
+	if t == nil {
+		t = &CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls_Edges{}
+	}
+	return t.Node
+}
+
+type CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls struct {
+	Edges []*CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls) GetEdges() []*CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls_Edges {
 	if t == nil {
 		t = &CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls{}
 	}
+	return t.Edges
+}
+
+type CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Subcontrols_Edges_Node struct {
+	Description *string "json:\"description,omitempty\" graphql:\"description\""
+	ID          string  "json:\"id\" graphql:\"id\""
+	RefCode     string  "json:\"refCode\" graphql:\"refCode\""
+}
+
+func (t *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Subcontrols_Edges_Node) GetDescription() *string {
+	if t == nil {
+		t = &CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Subcontrols_Edges_Node{}
+	}
+	return t.Description
+}
+func (t *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Subcontrols_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Subcontrols_Edges_Node{}
+	}
+	return t.ID
+}
+func (t *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Subcontrols_Edges_Node) GetRefCode() string {
+	if t == nil {
+		t = &CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Subcontrols_Edges_Node{}
+	}
 	return t.RefCode
+}
+
+type CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Subcontrols_Edges struct {
+	Node *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Subcontrols_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Subcontrols_Edges) GetNode() *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Subcontrols_Edges_Node {
+	if t == nil {
+		t = &CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Subcontrols_Edges{}
+	}
+	return t.Node
 }
 
 type CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Subcontrols struct {
-	Description *string "json:\"description,omitempty\" graphql:\"description\""
-	ID          string  "json:\"id\" graphql:\"id\""
-	RefCode     string  "json:\"refCode\" graphql:\"refCode\""
+	Edges []*CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Subcontrols_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Subcontrols) GetDescription() *string {
+func (t *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Subcontrols) GetEdges() []*CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Subcontrols_Edges {
 	if t == nil {
 		t = &CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Subcontrols{}
 	}
-	return t.Description
-}
-func (t *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Subcontrols) GetID() string {
-	if t == nil {
-		t = &CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Subcontrols{}
-	}
-	return t.ID
-}
-func (t *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Subcontrols) GetRefCode() string {
-	if t == nil {
-		t = &CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Subcontrols{}
-	}
-	return t.RefCode
+	return t.Edges
 }
 
 type CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls struct {
-	Controls    []*CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls    "json:\"controls,omitempty\" graphql:\"controls\""
-	CreatedAt   *time.Time                                                                          "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy   *string                                                                             "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	ID          string                                                                              "json:\"id\" graphql:\"id\""
-	MappingType *string                                                                             "json:\"mappingType,omitempty\" graphql:\"mappingType\""
-	Relation    *string                                                                             "json:\"relation,omitempty\" graphql:\"relation\""
-	Subcontrols []*CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Subcontrols "json:\"subcontrols,omitempty\" graphql:\"subcontrols\""
-	Tags        []string                                                                            "json:\"tags,omitempty\" graphql:\"tags\""
-	UpdatedAt   *time.Time                                                                          "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy   *string                                                                             "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Controls    CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls    "json:\"controls\" graphql:\"controls\""
+	CreatedAt   *time.Time                                                                       "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy   *string                                                                          "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	ID          string                                                                           "json:\"id\" graphql:\"id\""
+	MappingType *string                                                                          "json:\"mappingType,omitempty\" graphql:\"mappingType\""
+	Relation    *string                                                                          "json:\"relation,omitempty\" graphql:\"relation\""
+	Subcontrols CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Subcontrols "json:\"subcontrols\" graphql:\"subcontrols\""
+	Tags        []string                                                                         "json:\"tags,omitempty\" graphql:\"tags\""
+	UpdatedAt   *time.Time                                                                       "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy   *string                                                                          "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls) GetControls() []*CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls {
+func (t *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls) GetControls() *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Controls {
 	if t == nil {
 		t = &CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls{}
 	}
-	return t.Controls
+	return &t.Controls
 }
 func (t *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls) GetCreatedAt() *time.Time {
 	if t == nil {
@@ -26466,11 +29656,11 @@ func (t *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls) G
 	}
 	return t.Relation
 }
-func (t *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls) GetSubcontrols() []*CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Subcontrols {
+func (t *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls) GetSubcontrols() *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls_Subcontrols {
 	if t == nil {
 		t = &CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls{}
 	}
-	return t.Subcontrols
+	return &t.Subcontrols
 }
 func (t *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl_MappedControls) GetTags() []string {
 	if t == nil {
@@ -26502,74 +29692,118 @@ func (t *CreateBulkCSVMappedControl_CreateBulkCSVMappedControl) GetMappedControl
 	return t.MappedControls
 }
 
-type CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls struct {
+type CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls_Edges_Node struct {
 	Description *string "json:\"description,omitempty\" graphql:\"description\""
 	ID          string  "json:\"id\" graphql:\"id\""
 	RefCode     string  "json:\"refCode\" graphql:\"refCode\""
 }
 
-func (t *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls) GetDescription() *string {
+func (t *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls_Edges_Node) GetDescription() *string {
 	if t == nil {
-		t = &CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls{}
+		t = &CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls_Edges_Node{}
 	}
 	return t.Description
 }
-func (t *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls) GetID() string {
+func (t *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls{}
+		t = &CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls) GetRefCode() string {
+func (t *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls_Edges_Node) GetRefCode() string {
+	if t == nil {
+		t = &CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls_Edges_Node{}
+	}
+	return t.RefCode
+}
+
+type CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls_Edges struct {
+	Node *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls_Edges) GetNode() *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls_Edges_Node {
+	if t == nil {
+		t = &CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls_Edges{}
+	}
+	return t.Node
+}
+
+type CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls struct {
+	Edges []*CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls) GetEdges() []*CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls_Edges {
 	if t == nil {
 		t = &CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls{}
 	}
+	return t.Edges
+}
+
+type CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Subcontrols_Edges_Node struct {
+	Description *string "json:\"description,omitempty\" graphql:\"description\""
+	ID          string  "json:\"id\" graphql:\"id\""
+	RefCode     string  "json:\"refCode\" graphql:\"refCode\""
+}
+
+func (t *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Subcontrols_Edges_Node) GetDescription() *string {
+	if t == nil {
+		t = &CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Subcontrols_Edges_Node{}
+	}
+	return t.Description
+}
+func (t *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Subcontrols_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Subcontrols_Edges_Node{}
+	}
+	return t.ID
+}
+func (t *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Subcontrols_Edges_Node) GetRefCode() string {
+	if t == nil {
+		t = &CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Subcontrols_Edges_Node{}
+	}
 	return t.RefCode
+}
+
+type CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Subcontrols_Edges struct {
+	Node *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Subcontrols_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Subcontrols_Edges) GetNode() *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Subcontrols_Edges_Node {
+	if t == nil {
+		t = &CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Subcontrols_Edges{}
+	}
+	return t.Node
 }
 
 type CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Subcontrols struct {
-	Description *string "json:\"description,omitempty\" graphql:\"description\""
-	ID          string  "json:\"id\" graphql:\"id\""
-	RefCode     string  "json:\"refCode\" graphql:\"refCode\""
+	Edges []*CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Subcontrols_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Subcontrols) GetDescription() *string {
+func (t *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Subcontrols) GetEdges() []*CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Subcontrols_Edges {
 	if t == nil {
 		t = &CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Subcontrols{}
 	}
-	return t.Description
-}
-func (t *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Subcontrols) GetID() string {
-	if t == nil {
-		t = &CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Subcontrols{}
-	}
-	return t.ID
-}
-func (t *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Subcontrols) GetRefCode() string {
-	if t == nil {
-		t = &CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Subcontrols{}
-	}
-	return t.RefCode
+	return t.Edges
 }
 
 type CreateBulkMappedControl_CreateBulkMappedControl_MappedControls struct {
-	Controls    []*CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls    "json:\"controls,omitempty\" graphql:\"controls\""
-	CreatedAt   *time.Time                                                                    "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy   *string                                                                       "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	ID          string                                                                        "json:\"id\" graphql:\"id\""
-	MappingType *string                                                                       "json:\"mappingType,omitempty\" graphql:\"mappingType\""
-	Relation    *string                                                                       "json:\"relation,omitempty\" graphql:\"relation\""
-	Subcontrols []*CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Subcontrols "json:\"subcontrols,omitempty\" graphql:\"subcontrols\""
-	Tags        []string                                                                      "json:\"tags,omitempty\" graphql:\"tags\""
-	UpdatedAt   *time.Time                                                                    "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy   *string                                                                       "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Controls    CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls    "json:\"controls\" graphql:\"controls\""
+	CreatedAt   *time.Time                                                                 "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy   *string                                                                    "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	ID          string                                                                     "json:\"id\" graphql:\"id\""
+	MappingType *string                                                                    "json:\"mappingType,omitempty\" graphql:\"mappingType\""
+	Relation    *string                                                                    "json:\"relation,omitempty\" graphql:\"relation\""
+	Subcontrols CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Subcontrols "json:\"subcontrols\" graphql:\"subcontrols\""
+	Tags        []string                                                                   "json:\"tags,omitempty\" graphql:\"tags\""
+	UpdatedAt   *time.Time                                                                 "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy   *string                                                                    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls) GetControls() []*CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls {
+func (t *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls) GetControls() *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Controls {
 	if t == nil {
 		t = &CreateBulkMappedControl_CreateBulkMappedControl_MappedControls{}
 	}
-	return t.Controls
+	return &t.Controls
 }
 func (t *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls) GetCreatedAt() *time.Time {
 	if t == nil {
@@ -26601,11 +29835,11 @@ func (t *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls) GetRela
 	}
 	return t.Relation
 }
-func (t *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls) GetSubcontrols() []*CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Subcontrols {
+func (t *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls) GetSubcontrols() *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls_Subcontrols {
 	if t == nil {
 		t = &CreateBulkMappedControl_CreateBulkMappedControl_MappedControls{}
 	}
-	return t.Subcontrols
+	return &t.Subcontrols
 }
 func (t *CreateBulkMappedControl_CreateBulkMappedControl_MappedControls) GetTags() []string {
 	if t == nil {
@@ -26637,74 +29871,118 @@ func (t *CreateBulkMappedControl_CreateBulkMappedControl) GetMappedControls() []
 	return t.MappedControls
 }
 
-type CreateMappedControl_CreateMappedControl_MappedControl_Controls struct {
+type CreateMappedControl_CreateMappedControl_MappedControl_Controls_Edges_Node struct {
 	Description *string "json:\"description,omitempty\" graphql:\"description\""
 	ID          string  "json:\"id\" graphql:\"id\""
 	RefCode     string  "json:\"refCode\" graphql:\"refCode\""
 }
 
-func (t *CreateMappedControl_CreateMappedControl_MappedControl_Controls) GetDescription() *string {
+func (t *CreateMappedControl_CreateMappedControl_MappedControl_Controls_Edges_Node) GetDescription() *string {
 	if t == nil {
-		t = &CreateMappedControl_CreateMappedControl_MappedControl_Controls{}
+		t = &CreateMappedControl_CreateMappedControl_MappedControl_Controls_Edges_Node{}
 	}
 	return t.Description
 }
-func (t *CreateMappedControl_CreateMappedControl_MappedControl_Controls) GetID() string {
+func (t *CreateMappedControl_CreateMappedControl_MappedControl_Controls_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateMappedControl_CreateMappedControl_MappedControl_Controls{}
+		t = &CreateMappedControl_CreateMappedControl_MappedControl_Controls_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *CreateMappedControl_CreateMappedControl_MappedControl_Controls) GetRefCode() string {
+func (t *CreateMappedControl_CreateMappedControl_MappedControl_Controls_Edges_Node) GetRefCode() string {
+	if t == nil {
+		t = &CreateMappedControl_CreateMappedControl_MappedControl_Controls_Edges_Node{}
+	}
+	return t.RefCode
+}
+
+type CreateMappedControl_CreateMappedControl_MappedControl_Controls_Edges struct {
+	Node *CreateMappedControl_CreateMappedControl_MappedControl_Controls_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateMappedControl_CreateMappedControl_MappedControl_Controls_Edges) GetNode() *CreateMappedControl_CreateMappedControl_MappedControl_Controls_Edges_Node {
+	if t == nil {
+		t = &CreateMappedControl_CreateMappedControl_MappedControl_Controls_Edges{}
+	}
+	return t.Node
+}
+
+type CreateMappedControl_CreateMappedControl_MappedControl_Controls struct {
+	Edges []*CreateMappedControl_CreateMappedControl_MappedControl_Controls_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateMappedControl_CreateMappedControl_MappedControl_Controls) GetEdges() []*CreateMappedControl_CreateMappedControl_MappedControl_Controls_Edges {
 	if t == nil {
 		t = &CreateMappedControl_CreateMappedControl_MappedControl_Controls{}
 	}
+	return t.Edges
+}
+
+type CreateMappedControl_CreateMappedControl_MappedControl_Subcontrols_Edges_Node struct {
+	Description *string "json:\"description,omitempty\" graphql:\"description\""
+	ID          string  "json:\"id\" graphql:\"id\""
+	RefCode     string  "json:\"refCode\" graphql:\"refCode\""
+}
+
+func (t *CreateMappedControl_CreateMappedControl_MappedControl_Subcontrols_Edges_Node) GetDescription() *string {
+	if t == nil {
+		t = &CreateMappedControl_CreateMappedControl_MappedControl_Subcontrols_Edges_Node{}
+	}
+	return t.Description
+}
+func (t *CreateMappedControl_CreateMappedControl_MappedControl_Subcontrols_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateMappedControl_CreateMappedControl_MappedControl_Subcontrols_Edges_Node{}
+	}
+	return t.ID
+}
+func (t *CreateMappedControl_CreateMappedControl_MappedControl_Subcontrols_Edges_Node) GetRefCode() string {
+	if t == nil {
+		t = &CreateMappedControl_CreateMappedControl_MappedControl_Subcontrols_Edges_Node{}
+	}
 	return t.RefCode
+}
+
+type CreateMappedControl_CreateMappedControl_MappedControl_Subcontrols_Edges struct {
+	Node *CreateMappedControl_CreateMappedControl_MappedControl_Subcontrols_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateMappedControl_CreateMappedControl_MappedControl_Subcontrols_Edges) GetNode() *CreateMappedControl_CreateMappedControl_MappedControl_Subcontrols_Edges_Node {
+	if t == nil {
+		t = &CreateMappedControl_CreateMappedControl_MappedControl_Subcontrols_Edges{}
+	}
+	return t.Node
 }
 
 type CreateMappedControl_CreateMappedControl_MappedControl_Subcontrols struct {
-	Description *string "json:\"description,omitempty\" graphql:\"description\""
-	ID          string  "json:\"id\" graphql:\"id\""
-	RefCode     string  "json:\"refCode\" graphql:\"refCode\""
+	Edges []*CreateMappedControl_CreateMappedControl_MappedControl_Subcontrols_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateMappedControl_CreateMappedControl_MappedControl_Subcontrols) GetDescription() *string {
+func (t *CreateMappedControl_CreateMappedControl_MappedControl_Subcontrols) GetEdges() []*CreateMappedControl_CreateMappedControl_MappedControl_Subcontrols_Edges {
 	if t == nil {
 		t = &CreateMappedControl_CreateMappedControl_MappedControl_Subcontrols{}
 	}
-	return t.Description
-}
-func (t *CreateMappedControl_CreateMappedControl_MappedControl_Subcontrols) GetID() string {
-	if t == nil {
-		t = &CreateMappedControl_CreateMappedControl_MappedControl_Subcontrols{}
-	}
-	return t.ID
-}
-func (t *CreateMappedControl_CreateMappedControl_MappedControl_Subcontrols) GetRefCode() string {
-	if t == nil {
-		t = &CreateMappedControl_CreateMappedControl_MappedControl_Subcontrols{}
-	}
-	return t.RefCode
+	return t.Edges
 }
 
 type CreateMappedControl_CreateMappedControl_MappedControl struct {
-	Controls    []*CreateMappedControl_CreateMappedControl_MappedControl_Controls    "json:\"controls,omitempty\" graphql:\"controls\""
-	CreatedAt   *time.Time                                                           "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy   *string                                                              "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	ID          string                                                               "json:\"id\" graphql:\"id\""
-	MappingType *string                                                              "json:\"mappingType,omitempty\" graphql:\"mappingType\""
-	Relation    *string                                                              "json:\"relation,omitempty\" graphql:\"relation\""
-	Subcontrols []*CreateMappedControl_CreateMappedControl_MappedControl_Subcontrols "json:\"subcontrols,omitempty\" graphql:\"subcontrols\""
-	Tags        []string                                                             "json:\"tags,omitempty\" graphql:\"tags\""
-	UpdatedAt   *time.Time                                                           "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy   *string                                                              "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Controls    CreateMappedControl_CreateMappedControl_MappedControl_Controls    "json:\"controls\" graphql:\"controls\""
+	CreatedAt   *time.Time                                                        "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy   *string                                                           "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	ID          string                                                            "json:\"id\" graphql:\"id\""
+	MappingType *string                                                           "json:\"mappingType,omitempty\" graphql:\"mappingType\""
+	Relation    *string                                                           "json:\"relation,omitempty\" graphql:\"relation\""
+	Subcontrols CreateMappedControl_CreateMappedControl_MappedControl_Subcontrols "json:\"subcontrols\" graphql:\"subcontrols\""
+	Tags        []string                                                          "json:\"tags,omitempty\" graphql:\"tags\""
+	UpdatedAt   *time.Time                                                        "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy   *string                                                           "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *CreateMappedControl_CreateMappedControl_MappedControl) GetControls() []*CreateMappedControl_CreateMappedControl_MappedControl_Controls {
+func (t *CreateMappedControl_CreateMappedControl_MappedControl) GetControls() *CreateMappedControl_CreateMappedControl_MappedControl_Controls {
 	if t == nil {
 		t = &CreateMappedControl_CreateMappedControl_MappedControl{}
 	}
-	return t.Controls
+	return &t.Controls
 }
 func (t *CreateMappedControl_CreateMappedControl_MappedControl) GetCreatedAt() *time.Time {
 	if t == nil {
@@ -26736,11 +30014,11 @@ func (t *CreateMappedControl_CreateMappedControl_MappedControl) GetRelation() *s
 	}
 	return t.Relation
 }
-func (t *CreateMappedControl_CreateMappedControl_MappedControl) GetSubcontrols() []*CreateMappedControl_CreateMappedControl_MappedControl_Subcontrols {
+func (t *CreateMappedControl_CreateMappedControl_MappedControl) GetSubcontrols() *CreateMappedControl_CreateMappedControl_MappedControl_Subcontrols {
 	if t == nil {
 		t = &CreateMappedControl_CreateMappedControl_MappedControl{}
 	}
-	return t.Subcontrols
+	return &t.Subcontrols
 }
 func (t *CreateMappedControl_CreateMappedControl_MappedControl) GetTags() []string {
 	if t == nil {
@@ -26783,74 +30061,118 @@ func (t *DeleteMappedControl_DeleteMappedControl) GetDeletedID() string {
 	return t.DeletedID
 }
 
-type GetAllMappedControls_MappedControls_Edges_Node_Controls struct {
+type GetAllMappedControls_MappedControls_Edges_Node_Controls_Edges_Node struct {
 	Description *string "json:\"description,omitempty\" graphql:\"description\""
 	ID          string  "json:\"id\" graphql:\"id\""
 	RefCode     string  "json:\"refCode\" graphql:\"refCode\""
 }
 
-func (t *GetAllMappedControls_MappedControls_Edges_Node_Controls) GetDescription() *string {
+func (t *GetAllMappedControls_MappedControls_Edges_Node_Controls_Edges_Node) GetDescription() *string {
 	if t == nil {
-		t = &GetAllMappedControls_MappedControls_Edges_Node_Controls{}
+		t = &GetAllMappedControls_MappedControls_Edges_Node_Controls_Edges_Node{}
 	}
 	return t.Description
 }
-func (t *GetAllMappedControls_MappedControls_Edges_Node_Controls) GetID() string {
+func (t *GetAllMappedControls_MappedControls_Edges_Node_Controls_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetAllMappedControls_MappedControls_Edges_Node_Controls{}
+		t = &GetAllMappedControls_MappedControls_Edges_Node_Controls_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetAllMappedControls_MappedControls_Edges_Node_Controls) GetRefCode() string {
+func (t *GetAllMappedControls_MappedControls_Edges_Node_Controls_Edges_Node) GetRefCode() string {
+	if t == nil {
+		t = &GetAllMappedControls_MappedControls_Edges_Node_Controls_Edges_Node{}
+	}
+	return t.RefCode
+}
+
+type GetAllMappedControls_MappedControls_Edges_Node_Controls_Edges struct {
+	Node *GetAllMappedControls_MappedControls_Edges_Node_Controls_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllMappedControls_MappedControls_Edges_Node_Controls_Edges) GetNode() *GetAllMappedControls_MappedControls_Edges_Node_Controls_Edges_Node {
+	if t == nil {
+		t = &GetAllMappedControls_MappedControls_Edges_Node_Controls_Edges{}
+	}
+	return t.Node
+}
+
+type GetAllMappedControls_MappedControls_Edges_Node_Controls struct {
+	Edges []*GetAllMappedControls_MappedControls_Edges_Node_Controls_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetAllMappedControls_MappedControls_Edges_Node_Controls) GetEdges() []*GetAllMappedControls_MappedControls_Edges_Node_Controls_Edges {
 	if t == nil {
 		t = &GetAllMappedControls_MappedControls_Edges_Node_Controls{}
 	}
+	return t.Edges
+}
+
+type GetAllMappedControls_MappedControls_Edges_Node_Subcontrols_Edges_Node struct {
+	Description *string "json:\"description,omitempty\" graphql:\"description\""
+	ID          string  "json:\"id\" graphql:\"id\""
+	RefCode     string  "json:\"refCode\" graphql:\"refCode\""
+}
+
+func (t *GetAllMappedControls_MappedControls_Edges_Node_Subcontrols_Edges_Node) GetDescription() *string {
+	if t == nil {
+		t = &GetAllMappedControls_MappedControls_Edges_Node_Subcontrols_Edges_Node{}
+	}
+	return t.Description
+}
+func (t *GetAllMappedControls_MappedControls_Edges_Node_Subcontrols_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetAllMappedControls_MappedControls_Edges_Node_Subcontrols_Edges_Node{}
+	}
+	return t.ID
+}
+func (t *GetAllMappedControls_MappedControls_Edges_Node_Subcontrols_Edges_Node) GetRefCode() string {
+	if t == nil {
+		t = &GetAllMappedControls_MappedControls_Edges_Node_Subcontrols_Edges_Node{}
+	}
 	return t.RefCode
+}
+
+type GetAllMappedControls_MappedControls_Edges_Node_Subcontrols_Edges struct {
+	Node *GetAllMappedControls_MappedControls_Edges_Node_Subcontrols_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllMappedControls_MappedControls_Edges_Node_Subcontrols_Edges) GetNode() *GetAllMappedControls_MappedControls_Edges_Node_Subcontrols_Edges_Node {
+	if t == nil {
+		t = &GetAllMappedControls_MappedControls_Edges_Node_Subcontrols_Edges{}
+	}
+	return t.Node
 }
 
 type GetAllMappedControls_MappedControls_Edges_Node_Subcontrols struct {
-	Description *string "json:\"description,omitempty\" graphql:\"description\""
-	ID          string  "json:\"id\" graphql:\"id\""
-	RefCode     string  "json:\"refCode\" graphql:\"refCode\""
+	Edges []*GetAllMappedControls_MappedControls_Edges_Node_Subcontrols_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *GetAllMappedControls_MappedControls_Edges_Node_Subcontrols) GetDescription() *string {
+func (t *GetAllMappedControls_MappedControls_Edges_Node_Subcontrols) GetEdges() []*GetAllMappedControls_MappedControls_Edges_Node_Subcontrols_Edges {
 	if t == nil {
 		t = &GetAllMappedControls_MappedControls_Edges_Node_Subcontrols{}
 	}
-	return t.Description
-}
-func (t *GetAllMappedControls_MappedControls_Edges_Node_Subcontrols) GetID() string {
-	if t == nil {
-		t = &GetAllMappedControls_MappedControls_Edges_Node_Subcontrols{}
-	}
-	return t.ID
-}
-func (t *GetAllMappedControls_MappedControls_Edges_Node_Subcontrols) GetRefCode() string {
-	if t == nil {
-		t = &GetAllMappedControls_MappedControls_Edges_Node_Subcontrols{}
-	}
-	return t.RefCode
+	return t.Edges
 }
 
 type GetAllMappedControls_MappedControls_Edges_Node struct {
-	Controls    []*GetAllMappedControls_MappedControls_Edges_Node_Controls    "json:\"controls,omitempty\" graphql:\"controls\""
-	CreatedAt   *time.Time                                                    "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy   *string                                                       "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	ID          string                                                        "json:\"id\" graphql:\"id\""
-	MappingType *string                                                       "json:\"mappingType,omitempty\" graphql:\"mappingType\""
-	Relation    *string                                                       "json:\"relation,omitempty\" graphql:\"relation\""
-	Subcontrols []*GetAllMappedControls_MappedControls_Edges_Node_Subcontrols "json:\"subcontrols,omitempty\" graphql:\"subcontrols\""
-	Tags        []string                                                      "json:\"tags,omitempty\" graphql:\"tags\""
-	UpdatedAt   *time.Time                                                    "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy   *string                                                       "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Controls    GetAllMappedControls_MappedControls_Edges_Node_Controls    "json:\"controls\" graphql:\"controls\""
+	CreatedAt   *time.Time                                                 "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy   *string                                                    "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	ID          string                                                     "json:\"id\" graphql:\"id\""
+	MappingType *string                                                    "json:\"mappingType,omitempty\" graphql:\"mappingType\""
+	Relation    *string                                                    "json:\"relation,omitempty\" graphql:\"relation\""
+	Subcontrols GetAllMappedControls_MappedControls_Edges_Node_Subcontrols "json:\"subcontrols\" graphql:\"subcontrols\""
+	Tags        []string                                                   "json:\"tags,omitempty\" graphql:\"tags\""
+	UpdatedAt   *time.Time                                                 "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy   *string                                                    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *GetAllMappedControls_MappedControls_Edges_Node) GetControls() []*GetAllMappedControls_MappedControls_Edges_Node_Controls {
+func (t *GetAllMappedControls_MappedControls_Edges_Node) GetControls() *GetAllMappedControls_MappedControls_Edges_Node_Controls {
 	if t == nil {
 		t = &GetAllMappedControls_MappedControls_Edges_Node{}
 	}
-	return t.Controls
+	return &t.Controls
 }
 func (t *GetAllMappedControls_MappedControls_Edges_Node) GetCreatedAt() *time.Time {
 	if t == nil {
@@ -26882,11 +30204,11 @@ func (t *GetAllMappedControls_MappedControls_Edges_Node) GetRelation() *string {
 	}
 	return t.Relation
 }
-func (t *GetAllMappedControls_MappedControls_Edges_Node) GetSubcontrols() []*GetAllMappedControls_MappedControls_Edges_Node_Subcontrols {
+func (t *GetAllMappedControls_MappedControls_Edges_Node) GetSubcontrols() *GetAllMappedControls_MappedControls_Edges_Node_Subcontrols {
 	if t == nil {
 		t = &GetAllMappedControls_MappedControls_Edges_Node{}
 	}
-	return t.Subcontrols
+	return &t.Subcontrols
 }
 func (t *GetAllMappedControls_MappedControls_Edges_Node) GetTags() []string {
 	if t == nil {
@@ -26929,74 +30251,118 @@ func (t *GetAllMappedControls_MappedControls) GetEdges() []*GetAllMappedControls
 	return t.Edges
 }
 
-type GetMappedControlByID_MappedControl_Controls struct {
+type GetMappedControlByID_MappedControl_Controls_Edges_Node struct {
 	Description *string "json:\"description,omitempty\" graphql:\"description\""
 	ID          string  "json:\"id\" graphql:\"id\""
 	RefCode     string  "json:\"refCode\" graphql:\"refCode\""
 }
 
-func (t *GetMappedControlByID_MappedControl_Controls) GetDescription() *string {
+func (t *GetMappedControlByID_MappedControl_Controls_Edges_Node) GetDescription() *string {
 	if t == nil {
-		t = &GetMappedControlByID_MappedControl_Controls{}
+		t = &GetMappedControlByID_MappedControl_Controls_Edges_Node{}
 	}
 	return t.Description
 }
-func (t *GetMappedControlByID_MappedControl_Controls) GetID() string {
+func (t *GetMappedControlByID_MappedControl_Controls_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetMappedControlByID_MappedControl_Controls{}
+		t = &GetMappedControlByID_MappedControl_Controls_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetMappedControlByID_MappedControl_Controls) GetRefCode() string {
+func (t *GetMappedControlByID_MappedControl_Controls_Edges_Node) GetRefCode() string {
+	if t == nil {
+		t = &GetMappedControlByID_MappedControl_Controls_Edges_Node{}
+	}
+	return t.RefCode
+}
+
+type GetMappedControlByID_MappedControl_Controls_Edges struct {
+	Node *GetMappedControlByID_MappedControl_Controls_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetMappedControlByID_MappedControl_Controls_Edges) GetNode() *GetMappedControlByID_MappedControl_Controls_Edges_Node {
+	if t == nil {
+		t = &GetMappedControlByID_MappedControl_Controls_Edges{}
+	}
+	return t.Node
+}
+
+type GetMappedControlByID_MappedControl_Controls struct {
+	Edges []*GetMappedControlByID_MappedControl_Controls_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetMappedControlByID_MappedControl_Controls) GetEdges() []*GetMappedControlByID_MappedControl_Controls_Edges {
 	if t == nil {
 		t = &GetMappedControlByID_MappedControl_Controls{}
 	}
+	return t.Edges
+}
+
+type GetMappedControlByID_MappedControl_Subcontrols_Edges_Node struct {
+	Description *string "json:\"description,omitempty\" graphql:\"description\""
+	ID          string  "json:\"id\" graphql:\"id\""
+	RefCode     string  "json:\"refCode\" graphql:\"refCode\""
+}
+
+func (t *GetMappedControlByID_MappedControl_Subcontrols_Edges_Node) GetDescription() *string {
+	if t == nil {
+		t = &GetMappedControlByID_MappedControl_Subcontrols_Edges_Node{}
+	}
+	return t.Description
+}
+func (t *GetMappedControlByID_MappedControl_Subcontrols_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetMappedControlByID_MappedControl_Subcontrols_Edges_Node{}
+	}
+	return t.ID
+}
+func (t *GetMappedControlByID_MappedControl_Subcontrols_Edges_Node) GetRefCode() string {
+	if t == nil {
+		t = &GetMappedControlByID_MappedControl_Subcontrols_Edges_Node{}
+	}
 	return t.RefCode
+}
+
+type GetMappedControlByID_MappedControl_Subcontrols_Edges struct {
+	Node *GetMappedControlByID_MappedControl_Subcontrols_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetMappedControlByID_MappedControl_Subcontrols_Edges) GetNode() *GetMappedControlByID_MappedControl_Subcontrols_Edges_Node {
+	if t == nil {
+		t = &GetMappedControlByID_MappedControl_Subcontrols_Edges{}
+	}
+	return t.Node
 }
 
 type GetMappedControlByID_MappedControl_Subcontrols struct {
-	Description *string "json:\"description,omitempty\" graphql:\"description\""
-	ID          string  "json:\"id\" graphql:\"id\""
-	RefCode     string  "json:\"refCode\" graphql:\"refCode\""
+	Edges []*GetMappedControlByID_MappedControl_Subcontrols_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *GetMappedControlByID_MappedControl_Subcontrols) GetDescription() *string {
+func (t *GetMappedControlByID_MappedControl_Subcontrols) GetEdges() []*GetMappedControlByID_MappedControl_Subcontrols_Edges {
 	if t == nil {
 		t = &GetMappedControlByID_MappedControl_Subcontrols{}
 	}
-	return t.Description
-}
-func (t *GetMappedControlByID_MappedControl_Subcontrols) GetID() string {
-	if t == nil {
-		t = &GetMappedControlByID_MappedControl_Subcontrols{}
-	}
-	return t.ID
-}
-func (t *GetMappedControlByID_MappedControl_Subcontrols) GetRefCode() string {
-	if t == nil {
-		t = &GetMappedControlByID_MappedControl_Subcontrols{}
-	}
-	return t.RefCode
+	return t.Edges
 }
 
 type GetMappedControlByID_MappedControl struct {
-	Controls    []*GetMappedControlByID_MappedControl_Controls    "json:\"controls,omitempty\" graphql:\"controls\""
-	CreatedAt   *time.Time                                        "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy   *string                                           "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	ID          string                                            "json:\"id\" graphql:\"id\""
-	MappingType *string                                           "json:\"mappingType,omitempty\" graphql:\"mappingType\""
-	Relation    *string                                           "json:\"relation,omitempty\" graphql:\"relation\""
-	Subcontrols []*GetMappedControlByID_MappedControl_Subcontrols "json:\"subcontrols,omitempty\" graphql:\"subcontrols\""
-	Tags        []string                                          "json:\"tags,omitempty\" graphql:\"tags\""
-	UpdatedAt   *time.Time                                        "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy   *string                                           "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Controls    GetMappedControlByID_MappedControl_Controls    "json:\"controls\" graphql:\"controls\""
+	CreatedAt   *time.Time                                     "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy   *string                                        "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	ID          string                                         "json:\"id\" graphql:\"id\""
+	MappingType *string                                        "json:\"mappingType,omitempty\" graphql:\"mappingType\""
+	Relation    *string                                        "json:\"relation,omitempty\" graphql:\"relation\""
+	Subcontrols GetMappedControlByID_MappedControl_Subcontrols "json:\"subcontrols\" graphql:\"subcontrols\""
+	Tags        []string                                       "json:\"tags,omitempty\" graphql:\"tags\""
+	UpdatedAt   *time.Time                                     "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy   *string                                        "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *GetMappedControlByID_MappedControl) GetControls() []*GetMappedControlByID_MappedControl_Controls {
+func (t *GetMappedControlByID_MappedControl) GetControls() *GetMappedControlByID_MappedControl_Controls {
 	if t == nil {
 		t = &GetMappedControlByID_MappedControl{}
 	}
-	return t.Controls
+	return &t.Controls
 }
 func (t *GetMappedControlByID_MappedControl) GetCreatedAt() *time.Time {
 	if t == nil {
@@ -27028,11 +30394,11 @@ func (t *GetMappedControlByID_MappedControl) GetRelation() *string {
 	}
 	return t.Relation
 }
-func (t *GetMappedControlByID_MappedControl) GetSubcontrols() []*GetMappedControlByID_MappedControl_Subcontrols {
+func (t *GetMappedControlByID_MappedControl) GetSubcontrols() *GetMappedControlByID_MappedControl_Subcontrols {
 	if t == nil {
 		t = &GetMappedControlByID_MappedControl{}
 	}
-	return t.Subcontrols
+	return &t.Subcontrols
 }
 func (t *GetMappedControlByID_MappedControl) GetTags() []string {
 	if t == nil {
@@ -27053,74 +30419,118 @@ func (t *GetMappedControlByID_MappedControl) GetUpdatedBy() *string {
 	return t.UpdatedBy
 }
 
-type GetMappedControls_MappedControls_Edges_Node_Controls struct {
+type GetMappedControls_MappedControls_Edges_Node_Controls_Edges_Node struct {
 	Description *string "json:\"description,omitempty\" graphql:\"description\""
 	ID          string  "json:\"id\" graphql:\"id\""
 	RefCode     string  "json:\"refCode\" graphql:\"refCode\""
 }
 
-func (t *GetMappedControls_MappedControls_Edges_Node_Controls) GetDescription() *string {
+func (t *GetMappedControls_MappedControls_Edges_Node_Controls_Edges_Node) GetDescription() *string {
 	if t == nil {
-		t = &GetMappedControls_MappedControls_Edges_Node_Controls{}
+		t = &GetMappedControls_MappedControls_Edges_Node_Controls_Edges_Node{}
 	}
 	return t.Description
 }
-func (t *GetMappedControls_MappedControls_Edges_Node_Controls) GetID() string {
+func (t *GetMappedControls_MappedControls_Edges_Node_Controls_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetMappedControls_MappedControls_Edges_Node_Controls{}
+		t = &GetMappedControls_MappedControls_Edges_Node_Controls_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetMappedControls_MappedControls_Edges_Node_Controls) GetRefCode() string {
+func (t *GetMappedControls_MappedControls_Edges_Node_Controls_Edges_Node) GetRefCode() string {
+	if t == nil {
+		t = &GetMappedControls_MappedControls_Edges_Node_Controls_Edges_Node{}
+	}
+	return t.RefCode
+}
+
+type GetMappedControls_MappedControls_Edges_Node_Controls_Edges struct {
+	Node *GetMappedControls_MappedControls_Edges_Node_Controls_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetMappedControls_MappedControls_Edges_Node_Controls_Edges) GetNode() *GetMappedControls_MappedControls_Edges_Node_Controls_Edges_Node {
+	if t == nil {
+		t = &GetMappedControls_MappedControls_Edges_Node_Controls_Edges{}
+	}
+	return t.Node
+}
+
+type GetMappedControls_MappedControls_Edges_Node_Controls struct {
+	Edges []*GetMappedControls_MappedControls_Edges_Node_Controls_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetMappedControls_MappedControls_Edges_Node_Controls) GetEdges() []*GetMappedControls_MappedControls_Edges_Node_Controls_Edges {
 	if t == nil {
 		t = &GetMappedControls_MappedControls_Edges_Node_Controls{}
 	}
+	return t.Edges
+}
+
+type GetMappedControls_MappedControls_Edges_Node_Subcontrols_Edges_Node struct {
+	Description *string "json:\"description,omitempty\" graphql:\"description\""
+	ID          string  "json:\"id\" graphql:\"id\""
+	RefCode     string  "json:\"refCode\" graphql:\"refCode\""
+}
+
+func (t *GetMappedControls_MappedControls_Edges_Node_Subcontrols_Edges_Node) GetDescription() *string {
+	if t == nil {
+		t = &GetMappedControls_MappedControls_Edges_Node_Subcontrols_Edges_Node{}
+	}
+	return t.Description
+}
+func (t *GetMappedControls_MappedControls_Edges_Node_Subcontrols_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetMappedControls_MappedControls_Edges_Node_Subcontrols_Edges_Node{}
+	}
+	return t.ID
+}
+func (t *GetMappedControls_MappedControls_Edges_Node_Subcontrols_Edges_Node) GetRefCode() string {
+	if t == nil {
+		t = &GetMappedControls_MappedControls_Edges_Node_Subcontrols_Edges_Node{}
+	}
 	return t.RefCode
+}
+
+type GetMappedControls_MappedControls_Edges_Node_Subcontrols_Edges struct {
+	Node *GetMappedControls_MappedControls_Edges_Node_Subcontrols_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetMappedControls_MappedControls_Edges_Node_Subcontrols_Edges) GetNode() *GetMappedControls_MappedControls_Edges_Node_Subcontrols_Edges_Node {
+	if t == nil {
+		t = &GetMappedControls_MappedControls_Edges_Node_Subcontrols_Edges{}
+	}
+	return t.Node
 }
 
 type GetMappedControls_MappedControls_Edges_Node_Subcontrols struct {
-	Description *string "json:\"description,omitempty\" graphql:\"description\""
-	ID          string  "json:\"id\" graphql:\"id\""
-	RefCode     string  "json:\"refCode\" graphql:\"refCode\""
+	Edges []*GetMappedControls_MappedControls_Edges_Node_Subcontrols_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *GetMappedControls_MappedControls_Edges_Node_Subcontrols) GetDescription() *string {
+func (t *GetMappedControls_MappedControls_Edges_Node_Subcontrols) GetEdges() []*GetMappedControls_MappedControls_Edges_Node_Subcontrols_Edges {
 	if t == nil {
 		t = &GetMappedControls_MappedControls_Edges_Node_Subcontrols{}
 	}
-	return t.Description
-}
-func (t *GetMappedControls_MappedControls_Edges_Node_Subcontrols) GetID() string {
-	if t == nil {
-		t = &GetMappedControls_MappedControls_Edges_Node_Subcontrols{}
-	}
-	return t.ID
-}
-func (t *GetMappedControls_MappedControls_Edges_Node_Subcontrols) GetRefCode() string {
-	if t == nil {
-		t = &GetMappedControls_MappedControls_Edges_Node_Subcontrols{}
-	}
-	return t.RefCode
+	return t.Edges
 }
 
 type GetMappedControls_MappedControls_Edges_Node struct {
-	Controls    []*GetMappedControls_MappedControls_Edges_Node_Controls    "json:\"controls,omitempty\" graphql:\"controls\""
-	CreatedAt   *time.Time                                                 "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy   *string                                                    "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	ID          string                                                     "json:\"id\" graphql:\"id\""
-	MappingType *string                                                    "json:\"mappingType,omitempty\" graphql:\"mappingType\""
-	Relation    *string                                                    "json:\"relation,omitempty\" graphql:\"relation\""
-	Subcontrols []*GetMappedControls_MappedControls_Edges_Node_Subcontrols "json:\"subcontrols,omitempty\" graphql:\"subcontrols\""
-	Tags        []string                                                   "json:\"tags,omitempty\" graphql:\"tags\""
-	UpdatedAt   *time.Time                                                 "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy   *string                                                    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Controls    GetMappedControls_MappedControls_Edges_Node_Controls    "json:\"controls\" graphql:\"controls\""
+	CreatedAt   *time.Time                                              "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy   *string                                                 "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	ID          string                                                  "json:\"id\" graphql:\"id\""
+	MappingType *string                                                 "json:\"mappingType,omitempty\" graphql:\"mappingType\""
+	Relation    *string                                                 "json:\"relation,omitempty\" graphql:\"relation\""
+	Subcontrols GetMappedControls_MappedControls_Edges_Node_Subcontrols "json:\"subcontrols\" graphql:\"subcontrols\""
+	Tags        []string                                                "json:\"tags,omitempty\" graphql:\"tags\""
+	UpdatedAt   *time.Time                                              "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy   *string                                                 "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *GetMappedControls_MappedControls_Edges_Node) GetControls() []*GetMappedControls_MappedControls_Edges_Node_Controls {
+func (t *GetMappedControls_MappedControls_Edges_Node) GetControls() *GetMappedControls_MappedControls_Edges_Node_Controls {
 	if t == nil {
 		t = &GetMappedControls_MappedControls_Edges_Node{}
 	}
-	return t.Controls
+	return &t.Controls
 }
 func (t *GetMappedControls_MappedControls_Edges_Node) GetCreatedAt() *time.Time {
 	if t == nil {
@@ -27152,11 +30562,11 @@ func (t *GetMappedControls_MappedControls_Edges_Node) GetRelation() *string {
 	}
 	return t.Relation
 }
-func (t *GetMappedControls_MappedControls_Edges_Node) GetSubcontrols() []*GetMappedControls_MappedControls_Edges_Node_Subcontrols {
+func (t *GetMappedControls_MappedControls_Edges_Node) GetSubcontrols() *GetMappedControls_MappedControls_Edges_Node_Subcontrols {
 	if t == nil {
 		t = &GetMappedControls_MappedControls_Edges_Node{}
 	}
-	return t.Subcontrols
+	return &t.Subcontrols
 }
 func (t *GetMappedControls_MappedControls_Edges_Node) GetTags() []string {
 	if t == nil {
@@ -27199,74 +30609,118 @@ func (t *GetMappedControls_MappedControls) GetEdges() []*GetMappedControls_Mappe
 	return t.Edges
 }
 
-type UpdateMappedControl_UpdateMappedControl_MappedControl_Controls struct {
+type UpdateMappedControl_UpdateMappedControl_MappedControl_Controls_Edges_Node struct {
 	Description *string "json:\"description,omitempty\" graphql:\"description\""
 	ID          string  "json:\"id\" graphql:\"id\""
 	RefCode     string  "json:\"refCode\" graphql:\"refCode\""
 }
 
-func (t *UpdateMappedControl_UpdateMappedControl_MappedControl_Controls) GetDescription() *string {
+func (t *UpdateMappedControl_UpdateMappedControl_MappedControl_Controls_Edges_Node) GetDescription() *string {
 	if t == nil {
-		t = &UpdateMappedControl_UpdateMappedControl_MappedControl_Controls{}
+		t = &UpdateMappedControl_UpdateMappedControl_MappedControl_Controls_Edges_Node{}
 	}
 	return t.Description
 }
-func (t *UpdateMappedControl_UpdateMappedControl_MappedControl_Controls) GetID() string {
+func (t *UpdateMappedControl_UpdateMappedControl_MappedControl_Controls_Edges_Node) GetID() string {
 	if t == nil {
-		t = &UpdateMappedControl_UpdateMappedControl_MappedControl_Controls{}
+		t = &UpdateMappedControl_UpdateMappedControl_MappedControl_Controls_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *UpdateMappedControl_UpdateMappedControl_MappedControl_Controls) GetRefCode() string {
+func (t *UpdateMappedControl_UpdateMappedControl_MappedControl_Controls_Edges_Node) GetRefCode() string {
+	if t == nil {
+		t = &UpdateMappedControl_UpdateMappedControl_MappedControl_Controls_Edges_Node{}
+	}
+	return t.RefCode
+}
+
+type UpdateMappedControl_UpdateMappedControl_MappedControl_Controls_Edges struct {
+	Node *UpdateMappedControl_UpdateMappedControl_MappedControl_Controls_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateMappedControl_UpdateMappedControl_MappedControl_Controls_Edges) GetNode() *UpdateMappedControl_UpdateMappedControl_MappedControl_Controls_Edges_Node {
+	if t == nil {
+		t = &UpdateMappedControl_UpdateMappedControl_MappedControl_Controls_Edges{}
+	}
+	return t.Node
+}
+
+type UpdateMappedControl_UpdateMappedControl_MappedControl_Controls struct {
+	Edges []*UpdateMappedControl_UpdateMappedControl_MappedControl_Controls_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *UpdateMappedControl_UpdateMappedControl_MappedControl_Controls) GetEdges() []*UpdateMappedControl_UpdateMappedControl_MappedControl_Controls_Edges {
 	if t == nil {
 		t = &UpdateMappedControl_UpdateMappedControl_MappedControl_Controls{}
 	}
+	return t.Edges
+}
+
+type UpdateMappedControl_UpdateMappedControl_MappedControl_Subcontrols_Edges_Node struct {
+	Description *string "json:\"description,omitempty\" graphql:\"description\""
+	ID          string  "json:\"id\" graphql:\"id\""
+	RefCode     string  "json:\"refCode\" graphql:\"refCode\""
+}
+
+func (t *UpdateMappedControl_UpdateMappedControl_MappedControl_Subcontrols_Edges_Node) GetDescription() *string {
+	if t == nil {
+		t = &UpdateMappedControl_UpdateMappedControl_MappedControl_Subcontrols_Edges_Node{}
+	}
+	return t.Description
+}
+func (t *UpdateMappedControl_UpdateMappedControl_MappedControl_Subcontrols_Edges_Node) GetID() string {
+	if t == nil {
+		t = &UpdateMappedControl_UpdateMappedControl_MappedControl_Subcontrols_Edges_Node{}
+	}
+	return t.ID
+}
+func (t *UpdateMappedControl_UpdateMappedControl_MappedControl_Subcontrols_Edges_Node) GetRefCode() string {
+	if t == nil {
+		t = &UpdateMappedControl_UpdateMappedControl_MappedControl_Subcontrols_Edges_Node{}
+	}
 	return t.RefCode
+}
+
+type UpdateMappedControl_UpdateMappedControl_MappedControl_Subcontrols_Edges struct {
+	Node *UpdateMappedControl_UpdateMappedControl_MappedControl_Subcontrols_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateMappedControl_UpdateMappedControl_MappedControl_Subcontrols_Edges) GetNode() *UpdateMappedControl_UpdateMappedControl_MappedControl_Subcontrols_Edges_Node {
+	if t == nil {
+		t = &UpdateMappedControl_UpdateMappedControl_MappedControl_Subcontrols_Edges{}
+	}
+	return t.Node
 }
 
 type UpdateMappedControl_UpdateMappedControl_MappedControl_Subcontrols struct {
-	Description *string "json:\"description,omitempty\" graphql:\"description\""
-	ID          string  "json:\"id\" graphql:\"id\""
-	RefCode     string  "json:\"refCode\" graphql:\"refCode\""
+	Edges []*UpdateMappedControl_UpdateMappedControl_MappedControl_Subcontrols_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *UpdateMappedControl_UpdateMappedControl_MappedControl_Subcontrols) GetDescription() *string {
+func (t *UpdateMappedControl_UpdateMappedControl_MappedControl_Subcontrols) GetEdges() []*UpdateMappedControl_UpdateMappedControl_MappedControl_Subcontrols_Edges {
 	if t == nil {
 		t = &UpdateMappedControl_UpdateMappedControl_MappedControl_Subcontrols{}
 	}
-	return t.Description
-}
-func (t *UpdateMappedControl_UpdateMappedControl_MappedControl_Subcontrols) GetID() string {
-	if t == nil {
-		t = &UpdateMappedControl_UpdateMappedControl_MappedControl_Subcontrols{}
-	}
-	return t.ID
-}
-func (t *UpdateMappedControl_UpdateMappedControl_MappedControl_Subcontrols) GetRefCode() string {
-	if t == nil {
-		t = &UpdateMappedControl_UpdateMappedControl_MappedControl_Subcontrols{}
-	}
-	return t.RefCode
+	return t.Edges
 }
 
 type UpdateMappedControl_UpdateMappedControl_MappedControl struct {
-	Controls    []*UpdateMappedControl_UpdateMappedControl_MappedControl_Controls    "json:\"controls,omitempty\" graphql:\"controls\""
-	CreatedAt   *time.Time                                                           "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy   *string                                                              "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	ID          string                                                               "json:\"id\" graphql:\"id\""
-	MappingType *string                                                              "json:\"mappingType,omitempty\" graphql:\"mappingType\""
-	Relation    *string                                                              "json:\"relation,omitempty\" graphql:\"relation\""
-	Subcontrols []*UpdateMappedControl_UpdateMappedControl_MappedControl_Subcontrols "json:\"subcontrols,omitempty\" graphql:\"subcontrols\""
-	Tags        []string                                                             "json:\"tags,omitempty\" graphql:\"tags\""
-	UpdatedAt   *time.Time                                                           "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy   *string                                                              "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Controls    UpdateMappedControl_UpdateMappedControl_MappedControl_Controls    "json:\"controls\" graphql:\"controls\""
+	CreatedAt   *time.Time                                                        "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy   *string                                                           "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	ID          string                                                            "json:\"id\" graphql:\"id\""
+	MappingType *string                                                           "json:\"mappingType,omitempty\" graphql:\"mappingType\""
+	Relation    *string                                                           "json:\"relation,omitempty\" graphql:\"relation\""
+	Subcontrols UpdateMappedControl_UpdateMappedControl_MappedControl_Subcontrols "json:\"subcontrols\" graphql:\"subcontrols\""
+	Tags        []string                                                          "json:\"tags,omitempty\" graphql:\"tags\""
+	UpdatedAt   *time.Time                                                        "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy   *string                                                           "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *UpdateMappedControl_UpdateMappedControl_MappedControl) GetControls() []*UpdateMappedControl_UpdateMappedControl_MappedControl_Controls {
+func (t *UpdateMappedControl_UpdateMappedControl_MappedControl) GetControls() *UpdateMappedControl_UpdateMappedControl_MappedControl_Controls {
 	if t == nil {
 		t = &UpdateMappedControl_UpdateMappedControl_MappedControl{}
 	}
-	return t.Controls
+	return &t.Controls
 }
 func (t *UpdateMappedControl_UpdateMappedControl_MappedControl) GetCreatedAt() *time.Time {
 	if t == nil {
@@ -27298,11 +30752,11 @@ func (t *UpdateMappedControl_UpdateMappedControl_MappedControl) GetRelation() *s
 	}
 	return t.Relation
 }
-func (t *UpdateMappedControl_UpdateMappedControl_MappedControl) GetSubcontrols() []*UpdateMappedControl_UpdateMappedControl_MappedControl_Subcontrols {
+func (t *UpdateMappedControl_UpdateMappedControl_MappedControl) GetSubcontrols() *UpdateMappedControl_UpdateMappedControl_MappedControl_Subcontrols {
 	if t == nil {
 		t = &UpdateMappedControl_UpdateMappedControl_MappedControl{}
 	}
-	return t.Subcontrols
+	return &t.Subcontrols
 }
 func (t *UpdateMappedControl_UpdateMappedControl_MappedControl) GetTags() []string {
 	if t == nil {
@@ -27710,22 +31164,44 @@ func (t *CreateBulkNarrative_CreateBulkNarrative) GetNarratives() []*CreateBulkN
 	return t.Narratives
 }
 
-type CreateNarrative_CreateNarrative_Narrative_Programs struct {
+type CreateNarrative_CreateNarrative_Narrative_Programs_Edges_Node struct {
 	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
-func (t *CreateNarrative_CreateNarrative_Narrative_Programs) GetID() string {
+func (t *CreateNarrative_CreateNarrative_Narrative_Programs_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateNarrative_CreateNarrative_Narrative_Programs{}
+		t = &CreateNarrative_CreateNarrative_Narrative_Programs_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *CreateNarrative_CreateNarrative_Narrative_Programs) GetName() string {
+func (t *CreateNarrative_CreateNarrative_Narrative_Programs_Edges_Node) GetName() string {
+	if t == nil {
+		t = &CreateNarrative_CreateNarrative_Narrative_Programs_Edges_Node{}
+	}
+	return t.Name
+}
+
+type CreateNarrative_CreateNarrative_Narrative_Programs_Edges struct {
+	Node *CreateNarrative_CreateNarrative_Narrative_Programs_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateNarrative_CreateNarrative_Narrative_Programs_Edges) GetNode() *CreateNarrative_CreateNarrative_Narrative_Programs_Edges_Node {
+	if t == nil {
+		t = &CreateNarrative_CreateNarrative_Narrative_Programs_Edges{}
+	}
+	return t.Node
+}
+
+type CreateNarrative_CreateNarrative_Narrative_Programs struct {
+	Edges []*CreateNarrative_CreateNarrative_Narrative_Programs_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateNarrative_CreateNarrative_Narrative_Programs) GetEdges() []*CreateNarrative_CreateNarrative_Narrative_Programs_Edges {
 	if t == nil {
 		t = &CreateNarrative_CreateNarrative_Narrative_Programs{}
 	}
-	return t.Name
+	return t.Edges
 }
 
 type CreateNarrative_CreateNarrative_Narrative_Editors struct {
@@ -27792,7 +31268,7 @@ type CreateNarrative_CreateNarrative_Narrative struct {
 	Editors       []*CreateNarrative_CreateNarrative_Narrative_Editors       "json:\"editors,omitempty\" graphql:\"editors\""
 	ID            string                                                     "json:\"id\" graphql:\"id\""
 	Name          string                                                     "json:\"name\" graphql:\"name\""
-	Programs      []*CreateNarrative_CreateNarrative_Narrative_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
+	Programs      CreateNarrative_CreateNarrative_Narrative_Programs         "json:\"programs\" graphql:\"programs\""
 	Tags          []string                                                   "json:\"tags,omitempty\" graphql:\"tags\""
 	UpdatedAt     *time.Time                                                 "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
 	UpdatedBy     *string                                                    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
@@ -27853,11 +31329,11 @@ func (t *CreateNarrative_CreateNarrative_Narrative) GetName() string {
 	}
 	return t.Name
 }
-func (t *CreateNarrative_CreateNarrative_Narrative) GetPrograms() []*CreateNarrative_CreateNarrative_Narrative_Programs {
+func (t *CreateNarrative_CreateNarrative_Narrative) GetPrograms() *CreateNarrative_CreateNarrative_Narrative_Programs {
 	if t == nil {
 		t = &CreateNarrative_CreateNarrative_Narrative{}
 	}
-	return t.Programs
+	return &t.Programs
 }
 func (t *CreateNarrative_CreateNarrative_Narrative) GetTags() []string {
 	if t == nil {
@@ -27906,22 +31382,44 @@ func (t *DeleteNarrative_DeleteNarrative) GetDeletedID() string {
 	return t.DeletedID
 }
 
-type GetAllNarratives_Narratives_Edges_Node_Programs struct {
+type GetAllNarratives_Narratives_Edges_Node_Programs_Edges_Node struct {
 	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
-func (t *GetAllNarratives_Narratives_Edges_Node_Programs) GetID() string {
+func (t *GetAllNarratives_Narratives_Edges_Node_Programs_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetAllNarratives_Narratives_Edges_Node_Programs{}
+		t = &GetAllNarratives_Narratives_Edges_Node_Programs_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetAllNarratives_Narratives_Edges_Node_Programs) GetName() string {
+func (t *GetAllNarratives_Narratives_Edges_Node_Programs_Edges_Node) GetName() string {
+	if t == nil {
+		t = &GetAllNarratives_Narratives_Edges_Node_Programs_Edges_Node{}
+	}
+	return t.Name
+}
+
+type GetAllNarratives_Narratives_Edges_Node_Programs_Edges struct {
+	Node *GetAllNarratives_Narratives_Edges_Node_Programs_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllNarratives_Narratives_Edges_Node_Programs_Edges) GetNode() *GetAllNarratives_Narratives_Edges_Node_Programs_Edges_Node {
+	if t == nil {
+		t = &GetAllNarratives_Narratives_Edges_Node_Programs_Edges{}
+	}
+	return t.Node
+}
+
+type GetAllNarratives_Narratives_Edges_Node_Programs struct {
+	Edges []*GetAllNarratives_Narratives_Edges_Node_Programs_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetAllNarratives_Narratives_Edges_Node_Programs) GetEdges() []*GetAllNarratives_Narratives_Edges_Node_Programs_Edges {
 	if t == nil {
 		t = &GetAllNarratives_Narratives_Edges_Node_Programs{}
 	}
-	return t.Name
+	return t.Edges
 }
 
 type GetAllNarratives_Narratives_Edges_Node_Editors struct {
@@ -27988,7 +31486,7 @@ type GetAllNarratives_Narratives_Edges_Node struct {
 	Editors       []*GetAllNarratives_Narratives_Edges_Node_Editors       "json:\"editors,omitempty\" graphql:\"editors\""
 	ID            string                                                  "json:\"id\" graphql:\"id\""
 	Name          string                                                  "json:\"name\" graphql:\"name\""
-	Programs      []*GetAllNarratives_Narratives_Edges_Node_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
+	Programs      GetAllNarratives_Narratives_Edges_Node_Programs         "json:\"programs\" graphql:\"programs\""
 	Tags          []string                                                "json:\"tags,omitempty\" graphql:\"tags\""
 	UpdatedAt     *time.Time                                              "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
 	UpdatedBy     *string                                                 "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
@@ -28049,11 +31547,11 @@ func (t *GetAllNarratives_Narratives_Edges_Node) GetName() string {
 	}
 	return t.Name
 }
-func (t *GetAllNarratives_Narratives_Edges_Node) GetPrograms() []*GetAllNarratives_Narratives_Edges_Node_Programs {
+func (t *GetAllNarratives_Narratives_Edges_Node) GetPrograms() *GetAllNarratives_Narratives_Edges_Node_Programs {
 	if t == nil {
 		t = &GetAllNarratives_Narratives_Edges_Node{}
 	}
-	return t.Programs
+	return &t.Programs
 }
 func (t *GetAllNarratives_Narratives_Edges_Node) GetTags() []string {
 	if t == nil {
@@ -28102,22 +31600,44 @@ func (t *GetAllNarratives_Narratives) GetEdges() []*GetAllNarratives_Narratives_
 	return t.Edges
 }
 
-type GetNarrativeByID_Narrative_Programs struct {
+type GetNarrativeByID_Narrative_Programs_Edges_Node struct {
 	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
-func (t *GetNarrativeByID_Narrative_Programs) GetID() string {
+func (t *GetNarrativeByID_Narrative_Programs_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetNarrativeByID_Narrative_Programs{}
+		t = &GetNarrativeByID_Narrative_Programs_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetNarrativeByID_Narrative_Programs) GetName() string {
+func (t *GetNarrativeByID_Narrative_Programs_Edges_Node) GetName() string {
+	if t == nil {
+		t = &GetNarrativeByID_Narrative_Programs_Edges_Node{}
+	}
+	return t.Name
+}
+
+type GetNarrativeByID_Narrative_Programs_Edges struct {
+	Node *GetNarrativeByID_Narrative_Programs_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetNarrativeByID_Narrative_Programs_Edges) GetNode() *GetNarrativeByID_Narrative_Programs_Edges_Node {
+	if t == nil {
+		t = &GetNarrativeByID_Narrative_Programs_Edges{}
+	}
+	return t.Node
+}
+
+type GetNarrativeByID_Narrative_Programs struct {
+	Edges []*GetNarrativeByID_Narrative_Programs_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetNarrativeByID_Narrative_Programs) GetEdges() []*GetNarrativeByID_Narrative_Programs_Edges {
 	if t == nil {
 		t = &GetNarrativeByID_Narrative_Programs{}
 	}
-	return t.Name
+	return t.Edges
 }
 
 type GetNarrativeByID_Narrative_Editors struct {
@@ -28184,7 +31704,7 @@ type GetNarrativeByID_Narrative struct {
 	Editors       []*GetNarrativeByID_Narrative_Editors       "json:\"editors,omitempty\" graphql:\"editors\""
 	ID            string                                      "json:\"id\" graphql:\"id\""
 	Name          string                                      "json:\"name\" graphql:\"name\""
-	Programs      []*GetNarrativeByID_Narrative_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
+	Programs      GetNarrativeByID_Narrative_Programs         "json:\"programs\" graphql:\"programs\""
 	Tags          []string                                    "json:\"tags,omitempty\" graphql:\"tags\""
 	UpdatedAt     *time.Time                                  "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
 	UpdatedBy     *string                                     "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
@@ -28245,11 +31765,11 @@ func (t *GetNarrativeByID_Narrative) GetName() string {
 	}
 	return t.Name
 }
-func (t *GetNarrativeByID_Narrative) GetPrograms() []*GetNarrativeByID_Narrative_Programs {
+func (t *GetNarrativeByID_Narrative) GetPrograms() *GetNarrativeByID_Narrative_Programs {
 	if t == nil {
 		t = &GetNarrativeByID_Narrative{}
 	}
-	return t.Programs
+	return &t.Programs
 }
 func (t *GetNarrativeByID_Narrative) GetTags() []string {
 	if t == nil {
@@ -28276,22 +31796,44 @@ func (t *GetNarrativeByID_Narrative) GetViewers() []*GetNarrativeByID_Narrative_
 	return t.Viewers
 }
 
-type GetNarratives_Narratives_Edges_Node_Programs struct {
+type GetNarratives_Narratives_Edges_Node_Programs_Edges_Node struct {
 	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
-func (t *GetNarratives_Narratives_Edges_Node_Programs) GetID() string {
+func (t *GetNarratives_Narratives_Edges_Node_Programs_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetNarratives_Narratives_Edges_Node_Programs{}
+		t = &GetNarratives_Narratives_Edges_Node_Programs_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetNarratives_Narratives_Edges_Node_Programs) GetName() string {
+func (t *GetNarratives_Narratives_Edges_Node_Programs_Edges_Node) GetName() string {
+	if t == nil {
+		t = &GetNarratives_Narratives_Edges_Node_Programs_Edges_Node{}
+	}
+	return t.Name
+}
+
+type GetNarratives_Narratives_Edges_Node_Programs_Edges struct {
+	Node *GetNarratives_Narratives_Edges_Node_Programs_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetNarratives_Narratives_Edges_Node_Programs_Edges) GetNode() *GetNarratives_Narratives_Edges_Node_Programs_Edges_Node {
+	if t == nil {
+		t = &GetNarratives_Narratives_Edges_Node_Programs_Edges{}
+	}
+	return t.Node
+}
+
+type GetNarratives_Narratives_Edges_Node_Programs struct {
+	Edges []*GetNarratives_Narratives_Edges_Node_Programs_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetNarratives_Narratives_Edges_Node_Programs) GetEdges() []*GetNarratives_Narratives_Edges_Node_Programs_Edges {
 	if t == nil {
 		t = &GetNarratives_Narratives_Edges_Node_Programs{}
 	}
-	return t.Name
+	return t.Edges
 }
 
 type GetNarratives_Narratives_Edges_Node_Editors struct {
@@ -28358,7 +31900,7 @@ type GetNarratives_Narratives_Edges_Node struct {
 	Editors       []*GetNarratives_Narratives_Edges_Node_Editors       "json:\"editors,omitempty\" graphql:\"editors\""
 	ID            string                                               "json:\"id\" graphql:\"id\""
 	Name          string                                               "json:\"name\" graphql:\"name\""
-	Programs      []*GetNarratives_Narratives_Edges_Node_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
+	Programs      GetNarratives_Narratives_Edges_Node_Programs         "json:\"programs\" graphql:\"programs\""
 	Tags          []string                                             "json:\"tags,omitempty\" graphql:\"tags\""
 	UpdatedAt     *time.Time                                           "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
 	UpdatedBy     *string                                              "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
@@ -28419,11 +31961,11 @@ func (t *GetNarratives_Narratives_Edges_Node) GetName() string {
 	}
 	return t.Name
 }
-func (t *GetNarratives_Narratives_Edges_Node) GetPrograms() []*GetNarratives_Narratives_Edges_Node_Programs {
+func (t *GetNarratives_Narratives_Edges_Node) GetPrograms() *GetNarratives_Narratives_Edges_Node_Programs {
 	if t == nil {
 		t = &GetNarratives_Narratives_Edges_Node{}
 	}
-	return t.Programs
+	return &t.Programs
 }
 func (t *GetNarratives_Narratives_Edges_Node) GetTags() []string {
 	if t == nil {
@@ -28472,22 +32014,44 @@ func (t *GetNarratives_Narratives) GetEdges() []*GetNarratives_Narratives_Edges 
 	return t.Edges
 }
 
-type UpdateNarrative_UpdateNarrative_Narrative_Programs struct {
+type UpdateNarrative_UpdateNarrative_Narrative_Programs_Edges_Node struct {
 	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
-func (t *UpdateNarrative_UpdateNarrative_Narrative_Programs) GetID() string {
+func (t *UpdateNarrative_UpdateNarrative_Narrative_Programs_Edges_Node) GetID() string {
 	if t == nil {
-		t = &UpdateNarrative_UpdateNarrative_Narrative_Programs{}
+		t = &UpdateNarrative_UpdateNarrative_Narrative_Programs_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *UpdateNarrative_UpdateNarrative_Narrative_Programs) GetName() string {
+func (t *UpdateNarrative_UpdateNarrative_Narrative_Programs_Edges_Node) GetName() string {
+	if t == nil {
+		t = &UpdateNarrative_UpdateNarrative_Narrative_Programs_Edges_Node{}
+	}
+	return t.Name
+}
+
+type UpdateNarrative_UpdateNarrative_Narrative_Programs_Edges struct {
+	Node *UpdateNarrative_UpdateNarrative_Narrative_Programs_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateNarrative_UpdateNarrative_Narrative_Programs_Edges) GetNode() *UpdateNarrative_UpdateNarrative_Narrative_Programs_Edges_Node {
+	if t == nil {
+		t = &UpdateNarrative_UpdateNarrative_Narrative_Programs_Edges{}
+	}
+	return t.Node
+}
+
+type UpdateNarrative_UpdateNarrative_Narrative_Programs struct {
+	Edges []*UpdateNarrative_UpdateNarrative_Narrative_Programs_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *UpdateNarrative_UpdateNarrative_Narrative_Programs) GetEdges() []*UpdateNarrative_UpdateNarrative_Narrative_Programs_Edges {
 	if t == nil {
 		t = &UpdateNarrative_UpdateNarrative_Narrative_Programs{}
 	}
-	return t.Name
+	return t.Edges
 }
 
 type UpdateNarrative_UpdateNarrative_Narrative_Editors struct {
@@ -28554,7 +32118,7 @@ type UpdateNarrative_UpdateNarrative_Narrative struct {
 	Editors       []*UpdateNarrative_UpdateNarrative_Narrative_Editors       "json:\"editors,omitempty\" graphql:\"editors\""
 	ID            string                                                     "json:\"id\" graphql:\"id\""
 	Name          string                                                     "json:\"name\" graphql:\"name\""
-	Programs      []*UpdateNarrative_UpdateNarrative_Narrative_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
+	Programs      UpdateNarrative_UpdateNarrative_Narrative_Programs         "json:\"programs\" graphql:\"programs\""
 	Tags          []string                                                   "json:\"tags,omitempty\" graphql:\"tags\""
 	UpdatedAt     *time.Time                                                 "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
 	UpdatedBy     *string                                                    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
@@ -28615,11 +32179,11 @@ func (t *UpdateNarrative_UpdateNarrative_Narrative) GetName() string {
 	}
 	return t.Name
 }
-func (t *UpdateNarrative_UpdateNarrative_Narrative) GetPrograms() []*UpdateNarrative_UpdateNarrative_Narrative_Programs {
+func (t *UpdateNarrative_UpdateNarrative_Narrative) GetPrograms() *UpdateNarrative_UpdateNarrative_Narrative_Programs {
 	if t == nil {
 		t = &UpdateNarrative_UpdateNarrative_Narrative{}
 	}
-	return t.Programs
+	return &t.Programs
 }
 func (t *UpdateNarrative_UpdateNarrative_Narrative) GetTags() []string {
 	if t == nil {
@@ -34779,22 +38343,44 @@ func (t *GetOrgSubscriptionHistories_OrgSubscriptionHistories) GetEdges() []*Get
 	return t.Edges
 }
 
-type CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Organizations struct {
+type CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Organizations_Edges_Node struct {
 	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
-func (t *CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Organizations) GetID() string {
+func (t *CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Organizations_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Organizations{}
+		t = &CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Organizations_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Organizations) GetName() string {
+func (t *CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Organizations_Edges_Node) GetName() string {
+	if t == nil {
+		t = &CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Organizations_Edges_Node{}
+	}
+	return t.Name
+}
+
+type CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Organizations_Edges struct {
+	Node *CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Organizations_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Organizations_Edges) GetNode() *CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Organizations_Edges_Node {
+	if t == nil {
+		t = &CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Organizations_Edges{}
+	}
+	return t.Node
+}
+
+type CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Organizations struct {
+	Edges []*CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Organizations_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Organizations) GetEdges() []*CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Organizations_Edges {
 	if t == nil {
 		t = &CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Organizations{}
 	}
-	return t.Name
+	return t.Edges
 }
 
 type CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Owner struct {
@@ -34809,24 +38395,24 @@ func (t *CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken
 }
 
 type CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken struct {
-	CreatedAt     *time.Time                                                                               "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy     *string                                                                                  "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description   *string                                                                                  "json:\"description,omitempty\" graphql:\"description\""
-	ExpiresAt     *time.Time                                                                               "json:\"expiresAt,omitempty\" graphql:\"expiresAt\""
-	ID            string                                                                                   "json:\"id\" graphql:\"id\""
-	IsActive      *bool                                                                                    "json:\"isActive,omitempty\" graphql:\"isActive\""
-	LastUsedAt    *time.Time                                                                               "json:\"lastUsedAt,omitempty\" graphql:\"lastUsedAt\""
-	Name          string                                                                                   "json:\"name\" graphql:\"name\""
-	Organizations []*CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Organizations "json:\"organizations,omitempty\" graphql:\"organizations\""
-	Owner         CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Owner            "json:\"owner\" graphql:\"owner\""
-	RevokedAt     *time.Time                                                                               "json:\"revokedAt,omitempty\" graphql:\"revokedAt\""
-	RevokedBy     *string                                                                                  "json:\"revokedBy,omitempty\" graphql:\"revokedBy\""
-	RevokedReason *string                                                                                  "json:\"revokedReason,omitempty\" graphql:\"revokedReason\""
-	Scopes        []string                                                                                 "json:\"scopes,omitempty\" graphql:\"scopes\""
-	Tags          []string                                                                                 "json:\"tags,omitempty\" graphql:\"tags\""
-	Token         string                                                                                   "json:\"token\" graphql:\"token\""
-	UpdatedAt     *time.Time                                                                               "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy     *string                                                                                  "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	CreatedAt     *time.Time                                                                            "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy     *string                                                                               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description   *string                                                                               "json:\"description,omitempty\" graphql:\"description\""
+	ExpiresAt     *time.Time                                                                            "json:\"expiresAt,omitempty\" graphql:\"expiresAt\""
+	ID            string                                                                                "json:\"id\" graphql:\"id\""
+	IsActive      *bool                                                                                 "json:\"isActive,omitempty\" graphql:\"isActive\""
+	LastUsedAt    *time.Time                                                                            "json:\"lastUsedAt,omitempty\" graphql:\"lastUsedAt\""
+	Name          string                                                                                "json:\"name\" graphql:\"name\""
+	Organizations CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Organizations "json:\"organizations\" graphql:\"organizations\""
+	Owner         CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Owner         "json:\"owner\" graphql:\"owner\""
+	RevokedAt     *time.Time                                                                            "json:\"revokedAt,omitempty\" graphql:\"revokedAt\""
+	RevokedBy     *string                                                                               "json:\"revokedBy,omitempty\" graphql:\"revokedBy\""
+	RevokedReason *string                                                                               "json:\"revokedReason,omitempty\" graphql:\"revokedReason\""
+	Scopes        []string                                                                              "json:\"scopes,omitempty\" graphql:\"scopes\""
+	Tags          []string                                                                              "json:\"tags,omitempty\" graphql:\"tags\""
+	Token         string                                                                                "json:\"token\" graphql:\"token\""
+	UpdatedAt     *time.Time                                                                            "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy     *string                                                                               "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken) GetCreatedAt() *time.Time {
@@ -34877,11 +38463,11 @@ func (t *CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken
 	}
 	return t.Name
 }
-func (t *CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken) GetOrganizations() []*CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Organizations {
+func (t *CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken) GetOrganizations() *CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Organizations {
 	if t == nil {
 		t = &CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken{}
 	}
-	return t.Organizations
+	return &t.Organizations
 }
 func (t *CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken) GetOwner() *CreatePersonalAccessToken_CreatePersonalAccessToken_PersonalAccessToken_Owner {
 	if t == nil {
@@ -34960,42 +38546,64 @@ func (t *DeletePersonalAccessToken_DeletePersonalAccessToken) GetDeletedID() str
 	return t.DeletedID
 }
 
-type GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations struct {
+type GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations_Edges_Node struct {
 	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
-func (t *GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations) GetID() string {
+func (t *GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations{}
+		t = &GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations) GetName() string {
+func (t *GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations_Edges_Node) GetName() string {
 	if t == nil {
-		t = &GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations{}
+		t = &GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations_Edges_Node{}
 	}
 	return t.Name
 }
 
+type GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations_Edges struct {
+	Node *GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations_Edges) GetNode() *GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations_Edges_Node {
+	if t == nil {
+		t = &GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations_Edges{}
+	}
+	return t.Node
+}
+
+type GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations struct {
+	Edges []*GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations) GetEdges() []*GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations_Edges {
+	if t == nil {
+		t = &GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations{}
+	}
+	return t.Edges
+}
+
 type GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node struct {
-	CreatedAt     *time.Time                                                                  "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy     *string                                                                     "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description   *string                                                                     "json:\"description,omitempty\" graphql:\"description\""
-	ExpiresAt     *time.Time                                                                  "json:\"expiresAt,omitempty\" graphql:\"expiresAt\""
-	ID            string                                                                      "json:\"id\" graphql:\"id\""
-	IsActive      *bool                                                                       "json:\"isActive,omitempty\" graphql:\"isActive\""
-	LastUsedAt    *time.Time                                                                  "json:\"lastUsedAt,omitempty\" graphql:\"lastUsedAt\""
-	Name          string                                                                      "json:\"name\" graphql:\"name\""
-	Organizations []*GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations "json:\"organizations,omitempty\" graphql:\"organizations\""
-	RevokedAt     *time.Time                                                                  "json:\"revokedAt,omitempty\" graphql:\"revokedAt\""
-	RevokedBy     *string                                                                     "json:\"revokedBy,omitempty\" graphql:\"revokedBy\""
-	RevokedReason *string                                                                     "json:\"revokedReason,omitempty\" graphql:\"revokedReason\""
-	Scopes        []string                                                                    "json:\"scopes,omitempty\" graphql:\"scopes\""
-	Tags          []string                                                                    "json:\"tags,omitempty\" graphql:\"tags\""
-	Token         string                                                                      "json:\"token\" graphql:\"token\""
-	UpdatedAt     *time.Time                                                                  "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy     *string                                                                     "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	CreatedAt     *time.Time                                                               "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy     *string                                                                  "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description   *string                                                                  "json:\"description,omitempty\" graphql:\"description\""
+	ExpiresAt     *time.Time                                                               "json:\"expiresAt,omitempty\" graphql:\"expiresAt\""
+	ID            string                                                                   "json:\"id\" graphql:\"id\""
+	IsActive      *bool                                                                    "json:\"isActive,omitempty\" graphql:\"isActive\""
+	LastUsedAt    *time.Time                                                               "json:\"lastUsedAt,omitempty\" graphql:\"lastUsedAt\""
+	Name          string                                                                   "json:\"name\" graphql:\"name\""
+	Organizations GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations "json:\"organizations\" graphql:\"organizations\""
+	RevokedAt     *time.Time                                                               "json:\"revokedAt,omitempty\" graphql:\"revokedAt\""
+	RevokedBy     *string                                                                  "json:\"revokedBy,omitempty\" graphql:\"revokedBy\""
+	RevokedReason *string                                                                  "json:\"revokedReason,omitempty\" graphql:\"revokedReason\""
+	Scopes        []string                                                                 "json:\"scopes,omitempty\" graphql:\"scopes\""
+	Tags          []string                                                                 "json:\"tags,omitempty\" graphql:\"tags\""
+	Token         string                                                                   "json:\"token\" graphql:\"token\""
+	UpdatedAt     *time.Time                                                               "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy     *string                                                                  "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node) GetCreatedAt() *time.Time {
@@ -35046,11 +38654,11 @@ func (t *GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node) GetName() s
 	}
 	return t.Name
 }
-func (t *GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node) GetOrganizations() []*GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations {
+func (t *GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node) GetOrganizations() *GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations {
 	if t == nil {
 		t = &GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node{}
 	}
-	return t.Organizations
+	return &t.Organizations
 }
 func (t *GetAllPersonalAccessTokens_PersonalAccessTokens_Edges_Node) GetRevokedAt() *time.Time {
 	if t == nil {
@@ -35123,42 +38731,64 @@ func (t *GetAllPersonalAccessTokens_PersonalAccessTokens) GetEdges() []*GetAllPe
 	return t.Edges
 }
 
-type GetPersonalAccessTokenByID_PersonalAccessToken_Organizations struct {
+type GetPersonalAccessTokenByID_PersonalAccessToken_Organizations_Edges_Node struct {
 	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
-func (t *GetPersonalAccessTokenByID_PersonalAccessToken_Organizations) GetID() string {
+func (t *GetPersonalAccessTokenByID_PersonalAccessToken_Organizations_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetPersonalAccessTokenByID_PersonalAccessToken_Organizations{}
+		t = &GetPersonalAccessTokenByID_PersonalAccessToken_Organizations_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetPersonalAccessTokenByID_PersonalAccessToken_Organizations) GetName() string {
+func (t *GetPersonalAccessTokenByID_PersonalAccessToken_Organizations_Edges_Node) GetName() string {
 	if t == nil {
-		t = &GetPersonalAccessTokenByID_PersonalAccessToken_Organizations{}
+		t = &GetPersonalAccessTokenByID_PersonalAccessToken_Organizations_Edges_Node{}
 	}
 	return t.Name
 }
 
+type GetPersonalAccessTokenByID_PersonalAccessToken_Organizations_Edges struct {
+	Node *GetPersonalAccessTokenByID_PersonalAccessToken_Organizations_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetPersonalAccessTokenByID_PersonalAccessToken_Organizations_Edges) GetNode() *GetPersonalAccessTokenByID_PersonalAccessToken_Organizations_Edges_Node {
+	if t == nil {
+		t = &GetPersonalAccessTokenByID_PersonalAccessToken_Organizations_Edges{}
+	}
+	return t.Node
+}
+
+type GetPersonalAccessTokenByID_PersonalAccessToken_Organizations struct {
+	Edges []*GetPersonalAccessTokenByID_PersonalAccessToken_Organizations_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetPersonalAccessTokenByID_PersonalAccessToken_Organizations) GetEdges() []*GetPersonalAccessTokenByID_PersonalAccessToken_Organizations_Edges {
+	if t == nil {
+		t = &GetPersonalAccessTokenByID_PersonalAccessToken_Organizations{}
+	}
+	return t.Edges
+}
+
 type GetPersonalAccessTokenByID_PersonalAccessToken struct {
-	CreatedAt     *time.Time                                                      "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy     *string                                                         "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description   *string                                                         "json:\"description,omitempty\" graphql:\"description\""
-	ExpiresAt     *time.Time                                                      "json:\"expiresAt,omitempty\" graphql:\"expiresAt\""
-	ID            string                                                          "json:\"id\" graphql:\"id\""
-	IsActive      *bool                                                           "json:\"isActive,omitempty\" graphql:\"isActive\""
-	LastUsedAt    *time.Time                                                      "json:\"lastUsedAt,omitempty\" graphql:\"lastUsedAt\""
-	Name          string                                                          "json:\"name\" graphql:\"name\""
-	Organizations []*GetPersonalAccessTokenByID_PersonalAccessToken_Organizations "json:\"organizations,omitempty\" graphql:\"organizations\""
-	RevokedAt     *time.Time                                                      "json:\"revokedAt,omitempty\" graphql:\"revokedAt\""
-	RevokedBy     *string                                                         "json:\"revokedBy,omitempty\" graphql:\"revokedBy\""
-	RevokedReason *string                                                         "json:\"revokedReason,omitempty\" graphql:\"revokedReason\""
-	Scopes        []string                                                        "json:\"scopes,omitempty\" graphql:\"scopes\""
-	Tags          []string                                                        "json:\"tags,omitempty\" graphql:\"tags\""
-	Token         string                                                          "json:\"token\" graphql:\"token\""
-	UpdatedAt     *time.Time                                                      "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy     *string                                                         "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	CreatedAt     *time.Time                                                   "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy     *string                                                      "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description   *string                                                      "json:\"description,omitempty\" graphql:\"description\""
+	ExpiresAt     *time.Time                                                   "json:\"expiresAt,omitempty\" graphql:\"expiresAt\""
+	ID            string                                                       "json:\"id\" graphql:\"id\""
+	IsActive      *bool                                                        "json:\"isActive,omitempty\" graphql:\"isActive\""
+	LastUsedAt    *time.Time                                                   "json:\"lastUsedAt,omitempty\" graphql:\"lastUsedAt\""
+	Name          string                                                       "json:\"name\" graphql:\"name\""
+	Organizations GetPersonalAccessTokenByID_PersonalAccessToken_Organizations "json:\"organizations\" graphql:\"organizations\""
+	RevokedAt     *time.Time                                                   "json:\"revokedAt,omitempty\" graphql:\"revokedAt\""
+	RevokedBy     *string                                                      "json:\"revokedBy,omitempty\" graphql:\"revokedBy\""
+	RevokedReason *string                                                      "json:\"revokedReason,omitempty\" graphql:\"revokedReason\""
+	Scopes        []string                                                     "json:\"scopes,omitempty\" graphql:\"scopes\""
+	Tags          []string                                                     "json:\"tags,omitempty\" graphql:\"tags\""
+	Token         string                                                       "json:\"token\" graphql:\"token\""
+	UpdatedAt     *time.Time                                                   "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy     *string                                                      "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *GetPersonalAccessTokenByID_PersonalAccessToken) GetCreatedAt() *time.Time {
@@ -35209,11 +38839,11 @@ func (t *GetPersonalAccessTokenByID_PersonalAccessToken) GetName() string {
 	}
 	return t.Name
 }
-func (t *GetPersonalAccessTokenByID_PersonalAccessToken) GetOrganizations() []*GetPersonalAccessTokenByID_PersonalAccessToken_Organizations {
+func (t *GetPersonalAccessTokenByID_PersonalAccessToken) GetOrganizations() *GetPersonalAccessTokenByID_PersonalAccessToken_Organizations {
 	if t == nil {
 		t = &GetPersonalAccessTokenByID_PersonalAccessToken{}
 	}
-	return t.Organizations
+	return &t.Organizations
 }
 func (t *GetPersonalAccessTokenByID_PersonalAccessToken) GetRevokedAt() *time.Time {
 	if t == nil {
@@ -35264,42 +38894,64 @@ func (t *GetPersonalAccessTokenByID_PersonalAccessToken) GetUpdatedBy() *string 
 	return t.UpdatedBy
 }
 
-type GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations struct {
+type GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations_Edges_Node struct {
 	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
-func (t *GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations) GetID() string {
+func (t *GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations{}
+		t = &GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations) GetName() string {
+func (t *GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations_Edges_Node) GetName() string {
 	if t == nil {
-		t = &GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations{}
+		t = &GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations_Edges_Node{}
 	}
 	return t.Name
 }
 
+type GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations_Edges struct {
+	Node *GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations_Edges) GetNode() *GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations_Edges_Node {
+	if t == nil {
+		t = &GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations_Edges{}
+	}
+	return t.Node
+}
+
+type GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations struct {
+	Edges []*GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations) GetEdges() []*GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations_Edges {
+	if t == nil {
+		t = &GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations{}
+	}
+	return t.Edges
+}
+
 type GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node struct {
-	CreatedAt     *time.Time                                                               "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy     *string                                                                  "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description   *string                                                                  "json:\"description,omitempty\" graphql:\"description\""
-	ExpiresAt     *time.Time                                                               "json:\"expiresAt,omitempty\" graphql:\"expiresAt\""
-	ID            string                                                                   "json:\"id\" graphql:\"id\""
-	IsActive      *bool                                                                    "json:\"isActive,omitempty\" graphql:\"isActive\""
-	LastUsedAt    *time.Time                                                               "json:\"lastUsedAt,omitempty\" graphql:\"lastUsedAt\""
-	Name          string                                                                   "json:\"name\" graphql:\"name\""
-	Organizations []*GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations "json:\"organizations,omitempty\" graphql:\"organizations\""
-	RevokedAt     *time.Time                                                               "json:\"revokedAt,omitempty\" graphql:\"revokedAt\""
-	RevokedBy     *string                                                                  "json:\"revokedBy,omitempty\" graphql:\"revokedBy\""
-	RevokedReason *string                                                                  "json:\"revokedReason,omitempty\" graphql:\"revokedReason\""
-	Scopes        []string                                                                 "json:\"scopes,omitempty\" graphql:\"scopes\""
-	Tags          []string                                                                 "json:\"tags,omitempty\" graphql:\"tags\""
-	Token         string                                                                   "json:\"token\" graphql:\"token\""
-	UpdatedAt     *time.Time                                                               "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy     *string                                                                  "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	CreatedAt     *time.Time                                                            "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy     *string                                                               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description   *string                                                               "json:\"description,omitempty\" graphql:\"description\""
+	ExpiresAt     *time.Time                                                            "json:\"expiresAt,omitempty\" graphql:\"expiresAt\""
+	ID            string                                                                "json:\"id\" graphql:\"id\""
+	IsActive      *bool                                                                 "json:\"isActive,omitempty\" graphql:\"isActive\""
+	LastUsedAt    *time.Time                                                            "json:\"lastUsedAt,omitempty\" graphql:\"lastUsedAt\""
+	Name          string                                                                "json:\"name\" graphql:\"name\""
+	Organizations GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations "json:\"organizations\" graphql:\"organizations\""
+	RevokedAt     *time.Time                                                            "json:\"revokedAt,omitempty\" graphql:\"revokedAt\""
+	RevokedBy     *string                                                               "json:\"revokedBy,omitempty\" graphql:\"revokedBy\""
+	RevokedReason *string                                                               "json:\"revokedReason,omitempty\" graphql:\"revokedReason\""
+	Scopes        []string                                                              "json:\"scopes,omitempty\" graphql:\"scopes\""
+	Tags          []string                                                              "json:\"tags,omitempty\" graphql:\"tags\""
+	Token         string                                                                "json:\"token\" graphql:\"token\""
+	UpdatedAt     *time.Time                                                            "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy     *string                                                               "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node) GetCreatedAt() *time.Time {
@@ -35350,11 +39002,11 @@ func (t *GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node) GetName() stri
 	}
 	return t.Name
 }
-func (t *GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node) GetOrganizations() []*GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations {
+func (t *GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node) GetOrganizations() *GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node_Organizations {
 	if t == nil {
 		t = &GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node{}
 	}
-	return t.Organizations
+	return &t.Organizations
 }
 func (t *GetPersonalAccessTokens_PersonalAccessTokens_Edges_Node) GetRevokedAt() *time.Time {
 	if t == nil {
@@ -35427,22 +39079,44 @@ func (t *GetPersonalAccessTokens_PersonalAccessTokens) GetEdges() []*GetPersonal
 	return t.Edges
 }
 
-type UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Organizations struct {
+type UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Organizations_Edges_Node struct {
 	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
-func (t *UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Organizations) GetID() string {
+func (t *UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Organizations_Edges_Node) GetID() string {
 	if t == nil {
-		t = &UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Organizations{}
+		t = &UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Organizations_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Organizations) GetName() string {
+func (t *UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Organizations_Edges_Node) GetName() string {
+	if t == nil {
+		t = &UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Organizations_Edges_Node{}
+	}
+	return t.Name
+}
+
+type UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Organizations_Edges struct {
+	Node *UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Organizations_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Organizations_Edges) GetNode() *UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Organizations_Edges_Node {
+	if t == nil {
+		t = &UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Organizations_Edges{}
+	}
+	return t.Node
+}
+
+type UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Organizations struct {
+	Edges []*UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Organizations_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Organizations) GetEdges() []*UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Organizations_Edges {
 	if t == nil {
 		t = &UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Organizations{}
 	}
-	return t.Name
+	return t.Edges
 }
 
 type UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Owner struct {
@@ -35457,24 +39131,24 @@ func (t *UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken
 }
 
 type UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken struct {
-	CreatedAt     *time.Time                                                                               "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy     *string                                                                                  "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description   *string                                                                                  "json:\"description,omitempty\" graphql:\"description\""
-	ExpiresAt     *time.Time                                                                               "json:\"expiresAt,omitempty\" graphql:\"expiresAt\""
-	ID            string                                                                                   "json:\"id\" graphql:\"id\""
-	IsActive      *bool                                                                                    "json:\"isActive,omitempty\" graphql:\"isActive\""
-	LastUsedAt    *time.Time                                                                               "json:\"lastUsedAt,omitempty\" graphql:\"lastUsedAt\""
-	Name          string                                                                                   "json:\"name\" graphql:\"name\""
-	Organizations []*UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Organizations "json:\"organizations,omitempty\" graphql:\"organizations\""
-	Owner         UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Owner            "json:\"owner\" graphql:\"owner\""
-	RevokedAt     *time.Time                                                                               "json:\"revokedAt,omitempty\" graphql:\"revokedAt\""
-	RevokedBy     *string                                                                                  "json:\"revokedBy,omitempty\" graphql:\"revokedBy\""
-	RevokedReason *string                                                                                  "json:\"revokedReason,omitempty\" graphql:\"revokedReason\""
-	Scopes        []string                                                                                 "json:\"scopes,omitempty\" graphql:\"scopes\""
-	Tags          []string                                                                                 "json:\"tags,omitempty\" graphql:\"tags\""
-	Token         string                                                                                   "json:\"token\" graphql:\"token\""
-	UpdatedAt     *time.Time                                                                               "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy     *string                                                                                  "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	CreatedAt     *time.Time                                                                            "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy     *string                                                                               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description   *string                                                                               "json:\"description,omitempty\" graphql:\"description\""
+	ExpiresAt     *time.Time                                                                            "json:\"expiresAt,omitempty\" graphql:\"expiresAt\""
+	ID            string                                                                                "json:\"id\" graphql:\"id\""
+	IsActive      *bool                                                                                 "json:\"isActive,omitempty\" graphql:\"isActive\""
+	LastUsedAt    *time.Time                                                                            "json:\"lastUsedAt,omitempty\" graphql:\"lastUsedAt\""
+	Name          string                                                                                "json:\"name\" graphql:\"name\""
+	Organizations UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Organizations "json:\"organizations\" graphql:\"organizations\""
+	Owner         UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Owner         "json:\"owner\" graphql:\"owner\""
+	RevokedAt     *time.Time                                                                            "json:\"revokedAt,omitempty\" graphql:\"revokedAt\""
+	RevokedBy     *string                                                                               "json:\"revokedBy,omitempty\" graphql:\"revokedBy\""
+	RevokedReason *string                                                                               "json:\"revokedReason,omitempty\" graphql:\"revokedReason\""
+	Scopes        []string                                                                              "json:\"scopes,omitempty\" graphql:\"scopes\""
+	Tags          []string                                                                              "json:\"tags,omitempty\" graphql:\"tags\""
+	Token         string                                                                                "json:\"token\" graphql:\"token\""
+	UpdatedAt     *time.Time                                                                            "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy     *string                                                                               "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken) GetCreatedAt() *time.Time {
@@ -35525,11 +39199,11 @@ func (t *UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken
 	}
 	return t.Name
 }
-func (t *UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken) GetOrganizations() []*UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Organizations {
+func (t *UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken) GetOrganizations() *UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Organizations {
 	if t == nil {
 		t = &UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken{}
 	}
-	return t.Organizations
+	return &t.Organizations
 }
 func (t *UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken) GetOwner() *UpdatePersonalAccessToken_UpdatePersonalAccessToken_PersonalAccessToken_Owner {
 	if t == nil {
@@ -37330,28 +41004,50 @@ func (t *CreateBulkProgram_CreateBulkProgram) GetPrograms() []*CreateBulkProgram
 	return t.Programs
 }
 
-type CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control_Subcontrols struct {
+type CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control_Subcontrols_Edges_Node struct {
 	ID      string "json:\"id\" graphql:\"id\""
 	RefCode string "json:\"refCode\" graphql:\"refCode\""
 }
 
-func (t *CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control_Subcontrols) GetID() string {
+func (t *CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control_Subcontrols_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control_Subcontrols{}
+		t = &CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control_Subcontrols_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control_Subcontrols) GetRefCode() string {
+func (t *CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control_Subcontrols_Edges_Node) GetRefCode() string {
 	if t == nil {
-		t = &CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control_Subcontrols{}
+		t = &CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control_Subcontrols_Edges_Node{}
 	}
 	return t.RefCode
 }
 
+type CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control_Subcontrols_Edges struct {
+	Node *CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control_Subcontrols_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control_Subcontrols_Edges) GetNode() *CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control_Subcontrols_Edges_Node {
+	if t == nil {
+		t = &CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control_Subcontrols_Edges{}
+	}
+	return t.Node
+}
+
+type CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control_Subcontrols struct {
+	Edges []*CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control_Subcontrols_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control_Subcontrols) GetEdges() []*CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control_Subcontrols_Edges {
+	if t == nil {
+		t = &CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control_Subcontrols{}
+	}
+	return t.Edges
+}
+
 type CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control struct {
-	ID          string                                                                           "json:\"id\" graphql:\"id\""
-	RefCode     string                                                                           "json:\"refCode\" graphql:\"refCode\""
-	Subcontrols []*CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control_Subcontrols "json:\"subcontrols,omitempty\" graphql:\"subcontrols\""
+	ID          string                                                                        "json:\"id\" graphql:\"id\""
+	RefCode     string                                                                        "json:\"refCode\" graphql:\"refCode\""
+	Subcontrols CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control_Subcontrols "json:\"subcontrols\" graphql:\"subcontrols\""
 }
 
 func (t *CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control) GetID() string {
@@ -37366,11 +41062,11 @@ func (t *CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control) GetR
 	}
 	return t.RefCode
 }
-func (t *CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control) GetSubcontrols() []*CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control_Subcontrols {
+func (t *CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control) GetSubcontrols() *CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control_Subcontrols {
 	if t == nil {
 		t = &CreateControlWithSubcontrols_CreateControlWithSubcontrols_Control{}
 	}
-	return t.Subcontrols
+	return &t.Subcontrols
 }
 
 type CreateControlWithSubcontrols_CreateControlWithSubcontrols struct {
@@ -37384,151 +41080,283 @@ func (t *CreateControlWithSubcontrols_CreateControlWithSubcontrols) GetControl()
 	return &t.Control
 }
 
-type CreateFullProgram_CreateFullProgram_Program_Members struct {
+type CreateFullProgram_CreateFullProgram_Program_Members_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
 
-func (t *CreateFullProgram_CreateFullProgram_Program_Members) GetID() string {
+func (t *CreateFullProgram_CreateFullProgram_Program_Members_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateFullProgram_CreateFullProgram_Program_Members{}
+		t = &CreateFullProgram_CreateFullProgram_Program_Members_Edges_Node{}
 	}
 	return t.ID
 }
 
-type CreateFullProgram_CreateFullProgram_Program_Controls_Subcontrols struct {
+type CreateFullProgram_CreateFullProgram_Program_Members_Edges struct {
+	Node *CreateFullProgram_CreateFullProgram_Program_Members_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateFullProgram_CreateFullProgram_Program_Members_Edges) GetNode() *CreateFullProgram_CreateFullProgram_Program_Members_Edges_Node {
+	if t == nil {
+		t = &CreateFullProgram_CreateFullProgram_Program_Members_Edges{}
+	}
+	return t.Node
+}
+
+type CreateFullProgram_CreateFullProgram_Program_Members struct {
+	Edges []*CreateFullProgram_CreateFullProgram_Program_Members_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateFullProgram_CreateFullProgram_Program_Members) GetEdges() []*CreateFullProgram_CreateFullProgram_Program_Members_Edges {
+	if t == nil {
+		t = &CreateFullProgram_CreateFullProgram_Program_Members{}
+	}
+	return t.Edges
+}
+
+type CreateFullProgram_CreateFullProgram_Program_Controls_Edges_Node_Subcontrols_Edges_Node struct {
 	ID      string "json:\"id\" graphql:\"id\""
 	RefCode string "json:\"refCode\" graphql:\"refCode\""
 }
 
-func (t *CreateFullProgram_CreateFullProgram_Program_Controls_Subcontrols) GetID() string {
+func (t *CreateFullProgram_CreateFullProgram_Program_Controls_Edges_Node_Subcontrols_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateFullProgram_CreateFullProgram_Program_Controls_Subcontrols{}
+		t = &CreateFullProgram_CreateFullProgram_Program_Controls_Edges_Node_Subcontrols_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *CreateFullProgram_CreateFullProgram_Program_Controls_Subcontrols) GetRefCode() string {
+func (t *CreateFullProgram_CreateFullProgram_Program_Controls_Edges_Node_Subcontrols_Edges_Node) GetRefCode() string {
 	if t == nil {
-		t = &CreateFullProgram_CreateFullProgram_Program_Controls_Subcontrols{}
+		t = &CreateFullProgram_CreateFullProgram_Program_Controls_Edges_Node_Subcontrols_Edges_Node{}
 	}
 	return t.RefCode
+}
+
+type CreateFullProgram_CreateFullProgram_Program_Controls_Edges_Node_Subcontrols_Edges struct {
+	Node *CreateFullProgram_CreateFullProgram_Program_Controls_Edges_Node_Subcontrols_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateFullProgram_CreateFullProgram_Program_Controls_Edges_Node_Subcontrols_Edges) GetNode() *CreateFullProgram_CreateFullProgram_Program_Controls_Edges_Node_Subcontrols_Edges_Node {
+	if t == nil {
+		t = &CreateFullProgram_CreateFullProgram_Program_Controls_Edges_Node_Subcontrols_Edges{}
+	}
+	return t.Node
+}
+
+type CreateFullProgram_CreateFullProgram_Program_Controls_Edges_Node_Subcontrols struct {
+	Edges []*CreateFullProgram_CreateFullProgram_Program_Controls_Edges_Node_Subcontrols_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateFullProgram_CreateFullProgram_Program_Controls_Edges_Node_Subcontrols) GetEdges() []*CreateFullProgram_CreateFullProgram_Program_Controls_Edges_Node_Subcontrols_Edges {
+	if t == nil {
+		t = &CreateFullProgram_CreateFullProgram_Program_Controls_Edges_Node_Subcontrols{}
+	}
+	return t.Edges
+}
+
+type CreateFullProgram_CreateFullProgram_Program_Controls_Edges_Node struct {
+	ID          string                                                                      "json:\"id\" graphql:\"id\""
+	RefCode     string                                                                      "json:\"refCode\" graphql:\"refCode\""
+	Subcontrols CreateFullProgram_CreateFullProgram_Program_Controls_Edges_Node_Subcontrols "json:\"subcontrols\" graphql:\"subcontrols\""
+}
+
+func (t *CreateFullProgram_CreateFullProgram_Program_Controls_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateFullProgram_CreateFullProgram_Program_Controls_Edges_Node{}
+	}
+	return t.ID
+}
+func (t *CreateFullProgram_CreateFullProgram_Program_Controls_Edges_Node) GetRefCode() string {
+	if t == nil {
+		t = &CreateFullProgram_CreateFullProgram_Program_Controls_Edges_Node{}
+	}
+	return t.RefCode
+}
+func (t *CreateFullProgram_CreateFullProgram_Program_Controls_Edges_Node) GetSubcontrols() *CreateFullProgram_CreateFullProgram_Program_Controls_Edges_Node_Subcontrols {
+	if t == nil {
+		t = &CreateFullProgram_CreateFullProgram_Program_Controls_Edges_Node{}
+	}
+	return &t.Subcontrols
+}
+
+type CreateFullProgram_CreateFullProgram_Program_Controls_Edges struct {
+	Node *CreateFullProgram_CreateFullProgram_Program_Controls_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateFullProgram_CreateFullProgram_Program_Controls_Edges) GetNode() *CreateFullProgram_CreateFullProgram_Program_Controls_Edges_Node {
+	if t == nil {
+		t = &CreateFullProgram_CreateFullProgram_Program_Controls_Edges{}
+	}
+	return t.Node
 }
 
 type CreateFullProgram_CreateFullProgram_Program_Controls struct {
-	ID          string                                                              "json:\"id\" graphql:\"id\""
-	RefCode     string                                                              "json:\"refCode\" graphql:\"refCode\""
-	Subcontrols []*CreateFullProgram_CreateFullProgram_Program_Controls_Subcontrols "json:\"subcontrols,omitempty\" graphql:\"subcontrols\""
+	Edges []*CreateFullProgram_CreateFullProgram_Program_Controls_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateFullProgram_CreateFullProgram_Program_Controls) GetID() string {
+func (t *CreateFullProgram_CreateFullProgram_Program_Controls) GetEdges() []*CreateFullProgram_CreateFullProgram_Program_Controls_Edges {
 	if t == nil {
 		t = &CreateFullProgram_CreateFullProgram_Program_Controls{}
+	}
+	return t.Edges
+}
+
+type CreateFullProgram_CreateFullProgram_Program_Risks_Edges_Node struct {
+	DisplayID string "json:\"displayID\" graphql:\"displayID\""
+	ID        string "json:\"id\" graphql:\"id\""
+	Name      string "json:\"name\" graphql:\"name\""
+}
+
+func (t *CreateFullProgram_CreateFullProgram_Program_Risks_Edges_Node) GetDisplayID() string {
+	if t == nil {
+		t = &CreateFullProgram_CreateFullProgram_Program_Risks_Edges_Node{}
+	}
+	return t.DisplayID
+}
+func (t *CreateFullProgram_CreateFullProgram_Program_Risks_Edges_Node) GetID() string {
+	if t == nil {
+		t = &CreateFullProgram_CreateFullProgram_Program_Risks_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *CreateFullProgram_CreateFullProgram_Program_Controls) GetRefCode() string {
+func (t *CreateFullProgram_CreateFullProgram_Program_Risks_Edges_Node) GetName() string {
 	if t == nil {
-		t = &CreateFullProgram_CreateFullProgram_Program_Controls{}
+		t = &CreateFullProgram_CreateFullProgram_Program_Risks_Edges_Node{}
 	}
-	return t.RefCode
+	return t.Name
 }
-func (t *CreateFullProgram_CreateFullProgram_Program_Controls) GetSubcontrols() []*CreateFullProgram_CreateFullProgram_Program_Controls_Subcontrols {
+
+type CreateFullProgram_CreateFullProgram_Program_Risks_Edges struct {
+	Node *CreateFullProgram_CreateFullProgram_Program_Risks_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateFullProgram_CreateFullProgram_Program_Risks_Edges) GetNode() *CreateFullProgram_CreateFullProgram_Program_Risks_Edges_Node {
 	if t == nil {
-		t = &CreateFullProgram_CreateFullProgram_Program_Controls{}
+		t = &CreateFullProgram_CreateFullProgram_Program_Risks_Edges{}
 	}
-	return t.Subcontrols
+	return t.Node
 }
 
 type CreateFullProgram_CreateFullProgram_Program_Risks struct {
+	Edges []*CreateFullProgram_CreateFullProgram_Program_Risks_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateFullProgram_CreateFullProgram_Program_Risks) GetEdges() []*CreateFullProgram_CreateFullProgram_Program_Risks_Edges {
+	if t == nil {
+		t = &CreateFullProgram_CreateFullProgram_Program_Risks{}
+	}
+	return t.Edges
+}
+
+type CreateFullProgram_CreateFullProgram_Program_InternalPolicies_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	Name      string "json:\"name\" graphql:\"name\""
 }
 
-func (t *CreateFullProgram_CreateFullProgram_Program_Risks) GetDisplayID() string {
+func (t *CreateFullProgram_CreateFullProgram_Program_InternalPolicies_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &CreateFullProgram_CreateFullProgram_Program_Risks{}
+		t = &CreateFullProgram_CreateFullProgram_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *CreateFullProgram_CreateFullProgram_Program_Risks) GetID() string {
+func (t *CreateFullProgram_CreateFullProgram_Program_InternalPolicies_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateFullProgram_CreateFullProgram_Program_Risks{}
+		t = &CreateFullProgram_CreateFullProgram_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *CreateFullProgram_CreateFullProgram_Program_Risks) GetName() string {
+func (t *CreateFullProgram_CreateFullProgram_Program_InternalPolicies_Edges_Node) GetName() string {
 	if t == nil {
-		t = &CreateFullProgram_CreateFullProgram_Program_Risks{}
+		t = &CreateFullProgram_CreateFullProgram_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.Name
+}
+
+type CreateFullProgram_CreateFullProgram_Program_InternalPolicies_Edges struct {
+	Node *CreateFullProgram_CreateFullProgram_Program_InternalPolicies_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateFullProgram_CreateFullProgram_Program_InternalPolicies_Edges) GetNode() *CreateFullProgram_CreateFullProgram_Program_InternalPolicies_Edges_Node {
+	if t == nil {
+		t = &CreateFullProgram_CreateFullProgram_Program_InternalPolicies_Edges{}
+	}
+	return t.Node
 }
 
 type CreateFullProgram_CreateFullProgram_Program_InternalPolicies struct {
+	Edges []*CreateFullProgram_CreateFullProgram_Program_InternalPolicies_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateFullProgram_CreateFullProgram_Program_InternalPolicies) GetEdges() []*CreateFullProgram_CreateFullProgram_Program_InternalPolicies_Edges {
+	if t == nil {
+		t = &CreateFullProgram_CreateFullProgram_Program_InternalPolicies{}
+	}
+	return t.Edges
+}
+
+type CreateFullProgram_CreateFullProgram_Program_Procedures_Edges_Node struct {
 	DisplayID string "json:\"displayID\" graphql:\"displayID\""
 	ID        string "json:\"id\" graphql:\"id\""
 	Name      string "json:\"name\" graphql:\"name\""
 }
 
-func (t *CreateFullProgram_CreateFullProgram_Program_InternalPolicies) GetDisplayID() string {
+func (t *CreateFullProgram_CreateFullProgram_Program_Procedures_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &CreateFullProgram_CreateFullProgram_Program_InternalPolicies{}
+		t = &CreateFullProgram_CreateFullProgram_Program_Procedures_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *CreateFullProgram_CreateFullProgram_Program_InternalPolicies) GetID() string {
+func (t *CreateFullProgram_CreateFullProgram_Program_Procedures_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateFullProgram_CreateFullProgram_Program_InternalPolicies{}
+		t = &CreateFullProgram_CreateFullProgram_Program_Procedures_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *CreateFullProgram_CreateFullProgram_Program_InternalPolicies) GetName() string {
+func (t *CreateFullProgram_CreateFullProgram_Program_Procedures_Edges_Node) GetName() string {
 	if t == nil {
-		t = &CreateFullProgram_CreateFullProgram_Program_InternalPolicies{}
+		t = &CreateFullProgram_CreateFullProgram_Program_Procedures_Edges_Node{}
 	}
 	return t.Name
+}
+
+type CreateFullProgram_CreateFullProgram_Program_Procedures_Edges struct {
+	Node *CreateFullProgram_CreateFullProgram_Program_Procedures_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateFullProgram_CreateFullProgram_Program_Procedures_Edges) GetNode() *CreateFullProgram_CreateFullProgram_Program_Procedures_Edges_Node {
+	if t == nil {
+		t = &CreateFullProgram_CreateFullProgram_Program_Procedures_Edges{}
+	}
+	return t.Node
 }
 
 type CreateFullProgram_CreateFullProgram_Program_Procedures struct {
-	DisplayID string "json:\"displayID\" graphql:\"displayID\""
-	ID        string "json:\"id\" graphql:\"id\""
-	Name      string "json:\"name\" graphql:\"name\""
+	Edges []*CreateFullProgram_CreateFullProgram_Program_Procedures_Edges "json:\"edges,omitempty\" graphql:\"edges\""
 }
 
-func (t *CreateFullProgram_CreateFullProgram_Program_Procedures) GetDisplayID() string {
+func (t *CreateFullProgram_CreateFullProgram_Program_Procedures) GetEdges() []*CreateFullProgram_CreateFullProgram_Program_Procedures_Edges {
 	if t == nil {
 		t = &CreateFullProgram_CreateFullProgram_Program_Procedures{}
 	}
-	return t.DisplayID
-}
-func (t *CreateFullProgram_CreateFullProgram_Program_Procedures) GetID() string {
-	if t == nil {
-		t = &CreateFullProgram_CreateFullProgram_Program_Procedures{}
-	}
-	return t.ID
-}
-func (t *CreateFullProgram_CreateFullProgram_Program_Procedures) GetName() string {
-	if t == nil {
-		t = &CreateFullProgram_CreateFullProgram_Program_Procedures{}
-	}
-	return t.Name
+	return t.Edges
 }
 
 type CreateFullProgram_CreateFullProgram_Program struct {
-	Controls         []*CreateFullProgram_CreateFullProgram_Program_Controls         "json:\"controls,omitempty\" graphql:\"controls\""
-	DisplayID        string                                                          "json:\"displayID\" graphql:\"displayID\""
-	ID               string                                                          "json:\"id\" graphql:\"id\""
-	InternalPolicies []*CreateFullProgram_CreateFullProgram_Program_InternalPolicies "json:\"internalPolicies,omitempty\" graphql:\"internalPolicies\""
-	Members          []*CreateFullProgram_CreateFullProgram_Program_Members          "json:\"members,omitempty\" graphql:\"members\""
-	Name             string                                                          "json:\"name\" graphql:\"name\""
-	Procedures       []*CreateFullProgram_CreateFullProgram_Program_Procedures       "json:\"procedures,omitempty\" graphql:\"procedures\""
-	Risks            []*CreateFullProgram_CreateFullProgram_Program_Risks            "json:\"risks,omitempty\" graphql:\"risks\""
+	Controls         CreateFullProgram_CreateFullProgram_Program_Controls         "json:\"controls\" graphql:\"controls\""
+	DisplayID        string                                                       "json:\"displayID\" graphql:\"displayID\""
+	ID               string                                                       "json:\"id\" graphql:\"id\""
+	InternalPolicies CreateFullProgram_CreateFullProgram_Program_InternalPolicies "json:\"internalPolicies\" graphql:\"internalPolicies\""
+	Members          CreateFullProgram_CreateFullProgram_Program_Members          "json:\"members\" graphql:\"members\""
+	Name             string                                                       "json:\"name\" graphql:\"name\""
+	Procedures       CreateFullProgram_CreateFullProgram_Program_Procedures       "json:\"procedures\" graphql:\"procedures\""
+	Risks            CreateFullProgram_CreateFullProgram_Program_Risks            "json:\"risks\" graphql:\"risks\""
 }
 
-func (t *CreateFullProgram_CreateFullProgram_Program) GetControls() []*CreateFullProgram_CreateFullProgram_Program_Controls {
+func (t *CreateFullProgram_CreateFullProgram_Program) GetControls() *CreateFullProgram_CreateFullProgram_Program_Controls {
 	if t == nil {
 		t = &CreateFullProgram_CreateFullProgram_Program{}
 	}
-	return t.Controls
+	return &t.Controls
 }
 func (t *CreateFullProgram_CreateFullProgram_Program) GetDisplayID() string {
 	if t == nil {
@@ -37542,17 +41370,17 @@ func (t *CreateFullProgram_CreateFullProgram_Program) GetID() string {
 	}
 	return t.ID
 }
-func (t *CreateFullProgram_CreateFullProgram_Program) GetInternalPolicies() []*CreateFullProgram_CreateFullProgram_Program_InternalPolicies {
+func (t *CreateFullProgram_CreateFullProgram_Program) GetInternalPolicies() *CreateFullProgram_CreateFullProgram_Program_InternalPolicies {
 	if t == nil {
 		t = &CreateFullProgram_CreateFullProgram_Program{}
 	}
-	return t.InternalPolicies
+	return &t.InternalPolicies
 }
-func (t *CreateFullProgram_CreateFullProgram_Program) GetMembers() []*CreateFullProgram_CreateFullProgram_Program_Members {
+func (t *CreateFullProgram_CreateFullProgram_Program) GetMembers() *CreateFullProgram_CreateFullProgram_Program_Members {
 	if t == nil {
 		t = &CreateFullProgram_CreateFullProgram_Program{}
 	}
-	return t.Members
+	return &t.Members
 }
 func (t *CreateFullProgram_CreateFullProgram_Program) GetName() string {
 	if t == nil {
@@ -37560,17 +41388,17 @@ func (t *CreateFullProgram_CreateFullProgram_Program) GetName() string {
 	}
 	return t.Name
 }
-func (t *CreateFullProgram_CreateFullProgram_Program) GetProcedures() []*CreateFullProgram_CreateFullProgram_Program_Procedures {
+func (t *CreateFullProgram_CreateFullProgram_Program) GetProcedures() *CreateFullProgram_CreateFullProgram_Program_Procedures {
 	if t == nil {
 		t = &CreateFullProgram_CreateFullProgram_Program{}
 	}
-	return t.Procedures
+	return &t.Procedures
 }
-func (t *CreateFullProgram_CreateFullProgram_Program) GetRisks() []*CreateFullProgram_CreateFullProgram_Program_Risks {
+func (t *CreateFullProgram_CreateFullProgram_Program) GetRisks() *CreateFullProgram_CreateFullProgram_Program_Risks {
 	if t == nil {
 		t = &CreateFullProgram_CreateFullProgram_Program{}
 	}
-	return t.Risks
+	return &t.Risks
 }
 
 type CreateFullProgram_CreateFullProgram struct {
@@ -37584,7 +41412,7 @@ func (t *CreateFullProgram_CreateFullProgram) GetProgram() *CreateFullProgram_Cr
 	return &t.Program
 }
 
-type CreateProgram_CreateProgram_Program_Procedures struct {
+type CreateProgram_CreateProgram_Program_Procedures_Edges_Node struct {
 	CreatedAt     *time.Time            "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy     *string               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	Details       *string               "json:\"details,omitempty\" graphql:\"details\""
@@ -37599,80 +41427,102 @@ type CreateProgram_CreateProgram_Program_Procedures struct {
 	UpdatedBy     *string               "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *CreateProgram_CreateProgram_Program_Procedures) GetCreatedAt() *time.Time {
+func (t *CreateProgram_CreateProgram_Program_Procedures_Edges_Node) GetCreatedAt() *time.Time {
 	if t == nil {
-		t = &CreateProgram_CreateProgram_Program_Procedures{}
+		t = &CreateProgram_CreateProgram_Program_Procedures_Edges_Node{}
 	}
 	return t.CreatedAt
 }
-func (t *CreateProgram_CreateProgram_Program_Procedures) GetCreatedBy() *string {
+func (t *CreateProgram_CreateProgram_Program_Procedures_Edges_Node) GetCreatedBy() *string {
 	if t == nil {
-		t = &CreateProgram_CreateProgram_Program_Procedures{}
+		t = &CreateProgram_CreateProgram_Program_Procedures_Edges_Node{}
 	}
 	return t.CreatedBy
 }
-func (t *CreateProgram_CreateProgram_Program_Procedures) GetDetails() *string {
+func (t *CreateProgram_CreateProgram_Program_Procedures_Edges_Node) GetDetails() *string {
 	if t == nil {
-		t = &CreateProgram_CreateProgram_Program_Procedures{}
+		t = &CreateProgram_CreateProgram_Program_Procedures_Edges_Node{}
 	}
 	return t.Details
 }
-func (t *CreateProgram_CreateProgram_Program_Procedures) GetDisplayID() string {
+func (t *CreateProgram_CreateProgram_Program_Procedures_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &CreateProgram_CreateProgram_Program_Procedures{}
+		t = &CreateProgram_CreateProgram_Program_Procedures_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *CreateProgram_CreateProgram_Program_Procedures) GetID() string {
+func (t *CreateProgram_CreateProgram_Program_Procedures_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateProgram_CreateProgram_Program_Procedures{}
+		t = &CreateProgram_CreateProgram_Program_Procedures_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *CreateProgram_CreateProgram_Program_Procedures) GetName() string {
+func (t *CreateProgram_CreateProgram_Program_Procedures_Edges_Node) GetName() string {
 	if t == nil {
-		t = &CreateProgram_CreateProgram_Program_Procedures{}
+		t = &CreateProgram_CreateProgram_Program_Procedures_Edges_Node{}
 	}
 	return t.Name
 }
-func (t *CreateProgram_CreateProgram_Program_Procedures) GetProcedureType() *string {
+func (t *CreateProgram_CreateProgram_Program_Procedures_Edges_Node) GetProcedureType() *string {
 	if t == nil {
-		t = &CreateProgram_CreateProgram_Program_Procedures{}
+		t = &CreateProgram_CreateProgram_Program_Procedures_Edges_Node{}
 	}
 	return t.ProcedureType
 }
-func (t *CreateProgram_CreateProgram_Program_Procedures) GetRevision() *string {
+func (t *CreateProgram_CreateProgram_Program_Procedures_Edges_Node) GetRevision() *string {
 	if t == nil {
-		t = &CreateProgram_CreateProgram_Program_Procedures{}
+		t = &CreateProgram_CreateProgram_Program_Procedures_Edges_Node{}
 	}
 	return t.Revision
 }
-func (t *CreateProgram_CreateProgram_Program_Procedures) GetStatus() *enums.DocumentStatus {
+func (t *CreateProgram_CreateProgram_Program_Procedures_Edges_Node) GetStatus() *enums.DocumentStatus {
 	if t == nil {
-		t = &CreateProgram_CreateProgram_Program_Procedures{}
+		t = &CreateProgram_CreateProgram_Program_Procedures_Edges_Node{}
 	}
 	return t.Status
 }
-func (t *CreateProgram_CreateProgram_Program_Procedures) GetTags() []string {
+func (t *CreateProgram_CreateProgram_Program_Procedures_Edges_Node) GetTags() []string {
 	if t == nil {
-		t = &CreateProgram_CreateProgram_Program_Procedures{}
+		t = &CreateProgram_CreateProgram_Program_Procedures_Edges_Node{}
 	}
 	return t.Tags
 }
-func (t *CreateProgram_CreateProgram_Program_Procedures) GetUpdatedAt() *time.Time {
+func (t *CreateProgram_CreateProgram_Program_Procedures_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
-		t = &CreateProgram_CreateProgram_Program_Procedures{}
+		t = &CreateProgram_CreateProgram_Program_Procedures_Edges_Node{}
 	}
 	return t.UpdatedAt
 }
-func (t *CreateProgram_CreateProgram_Program_Procedures) GetUpdatedBy() *string {
+func (t *CreateProgram_CreateProgram_Program_Procedures_Edges_Node) GetUpdatedBy() *string {
 	if t == nil {
-		t = &CreateProgram_CreateProgram_Program_Procedures{}
+		t = &CreateProgram_CreateProgram_Program_Procedures_Edges_Node{}
 	}
 	return t.UpdatedBy
 }
 
-type CreateProgram_CreateProgram_Program_InternalPolicies struct {
+type CreateProgram_CreateProgram_Program_Procedures_Edges struct {
+	Node *CreateProgram_CreateProgram_Program_Procedures_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateProgram_CreateProgram_Program_Procedures_Edges) GetNode() *CreateProgram_CreateProgram_Program_Procedures_Edges_Node {
+	if t == nil {
+		t = &CreateProgram_CreateProgram_Program_Procedures_Edges{}
+	}
+	return t.Node
+}
+
+type CreateProgram_CreateProgram_Program_Procedures struct {
+	Edges []*CreateProgram_CreateProgram_Program_Procedures_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateProgram_CreateProgram_Program_Procedures) GetEdges() []*CreateProgram_CreateProgram_Program_Procedures_Edges {
+	if t == nil {
+		t = &CreateProgram_CreateProgram_Program_Procedures{}
+	}
+	return t.Edges
+}
+
+type CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node struct {
 	CreatedAt  *time.Time            "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy  *string               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	Details    *string               "json:\"details,omitempty\" graphql:\"details\""
@@ -37687,77 +41537,99 @@ type CreateProgram_CreateProgram_Program_InternalPolicies struct {
 	UpdatedBy  *string               "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *CreateProgram_CreateProgram_Program_InternalPolicies) GetCreatedAt() *time.Time {
+func (t *CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node) GetCreatedAt() *time.Time {
 	if t == nil {
-		t = &CreateProgram_CreateProgram_Program_InternalPolicies{}
+		t = &CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.CreatedAt
 }
-func (t *CreateProgram_CreateProgram_Program_InternalPolicies) GetCreatedBy() *string {
+func (t *CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node) GetCreatedBy() *string {
 	if t == nil {
-		t = &CreateProgram_CreateProgram_Program_InternalPolicies{}
+		t = &CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.CreatedBy
 }
-func (t *CreateProgram_CreateProgram_Program_InternalPolicies) GetDetails() *string {
+func (t *CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node) GetDetails() *string {
 	if t == nil {
-		t = &CreateProgram_CreateProgram_Program_InternalPolicies{}
+		t = &CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.Details
 }
-func (t *CreateProgram_CreateProgram_Program_InternalPolicies) GetDisplayID() string {
+func (t *CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &CreateProgram_CreateProgram_Program_InternalPolicies{}
+		t = &CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *CreateProgram_CreateProgram_Program_InternalPolicies) GetID() string {
+func (t *CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateProgram_CreateProgram_Program_InternalPolicies{}
+		t = &CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *CreateProgram_CreateProgram_Program_InternalPolicies) GetName() string {
+func (t *CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node) GetName() string {
 	if t == nil {
-		t = &CreateProgram_CreateProgram_Program_InternalPolicies{}
+		t = &CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.Name
 }
-func (t *CreateProgram_CreateProgram_Program_InternalPolicies) GetPolicyType() *string {
+func (t *CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node) GetPolicyType() *string {
 	if t == nil {
-		t = &CreateProgram_CreateProgram_Program_InternalPolicies{}
+		t = &CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.PolicyType
 }
-func (t *CreateProgram_CreateProgram_Program_InternalPolicies) GetRevision() *string {
+func (t *CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node) GetRevision() *string {
 	if t == nil {
-		t = &CreateProgram_CreateProgram_Program_InternalPolicies{}
+		t = &CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.Revision
 }
-func (t *CreateProgram_CreateProgram_Program_InternalPolicies) GetStatus() *enums.DocumentStatus {
+func (t *CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node) GetStatus() *enums.DocumentStatus {
 	if t == nil {
-		t = &CreateProgram_CreateProgram_Program_InternalPolicies{}
+		t = &CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.Status
 }
-func (t *CreateProgram_CreateProgram_Program_InternalPolicies) GetTags() []string {
+func (t *CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node) GetTags() []string {
 	if t == nil {
-		t = &CreateProgram_CreateProgram_Program_InternalPolicies{}
+		t = &CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.Tags
 }
-func (t *CreateProgram_CreateProgram_Program_InternalPolicies) GetUpdatedAt() *time.Time {
+func (t *CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
-		t = &CreateProgram_CreateProgram_Program_InternalPolicies{}
+		t = &CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.UpdatedAt
 }
-func (t *CreateProgram_CreateProgram_Program_InternalPolicies) GetUpdatedBy() *string {
+func (t *CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node) GetUpdatedBy() *string {
+	if t == nil {
+		t = &CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node{}
+	}
+	return t.UpdatedBy
+}
+
+type CreateProgram_CreateProgram_Program_InternalPolicies_Edges struct {
+	Node *CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateProgram_CreateProgram_Program_InternalPolicies_Edges) GetNode() *CreateProgram_CreateProgram_Program_InternalPolicies_Edges_Node {
+	if t == nil {
+		t = &CreateProgram_CreateProgram_Program_InternalPolicies_Edges{}
+	}
+	return t.Node
+}
+
+type CreateProgram_CreateProgram_Program_InternalPolicies struct {
+	Edges []*CreateProgram_CreateProgram_Program_InternalPolicies_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateProgram_CreateProgram_Program_InternalPolicies) GetEdges() []*CreateProgram_CreateProgram_Program_InternalPolicies_Edges {
 	if t == nil {
 		t = &CreateProgram_CreateProgram_Program_InternalPolicies{}
 	}
-	return t.UpdatedBy
+	return t.Edges
 }
 
 type CreateProgram_CreateProgram_Program_Editors struct {
@@ -37815,27 +41687,27 @@ func (t *CreateProgram_CreateProgram_Program_BlockedGroups) GetName() string {
 }
 
 type CreateProgram_CreateProgram_Program struct {
-	AuditorReadComments  bool                                                    "json:\"auditorReadComments\" graphql:\"auditorReadComments\""
-	AuditorReady         bool                                                    "json:\"auditorReady\" graphql:\"auditorReady\""
-	AuditorWriteComments bool                                                    "json:\"auditorWriteComments\" graphql:\"auditorWriteComments\""
-	BlockedGroups        []*CreateProgram_CreateProgram_Program_BlockedGroups    "json:\"blockedGroups,omitempty\" graphql:\"blockedGroups\""
-	CreatedAt            *time.Time                                              "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy            *string                                                 "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description          *string                                                 "json:\"description,omitempty\" graphql:\"description\""
-	DisplayID            string                                                  "json:\"displayID\" graphql:\"displayID\""
-	Editors              []*CreateProgram_CreateProgram_Program_Editors          "json:\"editors,omitempty\" graphql:\"editors\""
-	EndDate              *time.Time                                              "json:\"endDate,omitempty\" graphql:\"endDate\""
-	ID                   string                                                  "json:\"id\" graphql:\"id\""
-	InternalPolicies     []*CreateProgram_CreateProgram_Program_InternalPolicies "json:\"internalPolicies,omitempty\" graphql:\"internalPolicies\""
-	Name                 string                                                  "json:\"name\" graphql:\"name\""
-	OwnerID              *string                                                 "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Procedures           []*CreateProgram_CreateProgram_Program_Procedures       "json:\"procedures,omitempty\" graphql:\"procedures\""
-	StartDate            *time.Time                                              "json:\"startDate,omitempty\" graphql:\"startDate\""
-	Status               enums.ProgramStatus                                     "json:\"status\" graphql:\"status\""
-	Tags                 []string                                                "json:\"tags,omitempty\" graphql:\"tags\""
-	UpdatedAt            *time.Time                                              "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy            *string                                                 "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
-	Viewers              []*CreateProgram_CreateProgram_Program_Viewers          "json:\"viewers,omitempty\" graphql:\"viewers\""
+	AuditorReadComments  bool                                                 "json:\"auditorReadComments\" graphql:\"auditorReadComments\""
+	AuditorReady         bool                                                 "json:\"auditorReady\" graphql:\"auditorReady\""
+	AuditorWriteComments bool                                                 "json:\"auditorWriteComments\" graphql:\"auditorWriteComments\""
+	BlockedGroups        []*CreateProgram_CreateProgram_Program_BlockedGroups "json:\"blockedGroups,omitempty\" graphql:\"blockedGroups\""
+	CreatedAt            *time.Time                                           "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy            *string                                              "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description          *string                                              "json:\"description,omitempty\" graphql:\"description\""
+	DisplayID            string                                               "json:\"displayID\" graphql:\"displayID\""
+	Editors              []*CreateProgram_CreateProgram_Program_Editors       "json:\"editors,omitempty\" graphql:\"editors\""
+	EndDate              *time.Time                                           "json:\"endDate,omitempty\" graphql:\"endDate\""
+	ID                   string                                               "json:\"id\" graphql:\"id\""
+	InternalPolicies     CreateProgram_CreateProgram_Program_InternalPolicies "json:\"internalPolicies\" graphql:\"internalPolicies\""
+	Name                 string                                               "json:\"name\" graphql:\"name\""
+	OwnerID              *string                                              "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	Procedures           CreateProgram_CreateProgram_Program_Procedures       "json:\"procedures\" graphql:\"procedures\""
+	StartDate            *time.Time                                           "json:\"startDate,omitempty\" graphql:\"startDate\""
+	Status               enums.ProgramStatus                                  "json:\"status\" graphql:\"status\""
+	Tags                 []string                                             "json:\"tags,omitempty\" graphql:\"tags\""
+	UpdatedAt            *time.Time                                           "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy            *string                                              "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Viewers              []*CreateProgram_CreateProgram_Program_Viewers       "json:\"viewers,omitempty\" graphql:\"viewers\""
 }
 
 func (t *CreateProgram_CreateProgram_Program) GetAuditorReadComments() bool {
@@ -37904,11 +41776,11 @@ func (t *CreateProgram_CreateProgram_Program) GetID() string {
 	}
 	return t.ID
 }
-func (t *CreateProgram_CreateProgram_Program) GetInternalPolicies() []*CreateProgram_CreateProgram_Program_InternalPolicies {
+func (t *CreateProgram_CreateProgram_Program) GetInternalPolicies() *CreateProgram_CreateProgram_Program_InternalPolicies {
 	if t == nil {
 		t = &CreateProgram_CreateProgram_Program{}
 	}
-	return t.InternalPolicies
+	return &t.InternalPolicies
 }
 func (t *CreateProgram_CreateProgram_Program) GetName() string {
 	if t == nil {
@@ -37922,11 +41794,11 @@ func (t *CreateProgram_CreateProgram_Program) GetOwnerID() *string {
 	}
 	return t.OwnerID
 }
-func (t *CreateProgram_CreateProgram_Program) GetProcedures() []*CreateProgram_CreateProgram_Program_Procedures {
+func (t *CreateProgram_CreateProgram_Program) GetProcedures() *CreateProgram_CreateProgram_Program_Procedures {
 	if t == nil {
 		t = &CreateProgram_CreateProgram_Program{}
 	}
-	return t.Procedures
+	return &t.Procedures
 }
 func (t *CreateProgram_CreateProgram_Program) GetStartDate() *time.Time {
 	if t == nil {
@@ -37976,54 +41848,76 @@ func (t *CreateProgram_CreateProgram) GetProgram() *CreateProgram_CreateProgram_
 	return &t.Program
 }
 
-type CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_User struct {
+type CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_Edges_Node_User struct {
 	FirstName *string "json:\"firstName,omitempty\" graphql:\"firstName\""
 	ID        string  "json:\"id\" graphql:\"id\""
 	LastName  *string "json:\"lastName,omitempty\" graphql:\"lastName\""
 }
 
-func (t *CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_User) GetFirstName() *string {
+func (t *CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_Edges_Node_User) GetFirstName() *string {
 	if t == nil {
-		t = &CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_User{}
+		t = &CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_Edges_Node_User{}
 	}
 	return t.FirstName
 }
-func (t *CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_User) GetID() string {
+func (t *CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_Edges_Node_User) GetID() string {
 	if t == nil {
-		t = &CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_User{}
+		t = &CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_Edges_Node_User{}
 	}
 	return t.ID
 }
-func (t *CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_User) GetLastName() *string {
+func (t *CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_Edges_Node_User) GetLastName() *string {
 	if t == nil {
-		t = &CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_User{}
+		t = &CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_Edges_Node_User{}
 	}
 	return t.LastName
 }
 
-type CreateProgramWithMembers_CreateProgramWithMembers_Program_Members struct {
-	ID   string                                                                 "json:\"id\" graphql:\"id\""
-	User CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_User "json:\"user\" graphql:\"user\""
+type CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_Edges_Node struct {
+	ID   string                                                                            "json:\"id\" graphql:\"id\""
+	User CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_Edges_Node_User "json:\"user\" graphql:\"user\""
 }
 
-func (t *CreateProgramWithMembers_CreateProgramWithMembers_Program_Members) GetID() string {
+func (t *CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateProgramWithMembers_CreateProgramWithMembers_Program_Members{}
+		t = &CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *CreateProgramWithMembers_CreateProgramWithMembers_Program_Members) GetUser() *CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_User {
+func (t *CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_Edges_Node) GetUser() *CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_Edges_Node_User {
 	if t == nil {
-		t = &CreateProgramWithMembers_CreateProgramWithMembers_Program_Members{}
+		t = &CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_Edges_Node{}
 	}
 	return &t.User
 }
 
+type CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_Edges struct {
+	Node *CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_Edges) GetNode() *CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_Edges_Node {
+	if t == nil {
+		t = &CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_Edges{}
+	}
+	return t.Node
+}
+
+type CreateProgramWithMembers_CreateProgramWithMembers_Program_Members struct {
+	Edges []*CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateProgramWithMembers_CreateProgramWithMembers_Program_Members) GetEdges() []*CreateProgramWithMembers_CreateProgramWithMembers_Program_Members_Edges {
+	if t == nil {
+		t = &CreateProgramWithMembers_CreateProgramWithMembers_Program_Members{}
+	}
+	return t.Edges
+}
+
 type CreateProgramWithMembers_CreateProgramWithMembers_Program struct {
-	DisplayID string                                                               "json:\"displayID\" graphql:\"displayID\""
-	ID        string                                                               "json:\"id\" graphql:\"id\""
-	Members   []*CreateProgramWithMembers_CreateProgramWithMembers_Program_Members "json:\"members,omitempty\" graphql:\"members\""
-	Name      string                                                               "json:\"name\" graphql:\"name\""
+	DisplayID string                                                            "json:\"displayID\" graphql:\"displayID\""
+	ID        string                                                            "json:\"id\" graphql:\"id\""
+	Members   CreateProgramWithMembers_CreateProgramWithMembers_Program_Members "json:\"members\" graphql:\"members\""
+	Name      string                                                            "json:\"name\" graphql:\"name\""
 }
 
 func (t *CreateProgramWithMembers_CreateProgramWithMembers_Program) GetDisplayID() string {
@@ -38038,11 +41932,11 @@ func (t *CreateProgramWithMembers_CreateProgramWithMembers_Program) GetID() stri
 	}
 	return t.ID
 }
-func (t *CreateProgramWithMembers_CreateProgramWithMembers_Program) GetMembers() []*CreateProgramWithMembers_CreateProgramWithMembers_Program_Members {
+func (t *CreateProgramWithMembers_CreateProgramWithMembers_Program) GetMembers() *CreateProgramWithMembers_CreateProgramWithMembers_Program_Members {
 	if t == nil {
 		t = &CreateProgramWithMembers_CreateProgramWithMembers_Program{}
 	}
-	return t.Members
+	return &t.Members
 }
 func (t *CreateProgramWithMembers_CreateProgramWithMembers_Program) GetName() string {
 	if t == nil {
@@ -38073,7 +41967,7 @@ func (t *DeleteProgram_DeleteProgram) GetDeletedID() string {
 	return t.DeletedID
 }
 
-type GetAllPrograms_Programs_Edges_Node_Procedures struct {
+type GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node struct {
 	CreatedAt     *time.Time            "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy     *string               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	Details       *string               "json:\"details,omitempty\" graphql:\"details\""
@@ -38088,80 +41982,102 @@ type GetAllPrograms_Programs_Edges_Node_Procedures struct {
 	UpdatedBy     *string               "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *GetAllPrograms_Programs_Edges_Node_Procedures) GetCreatedAt() *time.Time {
+func (t *GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node) GetCreatedAt() *time.Time {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_Procedures{}
+		t = &GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node{}
 	}
 	return t.CreatedAt
 }
-func (t *GetAllPrograms_Programs_Edges_Node_Procedures) GetCreatedBy() *string {
+func (t *GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node) GetCreatedBy() *string {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_Procedures{}
+		t = &GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node{}
 	}
 	return t.CreatedBy
 }
-func (t *GetAllPrograms_Programs_Edges_Node_Procedures) GetDetails() *string {
+func (t *GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node) GetDetails() *string {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_Procedures{}
+		t = &GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node{}
 	}
 	return t.Details
 }
-func (t *GetAllPrograms_Programs_Edges_Node_Procedures) GetDisplayID() string {
+func (t *GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_Procedures{}
+		t = &GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetAllPrograms_Programs_Edges_Node_Procedures) GetID() string {
+func (t *GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_Procedures{}
+		t = &GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetAllPrograms_Programs_Edges_Node_Procedures) GetName() string {
+func (t *GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node) GetName() string {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_Procedures{}
+		t = &GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node{}
 	}
 	return t.Name
 }
-func (t *GetAllPrograms_Programs_Edges_Node_Procedures) GetProcedureType() *string {
+func (t *GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node) GetProcedureType() *string {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_Procedures{}
+		t = &GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node{}
 	}
 	return t.ProcedureType
 }
-func (t *GetAllPrograms_Programs_Edges_Node_Procedures) GetRevision() *string {
+func (t *GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node) GetRevision() *string {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_Procedures{}
+		t = &GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node{}
 	}
 	return t.Revision
 }
-func (t *GetAllPrograms_Programs_Edges_Node_Procedures) GetStatus() *enums.DocumentStatus {
+func (t *GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node) GetStatus() *enums.DocumentStatus {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_Procedures{}
+		t = &GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node{}
 	}
 	return t.Status
 }
-func (t *GetAllPrograms_Programs_Edges_Node_Procedures) GetTags() []string {
+func (t *GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node) GetTags() []string {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_Procedures{}
+		t = &GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node{}
 	}
 	return t.Tags
 }
-func (t *GetAllPrograms_Programs_Edges_Node_Procedures) GetUpdatedAt() *time.Time {
+func (t *GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_Procedures{}
+		t = &GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node{}
 	}
 	return t.UpdatedAt
 }
-func (t *GetAllPrograms_Programs_Edges_Node_Procedures) GetUpdatedBy() *string {
+func (t *GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node) GetUpdatedBy() *string {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_Procedures{}
+		t = &GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node{}
 	}
 	return t.UpdatedBy
 }
 
-type GetAllPrograms_Programs_Edges_Node_InternalPolicies struct {
+type GetAllPrograms_Programs_Edges_Node_Procedures_Edges struct {
+	Node *GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllPrograms_Programs_Edges_Node_Procedures_Edges) GetNode() *GetAllPrograms_Programs_Edges_Node_Procedures_Edges_Node {
+	if t == nil {
+		t = &GetAllPrograms_Programs_Edges_Node_Procedures_Edges{}
+	}
+	return t.Node
+}
+
+type GetAllPrograms_Programs_Edges_Node_Procedures struct {
+	Edges []*GetAllPrograms_Programs_Edges_Node_Procedures_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetAllPrograms_Programs_Edges_Node_Procedures) GetEdges() []*GetAllPrograms_Programs_Edges_Node_Procedures_Edges {
+	if t == nil {
+		t = &GetAllPrograms_Programs_Edges_Node_Procedures{}
+	}
+	return t.Edges
+}
+
+type GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node struct {
 	CreatedAt  *time.Time            "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy  *string               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	Details    *string               "json:\"details,omitempty\" graphql:\"details\""
@@ -38176,77 +42092,99 @@ type GetAllPrograms_Programs_Edges_Node_InternalPolicies struct {
 	UpdatedBy  *string               "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *GetAllPrograms_Programs_Edges_Node_InternalPolicies) GetCreatedAt() *time.Time {
+func (t *GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node) GetCreatedAt() *time.Time {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_InternalPolicies{}
+		t = &GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node{}
 	}
 	return t.CreatedAt
 }
-func (t *GetAllPrograms_Programs_Edges_Node_InternalPolicies) GetCreatedBy() *string {
+func (t *GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node) GetCreatedBy() *string {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_InternalPolicies{}
+		t = &GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node{}
 	}
 	return t.CreatedBy
 }
-func (t *GetAllPrograms_Programs_Edges_Node_InternalPolicies) GetDetails() *string {
+func (t *GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node) GetDetails() *string {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_InternalPolicies{}
+		t = &GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node{}
 	}
 	return t.Details
 }
-func (t *GetAllPrograms_Programs_Edges_Node_InternalPolicies) GetDisplayID() string {
+func (t *GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_InternalPolicies{}
+		t = &GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetAllPrograms_Programs_Edges_Node_InternalPolicies) GetID() string {
+func (t *GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_InternalPolicies{}
+		t = &GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetAllPrograms_Programs_Edges_Node_InternalPolicies) GetName() string {
+func (t *GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node) GetName() string {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_InternalPolicies{}
+		t = &GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node{}
 	}
 	return t.Name
 }
-func (t *GetAllPrograms_Programs_Edges_Node_InternalPolicies) GetPolicyType() *string {
+func (t *GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node) GetPolicyType() *string {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_InternalPolicies{}
+		t = &GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node{}
 	}
 	return t.PolicyType
 }
-func (t *GetAllPrograms_Programs_Edges_Node_InternalPolicies) GetRevision() *string {
+func (t *GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node) GetRevision() *string {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_InternalPolicies{}
+		t = &GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node{}
 	}
 	return t.Revision
 }
-func (t *GetAllPrograms_Programs_Edges_Node_InternalPolicies) GetStatus() *enums.DocumentStatus {
+func (t *GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node) GetStatus() *enums.DocumentStatus {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_InternalPolicies{}
+		t = &GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node{}
 	}
 	return t.Status
 }
-func (t *GetAllPrograms_Programs_Edges_Node_InternalPolicies) GetTags() []string {
+func (t *GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node) GetTags() []string {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_InternalPolicies{}
+		t = &GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node{}
 	}
 	return t.Tags
 }
-func (t *GetAllPrograms_Programs_Edges_Node_InternalPolicies) GetUpdatedAt() *time.Time {
+func (t *GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_InternalPolicies{}
+		t = &GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node{}
 	}
 	return t.UpdatedAt
 }
-func (t *GetAllPrograms_Programs_Edges_Node_InternalPolicies) GetUpdatedBy() *string {
+func (t *GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node) GetUpdatedBy() *string {
+	if t == nil {
+		t = &GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node{}
+	}
+	return t.UpdatedBy
+}
+
+type GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges struct {
+	Node *GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges) GetNode() *GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node {
+	if t == nil {
+		t = &GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges{}
+	}
+	return t.Node
+}
+
+type GetAllPrograms_Programs_Edges_Node_InternalPolicies struct {
+	Edges []*GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetAllPrograms_Programs_Edges_Node_InternalPolicies) GetEdges() []*GetAllPrograms_Programs_Edges_Node_InternalPolicies_Edges {
 	if t == nil {
 		t = &GetAllPrograms_Programs_Edges_Node_InternalPolicies{}
 	}
-	return t.UpdatedBy
+	return t.Edges
 }
 
 type GetAllPrograms_Programs_Edges_Node_Editors struct {
@@ -38303,72 +42241,94 @@ func (t *GetAllPrograms_Programs_Edges_Node_BlockedGroups) GetName() string {
 	return t.Name
 }
 
-type GetAllPrograms_Programs_Edges_Node_Members_User struct {
+type GetAllPrograms_Programs_Edges_Node_Members_Edges_Node_User struct {
 	FirstName *string "json:\"firstName,omitempty\" graphql:\"firstName\""
 	ID        string  "json:\"id\" graphql:\"id\""
 	LastName  *string "json:\"lastName,omitempty\" graphql:\"lastName\""
 }
 
-func (t *GetAllPrograms_Programs_Edges_Node_Members_User) GetFirstName() *string {
+func (t *GetAllPrograms_Programs_Edges_Node_Members_Edges_Node_User) GetFirstName() *string {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_Members_User{}
+		t = &GetAllPrograms_Programs_Edges_Node_Members_Edges_Node_User{}
 	}
 	return t.FirstName
 }
-func (t *GetAllPrograms_Programs_Edges_Node_Members_User) GetID() string {
+func (t *GetAllPrograms_Programs_Edges_Node_Members_Edges_Node_User) GetID() string {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_Members_User{}
+		t = &GetAllPrograms_Programs_Edges_Node_Members_Edges_Node_User{}
 	}
 	return t.ID
 }
-func (t *GetAllPrograms_Programs_Edges_Node_Members_User) GetLastName() *string {
+func (t *GetAllPrograms_Programs_Edges_Node_Members_Edges_Node_User) GetLastName() *string {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_Members_User{}
+		t = &GetAllPrograms_Programs_Edges_Node_Members_Edges_Node_User{}
 	}
 	return t.LastName
 }
 
-type GetAllPrograms_Programs_Edges_Node_Members struct {
-	ID   string                                          "json:\"id\" graphql:\"id\""
-	User GetAllPrograms_Programs_Edges_Node_Members_User "json:\"user\" graphql:\"user\""
+type GetAllPrograms_Programs_Edges_Node_Members_Edges_Node struct {
+	ID   string                                                     "json:\"id\" graphql:\"id\""
+	User GetAllPrograms_Programs_Edges_Node_Members_Edges_Node_User "json:\"user\" graphql:\"user\""
 }
 
-func (t *GetAllPrograms_Programs_Edges_Node_Members) GetID() string {
+func (t *GetAllPrograms_Programs_Edges_Node_Members_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_Members{}
+		t = &GetAllPrograms_Programs_Edges_Node_Members_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetAllPrograms_Programs_Edges_Node_Members) GetUser() *GetAllPrograms_Programs_Edges_Node_Members_User {
+func (t *GetAllPrograms_Programs_Edges_Node_Members_Edges_Node) GetUser() *GetAllPrograms_Programs_Edges_Node_Members_Edges_Node_User {
 	if t == nil {
-		t = &GetAllPrograms_Programs_Edges_Node_Members{}
+		t = &GetAllPrograms_Programs_Edges_Node_Members_Edges_Node{}
 	}
 	return &t.User
 }
 
+type GetAllPrograms_Programs_Edges_Node_Members_Edges struct {
+	Node *GetAllPrograms_Programs_Edges_Node_Members_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllPrograms_Programs_Edges_Node_Members_Edges) GetNode() *GetAllPrograms_Programs_Edges_Node_Members_Edges_Node {
+	if t == nil {
+		t = &GetAllPrograms_Programs_Edges_Node_Members_Edges{}
+	}
+	return t.Node
+}
+
+type GetAllPrograms_Programs_Edges_Node_Members struct {
+	Edges []*GetAllPrograms_Programs_Edges_Node_Members_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetAllPrograms_Programs_Edges_Node_Members) GetEdges() []*GetAllPrograms_Programs_Edges_Node_Members_Edges {
+	if t == nil {
+		t = &GetAllPrograms_Programs_Edges_Node_Members{}
+	}
+	return t.Edges
+}
+
 type GetAllPrograms_Programs_Edges_Node struct {
-	AuditorReadComments  bool                                                   "json:\"auditorReadComments\" graphql:\"auditorReadComments\""
-	AuditorReady         bool                                                   "json:\"auditorReady\" graphql:\"auditorReady\""
-	AuditorWriteComments bool                                                   "json:\"auditorWriteComments\" graphql:\"auditorWriteComments\""
-	BlockedGroups        []*GetAllPrograms_Programs_Edges_Node_BlockedGroups    "json:\"blockedGroups,omitempty\" graphql:\"blockedGroups\""
-	CreatedAt            *time.Time                                             "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy            *string                                                "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description          *string                                                "json:\"description,omitempty\" graphql:\"description\""
-	DisplayID            string                                                 "json:\"displayID\" graphql:\"displayID\""
-	Editors              []*GetAllPrograms_Programs_Edges_Node_Editors          "json:\"editors,omitempty\" graphql:\"editors\""
-	EndDate              *time.Time                                             "json:\"endDate,omitempty\" graphql:\"endDate\""
-	ID                   string                                                 "json:\"id\" graphql:\"id\""
-	InternalPolicies     []*GetAllPrograms_Programs_Edges_Node_InternalPolicies "json:\"internalPolicies,omitempty\" graphql:\"internalPolicies\""
-	Members              []*GetAllPrograms_Programs_Edges_Node_Members          "json:\"members,omitempty\" graphql:\"members\""
-	Name                 string                                                 "json:\"name\" graphql:\"name\""
-	OwnerID              *string                                                "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Procedures           []*GetAllPrograms_Programs_Edges_Node_Procedures       "json:\"procedures,omitempty\" graphql:\"procedures\""
-	StartDate            *time.Time                                             "json:\"startDate,omitempty\" graphql:\"startDate\""
-	Status               enums.ProgramStatus                                    "json:\"status\" graphql:\"status\""
-	Tags                 []string                                               "json:\"tags,omitempty\" graphql:\"tags\""
-	UpdatedAt            *time.Time                                             "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy            *string                                                "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
-	Viewers              []*GetAllPrograms_Programs_Edges_Node_Viewers          "json:\"viewers,omitempty\" graphql:\"viewers\""
+	AuditorReadComments  bool                                                "json:\"auditorReadComments\" graphql:\"auditorReadComments\""
+	AuditorReady         bool                                                "json:\"auditorReady\" graphql:\"auditorReady\""
+	AuditorWriteComments bool                                                "json:\"auditorWriteComments\" graphql:\"auditorWriteComments\""
+	BlockedGroups        []*GetAllPrograms_Programs_Edges_Node_BlockedGroups "json:\"blockedGroups,omitempty\" graphql:\"blockedGroups\""
+	CreatedAt            *time.Time                                          "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy            *string                                             "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description          *string                                             "json:\"description,omitempty\" graphql:\"description\""
+	DisplayID            string                                              "json:\"displayID\" graphql:\"displayID\""
+	Editors              []*GetAllPrograms_Programs_Edges_Node_Editors       "json:\"editors,omitempty\" graphql:\"editors\""
+	EndDate              *time.Time                                          "json:\"endDate,omitempty\" graphql:\"endDate\""
+	ID                   string                                              "json:\"id\" graphql:\"id\""
+	InternalPolicies     GetAllPrograms_Programs_Edges_Node_InternalPolicies "json:\"internalPolicies\" graphql:\"internalPolicies\""
+	Members              GetAllPrograms_Programs_Edges_Node_Members          "json:\"members\" graphql:\"members\""
+	Name                 string                                              "json:\"name\" graphql:\"name\""
+	OwnerID              *string                                             "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	Procedures           GetAllPrograms_Programs_Edges_Node_Procedures       "json:\"procedures\" graphql:\"procedures\""
+	StartDate            *time.Time                                          "json:\"startDate,omitempty\" graphql:\"startDate\""
+	Status               enums.ProgramStatus                                 "json:\"status\" graphql:\"status\""
+	Tags                 []string                                            "json:\"tags,omitempty\" graphql:\"tags\""
+	UpdatedAt            *time.Time                                          "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy            *string                                             "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Viewers              []*GetAllPrograms_Programs_Edges_Node_Viewers       "json:\"viewers,omitempty\" graphql:\"viewers\""
 }
 
 func (t *GetAllPrograms_Programs_Edges_Node) GetAuditorReadComments() bool {
@@ -38437,17 +42397,17 @@ func (t *GetAllPrograms_Programs_Edges_Node) GetID() string {
 	}
 	return t.ID
 }
-func (t *GetAllPrograms_Programs_Edges_Node) GetInternalPolicies() []*GetAllPrograms_Programs_Edges_Node_InternalPolicies {
+func (t *GetAllPrograms_Programs_Edges_Node) GetInternalPolicies() *GetAllPrograms_Programs_Edges_Node_InternalPolicies {
 	if t == nil {
 		t = &GetAllPrograms_Programs_Edges_Node{}
 	}
-	return t.InternalPolicies
+	return &t.InternalPolicies
 }
-func (t *GetAllPrograms_Programs_Edges_Node) GetMembers() []*GetAllPrograms_Programs_Edges_Node_Members {
+func (t *GetAllPrograms_Programs_Edges_Node) GetMembers() *GetAllPrograms_Programs_Edges_Node_Members {
 	if t == nil {
 		t = &GetAllPrograms_Programs_Edges_Node{}
 	}
-	return t.Members
+	return &t.Members
 }
 func (t *GetAllPrograms_Programs_Edges_Node) GetName() string {
 	if t == nil {
@@ -38461,11 +42421,11 @@ func (t *GetAllPrograms_Programs_Edges_Node) GetOwnerID() *string {
 	}
 	return t.OwnerID
 }
-func (t *GetAllPrograms_Programs_Edges_Node) GetProcedures() []*GetAllPrograms_Programs_Edges_Node_Procedures {
+func (t *GetAllPrograms_Programs_Edges_Node) GetProcedures() *GetAllPrograms_Programs_Edges_Node_Procedures {
 	if t == nil {
 		t = &GetAllPrograms_Programs_Edges_Node{}
 	}
-	return t.Procedures
+	return &t.Procedures
 }
 func (t *GetAllPrograms_Programs_Edges_Node) GetStartDate() *time.Time {
 	if t == nil {
@@ -38526,7 +42486,7 @@ func (t *GetAllPrograms_Programs) GetEdges() []*GetAllPrograms_Programs_Edges {
 	return t.Edges
 }
 
-type GetProgramByID_Program_Procedures struct {
+type GetProgramByID_Program_Procedures_Edges_Node struct {
 	CreatedAt     *time.Time            "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy     *string               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	Details       *string               "json:\"details,omitempty\" graphql:\"details\""
@@ -38541,80 +42501,102 @@ type GetProgramByID_Program_Procedures struct {
 	UpdatedBy     *string               "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *GetProgramByID_Program_Procedures) GetCreatedAt() *time.Time {
+func (t *GetProgramByID_Program_Procedures_Edges_Node) GetCreatedAt() *time.Time {
 	if t == nil {
-		t = &GetProgramByID_Program_Procedures{}
+		t = &GetProgramByID_Program_Procedures_Edges_Node{}
 	}
 	return t.CreatedAt
 }
-func (t *GetProgramByID_Program_Procedures) GetCreatedBy() *string {
+func (t *GetProgramByID_Program_Procedures_Edges_Node) GetCreatedBy() *string {
 	if t == nil {
-		t = &GetProgramByID_Program_Procedures{}
+		t = &GetProgramByID_Program_Procedures_Edges_Node{}
 	}
 	return t.CreatedBy
 }
-func (t *GetProgramByID_Program_Procedures) GetDetails() *string {
+func (t *GetProgramByID_Program_Procedures_Edges_Node) GetDetails() *string {
 	if t == nil {
-		t = &GetProgramByID_Program_Procedures{}
+		t = &GetProgramByID_Program_Procedures_Edges_Node{}
 	}
 	return t.Details
 }
-func (t *GetProgramByID_Program_Procedures) GetDisplayID() string {
+func (t *GetProgramByID_Program_Procedures_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetProgramByID_Program_Procedures{}
+		t = &GetProgramByID_Program_Procedures_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetProgramByID_Program_Procedures) GetID() string {
+func (t *GetProgramByID_Program_Procedures_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetProgramByID_Program_Procedures{}
+		t = &GetProgramByID_Program_Procedures_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetProgramByID_Program_Procedures) GetName() string {
+func (t *GetProgramByID_Program_Procedures_Edges_Node) GetName() string {
 	if t == nil {
-		t = &GetProgramByID_Program_Procedures{}
+		t = &GetProgramByID_Program_Procedures_Edges_Node{}
 	}
 	return t.Name
 }
-func (t *GetProgramByID_Program_Procedures) GetProcedureType() *string {
+func (t *GetProgramByID_Program_Procedures_Edges_Node) GetProcedureType() *string {
 	if t == nil {
-		t = &GetProgramByID_Program_Procedures{}
+		t = &GetProgramByID_Program_Procedures_Edges_Node{}
 	}
 	return t.ProcedureType
 }
-func (t *GetProgramByID_Program_Procedures) GetRevision() *string {
+func (t *GetProgramByID_Program_Procedures_Edges_Node) GetRevision() *string {
 	if t == nil {
-		t = &GetProgramByID_Program_Procedures{}
+		t = &GetProgramByID_Program_Procedures_Edges_Node{}
 	}
 	return t.Revision
 }
-func (t *GetProgramByID_Program_Procedures) GetStatus() *enums.DocumentStatus {
+func (t *GetProgramByID_Program_Procedures_Edges_Node) GetStatus() *enums.DocumentStatus {
 	if t == nil {
-		t = &GetProgramByID_Program_Procedures{}
+		t = &GetProgramByID_Program_Procedures_Edges_Node{}
 	}
 	return t.Status
 }
-func (t *GetProgramByID_Program_Procedures) GetTags() []string {
+func (t *GetProgramByID_Program_Procedures_Edges_Node) GetTags() []string {
 	if t == nil {
-		t = &GetProgramByID_Program_Procedures{}
+		t = &GetProgramByID_Program_Procedures_Edges_Node{}
 	}
 	return t.Tags
 }
-func (t *GetProgramByID_Program_Procedures) GetUpdatedAt() *time.Time {
+func (t *GetProgramByID_Program_Procedures_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
-		t = &GetProgramByID_Program_Procedures{}
+		t = &GetProgramByID_Program_Procedures_Edges_Node{}
 	}
 	return t.UpdatedAt
 }
-func (t *GetProgramByID_Program_Procedures) GetUpdatedBy() *string {
+func (t *GetProgramByID_Program_Procedures_Edges_Node) GetUpdatedBy() *string {
 	if t == nil {
-		t = &GetProgramByID_Program_Procedures{}
+		t = &GetProgramByID_Program_Procedures_Edges_Node{}
 	}
 	return t.UpdatedBy
 }
 
-type GetProgramByID_Program_InternalPolicies struct {
+type GetProgramByID_Program_Procedures_Edges struct {
+	Node *GetProgramByID_Program_Procedures_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetProgramByID_Program_Procedures_Edges) GetNode() *GetProgramByID_Program_Procedures_Edges_Node {
+	if t == nil {
+		t = &GetProgramByID_Program_Procedures_Edges{}
+	}
+	return t.Node
+}
+
+type GetProgramByID_Program_Procedures struct {
+	Edges []*GetProgramByID_Program_Procedures_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetProgramByID_Program_Procedures) GetEdges() []*GetProgramByID_Program_Procedures_Edges {
+	if t == nil {
+		t = &GetProgramByID_Program_Procedures{}
+	}
+	return t.Edges
+}
+
+type GetProgramByID_Program_InternalPolicies_Edges_Node struct {
 	CreatedAt  *time.Time            "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy  *string               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	Details    *string               "json:\"details,omitempty\" graphql:\"details\""
@@ -38629,77 +42611,99 @@ type GetProgramByID_Program_InternalPolicies struct {
 	UpdatedBy  *string               "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *GetProgramByID_Program_InternalPolicies) GetCreatedAt() *time.Time {
+func (t *GetProgramByID_Program_InternalPolicies_Edges_Node) GetCreatedAt() *time.Time {
 	if t == nil {
-		t = &GetProgramByID_Program_InternalPolicies{}
+		t = &GetProgramByID_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.CreatedAt
 }
-func (t *GetProgramByID_Program_InternalPolicies) GetCreatedBy() *string {
+func (t *GetProgramByID_Program_InternalPolicies_Edges_Node) GetCreatedBy() *string {
 	if t == nil {
-		t = &GetProgramByID_Program_InternalPolicies{}
+		t = &GetProgramByID_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.CreatedBy
 }
-func (t *GetProgramByID_Program_InternalPolicies) GetDetails() *string {
+func (t *GetProgramByID_Program_InternalPolicies_Edges_Node) GetDetails() *string {
 	if t == nil {
-		t = &GetProgramByID_Program_InternalPolicies{}
+		t = &GetProgramByID_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.Details
 }
-func (t *GetProgramByID_Program_InternalPolicies) GetDisplayID() string {
+func (t *GetProgramByID_Program_InternalPolicies_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetProgramByID_Program_InternalPolicies{}
+		t = &GetProgramByID_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetProgramByID_Program_InternalPolicies) GetID() string {
+func (t *GetProgramByID_Program_InternalPolicies_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetProgramByID_Program_InternalPolicies{}
+		t = &GetProgramByID_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetProgramByID_Program_InternalPolicies) GetName() string {
+func (t *GetProgramByID_Program_InternalPolicies_Edges_Node) GetName() string {
 	if t == nil {
-		t = &GetProgramByID_Program_InternalPolicies{}
+		t = &GetProgramByID_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.Name
 }
-func (t *GetProgramByID_Program_InternalPolicies) GetPolicyType() *string {
+func (t *GetProgramByID_Program_InternalPolicies_Edges_Node) GetPolicyType() *string {
 	if t == nil {
-		t = &GetProgramByID_Program_InternalPolicies{}
+		t = &GetProgramByID_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.PolicyType
 }
-func (t *GetProgramByID_Program_InternalPolicies) GetRevision() *string {
+func (t *GetProgramByID_Program_InternalPolicies_Edges_Node) GetRevision() *string {
 	if t == nil {
-		t = &GetProgramByID_Program_InternalPolicies{}
+		t = &GetProgramByID_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.Revision
 }
-func (t *GetProgramByID_Program_InternalPolicies) GetStatus() *enums.DocumentStatus {
+func (t *GetProgramByID_Program_InternalPolicies_Edges_Node) GetStatus() *enums.DocumentStatus {
 	if t == nil {
-		t = &GetProgramByID_Program_InternalPolicies{}
+		t = &GetProgramByID_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.Status
 }
-func (t *GetProgramByID_Program_InternalPolicies) GetTags() []string {
+func (t *GetProgramByID_Program_InternalPolicies_Edges_Node) GetTags() []string {
 	if t == nil {
-		t = &GetProgramByID_Program_InternalPolicies{}
+		t = &GetProgramByID_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.Tags
 }
-func (t *GetProgramByID_Program_InternalPolicies) GetUpdatedAt() *time.Time {
+func (t *GetProgramByID_Program_InternalPolicies_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
-		t = &GetProgramByID_Program_InternalPolicies{}
+		t = &GetProgramByID_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.UpdatedAt
 }
-func (t *GetProgramByID_Program_InternalPolicies) GetUpdatedBy() *string {
+func (t *GetProgramByID_Program_InternalPolicies_Edges_Node) GetUpdatedBy() *string {
+	if t == nil {
+		t = &GetProgramByID_Program_InternalPolicies_Edges_Node{}
+	}
+	return t.UpdatedBy
+}
+
+type GetProgramByID_Program_InternalPolicies_Edges struct {
+	Node *GetProgramByID_Program_InternalPolicies_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetProgramByID_Program_InternalPolicies_Edges) GetNode() *GetProgramByID_Program_InternalPolicies_Edges_Node {
+	if t == nil {
+		t = &GetProgramByID_Program_InternalPolicies_Edges{}
+	}
+	return t.Node
+}
+
+type GetProgramByID_Program_InternalPolicies struct {
+	Edges []*GetProgramByID_Program_InternalPolicies_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetProgramByID_Program_InternalPolicies) GetEdges() []*GetProgramByID_Program_InternalPolicies_Edges {
 	if t == nil {
 		t = &GetProgramByID_Program_InternalPolicies{}
 	}
-	return t.UpdatedBy
+	return t.Edges
 }
 
 type GetProgramByID_Program_Editors struct {
@@ -38756,72 +42760,94 @@ func (t *GetProgramByID_Program_BlockedGroups) GetName() string {
 	return t.Name
 }
 
-type GetProgramByID_Program_Members_User struct {
+type GetProgramByID_Program_Members_Edges_Node_User struct {
 	FirstName *string "json:\"firstName,omitempty\" graphql:\"firstName\""
 	ID        string  "json:\"id\" graphql:\"id\""
 	LastName  *string "json:\"lastName,omitempty\" graphql:\"lastName\""
 }
 
-func (t *GetProgramByID_Program_Members_User) GetFirstName() *string {
+func (t *GetProgramByID_Program_Members_Edges_Node_User) GetFirstName() *string {
 	if t == nil {
-		t = &GetProgramByID_Program_Members_User{}
+		t = &GetProgramByID_Program_Members_Edges_Node_User{}
 	}
 	return t.FirstName
 }
-func (t *GetProgramByID_Program_Members_User) GetID() string {
+func (t *GetProgramByID_Program_Members_Edges_Node_User) GetID() string {
 	if t == nil {
-		t = &GetProgramByID_Program_Members_User{}
+		t = &GetProgramByID_Program_Members_Edges_Node_User{}
 	}
 	return t.ID
 }
-func (t *GetProgramByID_Program_Members_User) GetLastName() *string {
+func (t *GetProgramByID_Program_Members_Edges_Node_User) GetLastName() *string {
 	if t == nil {
-		t = &GetProgramByID_Program_Members_User{}
+		t = &GetProgramByID_Program_Members_Edges_Node_User{}
 	}
 	return t.LastName
 }
 
-type GetProgramByID_Program_Members struct {
-	ID   string                              "json:\"id\" graphql:\"id\""
-	User GetProgramByID_Program_Members_User "json:\"user\" graphql:\"user\""
+type GetProgramByID_Program_Members_Edges_Node struct {
+	ID   string                                         "json:\"id\" graphql:\"id\""
+	User GetProgramByID_Program_Members_Edges_Node_User "json:\"user\" graphql:\"user\""
 }
 
-func (t *GetProgramByID_Program_Members) GetID() string {
+func (t *GetProgramByID_Program_Members_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetProgramByID_Program_Members{}
+		t = &GetProgramByID_Program_Members_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetProgramByID_Program_Members) GetUser() *GetProgramByID_Program_Members_User {
+func (t *GetProgramByID_Program_Members_Edges_Node) GetUser() *GetProgramByID_Program_Members_Edges_Node_User {
 	if t == nil {
-		t = &GetProgramByID_Program_Members{}
+		t = &GetProgramByID_Program_Members_Edges_Node{}
 	}
 	return &t.User
 }
 
+type GetProgramByID_Program_Members_Edges struct {
+	Node *GetProgramByID_Program_Members_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetProgramByID_Program_Members_Edges) GetNode() *GetProgramByID_Program_Members_Edges_Node {
+	if t == nil {
+		t = &GetProgramByID_Program_Members_Edges{}
+	}
+	return t.Node
+}
+
+type GetProgramByID_Program_Members struct {
+	Edges []*GetProgramByID_Program_Members_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetProgramByID_Program_Members) GetEdges() []*GetProgramByID_Program_Members_Edges {
+	if t == nil {
+		t = &GetProgramByID_Program_Members{}
+	}
+	return t.Edges
+}
+
 type GetProgramByID_Program struct {
-	AuditorReadComments  bool                                       "json:\"auditorReadComments\" graphql:\"auditorReadComments\""
-	AuditorReady         bool                                       "json:\"auditorReady\" graphql:\"auditorReady\""
-	AuditorWriteComments bool                                       "json:\"auditorWriteComments\" graphql:\"auditorWriteComments\""
-	BlockedGroups        []*GetProgramByID_Program_BlockedGroups    "json:\"blockedGroups,omitempty\" graphql:\"blockedGroups\""
-	CreatedAt            *time.Time                                 "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy            *string                                    "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description          *string                                    "json:\"description,omitempty\" graphql:\"description\""
-	DisplayID            string                                     "json:\"displayID\" graphql:\"displayID\""
-	Editors              []*GetProgramByID_Program_Editors          "json:\"editors,omitempty\" graphql:\"editors\""
-	EndDate              *time.Time                                 "json:\"endDate,omitempty\" graphql:\"endDate\""
-	ID                   string                                     "json:\"id\" graphql:\"id\""
-	InternalPolicies     []*GetProgramByID_Program_InternalPolicies "json:\"internalPolicies,omitempty\" graphql:\"internalPolicies\""
-	Members              []*GetProgramByID_Program_Members          "json:\"members,omitempty\" graphql:\"members\""
-	Name                 string                                     "json:\"name\" graphql:\"name\""
-	OwnerID              *string                                    "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Procedures           []*GetProgramByID_Program_Procedures       "json:\"procedures,omitempty\" graphql:\"procedures\""
-	StartDate            *time.Time                                 "json:\"startDate,omitempty\" graphql:\"startDate\""
-	Status               enums.ProgramStatus                        "json:\"status\" graphql:\"status\""
-	Tags                 []string                                   "json:\"tags,omitempty\" graphql:\"tags\""
-	UpdatedAt            *time.Time                                 "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy            *string                                    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
-	Viewers              []*GetProgramByID_Program_Viewers          "json:\"viewers,omitempty\" graphql:\"viewers\""
+	AuditorReadComments  bool                                    "json:\"auditorReadComments\" graphql:\"auditorReadComments\""
+	AuditorReady         bool                                    "json:\"auditorReady\" graphql:\"auditorReady\""
+	AuditorWriteComments bool                                    "json:\"auditorWriteComments\" graphql:\"auditorWriteComments\""
+	BlockedGroups        []*GetProgramByID_Program_BlockedGroups "json:\"blockedGroups,omitempty\" graphql:\"blockedGroups\""
+	CreatedAt            *time.Time                              "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy            *string                                 "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description          *string                                 "json:\"description,omitempty\" graphql:\"description\""
+	DisplayID            string                                  "json:\"displayID\" graphql:\"displayID\""
+	Editors              []*GetProgramByID_Program_Editors       "json:\"editors,omitempty\" graphql:\"editors\""
+	EndDate              *time.Time                              "json:\"endDate,omitempty\" graphql:\"endDate\""
+	ID                   string                                  "json:\"id\" graphql:\"id\""
+	InternalPolicies     GetProgramByID_Program_InternalPolicies "json:\"internalPolicies\" graphql:\"internalPolicies\""
+	Members              GetProgramByID_Program_Members          "json:\"members\" graphql:\"members\""
+	Name                 string                                  "json:\"name\" graphql:\"name\""
+	OwnerID              *string                                 "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	Procedures           GetProgramByID_Program_Procedures       "json:\"procedures\" graphql:\"procedures\""
+	StartDate            *time.Time                              "json:\"startDate,omitempty\" graphql:\"startDate\""
+	Status               enums.ProgramStatus                     "json:\"status\" graphql:\"status\""
+	Tags                 []string                                "json:\"tags,omitempty\" graphql:\"tags\""
+	UpdatedAt            *time.Time                              "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy            *string                                 "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Viewers              []*GetProgramByID_Program_Viewers       "json:\"viewers,omitempty\" graphql:\"viewers\""
 }
 
 func (t *GetProgramByID_Program) GetAuditorReadComments() bool {
@@ -38890,17 +42916,17 @@ func (t *GetProgramByID_Program) GetID() string {
 	}
 	return t.ID
 }
-func (t *GetProgramByID_Program) GetInternalPolicies() []*GetProgramByID_Program_InternalPolicies {
+func (t *GetProgramByID_Program) GetInternalPolicies() *GetProgramByID_Program_InternalPolicies {
 	if t == nil {
 		t = &GetProgramByID_Program{}
 	}
-	return t.InternalPolicies
+	return &t.InternalPolicies
 }
-func (t *GetProgramByID_Program) GetMembers() []*GetProgramByID_Program_Members {
+func (t *GetProgramByID_Program) GetMembers() *GetProgramByID_Program_Members {
 	if t == nil {
 		t = &GetProgramByID_Program{}
 	}
-	return t.Members
+	return &t.Members
 }
 func (t *GetProgramByID_Program) GetName() string {
 	if t == nil {
@@ -38914,11 +42940,11 @@ func (t *GetProgramByID_Program) GetOwnerID() *string {
 	}
 	return t.OwnerID
 }
-func (t *GetProgramByID_Program) GetProcedures() []*GetProgramByID_Program_Procedures {
+func (t *GetProgramByID_Program) GetProcedures() *GetProgramByID_Program_Procedures {
 	if t == nil {
 		t = &GetProgramByID_Program{}
 	}
-	return t.Procedures
+	return &t.Procedures
 }
 func (t *GetProgramByID_Program) GetStartDate() *time.Time {
 	if t == nil {
@@ -38957,7 +42983,7 @@ func (t *GetProgramByID_Program) GetViewers() []*GetProgramByID_Program_Viewers 
 	return t.Viewers
 }
 
-type GetPrograms_Programs_Edges_Node_Procedures struct {
+type GetPrograms_Programs_Edges_Node_Procedures_Edges_Node struct {
 	CreatedAt     *time.Time            "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy     *string               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	Details       *string               "json:\"details,omitempty\" graphql:\"details\""
@@ -38972,80 +42998,102 @@ type GetPrograms_Programs_Edges_Node_Procedures struct {
 	UpdatedBy     *string               "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *GetPrograms_Programs_Edges_Node_Procedures) GetCreatedAt() *time.Time {
+func (t *GetPrograms_Programs_Edges_Node_Procedures_Edges_Node) GetCreatedAt() *time.Time {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_Procedures{}
+		t = &GetPrograms_Programs_Edges_Node_Procedures_Edges_Node{}
 	}
 	return t.CreatedAt
 }
-func (t *GetPrograms_Programs_Edges_Node_Procedures) GetCreatedBy() *string {
+func (t *GetPrograms_Programs_Edges_Node_Procedures_Edges_Node) GetCreatedBy() *string {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_Procedures{}
+		t = &GetPrograms_Programs_Edges_Node_Procedures_Edges_Node{}
 	}
 	return t.CreatedBy
 }
-func (t *GetPrograms_Programs_Edges_Node_Procedures) GetDetails() *string {
+func (t *GetPrograms_Programs_Edges_Node_Procedures_Edges_Node) GetDetails() *string {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_Procedures{}
+		t = &GetPrograms_Programs_Edges_Node_Procedures_Edges_Node{}
 	}
 	return t.Details
 }
-func (t *GetPrograms_Programs_Edges_Node_Procedures) GetDisplayID() string {
+func (t *GetPrograms_Programs_Edges_Node_Procedures_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_Procedures{}
+		t = &GetPrograms_Programs_Edges_Node_Procedures_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetPrograms_Programs_Edges_Node_Procedures) GetID() string {
+func (t *GetPrograms_Programs_Edges_Node_Procedures_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_Procedures{}
+		t = &GetPrograms_Programs_Edges_Node_Procedures_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetPrograms_Programs_Edges_Node_Procedures) GetName() string {
+func (t *GetPrograms_Programs_Edges_Node_Procedures_Edges_Node) GetName() string {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_Procedures{}
+		t = &GetPrograms_Programs_Edges_Node_Procedures_Edges_Node{}
 	}
 	return t.Name
 }
-func (t *GetPrograms_Programs_Edges_Node_Procedures) GetProcedureType() *string {
+func (t *GetPrograms_Programs_Edges_Node_Procedures_Edges_Node) GetProcedureType() *string {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_Procedures{}
+		t = &GetPrograms_Programs_Edges_Node_Procedures_Edges_Node{}
 	}
 	return t.ProcedureType
 }
-func (t *GetPrograms_Programs_Edges_Node_Procedures) GetRevision() *string {
+func (t *GetPrograms_Programs_Edges_Node_Procedures_Edges_Node) GetRevision() *string {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_Procedures{}
+		t = &GetPrograms_Programs_Edges_Node_Procedures_Edges_Node{}
 	}
 	return t.Revision
 }
-func (t *GetPrograms_Programs_Edges_Node_Procedures) GetStatus() *enums.DocumentStatus {
+func (t *GetPrograms_Programs_Edges_Node_Procedures_Edges_Node) GetStatus() *enums.DocumentStatus {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_Procedures{}
+		t = &GetPrograms_Programs_Edges_Node_Procedures_Edges_Node{}
 	}
 	return t.Status
 }
-func (t *GetPrograms_Programs_Edges_Node_Procedures) GetTags() []string {
+func (t *GetPrograms_Programs_Edges_Node_Procedures_Edges_Node) GetTags() []string {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_Procedures{}
+		t = &GetPrograms_Programs_Edges_Node_Procedures_Edges_Node{}
 	}
 	return t.Tags
 }
-func (t *GetPrograms_Programs_Edges_Node_Procedures) GetUpdatedAt() *time.Time {
+func (t *GetPrograms_Programs_Edges_Node_Procedures_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_Procedures{}
+		t = &GetPrograms_Programs_Edges_Node_Procedures_Edges_Node{}
 	}
 	return t.UpdatedAt
 }
-func (t *GetPrograms_Programs_Edges_Node_Procedures) GetUpdatedBy() *string {
+func (t *GetPrograms_Programs_Edges_Node_Procedures_Edges_Node) GetUpdatedBy() *string {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_Procedures{}
+		t = &GetPrograms_Programs_Edges_Node_Procedures_Edges_Node{}
 	}
 	return t.UpdatedBy
 }
 
-type GetPrograms_Programs_Edges_Node_InternalPolicies struct {
+type GetPrograms_Programs_Edges_Node_Procedures_Edges struct {
+	Node *GetPrograms_Programs_Edges_Node_Procedures_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetPrograms_Programs_Edges_Node_Procedures_Edges) GetNode() *GetPrograms_Programs_Edges_Node_Procedures_Edges_Node {
+	if t == nil {
+		t = &GetPrograms_Programs_Edges_Node_Procedures_Edges{}
+	}
+	return t.Node
+}
+
+type GetPrograms_Programs_Edges_Node_Procedures struct {
+	Edges []*GetPrograms_Programs_Edges_Node_Procedures_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetPrograms_Programs_Edges_Node_Procedures) GetEdges() []*GetPrograms_Programs_Edges_Node_Procedures_Edges {
+	if t == nil {
+		t = &GetPrograms_Programs_Edges_Node_Procedures{}
+	}
+	return t.Edges
+}
+
+type GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node struct {
 	CreatedAt  *time.Time            "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy  *string               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	Details    *string               "json:\"details,omitempty\" graphql:\"details\""
@@ -39060,77 +43108,99 @@ type GetPrograms_Programs_Edges_Node_InternalPolicies struct {
 	UpdatedBy  *string               "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *GetPrograms_Programs_Edges_Node_InternalPolicies) GetCreatedAt() *time.Time {
+func (t *GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node) GetCreatedAt() *time.Time {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_InternalPolicies{}
+		t = &GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node{}
 	}
 	return t.CreatedAt
 }
-func (t *GetPrograms_Programs_Edges_Node_InternalPolicies) GetCreatedBy() *string {
+func (t *GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node) GetCreatedBy() *string {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_InternalPolicies{}
+		t = &GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node{}
 	}
 	return t.CreatedBy
 }
-func (t *GetPrograms_Programs_Edges_Node_InternalPolicies) GetDetails() *string {
+func (t *GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node) GetDetails() *string {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_InternalPolicies{}
+		t = &GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node{}
 	}
 	return t.Details
 }
-func (t *GetPrograms_Programs_Edges_Node_InternalPolicies) GetDisplayID() string {
+func (t *GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_InternalPolicies{}
+		t = &GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetPrograms_Programs_Edges_Node_InternalPolicies) GetID() string {
+func (t *GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_InternalPolicies{}
+		t = &GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetPrograms_Programs_Edges_Node_InternalPolicies) GetName() string {
+func (t *GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node) GetName() string {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_InternalPolicies{}
+		t = &GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node{}
 	}
 	return t.Name
 }
-func (t *GetPrograms_Programs_Edges_Node_InternalPolicies) GetPolicyType() *string {
+func (t *GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node) GetPolicyType() *string {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_InternalPolicies{}
+		t = &GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node{}
 	}
 	return t.PolicyType
 }
-func (t *GetPrograms_Programs_Edges_Node_InternalPolicies) GetRevision() *string {
+func (t *GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node) GetRevision() *string {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_InternalPolicies{}
+		t = &GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node{}
 	}
 	return t.Revision
 }
-func (t *GetPrograms_Programs_Edges_Node_InternalPolicies) GetStatus() *enums.DocumentStatus {
+func (t *GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node) GetStatus() *enums.DocumentStatus {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_InternalPolicies{}
+		t = &GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node{}
 	}
 	return t.Status
 }
-func (t *GetPrograms_Programs_Edges_Node_InternalPolicies) GetTags() []string {
+func (t *GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node) GetTags() []string {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_InternalPolicies{}
+		t = &GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node{}
 	}
 	return t.Tags
 }
-func (t *GetPrograms_Programs_Edges_Node_InternalPolicies) GetUpdatedAt() *time.Time {
+func (t *GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_InternalPolicies{}
+		t = &GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node{}
 	}
 	return t.UpdatedAt
 }
-func (t *GetPrograms_Programs_Edges_Node_InternalPolicies) GetUpdatedBy() *string {
+func (t *GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node) GetUpdatedBy() *string {
+	if t == nil {
+		t = &GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node{}
+	}
+	return t.UpdatedBy
+}
+
+type GetPrograms_Programs_Edges_Node_InternalPolicies_Edges struct {
+	Node *GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetPrograms_Programs_Edges_Node_InternalPolicies_Edges) GetNode() *GetPrograms_Programs_Edges_Node_InternalPolicies_Edges_Node {
+	if t == nil {
+		t = &GetPrograms_Programs_Edges_Node_InternalPolicies_Edges{}
+	}
+	return t.Node
+}
+
+type GetPrograms_Programs_Edges_Node_InternalPolicies struct {
+	Edges []*GetPrograms_Programs_Edges_Node_InternalPolicies_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetPrograms_Programs_Edges_Node_InternalPolicies) GetEdges() []*GetPrograms_Programs_Edges_Node_InternalPolicies_Edges {
 	if t == nil {
 		t = &GetPrograms_Programs_Edges_Node_InternalPolicies{}
 	}
-	return t.UpdatedBy
+	return t.Edges
 }
 
 type GetPrograms_Programs_Edges_Node_Editors struct {
@@ -39187,72 +43257,94 @@ func (t *GetPrograms_Programs_Edges_Node_BlockedGroups) GetName() string {
 	return t.Name
 }
 
-type GetPrograms_Programs_Edges_Node_Members_User struct {
+type GetPrograms_Programs_Edges_Node_Members_Edges_Node_User struct {
 	FirstName *string "json:\"firstName,omitempty\" graphql:\"firstName\""
 	ID        string  "json:\"id\" graphql:\"id\""
 	LastName  *string "json:\"lastName,omitempty\" graphql:\"lastName\""
 }
 
-func (t *GetPrograms_Programs_Edges_Node_Members_User) GetFirstName() *string {
+func (t *GetPrograms_Programs_Edges_Node_Members_Edges_Node_User) GetFirstName() *string {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_Members_User{}
+		t = &GetPrograms_Programs_Edges_Node_Members_Edges_Node_User{}
 	}
 	return t.FirstName
 }
-func (t *GetPrograms_Programs_Edges_Node_Members_User) GetID() string {
+func (t *GetPrograms_Programs_Edges_Node_Members_Edges_Node_User) GetID() string {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_Members_User{}
+		t = &GetPrograms_Programs_Edges_Node_Members_Edges_Node_User{}
 	}
 	return t.ID
 }
-func (t *GetPrograms_Programs_Edges_Node_Members_User) GetLastName() *string {
+func (t *GetPrograms_Programs_Edges_Node_Members_Edges_Node_User) GetLastName() *string {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_Members_User{}
+		t = &GetPrograms_Programs_Edges_Node_Members_Edges_Node_User{}
 	}
 	return t.LastName
 }
 
-type GetPrograms_Programs_Edges_Node_Members struct {
-	ID   string                                       "json:\"id\" graphql:\"id\""
-	User GetPrograms_Programs_Edges_Node_Members_User "json:\"user\" graphql:\"user\""
+type GetPrograms_Programs_Edges_Node_Members_Edges_Node struct {
+	ID   string                                                  "json:\"id\" graphql:\"id\""
+	User GetPrograms_Programs_Edges_Node_Members_Edges_Node_User "json:\"user\" graphql:\"user\""
 }
 
-func (t *GetPrograms_Programs_Edges_Node_Members) GetID() string {
+func (t *GetPrograms_Programs_Edges_Node_Members_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_Members{}
+		t = &GetPrograms_Programs_Edges_Node_Members_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetPrograms_Programs_Edges_Node_Members) GetUser() *GetPrograms_Programs_Edges_Node_Members_User {
+func (t *GetPrograms_Programs_Edges_Node_Members_Edges_Node) GetUser() *GetPrograms_Programs_Edges_Node_Members_Edges_Node_User {
 	if t == nil {
-		t = &GetPrograms_Programs_Edges_Node_Members{}
+		t = &GetPrograms_Programs_Edges_Node_Members_Edges_Node{}
 	}
 	return &t.User
 }
 
+type GetPrograms_Programs_Edges_Node_Members_Edges struct {
+	Node *GetPrograms_Programs_Edges_Node_Members_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetPrograms_Programs_Edges_Node_Members_Edges) GetNode() *GetPrograms_Programs_Edges_Node_Members_Edges_Node {
+	if t == nil {
+		t = &GetPrograms_Programs_Edges_Node_Members_Edges{}
+	}
+	return t.Node
+}
+
+type GetPrograms_Programs_Edges_Node_Members struct {
+	Edges []*GetPrograms_Programs_Edges_Node_Members_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetPrograms_Programs_Edges_Node_Members) GetEdges() []*GetPrograms_Programs_Edges_Node_Members_Edges {
+	if t == nil {
+		t = &GetPrograms_Programs_Edges_Node_Members{}
+	}
+	return t.Edges
+}
+
 type GetPrograms_Programs_Edges_Node struct {
-	AuditorReadComments  bool                                                "json:\"auditorReadComments\" graphql:\"auditorReadComments\""
-	AuditorReady         bool                                                "json:\"auditorReady\" graphql:\"auditorReady\""
-	AuditorWriteComments bool                                                "json:\"auditorWriteComments\" graphql:\"auditorWriteComments\""
-	BlockedGroups        []*GetPrograms_Programs_Edges_Node_BlockedGroups    "json:\"blockedGroups,omitempty\" graphql:\"blockedGroups\""
-	CreatedAt            *time.Time                                          "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy            *string                                             "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description          *string                                             "json:\"description,omitempty\" graphql:\"description\""
-	DisplayID            string                                              "json:\"displayID\" graphql:\"displayID\""
-	Editors              []*GetPrograms_Programs_Edges_Node_Editors          "json:\"editors,omitempty\" graphql:\"editors\""
-	EndDate              *time.Time                                          "json:\"endDate,omitempty\" graphql:\"endDate\""
-	ID                   string                                              "json:\"id\" graphql:\"id\""
-	InternalPolicies     []*GetPrograms_Programs_Edges_Node_InternalPolicies "json:\"internalPolicies,omitempty\" graphql:\"internalPolicies\""
-	Members              []*GetPrograms_Programs_Edges_Node_Members          "json:\"members,omitempty\" graphql:\"members\""
-	Name                 string                                              "json:\"name\" graphql:\"name\""
-	OwnerID              *string                                             "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Procedures           []*GetPrograms_Programs_Edges_Node_Procedures       "json:\"procedures,omitempty\" graphql:\"procedures\""
-	StartDate            *time.Time                                          "json:\"startDate,omitempty\" graphql:\"startDate\""
-	Status               enums.ProgramStatus                                 "json:\"status\" graphql:\"status\""
-	Tags                 []string                                            "json:\"tags,omitempty\" graphql:\"tags\""
-	UpdatedAt            *time.Time                                          "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy            *string                                             "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
-	Viewers              []*GetPrograms_Programs_Edges_Node_Viewers          "json:\"viewers,omitempty\" graphql:\"viewers\""
+	AuditorReadComments  bool                                             "json:\"auditorReadComments\" graphql:\"auditorReadComments\""
+	AuditorReady         bool                                             "json:\"auditorReady\" graphql:\"auditorReady\""
+	AuditorWriteComments bool                                             "json:\"auditorWriteComments\" graphql:\"auditorWriteComments\""
+	BlockedGroups        []*GetPrograms_Programs_Edges_Node_BlockedGroups "json:\"blockedGroups,omitempty\" graphql:\"blockedGroups\""
+	CreatedAt            *time.Time                                       "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy            *string                                          "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description          *string                                          "json:\"description,omitempty\" graphql:\"description\""
+	DisplayID            string                                           "json:\"displayID\" graphql:\"displayID\""
+	Editors              []*GetPrograms_Programs_Edges_Node_Editors       "json:\"editors,omitempty\" graphql:\"editors\""
+	EndDate              *time.Time                                       "json:\"endDate,omitempty\" graphql:\"endDate\""
+	ID                   string                                           "json:\"id\" graphql:\"id\""
+	InternalPolicies     GetPrograms_Programs_Edges_Node_InternalPolicies "json:\"internalPolicies\" graphql:\"internalPolicies\""
+	Members              GetPrograms_Programs_Edges_Node_Members          "json:\"members\" graphql:\"members\""
+	Name                 string                                           "json:\"name\" graphql:\"name\""
+	OwnerID              *string                                          "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	Procedures           GetPrograms_Programs_Edges_Node_Procedures       "json:\"procedures\" graphql:\"procedures\""
+	StartDate            *time.Time                                       "json:\"startDate,omitempty\" graphql:\"startDate\""
+	Status               enums.ProgramStatus                              "json:\"status\" graphql:\"status\""
+	Tags                 []string                                         "json:\"tags,omitempty\" graphql:\"tags\""
+	UpdatedAt            *time.Time                                       "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy            *string                                          "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Viewers              []*GetPrograms_Programs_Edges_Node_Viewers       "json:\"viewers,omitempty\" graphql:\"viewers\""
 }
 
 func (t *GetPrograms_Programs_Edges_Node) GetAuditorReadComments() bool {
@@ -39321,17 +43413,17 @@ func (t *GetPrograms_Programs_Edges_Node) GetID() string {
 	}
 	return t.ID
 }
-func (t *GetPrograms_Programs_Edges_Node) GetInternalPolicies() []*GetPrograms_Programs_Edges_Node_InternalPolicies {
+func (t *GetPrograms_Programs_Edges_Node) GetInternalPolicies() *GetPrograms_Programs_Edges_Node_InternalPolicies {
 	if t == nil {
 		t = &GetPrograms_Programs_Edges_Node{}
 	}
-	return t.InternalPolicies
+	return &t.InternalPolicies
 }
-func (t *GetPrograms_Programs_Edges_Node) GetMembers() []*GetPrograms_Programs_Edges_Node_Members {
+func (t *GetPrograms_Programs_Edges_Node) GetMembers() *GetPrograms_Programs_Edges_Node_Members {
 	if t == nil {
 		t = &GetPrograms_Programs_Edges_Node{}
 	}
-	return t.Members
+	return &t.Members
 }
 func (t *GetPrograms_Programs_Edges_Node) GetName() string {
 	if t == nil {
@@ -39345,11 +43437,11 @@ func (t *GetPrograms_Programs_Edges_Node) GetOwnerID() *string {
 	}
 	return t.OwnerID
 }
-func (t *GetPrograms_Programs_Edges_Node) GetProcedures() []*GetPrograms_Programs_Edges_Node_Procedures {
+func (t *GetPrograms_Programs_Edges_Node) GetProcedures() *GetPrograms_Programs_Edges_Node_Procedures {
 	if t == nil {
 		t = &GetPrograms_Programs_Edges_Node{}
 	}
-	return t.Procedures
+	return &t.Procedures
 }
 func (t *GetPrograms_Programs_Edges_Node) GetStartDate() *time.Time {
 	if t == nil {
@@ -39410,10 +43502,11 @@ func (t *GetPrograms_Programs) GetEdges() []*GetPrograms_Programs_Edges {
 	return t.Edges
 }
 
-type UpdateProgram_UpdateProgram_Program_Procedures struct {
+type UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node struct {
 	CreatedAt     *time.Time            "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy     *string               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	Details       *string               "json:\"details,omitempty\" graphql:\"details\""
+	DisplayID     string                "json:\"displayID\" graphql:\"displayID\""
 	ID            string                "json:\"id\" graphql:\"id\""
 	Name          string                "json:\"name\" graphql:\"name\""
 	ProcedureType *string               "json:\"procedureType,omitempty\" graphql:\"procedureType\""
@@ -39424,77 +43517,106 @@ type UpdateProgram_UpdateProgram_Program_Procedures struct {
 	UpdatedBy     *string               "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *UpdateProgram_UpdateProgram_Program_Procedures) GetCreatedAt() *time.Time {
+func (t *UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node) GetCreatedAt() *time.Time {
 	if t == nil {
-		t = &UpdateProgram_UpdateProgram_Program_Procedures{}
+		t = &UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node{}
 	}
 	return t.CreatedAt
 }
-func (t *UpdateProgram_UpdateProgram_Program_Procedures) GetCreatedBy() *string {
+func (t *UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node) GetCreatedBy() *string {
 	if t == nil {
-		t = &UpdateProgram_UpdateProgram_Program_Procedures{}
+		t = &UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node{}
 	}
 	return t.CreatedBy
 }
-func (t *UpdateProgram_UpdateProgram_Program_Procedures) GetDetails() *string {
+func (t *UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node) GetDetails() *string {
 	if t == nil {
-		t = &UpdateProgram_UpdateProgram_Program_Procedures{}
+		t = &UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node{}
 	}
 	return t.Details
 }
-func (t *UpdateProgram_UpdateProgram_Program_Procedures) GetID() string {
+func (t *UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &UpdateProgram_UpdateProgram_Program_Procedures{}
+		t = &UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node{}
+	}
+	return t.DisplayID
+}
+func (t *UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node) GetID() string {
+	if t == nil {
+		t = &UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *UpdateProgram_UpdateProgram_Program_Procedures) GetName() string {
+func (t *UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node) GetName() string {
 	if t == nil {
-		t = &UpdateProgram_UpdateProgram_Program_Procedures{}
+		t = &UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node{}
 	}
 	return t.Name
 }
-func (t *UpdateProgram_UpdateProgram_Program_Procedures) GetProcedureType() *string {
+func (t *UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node) GetProcedureType() *string {
 	if t == nil {
-		t = &UpdateProgram_UpdateProgram_Program_Procedures{}
+		t = &UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node{}
 	}
 	return t.ProcedureType
 }
-func (t *UpdateProgram_UpdateProgram_Program_Procedures) GetRevision() *string {
+func (t *UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node) GetRevision() *string {
 	if t == nil {
-		t = &UpdateProgram_UpdateProgram_Program_Procedures{}
+		t = &UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node{}
 	}
 	return t.Revision
 }
-func (t *UpdateProgram_UpdateProgram_Program_Procedures) GetStatus() *enums.DocumentStatus {
+func (t *UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node) GetStatus() *enums.DocumentStatus {
 	if t == nil {
-		t = &UpdateProgram_UpdateProgram_Program_Procedures{}
+		t = &UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node{}
 	}
 	return t.Status
 }
-func (t *UpdateProgram_UpdateProgram_Program_Procedures) GetTags() []string {
+func (t *UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node) GetTags() []string {
 	if t == nil {
-		t = &UpdateProgram_UpdateProgram_Program_Procedures{}
+		t = &UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node{}
 	}
 	return t.Tags
 }
-func (t *UpdateProgram_UpdateProgram_Program_Procedures) GetUpdatedAt() *time.Time {
+func (t *UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
-		t = &UpdateProgram_UpdateProgram_Program_Procedures{}
+		t = &UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node{}
 	}
 	return t.UpdatedAt
 }
-func (t *UpdateProgram_UpdateProgram_Program_Procedures) GetUpdatedBy() *string {
+func (t *UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node) GetUpdatedBy() *string {
 	if t == nil {
-		t = &UpdateProgram_UpdateProgram_Program_Procedures{}
+		t = &UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node{}
 	}
 	return t.UpdatedBy
 }
 
-type UpdateProgram_UpdateProgram_Program_InternalPolicies struct {
+type UpdateProgram_UpdateProgram_Program_Procedures_Edges struct {
+	Node *UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateProgram_UpdateProgram_Program_Procedures_Edges) GetNode() *UpdateProgram_UpdateProgram_Program_Procedures_Edges_Node {
+	if t == nil {
+		t = &UpdateProgram_UpdateProgram_Program_Procedures_Edges{}
+	}
+	return t.Node
+}
+
+type UpdateProgram_UpdateProgram_Program_Procedures struct {
+	Edges []*UpdateProgram_UpdateProgram_Program_Procedures_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *UpdateProgram_UpdateProgram_Program_Procedures) GetEdges() []*UpdateProgram_UpdateProgram_Program_Procedures_Edges {
+	if t == nil {
+		t = &UpdateProgram_UpdateProgram_Program_Procedures{}
+	}
+	return t.Edges
+}
+
+type UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node struct {
 	CreatedAt  *time.Time            "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy  *string               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	Details    *string               "json:\"details,omitempty\" graphql:\"details\""
+	DisplayID  string                "json:\"displayID\" graphql:\"displayID\""
 	ID         string                "json:\"id\" graphql:\"id\""
 	Name       string                "json:\"name\" graphql:\"name\""
 	PolicyType *string               "json:\"policyType,omitempty\" graphql:\"policyType\""
@@ -39505,71 +43627,99 @@ type UpdateProgram_UpdateProgram_Program_InternalPolicies struct {
 	UpdatedBy  *string               "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *UpdateProgram_UpdateProgram_Program_InternalPolicies) GetCreatedAt() *time.Time {
+func (t *UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node) GetCreatedAt() *time.Time {
 	if t == nil {
-		t = &UpdateProgram_UpdateProgram_Program_InternalPolicies{}
+		t = &UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.CreatedAt
 }
-func (t *UpdateProgram_UpdateProgram_Program_InternalPolicies) GetCreatedBy() *string {
+func (t *UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node) GetCreatedBy() *string {
 	if t == nil {
-		t = &UpdateProgram_UpdateProgram_Program_InternalPolicies{}
+		t = &UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.CreatedBy
 }
-func (t *UpdateProgram_UpdateProgram_Program_InternalPolicies) GetDetails() *string {
+func (t *UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node) GetDetails() *string {
 	if t == nil {
-		t = &UpdateProgram_UpdateProgram_Program_InternalPolicies{}
+		t = &UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.Details
 }
-func (t *UpdateProgram_UpdateProgram_Program_InternalPolicies) GetID() string {
+func (t *UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &UpdateProgram_UpdateProgram_Program_InternalPolicies{}
+		t = &UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node{}
+	}
+	return t.DisplayID
+}
+func (t *UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node) GetID() string {
+	if t == nil {
+		t = &UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *UpdateProgram_UpdateProgram_Program_InternalPolicies) GetName() string {
+func (t *UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node) GetName() string {
 	if t == nil {
-		t = &UpdateProgram_UpdateProgram_Program_InternalPolicies{}
+		t = &UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.Name
 }
-func (t *UpdateProgram_UpdateProgram_Program_InternalPolicies) GetPolicyType() *string {
+func (t *UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node) GetPolicyType() *string {
 	if t == nil {
-		t = &UpdateProgram_UpdateProgram_Program_InternalPolicies{}
+		t = &UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.PolicyType
 }
-func (t *UpdateProgram_UpdateProgram_Program_InternalPolicies) GetRevision() *string {
+func (t *UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node) GetRevision() *string {
 	if t == nil {
-		t = &UpdateProgram_UpdateProgram_Program_InternalPolicies{}
+		t = &UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.Revision
 }
-func (t *UpdateProgram_UpdateProgram_Program_InternalPolicies) GetStatus() *enums.DocumentStatus {
+func (t *UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node) GetStatus() *enums.DocumentStatus {
 	if t == nil {
-		t = &UpdateProgram_UpdateProgram_Program_InternalPolicies{}
+		t = &UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.Status
 }
-func (t *UpdateProgram_UpdateProgram_Program_InternalPolicies) GetTags() []string {
+func (t *UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node) GetTags() []string {
 	if t == nil {
-		t = &UpdateProgram_UpdateProgram_Program_InternalPolicies{}
+		t = &UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.Tags
 }
-func (t *UpdateProgram_UpdateProgram_Program_InternalPolicies) GetUpdatedAt() *time.Time {
+func (t *UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
-		t = &UpdateProgram_UpdateProgram_Program_InternalPolicies{}
+		t = &UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node{}
 	}
 	return t.UpdatedAt
 }
-func (t *UpdateProgram_UpdateProgram_Program_InternalPolicies) GetUpdatedBy() *string {
+func (t *UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node) GetUpdatedBy() *string {
+	if t == nil {
+		t = &UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node{}
+	}
+	return t.UpdatedBy
+}
+
+type UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges struct {
+	Node *UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges) GetNode() *UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges_Node {
+	if t == nil {
+		t = &UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges{}
+	}
+	return t.Node
+}
+
+type UpdateProgram_UpdateProgram_Program_InternalPolicies struct {
+	Edges []*UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *UpdateProgram_UpdateProgram_Program_InternalPolicies) GetEdges() []*UpdateProgram_UpdateProgram_Program_InternalPolicies_Edges {
 	if t == nil {
 		t = &UpdateProgram_UpdateProgram_Program_InternalPolicies{}
 	}
-	return t.UpdatedBy
+	return t.Edges
 }
 
 type UpdateProgram_UpdateProgram_Program_Editors struct {
@@ -39626,71 +43776,93 @@ func (t *UpdateProgram_UpdateProgram_Program_BlockedGroups) GetName() string {
 	return t.Name
 }
 
-type UpdateProgram_UpdateProgram_Program_Members_User struct {
+type UpdateProgram_UpdateProgram_Program_Members_Edges_Node_User struct {
 	FirstName *string "json:\"firstName,omitempty\" graphql:\"firstName\""
 	ID        string  "json:\"id\" graphql:\"id\""
 	LastName  *string "json:\"lastName,omitempty\" graphql:\"lastName\""
 }
 
-func (t *UpdateProgram_UpdateProgram_Program_Members_User) GetFirstName() *string {
+func (t *UpdateProgram_UpdateProgram_Program_Members_Edges_Node_User) GetFirstName() *string {
 	if t == nil {
-		t = &UpdateProgram_UpdateProgram_Program_Members_User{}
+		t = &UpdateProgram_UpdateProgram_Program_Members_Edges_Node_User{}
 	}
 	return t.FirstName
 }
-func (t *UpdateProgram_UpdateProgram_Program_Members_User) GetID() string {
+func (t *UpdateProgram_UpdateProgram_Program_Members_Edges_Node_User) GetID() string {
 	if t == nil {
-		t = &UpdateProgram_UpdateProgram_Program_Members_User{}
+		t = &UpdateProgram_UpdateProgram_Program_Members_Edges_Node_User{}
 	}
 	return t.ID
 }
-func (t *UpdateProgram_UpdateProgram_Program_Members_User) GetLastName() *string {
+func (t *UpdateProgram_UpdateProgram_Program_Members_Edges_Node_User) GetLastName() *string {
 	if t == nil {
-		t = &UpdateProgram_UpdateProgram_Program_Members_User{}
+		t = &UpdateProgram_UpdateProgram_Program_Members_Edges_Node_User{}
 	}
 	return t.LastName
 }
 
-type UpdateProgram_UpdateProgram_Program_Members struct {
-	ID   string                                           "json:\"id\" graphql:\"id\""
-	User UpdateProgram_UpdateProgram_Program_Members_User "json:\"user\" graphql:\"user\""
+type UpdateProgram_UpdateProgram_Program_Members_Edges_Node struct {
+	ID   string                                                      "json:\"id\" graphql:\"id\""
+	User UpdateProgram_UpdateProgram_Program_Members_Edges_Node_User "json:\"user\" graphql:\"user\""
 }
 
-func (t *UpdateProgram_UpdateProgram_Program_Members) GetID() string {
+func (t *UpdateProgram_UpdateProgram_Program_Members_Edges_Node) GetID() string {
 	if t == nil {
-		t = &UpdateProgram_UpdateProgram_Program_Members{}
+		t = &UpdateProgram_UpdateProgram_Program_Members_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *UpdateProgram_UpdateProgram_Program_Members) GetUser() *UpdateProgram_UpdateProgram_Program_Members_User {
+func (t *UpdateProgram_UpdateProgram_Program_Members_Edges_Node) GetUser() *UpdateProgram_UpdateProgram_Program_Members_Edges_Node_User {
 	if t == nil {
-		t = &UpdateProgram_UpdateProgram_Program_Members{}
+		t = &UpdateProgram_UpdateProgram_Program_Members_Edges_Node{}
 	}
 	return &t.User
 }
 
+type UpdateProgram_UpdateProgram_Program_Members_Edges struct {
+	Node *UpdateProgram_UpdateProgram_Program_Members_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateProgram_UpdateProgram_Program_Members_Edges) GetNode() *UpdateProgram_UpdateProgram_Program_Members_Edges_Node {
+	if t == nil {
+		t = &UpdateProgram_UpdateProgram_Program_Members_Edges{}
+	}
+	return t.Node
+}
+
+type UpdateProgram_UpdateProgram_Program_Members struct {
+	Edges []*UpdateProgram_UpdateProgram_Program_Members_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *UpdateProgram_UpdateProgram_Program_Members) GetEdges() []*UpdateProgram_UpdateProgram_Program_Members_Edges {
+	if t == nil {
+		t = &UpdateProgram_UpdateProgram_Program_Members{}
+	}
+	return t.Edges
+}
+
 type UpdateProgram_UpdateProgram_Program struct {
-	AuditorReadComments  bool                                                    "json:\"auditorReadComments\" graphql:\"auditorReadComments\""
-	AuditorReady         bool                                                    "json:\"auditorReady\" graphql:\"auditorReady\""
-	AuditorWriteComments bool                                                    "json:\"auditorWriteComments\" graphql:\"auditorWriteComments\""
-	BlockedGroups        []*UpdateProgram_UpdateProgram_Program_BlockedGroups    "json:\"blockedGroups,omitempty\" graphql:\"blockedGroups\""
-	CreatedAt            *time.Time                                              "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy            *string                                                 "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description          *string                                                 "json:\"description,omitempty\" graphql:\"description\""
-	Editors              []*UpdateProgram_UpdateProgram_Program_Editors          "json:\"editors,omitempty\" graphql:\"editors\""
-	EndDate              *time.Time                                              "json:\"endDate,omitempty\" graphql:\"endDate\""
-	ID                   string                                                  "json:\"id\" graphql:\"id\""
-	InternalPolicies     []*UpdateProgram_UpdateProgram_Program_InternalPolicies "json:\"internalPolicies,omitempty\" graphql:\"internalPolicies\""
-	Members              []*UpdateProgram_UpdateProgram_Program_Members          "json:\"members,omitempty\" graphql:\"members\""
-	Name                 string                                                  "json:\"name\" graphql:\"name\""
-	OwnerID              *string                                                 "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Procedures           []*UpdateProgram_UpdateProgram_Program_Procedures       "json:\"procedures,omitempty\" graphql:\"procedures\""
-	StartDate            *time.Time                                              "json:\"startDate,omitempty\" graphql:\"startDate\""
-	Status               enums.ProgramStatus                                     "json:\"status\" graphql:\"status\""
-	Tags                 []string                                                "json:\"tags,omitempty\" graphql:\"tags\""
-	UpdatedAt            *time.Time                                              "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy            *string                                                 "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
-	Viewers              []*UpdateProgram_UpdateProgram_Program_Viewers          "json:\"viewers,omitempty\" graphql:\"viewers\""
+	AuditorReadComments  bool                                                 "json:\"auditorReadComments\" graphql:\"auditorReadComments\""
+	AuditorReady         bool                                                 "json:\"auditorReady\" graphql:\"auditorReady\""
+	AuditorWriteComments bool                                                 "json:\"auditorWriteComments\" graphql:\"auditorWriteComments\""
+	BlockedGroups        []*UpdateProgram_UpdateProgram_Program_BlockedGroups "json:\"blockedGroups,omitempty\" graphql:\"blockedGroups\""
+	CreatedAt            *time.Time                                           "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy            *string                                              "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description          *string                                              "json:\"description,omitempty\" graphql:\"description\""
+	Editors              []*UpdateProgram_UpdateProgram_Program_Editors       "json:\"editors,omitempty\" graphql:\"editors\""
+	EndDate              *time.Time                                           "json:\"endDate,omitempty\" graphql:\"endDate\""
+	ID                   string                                               "json:\"id\" graphql:\"id\""
+	InternalPolicies     UpdateProgram_UpdateProgram_Program_InternalPolicies "json:\"internalPolicies\" graphql:\"internalPolicies\""
+	Members              UpdateProgram_UpdateProgram_Program_Members          "json:\"members\" graphql:\"members\""
+	Name                 string                                               "json:\"name\" graphql:\"name\""
+	OwnerID              *string                                              "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	Procedures           UpdateProgram_UpdateProgram_Program_Procedures       "json:\"procedures\" graphql:\"procedures\""
+	StartDate            *time.Time                                           "json:\"startDate,omitempty\" graphql:\"startDate\""
+	Status               enums.ProgramStatus                                  "json:\"status\" graphql:\"status\""
+	Tags                 []string                                             "json:\"tags,omitempty\" graphql:\"tags\""
+	UpdatedAt            *time.Time                                           "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy            *string                                              "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Viewers              []*UpdateProgram_UpdateProgram_Program_Viewers       "json:\"viewers,omitempty\" graphql:\"viewers\""
 }
 
 func (t *UpdateProgram_UpdateProgram_Program) GetAuditorReadComments() bool {
@@ -39753,17 +43925,17 @@ func (t *UpdateProgram_UpdateProgram_Program) GetID() string {
 	}
 	return t.ID
 }
-func (t *UpdateProgram_UpdateProgram_Program) GetInternalPolicies() []*UpdateProgram_UpdateProgram_Program_InternalPolicies {
+func (t *UpdateProgram_UpdateProgram_Program) GetInternalPolicies() *UpdateProgram_UpdateProgram_Program_InternalPolicies {
 	if t == nil {
 		t = &UpdateProgram_UpdateProgram_Program{}
 	}
-	return t.InternalPolicies
+	return &t.InternalPolicies
 }
-func (t *UpdateProgram_UpdateProgram_Program) GetMembers() []*UpdateProgram_UpdateProgram_Program_Members {
+func (t *UpdateProgram_UpdateProgram_Program) GetMembers() *UpdateProgram_UpdateProgram_Program_Members {
 	if t == nil {
 		t = &UpdateProgram_UpdateProgram_Program{}
 	}
-	return t.Members
+	return &t.Members
 }
 func (t *UpdateProgram_UpdateProgram_Program) GetName() string {
 	if t == nil {
@@ -39777,11 +43949,11 @@ func (t *UpdateProgram_UpdateProgram_Program) GetOwnerID() *string {
 	}
 	return t.OwnerID
 }
-func (t *UpdateProgram_UpdateProgram_Program) GetProcedures() []*UpdateProgram_UpdateProgram_Program_Procedures {
+func (t *UpdateProgram_UpdateProgram_Program) GetProcedures() *UpdateProgram_UpdateProgram_Program_Procedures {
 	if t == nil {
 		t = &UpdateProgram_UpdateProgram_Program{}
 	}
-	return t.Procedures
+	return &t.Procedures
 }
 func (t *UpdateProgram_UpdateProgram_Program) GetStartDate() *time.Time {
 	if t == nil {
@@ -41706,22 +45878,44 @@ func (t *CreateBulkRisk_CreateBulkRisk) GetRisks() []*CreateBulkRisk_CreateBulkR
 	return t.Risks
 }
 
-type CreateRisk_CreateRisk_Risk_Programs struct {
+type CreateRisk_CreateRisk_Risk_Programs_Edges_Node struct {
 	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
-func (t *CreateRisk_CreateRisk_Risk_Programs) GetID() string {
+func (t *CreateRisk_CreateRisk_Risk_Programs_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateRisk_CreateRisk_Risk_Programs{}
+		t = &CreateRisk_CreateRisk_Risk_Programs_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *CreateRisk_CreateRisk_Risk_Programs) GetName() string {
+func (t *CreateRisk_CreateRisk_Risk_Programs_Edges_Node) GetName() string {
+	if t == nil {
+		t = &CreateRisk_CreateRisk_Risk_Programs_Edges_Node{}
+	}
+	return t.Name
+}
+
+type CreateRisk_CreateRisk_Risk_Programs_Edges struct {
+	Node *CreateRisk_CreateRisk_Risk_Programs_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateRisk_CreateRisk_Risk_Programs_Edges) GetNode() *CreateRisk_CreateRisk_Risk_Programs_Edges_Node {
+	if t == nil {
+		t = &CreateRisk_CreateRisk_Risk_Programs_Edges{}
+	}
+	return t.Node
+}
+
+type CreateRisk_CreateRisk_Risk_Programs struct {
+	Edges []*CreateRisk_CreateRisk_Risk_Programs_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateRisk_CreateRisk_Risk_Programs) GetEdges() []*CreateRisk_CreateRisk_Risk_Programs_Edges {
 	if t == nil {
 		t = &CreateRisk_CreateRisk_Risk_Programs{}
 	}
-	return t.Name
+	return t.Edges
 }
 
 type CreateRisk_CreateRisk_Risk_Editors struct {
@@ -41791,7 +45985,7 @@ type CreateRisk_CreateRisk_Risk struct {
 	Likelihood    *enums.RiskLikelihood                       "json:\"likelihood,omitempty\" graphql:\"likelihood\""
 	Mitigation    *string                                     "json:\"mitigation,omitempty\" graphql:\"mitigation\""
 	Name          string                                      "json:\"name\" graphql:\"name\""
-	Programs      []*CreateRisk_CreateRisk_Risk_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
+	Programs      CreateRisk_CreateRisk_Risk_Programs         "json:\"programs\" graphql:\"programs\""
 	RiskType      *string                                     "json:\"riskType,omitempty\" graphql:\"riskType\""
 	Score         *int64                                      "json:\"score,omitempty\" graphql:\"score\""
 	Status        *enums.RiskStatus                           "json:\"status,omitempty\" graphql:\"status\""
@@ -41873,11 +46067,11 @@ func (t *CreateRisk_CreateRisk_Risk) GetName() string {
 	}
 	return t.Name
 }
-func (t *CreateRisk_CreateRisk_Risk) GetPrograms() []*CreateRisk_CreateRisk_Risk_Programs {
+func (t *CreateRisk_CreateRisk_Risk) GetPrograms() *CreateRisk_CreateRisk_Risk_Programs {
 	if t == nil {
 		t = &CreateRisk_CreateRisk_Risk{}
 	}
-	return t.Programs
+	return &t.Programs
 }
 func (t *CreateRisk_CreateRisk_Risk) GetRiskType() *string {
 	if t == nil {
@@ -41944,22 +46138,44 @@ func (t *DeleteRisk_DeleteRisk) GetDeletedID() string {
 	return t.DeletedID
 }
 
-type GetAllRisks_Risks_Edges_Node_Programs struct {
+type GetAllRisks_Risks_Edges_Node_Programs_Edges_Node struct {
 	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
-func (t *GetAllRisks_Risks_Edges_Node_Programs) GetID() string {
+func (t *GetAllRisks_Risks_Edges_Node_Programs_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetAllRisks_Risks_Edges_Node_Programs{}
+		t = &GetAllRisks_Risks_Edges_Node_Programs_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetAllRisks_Risks_Edges_Node_Programs) GetName() string {
+func (t *GetAllRisks_Risks_Edges_Node_Programs_Edges_Node) GetName() string {
+	if t == nil {
+		t = &GetAllRisks_Risks_Edges_Node_Programs_Edges_Node{}
+	}
+	return t.Name
+}
+
+type GetAllRisks_Risks_Edges_Node_Programs_Edges struct {
+	Node *GetAllRisks_Risks_Edges_Node_Programs_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllRisks_Risks_Edges_Node_Programs_Edges) GetNode() *GetAllRisks_Risks_Edges_Node_Programs_Edges_Node {
+	if t == nil {
+		t = &GetAllRisks_Risks_Edges_Node_Programs_Edges{}
+	}
+	return t.Node
+}
+
+type GetAllRisks_Risks_Edges_Node_Programs struct {
+	Edges []*GetAllRisks_Risks_Edges_Node_Programs_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetAllRisks_Risks_Edges_Node_Programs) GetEdges() []*GetAllRisks_Risks_Edges_Node_Programs_Edges {
 	if t == nil {
 		t = &GetAllRisks_Risks_Edges_Node_Programs{}
 	}
-	return t.Name
+	return t.Edges
 }
 
 type GetAllRisks_Risks_Edges_Node_Editors struct {
@@ -42029,7 +46245,7 @@ type GetAllRisks_Risks_Edges_Node struct {
 	Likelihood    *enums.RiskLikelihood                         "json:\"likelihood,omitempty\" graphql:\"likelihood\""
 	Mitigation    *string                                       "json:\"mitigation,omitempty\" graphql:\"mitigation\""
 	Name          string                                        "json:\"name\" graphql:\"name\""
-	Programs      []*GetAllRisks_Risks_Edges_Node_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
+	Programs      GetAllRisks_Risks_Edges_Node_Programs         "json:\"programs\" graphql:\"programs\""
 	RiskType      *string                                       "json:\"riskType,omitempty\" graphql:\"riskType\""
 	Score         *int64                                        "json:\"score,omitempty\" graphql:\"score\""
 	Status        *enums.RiskStatus                             "json:\"status,omitempty\" graphql:\"status\""
@@ -42111,11 +46327,11 @@ func (t *GetAllRisks_Risks_Edges_Node) GetName() string {
 	}
 	return t.Name
 }
-func (t *GetAllRisks_Risks_Edges_Node) GetPrograms() []*GetAllRisks_Risks_Edges_Node_Programs {
+func (t *GetAllRisks_Risks_Edges_Node) GetPrograms() *GetAllRisks_Risks_Edges_Node_Programs {
 	if t == nil {
 		t = &GetAllRisks_Risks_Edges_Node{}
 	}
-	return t.Programs
+	return &t.Programs
 }
 func (t *GetAllRisks_Risks_Edges_Node) GetRiskType() *string {
 	if t == nil {
@@ -42182,22 +46398,44 @@ func (t *GetAllRisks_Risks) GetEdges() []*GetAllRisks_Risks_Edges {
 	return t.Edges
 }
 
-type GetRiskByID_Risk_Programs struct {
+type GetRiskByID_Risk_Programs_Edges_Node struct {
 	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
-func (t *GetRiskByID_Risk_Programs) GetID() string {
+func (t *GetRiskByID_Risk_Programs_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetRiskByID_Risk_Programs{}
+		t = &GetRiskByID_Risk_Programs_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetRiskByID_Risk_Programs) GetName() string {
+func (t *GetRiskByID_Risk_Programs_Edges_Node) GetName() string {
+	if t == nil {
+		t = &GetRiskByID_Risk_Programs_Edges_Node{}
+	}
+	return t.Name
+}
+
+type GetRiskByID_Risk_Programs_Edges struct {
+	Node *GetRiskByID_Risk_Programs_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetRiskByID_Risk_Programs_Edges) GetNode() *GetRiskByID_Risk_Programs_Edges_Node {
+	if t == nil {
+		t = &GetRiskByID_Risk_Programs_Edges{}
+	}
+	return t.Node
+}
+
+type GetRiskByID_Risk_Programs struct {
+	Edges []*GetRiskByID_Risk_Programs_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetRiskByID_Risk_Programs) GetEdges() []*GetRiskByID_Risk_Programs_Edges {
 	if t == nil {
 		t = &GetRiskByID_Risk_Programs{}
 	}
-	return t.Name
+	return t.Edges
 }
 
 type GetRiskByID_Risk_Editors struct {
@@ -42267,7 +46505,7 @@ type GetRiskByID_Risk struct {
 	Likelihood    *enums.RiskLikelihood             "json:\"likelihood,omitempty\" graphql:\"likelihood\""
 	Mitigation    *string                           "json:\"mitigation,omitempty\" graphql:\"mitigation\""
 	Name          string                            "json:\"name\" graphql:\"name\""
-	Programs      []*GetRiskByID_Risk_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
+	Programs      GetRiskByID_Risk_Programs         "json:\"programs\" graphql:\"programs\""
 	RiskType      *string                           "json:\"riskType,omitempty\" graphql:\"riskType\""
 	Score         *int64                            "json:\"score,omitempty\" graphql:\"score\""
 	Status        *enums.RiskStatus                 "json:\"status,omitempty\" graphql:\"status\""
@@ -42349,11 +46587,11 @@ func (t *GetRiskByID_Risk) GetName() string {
 	}
 	return t.Name
 }
-func (t *GetRiskByID_Risk) GetPrograms() []*GetRiskByID_Risk_Programs {
+func (t *GetRiskByID_Risk) GetPrograms() *GetRiskByID_Risk_Programs {
 	if t == nil {
 		t = &GetRiskByID_Risk{}
 	}
-	return t.Programs
+	return &t.Programs
 }
 func (t *GetRiskByID_Risk) GetRiskType() *string {
 	if t == nil {
@@ -42398,22 +46636,44 @@ func (t *GetRiskByID_Risk) GetViewers() []*GetRiskByID_Risk_Viewers {
 	return t.Viewers
 }
 
-type GetRisks_Risks_Edges_Node_Programs struct {
+type GetRisks_Risks_Edges_Node_Programs_Edges_Node struct {
 	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
-func (t *GetRisks_Risks_Edges_Node_Programs) GetID() string {
+func (t *GetRisks_Risks_Edges_Node_Programs_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetRisks_Risks_Edges_Node_Programs{}
+		t = &GetRisks_Risks_Edges_Node_Programs_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetRisks_Risks_Edges_Node_Programs) GetName() string {
+func (t *GetRisks_Risks_Edges_Node_Programs_Edges_Node) GetName() string {
+	if t == nil {
+		t = &GetRisks_Risks_Edges_Node_Programs_Edges_Node{}
+	}
+	return t.Name
+}
+
+type GetRisks_Risks_Edges_Node_Programs_Edges struct {
+	Node *GetRisks_Risks_Edges_Node_Programs_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetRisks_Risks_Edges_Node_Programs_Edges) GetNode() *GetRisks_Risks_Edges_Node_Programs_Edges_Node {
+	if t == nil {
+		t = &GetRisks_Risks_Edges_Node_Programs_Edges{}
+	}
+	return t.Node
+}
+
+type GetRisks_Risks_Edges_Node_Programs struct {
+	Edges []*GetRisks_Risks_Edges_Node_Programs_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetRisks_Risks_Edges_Node_Programs) GetEdges() []*GetRisks_Risks_Edges_Node_Programs_Edges {
 	if t == nil {
 		t = &GetRisks_Risks_Edges_Node_Programs{}
 	}
-	return t.Name
+	return t.Edges
 }
 
 type GetRisks_Risks_Edges_Node_Editors struct {
@@ -42483,7 +46743,7 @@ type GetRisks_Risks_Edges_Node struct {
 	Likelihood    *enums.RiskLikelihood                      "json:\"likelihood,omitempty\" graphql:\"likelihood\""
 	Mitigation    *string                                    "json:\"mitigation,omitempty\" graphql:\"mitigation\""
 	Name          string                                     "json:\"name\" graphql:\"name\""
-	Programs      []*GetRisks_Risks_Edges_Node_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
+	Programs      GetRisks_Risks_Edges_Node_Programs         "json:\"programs\" graphql:\"programs\""
 	RiskType      *string                                    "json:\"riskType,omitempty\" graphql:\"riskType\""
 	Score         *int64                                     "json:\"score,omitempty\" graphql:\"score\""
 	Status        *enums.RiskStatus                          "json:\"status,omitempty\" graphql:\"status\""
@@ -42565,11 +46825,11 @@ func (t *GetRisks_Risks_Edges_Node) GetName() string {
 	}
 	return t.Name
 }
-func (t *GetRisks_Risks_Edges_Node) GetPrograms() []*GetRisks_Risks_Edges_Node_Programs {
+func (t *GetRisks_Risks_Edges_Node) GetPrograms() *GetRisks_Risks_Edges_Node_Programs {
 	if t == nil {
 		t = &GetRisks_Risks_Edges_Node{}
 	}
-	return t.Programs
+	return &t.Programs
 }
 func (t *GetRisks_Risks_Edges_Node) GetRiskType() *string {
 	if t == nil {
@@ -42636,22 +46896,44 @@ func (t *GetRisks_Risks) GetEdges() []*GetRisks_Risks_Edges {
 	return t.Edges
 }
 
-type UpdateRisk_UpdateRisk_Risk_Programs struct {
+type UpdateRisk_UpdateRisk_Risk_Programs_Edges_Node struct {
 	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
-func (t *UpdateRisk_UpdateRisk_Risk_Programs) GetID() string {
+func (t *UpdateRisk_UpdateRisk_Risk_Programs_Edges_Node) GetID() string {
 	if t == nil {
-		t = &UpdateRisk_UpdateRisk_Risk_Programs{}
+		t = &UpdateRisk_UpdateRisk_Risk_Programs_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *UpdateRisk_UpdateRisk_Risk_Programs) GetName() string {
+func (t *UpdateRisk_UpdateRisk_Risk_Programs_Edges_Node) GetName() string {
+	if t == nil {
+		t = &UpdateRisk_UpdateRisk_Risk_Programs_Edges_Node{}
+	}
+	return t.Name
+}
+
+type UpdateRisk_UpdateRisk_Risk_Programs_Edges struct {
+	Node *UpdateRisk_UpdateRisk_Risk_Programs_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateRisk_UpdateRisk_Risk_Programs_Edges) GetNode() *UpdateRisk_UpdateRisk_Risk_Programs_Edges_Node {
+	if t == nil {
+		t = &UpdateRisk_UpdateRisk_Risk_Programs_Edges{}
+	}
+	return t.Node
+}
+
+type UpdateRisk_UpdateRisk_Risk_Programs struct {
+	Edges []*UpdateRisk_UpdateRisk_Risk_Programs_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *UpdateRisk_UpdateRisk_Risk_Programs) GetEdges() []*UpdateRisk_UpdateRisk_Risk_Programs_Edges {
 	if t == nil {
 		t = &UpdateRisk_UpdateRisk_Risk_Programs{}
 	}
-	return t.Name
+	return t.Edges
 }
 
 type UpdateRisk_UpdateRisk_Risk_Editors struct {
@@ -42721,7 +47003,7 @@ type UpdateRisk_UpdateRisk_Risk struct {
 	Likelihood    *enums.RiskLikelihood                       "json:\"likelihood,omitempty\" graphql:\"likelihood\""
 	Mitigation    *string                                     "json:\"mitigation,omitempty\" graphql:\"mitigation\""
 	Name          string                                      "json:\"name\" graphql:\"name\""
-	Programs      []*UpdateRisk_UpdateRisk_Risk_Programs      "json:\"programs,omitempty\" graphql:\"programs\""
+	Programs      UpdateRisk_UpdateRisk_Risk_Programs         "json:\"programs\" graphql:\"programs\""
 	RiskType      *string                                     "json:\"riskType,omitempty\" graphql:\"riskType\""
 	Score         *int64                                      "json:\"score,omitempty\" graphql:\"score\""
 	Status        *enums.RiskStatus                           "json:\"status,omitempty\" graphql:\"status\""
@@ -42803,11 +47085,11 @@ func (t *UpdateRisk_UpdateRisk_Risk) GetName() string {
 	}
 	return t.Name
 }
-func (t *UpdateRisk_UpdateRisk_Risk) GetPrograms() []*UpdateRisk_UpdateRisk_Risk_Programs {
+func (t *UpdateRisk_UpdateRisk_Risk) GetPrograms() *UpdateRisk_UpdateRisk_Risk_Programs {
 	if t == nil {
 		t = &UpdateRisk_UpdateRisk_Risk{}
 	}
-	return t.Programs
+	return &t.Programs
 }
 func (t *UpdateRisk_UpdateRisk_Risk) GetRiskType() *string {
 	if t == nil {
@@ -43282,11 +47564,18 @@ func (t *GlobalSearch_Search_Nodes_ActionPlanSearchResult) GetActionPlans() []*G
 }
 
 type GlobalSearch_Search_Nodes_ContactSearchResult_Contacts struct {
+	Email    *string  "json:\"email,omitempty\" graphql:\"email\""
 	FullName string   "json:\"fullName\" graphql:\"fullName\""
 	ID       string   "json:\"id\" graphql:\"id\""
 	Tags     []string "json:\"tags,omitempty\" graphql:\"tags\""
 }
 
+func (t *GlobalSearch_Search_Nodes_ContactSearchResult_Contacts) GetEmail() *string {
+	if t == nil {
+		t = &GlobalSearch_Search_Nodes_ContactSearchResult_Contacts{}
+	}
+	return t.Email
+}
 func (t *GlobalSearch_Search_Nodes_ContactSearchResult_Contacts) GetFullName() string {
 	if t == nil {
 		t = &GlobalSearch_Search_Nodes_ContactSearchResult_Contacts{}
@@ -43614,6 +47903,7 @@ func (t *GlobalSearch_Search_Nodes_EventSearchResult) GetEvents() []*GlobalSearc
 type GlobalSearch_Search_Nodes_EvidenceSearchResult_Evidences struct {
 	DisplayID string   "json:\"displayID\" graphql:\"displayID\""
 	ID        string   "json:\"id\" graphql:\"id\""
+	Name      string   "json:\"name\" graphql:\"name\""
 	Tags      []string "json:\"tags,omitempty\" graphql:\"tags\""
 }
 
@@ -43628,6 +47918,12 @@ func (t *GlobalSearch_Search_Nodes_EvidenceSearchResult_Evidences) GetID() strin
 		t = &GlobalSearch_Search_Nodes_EvidenceSearchResult_Evidences{}
 	}
 	return t.ID
+}
+func (t *GlobalSearch_Search_Nodes_EvidenceSearchResult_Evidences) GetName() string {
+	if t == nil {
+		t = &GlobalSearch_Search_Nodes_EvidenceSearchResult_Evidences{}
+	}
+	return t.Name
 }
 func (t *GlobalSearch_Search_Nodes_EvidenceSearchResult_Evidences) GetTags() []string {
 	if t == nil {
@@ -44158,12 +48454,33 @@ func (t *GlobalSearch_Search_Nodes_RiskSearchResult) GetRisks() []*GlobalSearch_
 }
 
 type GlobalSearch_Search_Nodes_StandardSearchResult_Standards struct {
-	ID        string   "json:\"id\" graphql:\"id\""
-	Name      string   "json:\"name\" graphql:\"name\""
-	ShortName *string  "json:\"shortName,omitempty\" graphql:\"shortName\""
-	Tags      []string "json:\"tags,omitempty\" graphql:\"tags\""
+	Domains       []string "json:\"domains,omitempty\" graphql:\"domains\""
+	Framework     *string  "json:\"framework,omitempty\" graphql:\"framework\""
+	GoverningBody *string  "json:\"governingBody,omitempty\" graphql:\"governingBody\""
+	ID            string   "json:\"id\" graphql:\"id\""
+	Name          string   "json:\"name\" graphql:\"name\""
+	ShortName     *string  "json:\"shortName,omitempty\" graphql:\"shortName\""
+	Tags          []string "json:\"tags,omitempty\" graphql:\"tags\""
 }
 
+func (t *GlobalSearch_Search_Nodes_StandardSearchResult_Standards) GetDomains() []string {
+	if t == nil {
+		t = &GlobalSearch_Search_Nodes_StandardSearchResult_Standards{}
+	}
+	return t.Domains
+}
+func (t *GlobalSearch_Search_Nodes_StandardSearchResult_Standards) GetFramework() *string {
+	if t == nil {
+		t = &GlobalSearch_Search_Nodes_StandardSearchResult_Standards{}
+	}
+	return t.Framework
+}
+func (t *GlobalSearch_Search_Nodes_StandardSearchResult_Standards) GetGoverningBody() *string {
+	if t == nil {
+		t = &GlobalSearch_Search_Nodes_StandardSearchResult_Standards{}
+	}
+	return t.GoverningBody
+}
 func (t *GlobalSearch_Search_Nodes_StandardSearchResult_Standards) GetID() string {
 	if t == nil {
 		t = &GlobalSearch_Search_Nodes_StandardSearchResult_Standards{}
@@ -48470,7 +52787,7 @@ func (t *CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Assigner) GetLastName() *stri
 	return t.LastName
 }
 
-type CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments struct {
+type CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments_Edges_Node struct {
 	CreatedAt *time.Time "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy *string    "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	DisplayID string     "json:\"displayID\" graphql:\"displayID\""
@@ -48480,67 +52797,89 @@ type CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments struct {
 	UpdatedBy *string    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments) GetCreatedAt() *time.Time {
+func (t *CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments_Edges_Node) GetCreatedAt() *time.Time {
 	if t == nil {
-		t = &CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments{}
+		t = &CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments_Edges_Node{}
 	}
 	return t.CreatedAt
 }
-func (t *CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments) GetCreatedBy() *string {
+func (t *CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments_Edges_Node) GetCreatedBy() *string {
 	if t == nil {
-		t = &CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments{}
+		t = &CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments_Edges_Node{}
 	}
 	return t.CreatedBy
 }
-func (t *CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments) GetDisplayID() string {
+func (t *CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments{}
+		t = &CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments) GetID() string {
+func (t *CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments{}
+		t = &CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments) GetText() string {
+func (t *CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments_Edges_Node) GetText() string {
 	if t == nil {
-		t = &CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments{}
+		t = &CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments_Edges_Node{}
 	}
 	return t.Text
 }
-func (t *CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments) GetUpdatedAt() *time.Time {
+func (t *CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
-		t = &CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments{}
+		t = &CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments_Edges_Node{}
 	}
 	return t.UpdatedAt
 }
-func (t *CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments) GetUpdatedBy() *string {
+func (t *CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments_Edges_Node) GetUpdatedBy() *string {
 	if t == nil {
-		t = &CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments{}
+		t = &CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments_Edges_Node{}
 	}
 	return t.UpdatedBy
 }
 
+type CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments_Edges struct {
+	Node *CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments_Edges) GetNode() *CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments_Edges_Node {
+	if t == nil {
+		t = &CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments_Edges{}
+	}
+	return t.Node
+}
+
+type CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments struct {
+	Edges []*CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments) GetEdges() []*CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments_Edges {
+	if t == nil {
+		t = &CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments{}
+	}
+	return t.Edges
+}
+
 type CreateBulkCSVTask_CreateBulkCSVTask_Tasks struct {
-	Assignee    *CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Assignee   "json:\"assignee,omitempty\" graphql:\"assignee\""
-	Assigner    *CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Assigner   "json:\"assigner,omitempty\" graphql:\"assigner\""
-	Category    *string                                               "json:\"category,omitempty\" graphql:\"category\""
-	Comments    []*CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments "json:\"comments,omitempty\" graphql:\"comments\""
-	Completed   *time.Time                                            "json:\"completed,omitempty\" graphql:\"completed\""
-	CreatedAt   *time.Time                                            "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy   *string                                               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description *string                                               "json:\"description,omitempty\" graphql:\"description\""
-	Details     *string                                               "json:\"details,omitempty\" graphql:\"details\""
-	DisplayID   string                                                "json:\"displayID\" graphql:\"displayID\""
-	Due         *time.Time                                            "json:\"due,omitempty\" graphql:\"due\""
-	ID          string                                                "json:\"id\" graphql:\"id\""
-	Status      enums.TaskStatus                                      "json:\"status\" graphql:\"status\""
-	Tags        []string                                              "json:\"tags,omitempty\" graphql:\"tags\""
-	Title       string                                                "json:\"title\" graphql:\"title\""
-	UpdatedAt   *time.Time                                            "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy   *string                                               "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Assignee    *CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Assignee "json:\"assignee,omitempty\" graphql:\"assignee\""
+	Assigner    *CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Assigner "json:\"assigner,omitempty\" graphql:\"assigner\""
+	Category    *string                                             "json:\"category,omitempty\" graphql:\"category\""
+	Comments    CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments  "json:\"comments\" graphql:\"comments\""
+	Completed   *time.Time                                          "json:\"completed,omitempty\" graphql:\"completed\""
+	CreatedAt   *time.Time                                          "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy   *string                                             "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description *string                                             "json:\"description,omitempty\" graphql:\"description\""
+	Details     *string                                             "json:\"details,omitempty\" graphql:\"details\""
+	DisplayID   string                                              "json:\"displayID\" graphql:\"displayID\""
+	Due         *time.Time                                          "json:\"due,omitempty\" graphql:\"due\""
+	ID          string                                              "json:\"id\" graphql:\"id\""
+	Status      enums.TaskStatus                                    "json:\"status\" graphql:\"status\""
+	Tags        []string                                            "json:\"tags,omitempty\" graphql:\"tags\""
+	Title       string                                              "json:\"title\" graphql:\"title\""
+	UpdatedAt   *time.Time                                          "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy   *string                                             "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *CreateBulkCSVTask_CreateBulkCSVTask_Tasks) GetAssignee() *CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Assignee {
@@ -48561,11 +52900,11 @@ func (t *CreateBulkCSVTask_CreateBulkCSVTask_Tasks) GetCategory() *string {
 	}
 	return t.Category
 }
-func (t *CreateBulkCSVTask_CreateBulkCSVTask_Tasks) GetComments() []*CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments {
+func (t *CreateBulkCSVTask_CreateBulkCSVTask_Tasks) GetComments() *CreateBulkCSVTask_CreateBulkCSVTask_Tasks_Comments {
 	if t == nil {
 		t = &CreateBulkCSVTask_CreateBulkCSVTask_Tasks{}
 	}
-	return t.Comments
+	return &t.Comments
 }
 func (t *CreateBulkCSVTask_CreateBulkCSVTask_Tasks) GetCompleted() *time.Time {
 	if t == nil {
@@ -48707,7 +53046,7 @@ func (t *CreateBulkTask_CreateBulkTask_Tasks_Assigner) GetLastName() *string {
 	return t.LastName
 }
 
-type CreateBulkTask_CreateBulkTask_Tasks_Comments struct {
+type CreateBulkTask_CreateBulkTask_Tasks_Comments_Edges_Node struct {
 	CreatedAt *time.Time "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy *string    "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	DisplayID string     "json:\"displayID\" graphql:\"displayID\""
@@ -48717,67 +53056,89 @@ type CreateBulkTask_CreateBulkTask_Tasks_Comments struct {
 	UpdatedBy *string    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *CreateBulkTask_CreateBulkTask_Tasks_Comments) GetCreatedAt() *time.Time {
+func (t *CreateBulkTask_CreateBulkTask_Tasks_Comments_Edges_Node) GetCreatedAt() *time.Time {
 	if t == nil {
-		t = &CreateBulkTask_CreateBulkTask_Tasks_Comments{}
+		t = &CreateBulkTask_CreateBulkTask_Tasks_Comments_Edges_Node{}
 	}
 	return t.CreatedAt
 }
-func (t *CreateBulkTask_CreateBulkTask_Tasks_Comments) GetCreatedBy() *string {
+func (t *CreateBulkTask_CreateBulkTask_Tasks_Comments_Edges_Node) GetCreatedBy() *string {
 	if t == nil {
-		t = &CreateBulkTask_CreateBulkTask_Tasks_Comments{}
+		t = &CreateBulkTask_CreateBulkTask_Tasks_Comments_Edges_Node{}
 	}
 	return t.CreatedBy
 }
-func (t *CreateBulkTask_CreateBulkTask_Tasks_Comments) GetDisplayID() string {
+func (t *CreateBulkTask_CreateBulkTask_Tasks_Comments_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &CreateBulkTask_CreateBulkTask_Tasks_Comments{}
+		t = &CreateBulkTask_CreateBulkTask_Tasks_Comments_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *CreateBulkTask_CreateBulkTask_Tasks_Comments) GetID() string {
+func (t *CreateBulkTask_CreateBulkTask_Tasks_Comments_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateBulkTask_CreateBulkTask_Tasks_Comments{}
+		t = &CreateBulkTask_CreateBulkTask_Tasks_Comments_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *CreateBulkTask_CreateBulkTask_Tasks_Comments) GetText() string {
+func (t *CreateBulkTask_CreateBulkTask_Tasks_Comments_Edges_Node) GetText() string {
 	if t == nil {
-		t = &CreateBulkTask_CreateBulkTask_Tasks_Comments{}
+		t = &CreateBulkTask_CreateBulkTask_Tasks_Comments_Edges_Node{}
 	}
 	return t.Text
 }
-func (t *CreateBulkTask_CreateBulkTask_Tasks_Comments) GetUpdatedAt() *time.Time {
+func (t *CreateBulkTask_CreateBulkTask_Tasks_Comments_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
-		t = &CreateBulkTask_CreateBulkTask_Tasks_Comments{}
+		t = &CreateBulkTask_CreateBulkTask_Tasks_Comments_Edges_Node{}
 	}
 	return t.UpdatedAt
 }
-func (t *CreateBulkTask_CreateBulkTask_Tasks_Comments) GetUpdatedBy() *string {
+func (t *CreateBulkTask_CreateBulkTask_Tasks_Comments_Edges_Node) GetUpdatedBy() *string {
 	if t == nil {
-		t = &CreateBulkTask_CreateBulkTask_Tasks_Comments{}
+		t = &CreateBulkTask_CreateBulkTask_Tasks_Comments_Edges_Node{}
 	}
 	return t.UpdatedBy
 }
 
+type CreateBulkTask_CreateBulkTask_Tasks_Comments_Edges struct {
+	Node *CreateBulkTask_CreateBulkTask_Tasks_Comments_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateBulkTask_CreateBulkTask_Tasks_Comments_Edges) GetNode() *CreateBulkTask_CreateBulkTask_Tasks_Comments_Edges_Node {
+	if t == nil {
+		t = &CreateBulkTask_CreateBulkTask_Tasks_Comments_Edges{}
+	}
+	return t.Node
+}
+
+type CreateBulkTask_CreateBulkTask_Tasks_Comments struct {
+	Edges []*CreateBulkTask_CreateBulkTask_Tasks_Comments_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateBulkTask_CreateBulkTask_Tasks_Comments) GetEdges() []*CreateBulkTask_CreateBulkTask_Tasks_Comments_Edges {
+	if t == nil {
+		t = &CreateBulkTask_CreateBulkTask_Tasks_Comments{}
+	}
+	return t.Edges
+}
+
 type CreateBulkTask_CreateBulkTask_Tasks struct {
-	Assignee    *CreateBulkTask_CreateBulkTask_Tasks_Assignee   "json:\"assignee,omitempty\" graphql:\"assignee\""
-	Assigner    *CreateBulkTask_CreateBulkTask_Tasks_Assigner   "json:\"assigner,omitempty\" graphql:\"assigner\""
-	Category    *string                                         "json:\"category,omitempty\" graphql:\"category\""
-	Comments    []*CreateBulkTask_CreateBulkTask_Tasks_Comments "json:\"comments,omitempty\" graphql:\"comments\""
-	Completed   *time.Time                                      "json:\"completed,omitempty\" graphql:\"completed\""
-	CreatedAt   *time.Time                                      "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy   *string                                         "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description *string                                         "json:\"description,omitempty\" graphql:\"description\""
-	Details     *string                                         "json:\"details,omitempty\" graphql:\"details\""
-	DisplayID   string                                          "json:\"displayID\" graphql:\"displayID\""
-	Due         *time.Time                                      "json:\"due,omitempty\" graphql:\"due\""
-	ID          string                                          "json:\"id\" graphql:\"id\""
-	Status      enums.TaskStatus                                "json:\"status\" graphql:\"status\""
-	Tags        []string                                        "json:\"tags,omitempty\" graphql:\"tags\""
-	Title       string                                          "json:\"title\" graphql:\"title\""
-	UpdatedAt   *time.Time                                      "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy   *string                                         "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Assignee    *CreateBulkTask_CreateBulkTask_Tasks_Assignee "json:\"assignee,omitempty\" graphql:\"assignee\""
+	Assigner    *CreateBulkTask_CreateBulkTask_Tasks_Assigner "json:\"assigner,omitempty\" graphql:\"assigner\""
+	Category    *string                                       "json:\"category,omitempty\" graphql:\"category\""
+	Comments    CreateBulkTask_CreateBulkTask_Tasks_Comments  "json:\"comments\" graphql:\"comments\""
+	Completed   *time.Time                                    "json:\"completed,omitempty\" graphql:\"completed\""
+	CreatedAt   *time.Time                                    "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy   *string                                       "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description *string                                       "json:\"description,omitempty\" graphql:\"description\""
+	Details     *string                                       "json:\"details,omitempty\" graphql:\"details\""
+	DisplayID   string                                        "json:\"displayID\" graphql:\"displayID\""
+	Due         *time.Time                                    "json:\"due,omitempty\" graphql:\"due\""
+	ID          string                                        "json:\"id\" graphql:\"id\""
+	Status      enums.TaskStatus                              "json:\"status\" graphql:\"status\""
+	Tags        []string                                      "json:\"tags,omitempty\" graphql:\"tags\""
+	Title       string                                        "json:\"title\" graphql:\"title\""
+	UpdatedAt   *time.Time                                    "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy   *string                                       "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *CreateBulkTask_CreateBulkTask_Tasks) GetAssignee() *CreateBulkTask_CreateBulkTask_Tasks_Assignee {
@@ -48798,11 +53159,11 @@ func (t *CreateBulkTask_CreateBulkTask_Tasks) GetCategory() *string {
 	}
 	return t.Category
 }
-func (t *CreateBulkTask_CreateBulkTask_Tasks) GetComments() []*CreateBulkTask_CreateBulkTask_Tasks_Comments {
+func (t *CreateBulkTask_CreateBulkTask_Tasks) GetComments() *CreateBulkTask_CreateBulkTask_Tasks_Comments {
 	if t == nil {
 		t = &CreateBulkTask_CreateBulkTask_Tasks{}
 	}
-	return t.Comments
+	return &t.Comments
 }
 func (t *CreateBulkTask_CreateBulkTask_Tasks) GetCompleted() *time.Time {
 	if t == nil {
@@ -48944,7 +53305,7 @@ func (t *CreateTask_CreateTask_Task_Assigner) GetLastName() *string {
 	return t.LastName
 }
 
-type CreateTask_CreateTask_Task_Comments struct {
+type CreateTask_CreateTask_Task_Comments_Edges_Node struct {
 	CreatedAt *time.Time "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy *string    "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	DisplayID string     "json:\"displayID\" graphql:\"displayID\""
@@ -48954,68 +53315,90 @@ type CreateTask_CreateTask_Task_Comments struct {
 	UpdatedBy *string    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *CreateTask_CreateTask_Task_Comments) GetCreatedAt() *time.Time {
+func (t *CreateTask_CreateTask_Task_Comments_Edges_Node) GetCreatedAt() *time.Time {
 	if t == nil {
-		t = &CreateTask_CreateTask_Task_Comments{}
+		t = &CreateTask_CreateTask_Task_Comments_Edges_Node{}
 	}
 	return t.CreatedAt
 }
-func (t *CreateTask_CreateTask_Task_Comments) GetCreatedBy() *string {
+func (t *CreateTask_CreateTask_Task_Comments_Edges_Node) GetCreatedBy() *string {
 	if t == nil {
-		t = &CreateTask_CreateTask_Task_Comments{}
+		t = &CreateTask_CreateTask_Task_Comments_Edges_Node{}
 	}
 	return t.CreatedBy
 }
-func (t *CreateTask_CreateTask_Task_Comments) GetDisplayID() string {
+func (t *CreateTask_CreateTask_Task_Comments_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &CreateTask_CreateTask_Task_Comments{}
+		t = &CreateTask_CreateTask_Task_Comments_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *CreateTask_CreateTask_Task_Comments) GetID() string {
+func (t *CreateTask_CreateTask_Task_Comments_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateTask_CreateTask_Task_Comments{}
+		t = &CreateTask_CreateTask_Task_Comments_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *CreateTask_CreateTask_Task_Comments) GetText() string {
+func (t *CreateTask_CreateTask_Task_Comments_Edges_Node) GetText() string {
 	if t == nil {
-		t = &CreateTask_CreateTask_Task_Comments{}
+		t = &CreateTask_CreateTask_Task_Comments_Edges_Node{}
 	}
 	return t.Text
 }
-func (t *CreateTask_CreateTask_Task_Comments) GetUpdatedAt() *time.Time {
+func (t *CreateTask_CreateTask_Task_Comments_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
-		t = &CreateTask_CreateTask_Task_Comments{}
+		t = &CreateTask_CreateTask_Task_Comments_Edges_Node{}
 	}
 	return t.UpdatedAt
 }
-func (t *CreateTask_CreateTask_Task_Comments) GetUpdatedBy() *string {
+func (t *CreateTask_CreateTask_Task_Comments_Edges_Node) GetUpdatedBy() *string {
 	if t == nil {
-		t = &CreateTask_CreateTask_Task_Comments{}
+		t = &CreateTask_CreateTask_Task_Comments_Edges_Node{}
 	}
 	return t.UpdatedBy
 }
 
+type CreateTask_CreateTask_Task_Comments_Edges struct {
+	Node *CreateTask_CreateTask_Task_Comments_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateTask_CreateTask_Task_Comments_Edges) GetNode() *CreateTask_CreateTask_Task_Comments_Edges_Node {
+	if t == nil {
+		t = &CreateTask_CreateTask_Task_Comments_Edges{}
+	}
+	return t.Node
+}
+
+type CreateTask_CreateTask_Task_Comments struct {
+	Edges []*CreateTask_CreateTask_Task_Comments_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateTask_CreateTask_Task_Comments) GetEdges() []*CreateTask_CreateTask_Task_Comments_Edges {
+	if t == nil {
+		t = &CreateTask_CreateTask_Task_Comments{}
+	}
+	return t.Edges
+}
+
 type CreateTask_CreateTask_Task struct {
-	Assignee    *CreateTask_CreateTask_Task_Assignee   "json:\"assignee,omitempty\" graphql:\"assignee\""
-	Assigner    *CreateTask_CreateTask_Task_Assigner   "json:\"assigner,omitempty\" graphql:\"assigner\""
-	Category    *string                                "json:\"category,omitempty\" graphql:\"category\""
-	Comments    []*CreateTask_CreateTask_Task_Comments "json:\"comments,omitempty\" graphql:\"comments\""
-	Completed   *time.Time                             "json:\"completed,omitempty\" graphql:\"completed\""
-	CreatedAt   *time.Time                             "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy   *string                                "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description *string                                "json:\"description,omitempty\" graphql:\"description\""
-	Details     *string                                "json:\"details,omitempty\" graphql:\"details\""
-	DisplayID   string                                 "json:\"displayID\" graphql:\"displayID\""
-	Due         *time.Time                             "json:\"due,omitempty\" graphql:\"due\""
-	ID          string                                 "json:\"id\" graphql:\"id\""
-	OwnerID     *string                                "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Status      enums.TaskStatus                       "json:\"status\" graphql:\"status\""
-	Tags        []string                               "json:\"tags,omitempty\" graphql:\"tags\""
-	Title       string                                 "json:\"title\" graphql:\"title\""
-	UpdatedAt   *time.Time                             "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy   *string                                "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Assignee    *CreateTask_CreateTask_Task_Assignee "json:\"assignee,omitempty\" graphql:\"assignee\""
+	Assigner    *CreateTask_CreateTask_Task_Assigner "json:\"assigner,omitempty\" graphql:\"assigner\""
+	Category    *string                              "json:\"category,omitempty\" graphql:\"category\""
+	Comments    CreateTask_CreateTask_Task_Comments  "json:\"comments\" graphql:\"comments\""
+	Completed   *time.Time                           "json:\"completed,omitempty\" graphql:\"completed\""
+	CreatedAt   *time.Time                           "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy   *string                              "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description *string                              "json:\"description,omitempty\" graphql:\"description\""
+	Details     *string                              "json:\"details,omitempty\" graphql:\"details\""
+	DisplayID   string                               "json:\"displayID\" graphql:\"displayID\""
+	Due         *time.Time                           "json:\"due,omitempty\" graphql:\"due\""
+	ID          string                               "json:\"id\" graphql:\"id\""
+	OwnerID     *string                              "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	Status      enums.TaskStatus                     "json:\"status\" graphql:\"status\""
+	Tags        []string                             "json:\"tags,omitempty\" graphql:\"tags\""
+	Title       string                               "json:\"title\" graphql:\"title\""
+	UpdatedAt   *time.Time                           "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy   *string                              "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *CreateTask_CreateTask_Task) GetAssignee() *CreateTask_CreateTask_Task_Assignee {
@@ -49036,11 +53419,11 @@ func (t *CreateTask_CreateTask_Task) GetCategory() *string {
 	}
 	return t.Category
 }
-func (t *CreateTask_CreateTask_Task) GetComments() []*CreateTask_CreateTask_Task_Comments {
+func (t *CreateTask_CreateTask_Task) GetComments() *CreateTask_CreateTask_Task_Comments {
 	if t == nil {
 		t = &CreateTask_CreateTask_Task{}
 	}
-	return t.Comments
+	return &t.Comments
 }
 func (t *CreateTask_CreateTask_Task) GetCompleted() *time.Time {
 	if t == nil {
@@ -49217,7 +53600,7 @@ func (t *GetAllTasks_Tasks_Edges_Node_Owner) GetName() string {
 	return t.Name
 }
 
-type GetAllTasks_Tasks_Edges_Node_Comments struct {
+type GetAllTasks_Tasks_Edges_Node_Comments_Edges_Node struct {
 	CreatedAt *time.Time "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy *string    "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	DisplayID string     "json:\"displayID\" graphql:\"displayID\""
@@ -49227,68 +53610,90 @@ type GetAllTasks_Tasks_Edges_Node_Comments struct {
 	UpdatedBy *string    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *GetAllTasks_Tasks_Edges_Node_Comments) GetCreatedAt() *time.Time {
+func (t *GetAllTasks_Tasks_Edges_Node_Comments_Edges_Node) GetCreatedAt() *time.Time {
 	if t == nil {
-		t = &GetAllTasks_Tasks_Edges_Node_Comments{}
+		t = &GetAllTasks_Tasks_Edges_Node_Comments_Edges_Node{}
 	}
 	return t.CreatedAt
 }
-func (t *GetAllTasks_Tasks_Edges_Node_Comments) GetCreatedBy() *string {
+func (t *GetAllTasks_Tasks_Edges_Node_Comments_Edges_Node) GetCreatedBy() *string {
 	if t == nil {
-		t = &GetAllTasks_Tasks_Edges_Node_Comments{}
+		t = &GetAllTasks_Tasks_Edges_Node_Comments_Edges_Node{}
 	}
 	return t.CreatedBy
 }
-func (t *GetAllTasks_Tasks_Edges_Node_Comments) GetDisplayID() string {
+func (t *GetAllTasks_Tasks_Edges_Node_Comments_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetAllTasks_Tasks_Edges_Node_Comments{}
+		t = &GetAllTasks_Tasks_Edges_Node_Comments_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetAllTasks_Tasks_Edges_Node_Comments) GetID() string {
+func (t *GetAllTasks_Tasks_Edges_Node_Comments_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetAllTasks_Tasks_Edges_Node_Comments{}
+		t = &GetAllTasks_Tasks_Edges_Node_Comments_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetAllTasks_Tasks_Edges_Node_Comments) GetText() string {
+func (t *GetAllTasks_Tasks_Edges_Node_Comments_Edges_Node) GetText() string {
 	if t == nil {
-		t = &GetAllTasks_Tasks_Edges_Node_Comments{}
+		t = &GetAllTasks_Tasks_Edges_Node_Comments_Edges_Node{}
 	}
 	return t.Text
 }
-func (t *GetAllTasks_Tasks_Edges_Node_Comments) GetUpdatedAt() *time.Time {
+func (t *GetAllTasks_Tasks_Edges_Node_Comments_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
-		t = &GetAllTasks_Tasks_Edges_Node_Comments{}
+		t = &GetAllTasks_Tasks_Edges_Node_Comments_Edges_Node{}
 	}
 	return t.UpdatedAt
 }
-func (t *GetAllTasks_Tasks_Edges_Node_Comments) GetUpdatedBy() *string {
+func (t *GetAllTasks_Tasks_Edges_Node_Comments_Edges_Node) GetUpdatedBy() *string {
 	if t == nil {
-		t = &GetAllTasks_Tasks_Edges_Node_Comments{}
+		t = &GetAllTasks_Tasks_Edges_Node_Comments_Edges_Node{}
 	}
 	return t.UpdatedBy
 }
 
+type GetAllTasks_Tasks_Edges_Node_Comments_Edges struct {
+	Node *GetAllTasks_Tasks_Edges_Node_Comments_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllTasks_Tasks_Edges_Node_Comments_Edges) GetNode() *GetAllTasks_Tasks_Edges_Node_Comments_Edges_Node {
+	if t == nil {
+		t = &GetAllTasks_Tasks_Edges_Node_Comments_Edges{}
+	}
+	return t.Node
+}
+
+type GetAllTasks_Tasks_Edges_Node_Comments struct {
+	Edges []*GetAllTasks_Tasks_Edges_Node_Comments_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetAllTasks_Tasks_Edges_Node_Comments) GetEdges() []*GetAllTasks_Tasks_Edges_Node_Comments_Edges {
+	if t == nil {
+		t = &GetAllTasks_Tasks_Edges_Node_Comments{}
+	}
+	return t.Edges
+}
+
 type GetAllTasks_Tasks_Edges_Node struct {
-	Assignee    *GetAllTasks_Tasks_Edges_Node_Assignee   "json:\"assignee,omitempty\" graphql:\"assignee\""
-	Assigner    *GetAllTasks_Tasks_Edges_Node_Assigner   "json:\"assigner,omitempty\" graphql:\"assigner\""
-	Category    *string                                  "json:\"category,omitempty\" graphql:\"category\""
-	Comments    []*GetAllTasks_Tasks_Edges_Node_Comments "json:\"comments,omitempty\" graphql:\"comments\""
-	Completed   *time.Time                               "json:\"completed,omitempty\" graphql:\"completed\""
-	CreatedAt   *time.Time                               "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy   *string                                  "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description *string                                  "json:\"description,omitempty\" graphql:\"description\""
-	Details     *string                                  "json:\"details,omitempty\" graphql:\"details\""
-	DisplayID   string                                   "json:\"displayID\" graphql:\"displayID\""
-	Due         *time.Time                               "json:\"due,omitempty\" graphql:\"due\""
-	ID          string                                   "json:\"id\" graphql:\"id\""
-	Owner       *GetAllTasks_Tasks_Edges_Node_Owner      "json:\"owner,omitempty\" graphql:\"owner\""
-	Status      enums.TaskStatus                         "json:\"status\" graphql:\"status\""
-	Tags        []string                                 "json:\"tags,omitempty\" graphql:\"tags\""
-	Title       string                                   "json:\"title\" graphql:\"title\""
-	UpdatedAt   *time.Time                               "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy   *string                                  "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Assignee    *GetAllTasks_Tasks_Edges_Node_Assignee "json:\"assignee,omitempty\" graphql:\"assignee\""
+	Assigner    *GetAllTasks_Tasks_Edges_Node_Assigner "json:\"assigner,omitempty\" graphql:\"assigner\""
+	Category    *string                                "json:\"category,omitempty\" graphql:\"category\""
+	Comments    GetAllTasks_Tasks_Edges_Node_Comments  "json:\"comments\" graphql:\"comments\""
+	Completed   *time.Time                             "json:\"completed,omitempty\" graphql:\"completed\""
+	CreatedAt   *time.Time                             "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy   *string                                "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description *string                                "json:\"description,omitempty\" graphql:\"description\""
+	Details     *string                                "json:\"details,omitempty\" graphql:\"details\""
+	DisplayID   string                                 "json:\"displayID\" graphql:\"displayID\""
+	Due         *time.Time                             "json:\"due,omitempty\" graphql:\"due\""
+	ID          string                                 "json:\"id\" graphql:\"id\""
+	Owner       *GetAllTasks_Tasks_Edges_Node_Owner    "json:\"owner,omitempty\" graphql:\"owner\""
+	Status      enums.TaskStatus                       "json:\"status\" graphql:\"status\""
+	Tags        []string                               "json:\"tags,omitempty\" graphql:\"tags\""
+	Title       string                                 "json:\"title\" graphql:\"title\""
+	UpdatedAt   *time.Time                             "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy   *string                                "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *GetAllTasks_Tasks_Edges_Node) GetAssignee() *GetAllTasks_Tasks_Edges_Node_Assignee {
@@ -49309,11 +53714,11 @@ func (t *GetAllTasks_Tasks_Edges_Node) GetCategory() *string {
 	}
 	return t.Category
 }
-func (t *GetAllTasks_Tasks_Edges_Node) GetComments() []*GetAllTasks_Tasks_Edges_Node_Comments {
+func (t *GetAllTasks_Tasks_Edges_Node) GetComments() *GetAllTasks_Tasks_Edges_Node_Comments {
 	if t == nil {
 		t = &GetAllTasks_Tasks_Edges_Node{}
 	}
-	return t.Comments
+	return &t.Comments
 }
 func (t *GetAllTasks_Tasks_Edges_Node) GetCompleted() *time.Time {
 	if t == nil {
@@ -49490,7 +53895,7 @@ func (t *GetTaskByID_Task_Owner) GetName() string {
 	return t.Name
 }
 
-type GetTaskByID_Task_Comments struct {
+type GetTaskByID_Task_Comments_Edges_Node struct {
 	CreatedAt *time.Time "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy *string    "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	DisplayID string     "json:\"displayID\" graphql:\"displayID\""
@@ -49500,68 +53905,90 @@ type GetTaskByID_Task_Comments struct {
 	UpdatedBy *string    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *GetTaskByID_Task_Comments) GetCreatedAt() *time.Time {
+func (t *GetTaskByID_Task_Comments_Edges_Node) GetCreatedAt() *time.Time {
 	if t == nil {
-		t = &GetTaskByID_Task_Comments{}
+		t = &GetTaskByID_Task_Comments_Edges_Node{}
 	}
 	return t.CreatedAt
 }
-func (t *GetTaskByID_Task_Comments) GetCreatedBy() *string {
+func (t *GetTaskByID_Task_Comments_Edges_Node) GetCreatedBy() *string {
 	if t == nil {
-		t = &GetTaskByID_Task_Comments{}
+		t = &GetTaskByID_Task_Comments_Edges_Node{}
 	}
 	return t.CreatedBy
 }
-func (t *GetTaskByID_Task_Comments) GetDisplayID() string {
+func (t *GetTaskByID_Task_Comments_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetTaskByID_Task_Comments{}
+		t = &GetTaskByID_Task_Comments_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetTaskByID_Task_Comments) GetID() string {
+func (t *GetTaskByID_Task_Comments_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetTaskByID_Task_Comments{}
+		t = &GetTaskByID_Task_Comments_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetTaskByID_Task_Comments) GetText() string {
+func (t *GetTaskByID_Task_Comments_Edges_Node) GetText() string {
 	if t == nil {
-		t = &GetTaskByID_Task_Comments{}
+		t = &GetTaskByID_Task_Comments_Edges_Node{}
 	}
 	return t.Text
 }
-func (t *GetTaskByID_Task_Comments) GetUpdatedAt() *time.Time {
+func (t *GetTaskByID_Task_Comments_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
-		t = &GetTaskByID_Task_Comments{}
+		t = &GetTaskByID_Task_Comments_Edges_Node{}
 	}
 	return t.UpdatedAt
 }
-func (t *GetTaskByID_Task_Comments) GetUpdatedBy() *string {
+func (t *GetTaskByID_Task_Comments_Edges_Node) GetUpdatedBy() *string {
 	if t == nil {
-		t = &GetTaskByID_Task_Comments{}
+		t = &GetTaskByID_Task_Comments_Edges_Node{}
 	}
 	return t.UpdatedBy
 }
 
+type GetTaskByID_Task_Comments_Edges struct {
+	Node *GetTaskByID_Task_Comments_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetTaskByID_Task_Comments_Edges) GetNode() *GetTaskByID_Task_Comments_Edges_Node {
+	if t == nil {
+		t = &GetTaskByID_Task_Comments_Edges{}
+	}
+	return t.Node
+}
+
+type GetTaskByID_Task_Comments struct {
+	Edges []*GetTaskByID_Task_Comments_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetTaskByID_Task_Comments) GetEdges() []*GetTaskByID_Task_Comments_Edges {
+	if t == nil {
+		t = &GetTaskByID_Task_Comments{}
+	}
+	return t.Edges
+}
+
 type GetTaskByID_Task struct {
-	Assignee    *GetTaskByID_Task_Assignee   "json:\"assignee,omitempty\" graphql:\"assignee\""
-	Assigner    *GetTaskByID_Task_Assigner   "json:\"assigner,omitempty\" graphql:\"assigner\""
-	Category    *string                      "json:\"category,omitempty\" graphql:\"category\""
-	Comments    []*GetTaskByID_Task_Comments "json:\"comments,omitempty\" graphql:\"comments\""
-	Completed   *time.Time                   "json:\"completed,omitempty\" graphql:\"completed\""
-	CreatedAt   *time.Time                   "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy   *string                      "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description *string                      "json:\"description,omitempty\" graphql:\"description\""
-	Details     *string                      "json:\"details,omitempty\" graphql:\"details\""
-	DisplayID   string                       "json:\"displayID\" graphql:\"displayID\""
-	Due         *time.Time                   "json:\"due,omitempty\" graphql:\"due\""
-	ID          string                       "json:\"id\" graphql:\"id\""
-	Owner       *GetTaskByID_Task_Owner      "json:\"owner,omitempty\" graphql:\"owner\""
-	Status      enums.TaskStatus             "json:\"status\" graphql:\"status\""
-	Tags        []string                     "json:\"tags,omitempty\" graphql:\"tags\""
-	Title       string                       "json:\"title\" graphql:\"title\""
-	UpdatedAt   *time.Time                   "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy   *string                      "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Assignee    *GetTaskByID_Task_Assignee "json:\"assignee,omitempty\" graphql:\"assignee\""
+	Assigner    *GetTaskByID_Task_Assigner "json:\"assigner,omitempty\" graphql:\"assigner\""
+	Category    *string                    "json:\"category,omitempty\" graphql:\"category\""
+	Comments    GetTaskByID_Task_Comments  "json:\"comments\" graphql:\"comments\""
+	Completed   *time.Time                 "json:\"completed,omitempty\" graphql:\"completed\""
+	CreatedAt   *time.Time                 "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy   *string                    "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description *string                    "json:\"description,omitempty\" graphql:\"description\""
+	Details     *string                    "json:\"details,omitempty\" graphql:\"details\""
+	DisplayID   string                     "json:\"displayID\" graphql:\"displayID\""
+	Due         *time.Time                 "json:\"due,omitempty\" graphql:\"due\""
+	ID          string                     "json:\"id\" graphql:\"id\""
+	Owner       *GetTaskByID_Task_Owner    "json:\"owner,omitempty\" graphql:\"owner\""
+	Status      enums.TaskStatus           "json:\"status\" graphql:\"status\""
+	Tags        []string                   "json:\"tags,omitempty\" graphql:\"tags\""
+	Title       string                     "json:\"title\" graphql:\"title\""
+	UpdatedAt   *time.Time                 "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy   *string                    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *GetTaskByID_Task) GetAssignee() *GetTaskByID_Task_Assignee {
@@ -49582,11 +54009,11 @@ func (t *GetTaskByID_Task) GetCategory() *string {
 	}
 	return t.Category
 }
-func (t *GetTaskByID_Task) GetComments() []*GetTaskByID_Task_Comments {
+func (t *GetTaskByID_Task) GetComments() *GetTaskByID_Task_Comments {
 	if t == nil {
 		t = &GetTaskByID_Task{}
 	}
-	return t.Comments
+	return &t.Comments
 }
 func (t *GetTaskByID_Task) GetCompleted() *time.Time {
 	if t == nil {
@@ -49723,7 +54150,7 @@ func (t *GetTasks_Tasks_Edges_Node_Assigner) GetLastName() *string {
 	return t.LastName
 }
 
-type GetTasks_Tasks_Edges_Node_Comments struct {
+type GetTasks_Tasks_Edges_Node_Comments_Edges_Node struct {
 	CreatedAt *time.Time "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy *string    "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	DisplayID string     "json:\"displayID\" graphql:\"displayID\""
@@ -49733,67 +54160,89 @@ type GetTasks_Tasks_Edges_Node_Comments struct {
 	UpdatedBy *string    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *GetTasks_Tasks_Edges_Node_Comments) GetCreatedAt() *time.Time {
+func (t *GetTasks_Tasks_Edges_Node_Comments_Edges_Node) GetCreatedAt() *time.Time {
 	if t == nil {
-		t = &GetTasks_Tasks_Edges_Node_Comments{}
+		t = &GetTasks_Tasks_Edges_Node_Comments_Edges_Node{}
 	}
 	return t.CreatedAt
 }
-func (t *GetTasks_Tasks_Edges_Node_Comments) GetCreatedBy() *string {
+func (t *GetTasks_Tasks_Edges_Node_Comments_Edges_Node) GetCreatedBy() *string {
 	if t == nil {
-		t = &GetTasks_Tasks_Edges_Node_Comments{}
+		t = &GetTasks_Tasks_Edges_Node_Comments_Edges_Node{}
 	}
 	return t.CreatedBy
 }
-func (t *GetTasks_Tasks_Edges_Node_Comments) GetDisplayID() string {
+func (t *GetTasks_Tasks_Edges_Node_Comments_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &GetTasks_Tasks_Edges_Node_Comments{}
+		t = &GetTasks_Tasks_Edges_Node_Comments_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *GetTasks_Tasks_Edges_Node_Comments) GetID() string {
+func (t *GetTasks_Tasks_Edges_Node_Comments_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetTasks_Tasks_Edges_Node_Comments{}
+		t = &GetTasks_Tasks_Edges_Node_Comments_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetTasks_Tasks_Edges_Node_Comments) GetText() string {
+func (t *GetTasks_Tasks_Edges_Node_Comments_Edges_Node) GetText() string {
 	if t == nil {
-		t = &GetTasks_Tasks_Edges_Node_Comments{}
+		t = &GetTasks_Tasks_Edges_Node_Comments_Edges_Node{}
 	}
 	return t.Text
 }
-func (t *GetTasks_Tasks_Edges_Node_Comments) GetUpdatedAt() *time.Time {
+func (t *GetTasks_Tasks_Edges_Node_Comments_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
-		t = &GetTasks_Tasks_Edges_Node_Comments{}
+		t = &GetTasks_Tasks_Edges_Node_Comments_Edges_Node{}
 	}
 	return t.UpdatedAt
 }
-func (t *GetTasks_Tasks_Edges_Node_Comments) GetUpdatedBy() *string {
+func (t *GetTasks_Tasks_Edges_Node_Comments_Edges_Node) GetUpdatedBy() *string {
 	if t == nil {
-		t = &GetTasks_Tasks_Edges_Node_Comments{}
+		t = &GetTasks_Tasks_Edges_Node_Comments_Edges_Node{}
 	}
 	return t.UpdatedBy
 }
 
+type GetTasks_Tasks_Edges_Node_Comments_Edges struct {
+	Node *GetTasks_Tasks_Edges_Node_Comments_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetTasks_Tasks_Edges_Node_Comments_Edges) GetNode() *GetTasks_Tasks_Edges_Node_Comments_Edges_Node {
+	if t == nil {
+		t = &GetTasks_Tasks_Edges_Node_Comments_Edges{}
+	}
+	return t.Node
+}
+
+type GetTasks_Tasks_Edges_Node_Comments struct {
+	Edges []*GetTasks_Tasks_Edges_Node_Comments_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetTasks_Tasks_Edges_Node_Comments) GetEdges() []*GetTasks_Tasks_Edges_Node_Comments_Edges {
+	if t == nil {
+		t = &GetTasks_Tasks_Edges_Node_Comments{}
+	}
+	return t.Edges
+}
+
 type GetTasks_Tasks_Edges_Node struct {
-	Assignee    *GetTasks_Tasks_Edges_Node_Assignee   "json:\"assignee,omitempty\" graphql:\"assignee\""
-	Assigner    *GetTasks_Tasks_Edges_Node_Assigner   "json:\"assigner,omitempty\" graphql:\"assigner\""
-	Category    *string                               "json:\"category,omitempty\" graphql:\"category\""
-	Comments    []*GetTasks_Tasks_Edges_Node_Comments "json:\"comments,omitempty\" graphql:\"comments\""
-	Completed   *time.Time                            "json:\"completed,omitempty\" graphql:\"completed\""
-	CreatedAt   *time.Time                            "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy   *string                               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description *string                               "json:\"description,omitempty\" graphql:\"description\""
-	Details     *string                               "json:\"details,omitempty\" graphql:\"details\""
-	DisplayID   string                                "json:\"displayID\" graphql:\"displayID\""
-	Due         *time.Time                            "json:\"due,omitempty\" graphql:\"due\""
-	ID          string                                "json:\"id\" graphql:\"id\""
-	Status      enums.TaskStatus                      "json:\"status\" graphql:\"status\""
-	Tags        []string                              "json:\"tags,omitempty\" graphql:\"tags\""
-	Title       string                                "json:\"title\" graphql:\"title\""
-	UpdatedAt   *time.Time                            "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy   *string                               "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Assignee    *GetTasks_Tasks_Edges_Node_Assignee "json:\"assignee,omitempty\" graphql:\"assignee\""
+	Assigner    *GetTasks_Tasks_Edges_Node_Assigner "json:\"assigner,omitempty\" graphql:\"assigner\""
+	Category    *string                             "json:\"category,omitempty\" graphql:\"category\""
+	Comments    GetTasks_Tasks_Edges_Node_Comments  "json:\"comments\" graphql:\"comments\""
+	Completed   *time.Time                          "json:\"completed,omitempty\" graphql:\"completed\""
+	CreatedAt   *time.Time                          "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy   *string                             "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description *string                             "json:\"description,omitempty\" graphql:\"description\""
+	Details     *string                             "json:\"details,omitempty\" graphql:\"details\""
+	DisplayID   string                              "json:\"displayID\" graphql:\"displayID\""
+	Due         *time.Time                          "json:\"due,omitempty\" graphql:\"due\""
+	ID          string                              "json:\"id\" graphql:\"id\""
+	Status      enums.TaskStatus                    "json:\"status\" graphql:\"status\""
+	Tags        []string                            "json:\"tags,omitempty\" graphql:\"tags\""
+	Title       string                              "json:\"title\" graphql:\"title\""
+	UpdatedAt   *time.Time                          "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy   *string                             "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *GetTasks_Tasks_Edges_Node) GetAssignee() *GetTasks_Tasks_Edges_Node_Assignee {
@@ -49814,11 +54263,11 @@ func (t *GetTasks_Tasks_Edges_Node) GetCategory() *string {
 	}
 	return t.Category
 }
-func (t *GetTasks_Tasks_Edges_Node) GetComments() []*GetTasks_Tasks_Edges_Node_Comments {
+func (t *GetTasks_Tasks_Edges_Node) GetComments() *GetTasks_Tasks_Edges_Node_Comments {
 	if t == nil {
 		t = &GetTasks_Tasks_Edges_Node{}
 	}
-	return t.Comments
+	return &t.Comments
 }
 func (t *GetTasks_Tasks_Edges_Node) GetCompleted() *time.Time {
 	if t == nil {
@@ -49971,7 +54420,7 @@ func (t *UpdateTask_UpdateTask_Task_Assigner) GetLastName() *string {
 	return t.LastName
 }
 
-type UpdateTask_UpdateTask_Task_Comments struct {
+type UpdateTask_UpdateTask_Task_Comments_Edges_Node struct {
 	CreatedAt *time.Time "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy *string    "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	DisplayID string     "json:\"displayID\" graphql:\"displayID\""
@@ -49981,67 +54430,89 @@ type UpdateTask_UpdateTask_Task_Comments struct {
 	UpdatedBy *string    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *UpdateTask_UpdateTask_Task_Comments) GetCreatedAt() *time.Time {
+func (t *UpdateTask_UpdateTask_Task_Comments_Edges_Node) GetCreatedAt() *time.Time {
 	if t == nil {
-		t = &UpdateTask_UpdateTask_Task_Comments{}
+		t = &UpdateTask_UpdateTask_Task_Comments_Edges_Node{}
 	}
 	return t.CreatedAt
 }
-func (t *UpdateTask_UpdateTask_Task_Comments) GetCreatedBy() *string {
+func (t *UpdateTask_UpdateTask_Task_Comments_Edges_Node) GetCreatedBy() *string {
 	if t == nil {
-		t = &UpdateTask_UpdateTask_Task_Comments{}
+		t = &UpdateTask_UpdateTask_Task_Comments_Edges_Node{}
 	}
 	return t.CreatedBy
 }
-func (t *UpdateTask_UpdateTask_Task_Comments) GetDisplayID() string {
+func (t *UpdateTask_UpdateTask_Task_Comments_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &UpdateTask_UpdateTask_Task_Comments{}
+		t = &UpdateTask_UpdateTask_Task_Comments_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *UpdateTask_UpdateTask_Task_Comments) GetID() string {
+func (t *UpdateTask_UpdateTask_Task_Comments_Edges_Node) GetID() string {
 	if t == nil {
-		t = &UpdateTask_UpdateTask_Task_Comments{}
+		t = &UpdateTask_UpdateTask_Task_Comments_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *UpdateTask_UpdateTask_Task_Comments) GetText() string {
+func (t *UpdateTask_UpdateTask_Task_Comments_Edges_Node) GetText() string {
 	if t == nil {
-		t = &UpdateTask_UpdateTask_Task_Comments{}
+		t = &UpdateTask_UpdateTask_Task_Comments_Edges_Node{}
 	}
 	return t.Text
 }
-func (t *UpdateTask_UpdateTask_Task_Comments) GetUpdatedAt() *time.Time {
+func (t *UpdateTask_UpdateTask_Task_Comments_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
-		t = &UpdateTask_UpdateTask_Task_Comments{}
+		t = &UpdateTask_UpdateTask_Task_Comments_Edges_Node{}
 	}
 	return t.UpdatedAt
 }
-func (t *UpdateTask_UpdateTask_Task_Comments) GetUpdatedBy() *string {
+func (t *UpdateTask_UpdateTask_Task_Comments_Edges_Node) GetUpdatedBy() *string {
 	if t == nil {
-		t = &UpdateTask_UpdateTask_Task_Comments{}
+		t = &UpdateTask_UpdateTask_Task_Comments_Edges_Node{}
 	}
 	return t.UpdatedBy
 }
 
+type UpdateTask_UpdateTask_Task_Comments_Edges struct {
+	Node *UpdateTask_UpdateTask_Task_Comments_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateTask_UpdateTask_Task_Comments_Edges) GetNode() *UpdateTask_UpdateTask_Task_Comments_Edges_Node {
+	if t == nil {
+		t = &UpdateTask_UpdateTask_Task_Comments_Edges{}
+	}
+	return t.Node
+}
+
+type UpdateTask_UpdateTask_Task_Comments struct {
+	Edges []*UpdateTask_UpdateTask_Task_Comments_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *UpdateTask_UpdateTask_Task_Comments) GetEdges() []*UpdateTask_UpdateTask_Task_Comments_Edges {
+	if t == nil {
+		t = &UpdateTask_UpdateTask_Task_Comments{}
+	}
+	return t.Edges
+}
+
 type UpdateTask_UpdateTask_Task struct {
-	Assignee    *UpdateTask_UpdateTask_Task_Assignee   "json:\"assignee,omitempty\" graphql:\"assignee\""
-	Assigner    *UpdateTask_UpdateTask_Task_Assigner   "json:\"assigner,omitempty\" graphql:\"assigner\""
-	Category    *string                                "json:\"category,omitempty\" graphql:\"category\""
-	Comments    []*UpdateTask_UpdateTask_Task_Comments "json:\"comments,omitempty\" graphql:\"comments\""
-	Completed   *time.Time                             "json:\"completed,omitempty\" graphql:\"completed\""
-	CreatedAt   *time.Time                             "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy   *string                                "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description *string                                "json:\"description,omitempty\" graphql:\"description\""
-	Details     *string                                "json:\"details,omitempty\" graphql:\"details\""
-	DisplayID   string                                 "json:\"displayID\" graphql:\"displayID\""
-	Due         *time.Time                             "json:\"due,omitempty\" graphql:\"due\""
-	ID          string                                 "json:\"id\" graphql:\"id\""
-	Status      enums.TaskStatus                       "json:\"status\" graphql:\"status\""
-	Tags        []string                               "json:\"tags,omitempty\" graphql:\"tags\""
-	Title       string                                 "json:\"title\" graphql:\"title\""
-	UpdatedAt   *time.Time                             "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy   *string                                "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Assignee    *UpdateTask_UpdateTask_Task_Assignee "json:\"assignee,omitempty\" graphql:\"assignee\""
+	Assigner    *UpdateTask_UpdateTask_Task_Assigner "json:\"assigner,omitempty\" graphql:\"assigner\""
+	Category    *string                              "json:\"category,omitempty\" graphql:\"category\""
+	Comments    UpdateTask_UpdateTask_Task_Comments  "json:\"comments\" graphql:\"comments\""
+	Completed   *time.Time                           "json:\"completed,omitempty\" graphql:\"completed\""
+	CreatedAt   *time.Time                           "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy   *string                              "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description *string                              "json:\"description,omitempty\" graphql:\"description\""
+	Details     *string                              "json:\"details,omitempty\" graphql:\"details\""
+	DisplayID   string                               "json:\"displayID\" graphql:\"displayID\""
+	Due         *time.Time                           "json:\"due,omitempty\" graphql:\"due\""
+	ID          string                               "json:\"id\" graphql:\"id\""
+	Status      enums.TaskStatus                     "json:\"status\" graphql:\"status\""
+	Tags        []string                             "json:\"tags,omitempty\" graphql:\"tags\""
+	Title       string                               "json:\"title\" graphql:\"title\""
+	UpdatedAt   *time.Time                           "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy   *string                              "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *UpdateTask_UpdateTask_Task) GetAssignee() *UpdateTask_UpdateTask_Task_Assignee {
@@ -50062,11 +54533,11 @@ func (t *UpdateTask_UpdateTask_Task) GetCategory() *string {
 	}
 	return t.Category
 }
-func (t *UpdateTask_UpdateTask_Task) GetComments() []*UpdateTask_UpdateTask_Task_Comments {
+func (t *UpdateTask_UpdateTask_Task) GetComments() *UpdateTask_UpdateTask_Task_Comments {
 	if t == nil {
 		t = &UpdateTask_UpdateTask_Task{}
 	}
-	return t.Comments
+	return &t.Comments
 }
 func (t *UpdateTask_UpdateTask_Task) GetCompleted() *time.Time {
 	if t == nil {
@@ -50208,7 +54679,7 @@ func (t *UpdateTaskComment_UpdateTaskComment_Task_Assigner) GetLastName() *strin
 	return t.LastName
 }
 
-type UpdateTaskComment_UpdateTaskComment_Task_Comments struct {
+type UpdateTaskComment_UpdateTaskComment_Task_Comments_Edges_Node struct {
 	CreatedAt *time.Time "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy *string    "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	DisplayID string     "json:\"displayID\" graphql:\"displayID\""
@@ -50218,67 +54689,89 @@ type UpdateTaskComment_UpdateTaskComment_Task_Comments struct {
 	UpdatedBy *string    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *UpdateTaskComment_UpdateTaskComment_Task_Comments) GetCreatedAt() *time.Time {
+func (t *UpdateTaskComment_UpdateTaskComment_Task_Comments_Edges_Node) GetCreatedAt() *time.Time {
 	if t == nil {
-		t = &UpdateTaskComment_UpdateTaskComment_Task_Comments{}
+		t = &UpdateTaskComment_UpdateTaskComment_Task_Comments_Edges_Node{}
 	}
 	return t.CreatedAt
 }
-func (t *UpdateTaskComment_UpdateTaskComment_Task_Comments) GetCreatedBy() *string {
+func (t *UpdateTaskComment_UpdateTaskComment_Task_Comments_Edges_Node) GetCreatedBy() *string {
 	if t == nil {
-		t = &UpdateTaskComment_UpdateTaskComment_Task_Comments{}
+		t = &UpdateTaskComment_UpdateTaskComment_Task_Comments_Edges_Node{}
 	}
 	return t.CreatedBy
 }
-func (t *UpdateTaskComment_UpdateTaskComment_Task_Comments) GetDisplayID() string {
+func (t *UpdateTaskComment_UpdateTaskComment_Task_Comments_Edges_Node) GetDisplayID() string {
 	if t == nil {
-		t = &UpdateTaskComment_UpdateTaskComment_Task_Comments{}
+		t = &UpdateTaskComment_UpdateTaskComment_Task_Comments_Edges_Node{}
 	}
 	return t.DisplayID
 }
-func (t *UpdateTaskComment_UpdateTaskComment_Task_Comments) GetID() string {
+func (t *UpdateTaskComment_UpdateTaskComment_Task_Comments_Edges_Node) GetID() string {
 	if t == nil {
-		t = &UpdateTaskComment_UpdateTaskComment_Task_Comments{}
+		t = &UpdateTaskComment_UpdateTaskComment_Task_Comments_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *UpdateTaskComment_UpdateTaskComment_Task_Comments) GetText() string {
+func (t *UpdateTaskComment_UpdateTaskComment_Task_Comments_Edges_Node) GetText() string {
 	if t == nil {
-		t = &UpdateTaskComment_UpdateTaskComment_Task_Comments{}
+		t = &UpdateTaskComment_UpdateTaskComment_Task_Comments_Edges_Node{}
 	}
 	return t.Text
 }
-func (t *UpdateTaskComment_UpdateTaskComment_Task_Comments) GetUpdatedAt() *time.Time {
+func (t *UpdateTaskComment_UpdateTaskComment_Task_Comments_Edges_Node) GetUpdatedAt() *time.Time {
 	if t == nil {
-		t = &UpdateTaskComment_UpdateTaskComment_Task_Comments{}
+		t = &UpdateTaskComment_UpdateTaskComment_Task_Comments_Edges_Node{}
 	}
 	return t.UpdatedAt
 }
-func (t *UpdateTaskComment_UpdateTaskComment_Task_Comments) GetUpdatedBy() *string {
+func (t *UpdateTaskComment_UpdateTaskComment_Task_Comments_Edges_Node) GetUpdatedBy() *string {
 	if t == nil {
-		t = &UpdateTaskComment_UpdateTaskComment_Task_Comments{}
+		t = &UpdateTaskComment_UpdateTaskComment_Task_Comments_Edges_Node{}
 	}
 	return t.UpdatedBy
 }
 
+type UpdateTaskComment_UpdateTaskComment_Task_Comments_Edges struct {
+	Node *UpdateTaskComment_UpdateTaskComment_Task_Comments_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateTaskComment_UpdateTaskComment_Task_Comments_Edges) GetNode() *UpdateTaskComment_UpdateTaskComment_Task_Comments_Edges_Node {
+	if t == nil {
+		t = &UpdateTaskComment_UpdateTaskComment_Task_Comments_Edges{}
+	}
+	return t.Node
+}
+
+type UpdateTaskComment_UpdateTaskComment_Task_Comments struct {
+	Edges []*UpdateTaskComment_UpdateTaskComment_Task_Comments_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *UpdateTaskComment_UpdateTaskComment_Task_Comments) GetEdges() []*UpdateTaskComment_UpdateTaskComment_Task_Comments_Edges {
+	if t == nil {
+		t = &UpdateTaskComment_UpdateTaskComment_Task_Comments{}
+	}
+	return t.Edges
+}
+
 type UpdateTaskComment_UpdateTaskComment_Task struct {
-	Assignee    *UpdateTaskComment_UpdateTaskComment_Task_Assignee   "json:\"assignee,omitempty\" graphql:\"assignee\""
-	Assigner    *UpdateTaskComment_UpdateTaskComment_Task_Assigner   "json:\"assigner,omitempty\" graphql:\"assigner\""
-	Category    *string                                              "json:\"category,omitempty\" graphql:\"category\""
-	Comments    []*UpdateTaskComment_UpdateTaskComment_Task_Comments "json:\"comments,omitempty\" graphql:\"comments\""
-	Completed   *time.Time                                           "json:\"completed,omitempty\" graphql:\"completed\""
-	CreatedAt   *time.Time                                           "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy   *string                                              "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description *string                                              "json:\"description,omitempty\" graphql:\"description\""
-	Details     *string                                              "json:\"details,omitempty\" graphql:\"details\""
-	DisplayID   string                                               "json:\"displayID\" graphql:\"displayID\""
-	Due         *time.Time                                           "json:\"due,omitempty\" graphql:\"due\""
-	ID          string                                               "json:\"id\" graphql:\"id\""
-	Status      enums.TaskStatus                                     "json:\"status\" graphql:\"status\""
-	Tags        []string                                             "json:\"tags,omitempty\" graphql:\"tags\""
-	Title       string                                               "json:\"title\" graphql:\"title\""
-	UpdatedAt   *time.Time                                           "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy   *string                                              "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Assignee    *UpdateTaskComment_UpdateTaskComment_Task_Assignee "json:\"assignee,omitempty\" graphql:\"assignee\""
+	Assigner    *UpdateTaskComment_UpdateTaskComment_Task_Assigner "json:\"assigner,omitempty\" graphql:\"assigner\""
+	Category    *string                                            "json:\"category,omitempty\" graphql:\"category\""
+	Comments    UpdateTaskComment_UpdateTaskComment_Task_Comments  "json:\"comments\" graphql:\"comments\""
+	Completed   *time.Time                                         "json:\"completed,omitempty\" graphql:\"completed\""
+	CreatedAt   *time.Time                                         "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy   *string                                            "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description *string                                            "json:\"description,omitempty\" graphql:\"description\""
+	Details     *string                                            "json:\"details,omitempty\" graphql:\"details\""
+	DisplayID   string                                             "json:\"displayID\" graphql:\"displayID\""
+	Due         *time.Time                                         "json:\"due,omitempty\" graphql:\"due\""
+	ID          string                                             "json:\"id\" graphql:\"id\""
+	Status      enums.TaskStatus                                   "json:\"status\" graphql:\"status\""
+	Tags        []string                                           "json:\"tags,omitempty\" graphql:\"tags\""
+	Title       string                                             "json:\"title\" graphql:\"title\""
+	UpdatedAt   *time.Time                                         "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy   *string                                            "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *UpdateTaskComment_UpdateTaskComment_Task) GetAssignee() *UpdateTaskComment_UpdateTaskComment_Task_Assignee {
@@ -50299,11 +54792,11 @@ func (t *UpdateTaskComment_UpdateTaskComment_Task) GetCategory() *string {
 	}
 	return t.Category
 }
-func (t *UpdateTaskComment_UpdateTaskComment_Task) GetComments() []*UpdateTaskComment_UpdateTaskComment_Task_Comments {
+func (t *UpdateTaskComment_UpdateTaskComment_Task) GetComments() *UpdateTaskComment_UpdateTaskComment_Task_Comments {
 	if t == nil {
 		t = &UpdateTaskComment_UpdateTaskComment_Task{}
 	}
-	return t.Comments
+	return &t.Comments
 }
 func (t *UpdateTaskComment_UpdateTaskComment_Task) GetCompleted() *time.Time {
 	if t == nil {
@@ -52173,44 +56666,66 @@ func (t *GetSelf_Self_Setting) GetUpdatedBy() *string {
 	return t.UpdatedBy
 }
 
-type GetSelf_Self_TfaSettings struct {
+type GetSelf_Self_TfaSettings_Edges_Node struct {
 	TotpAllowed *bool "json:\"totpAllowed,omitempty\" graphql:\"totpAllowed\""
 	Verified    bool  "json:\"verified\" graphql:\"verified\""
 }
 
-func (t *GetSelf_Self_TfaSettings) GetTotpAllowed() *bool {
+func (t *GetSelf_Self_TfaSettings_Edges_Node) GetTotpAllowed() *bool {
 	if t == nil {
-		t = &GetSelf_Self_TfaSettings{}
+		t = &GetSelf_Self_TfaSettings_Edges_Node{}
 	}
 	return t.TotpAllowed
 }
-func (t *GetSelf_Self_TfaSettings) GetVerified() bool {
+func (t *GetSelf_Self_TfaSettings_Edges_Node) GetVerified() bool {
 	if t == nil {
-		t = &GetSelf_Self_TfaSettings{}
+		t = &GetSelf_Self_TfaSettings_Edges_Node{}
 	}
 	return t.Verified
 }
 
+type GetSelf_Self_TfaSettings_Edges struct {
+	Node *GetSelf_Self_TfaSettings_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetSelf_Self_TfaSettings_Edges) GetNode() *GetSelf_Self_TfaSettings_Edges_Node {
+	if t == nil {
+		t = &GetSelf_Self_TfaSettings_Edges{}
+	}
+	return t.Node
+}
+
+type GetSelf_Self_TfaSettings struct {
+	Edges []*GetSelf_Self_TfaSettings_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetSelf_Self_TfaSettings) GetEdges() []*GetSelf_Self_TfaSettings_Edges {
+	if t == nil {
+		t = &GetSelf_Self_TfaSettings{}
+	}
+	return t.Edges
+}
+
 type GetSelf_Self struct {
-	AuthProvider      enums.AuthProvider          "json:\"authProvider\" graphql:\"authProvider\""
-	AvatarFile        *GetSelf_Self_AvatarFile    "json:\"avatarFile,omitempty\" graphql:\"avatarFile\""
-	AvatarLocalFileID *string                     "json:\"avatarLocalFileID,omitempty\" graphql:\"avatarLocalFileID\""
-	AvatarRemoteURL   *string                     "json:\"avatarRemoteURL,omitempty\" graphql:\"avatarRemoteURL\""
-	CreatedAt         *time.Time                  "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy         *string                     "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	DisplayID         string                      "json:\"displayID\" graphql:\"displayID\""
-	DisplayName       string                      "json:\"displayName\" graphql:\"displayName\""
-	Email             string                      "json:\"email\" graphql:\"email\""
-	FirstName         *string                     "json:\"firstName,omitempty\" graphql:\"firstName\""
-	ID                string                      "json:\"id\" graphql:\"id\""
-	LastName          *string                     "json:\"lastName,omitempty\" graphql:\"lastName\""
-	LastSeen          *time.Time                  "json:\"lastSeen,omitempty\" graphql:\"lastSeen\""
-	Setting           GetSelf_Self_Setting        "json:\"setting\" graphql:\"setting\""
-	Sub               *string                     "json:\"sub,omitempty\" graphql:\"sub\""
-	Tags              []string                    "json:\"tags,omitempty\" graphql:\"tags\""
-	TfaSettings       []*GetSelf_Self_TfaSettings "json:\"tfaSettings,omitempty\" graphql:\"tfaSettings\""
-	UpdatedAt         *time.Time                  "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy         *string                     "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	AuthProvider      enums.AuthProvider       "json:\"authProvider\" graphql:\"authProvider\""
+	AvatarFile        *GetSelf_Self_AvatarFile "json:\"avatarFile,omitempty\" graphql:\"avatarFile\""
+	AvatarLocalFileID *string                  "json:\"avatarLocalFileID,omitempty\" graphql:\"avatarLocalFileID\""
+	AvatarRemoteURL   *string                  "json:\"avatarRemoteURL,omitempty\" graphql:\"avatarRemoteURL\""
+	CreatedAt         *time.Time               "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy         *string                  "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	DisplayID         string                   "json:\"displayID\" graphql:\"displayID\""
+	DisplayName       string                   "json:\"displayName\" graphql:\"displayName\""
+	Email             string                   "json:\"email\" graphql:\"email\""
+	FirstName         *string                  "json:\"firstName,omitempty\" graphql:\"firstName\""
+	ID                string                   "json:\"id\" graphql:\"id\""
+	LastName          *string                  "json:\"lastName,omitempty\" graphql:\"lastName\""
+	LastSeen          *time.Time               "json:\"lastSeen,omitempty\" graphql:\"lastSeen\""
+	Setting           GetSelf_Self_Setting     "json:\"setting\" graphql:\"setting\""
+	Sub               *string                  "json:\"sub,omitempty\" graphql:\"sub\""
+	Tags              []string                 "json:\"tags,omitempty\" graphql:\"tags\""
+	TfaSettings       GetSelf_Self_TfaSettings "json:\"tfaSettings\" graphql:\"tfaSettings\""
+	UpdatedAt         *time.Time               "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy         *string                  "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *GetSelf_Self) GetAuthProvider() *enums.AuthProvider {
@@ -52309,11 +56824,11 @@ func (t *GetSelf_Self) GetTags() []string {
 	}
 	return t.Tags
 }
-func (t *GetSelf_Self) GetTfaSettings() []*GetSelf_Self_TfaSettings {
+func (t *GetSelf_Self) GetTfaSettings() *GetSelf_Self_TfaSettings {
 	if t == nil {
 		t = &GetSelf_Self{}
 	}
-	return t.TfaSettings
+	return &t.TfaSettings
 }
 func (t *GetSelf_Self) GetUpdatedAt() *time.Time {
 	if t == nil {
@@ -59727,9 +64242,13 @@ const CreateControlDocument = `mutation CreateControl ($input: CreateControlInpu
 				name
 			}
 			programs {
-				id
-				displayID
-				name
+				edges {
+					node {
+						id
+						displayID
+						name
+					}
+				}
 			}
 			editors {
 				id
@@ -59832,9 +64351,13 @@ const GetAllControlsDocument = `query GetAllControls {
 					governingBody
 				}
 				programs {
-					id
-					displayID
-					name
+					edges {
+						node {
+							id
+							displayID
+							name
+						}
+					}
 				}
 				editors {
 					id
@@ -59910,9 +64433,13 @@ const GetControlByIDDocument = `query GetControlByID ($controlId: ID!) {
 			governingBody
 		}
 		programs {
-			id
-			displayID
-			name
+			edges {
+				node {
+					id
+					displayID
+					name
+				}
+			}
 		}
 		editors {
 			id
@@ -59990,9 +64517,13 @@ const GetControlsDocument = `query GetControls ($where: ControlWhereInput) {
 					governingBody
 				}
 				programs {
-					id
-					displayID
-					name
+					edges {
+						node {
+							id
+							displayID
+							name
+						}
+					}
 				}
 				editors {
 					id
@@ -60071,9 +64602,13 @@ const UpdateControlDocument = `mutation UpdateControl ($updateControlId: ID!, $i
 				governingBody
 			}
 			programs {
-				id
-				displayID
-				name
+				edges {
+					node {
+						id
+						displayID
+						name
+					}
+				}
 			}
 			editors {
 				id
@@ -60675,15 +65210,23 @@ const CreateControlObjectiveDocument = `mutation CreateControlObjective ($input:
 			updatedBy
 			revision
 			controls {
-				id
-				displayID
-				refCode
-				description
+				edges {
+					node {
+						id
+						displayID
+						refCode
+						description
+					}
+				}
 			}
 			programs {
-				id
-				displayID
-				name
+				edges {
+					node {
+						id
+						displayID
+						name
+					}
+				}
 			}
 			editors {
 				id
@@ -60764,15 +65307,23 @@ const GetAllControlObjectivesDocument = `query GetAllControlObjectives {
 				updatedBy
 				revision
 				controls {
-					id
-					displayID
-					refCode
-					description
+					edges {
+						node {
+							id
+							displayID
+							refCode
+							description
+						}
+					}
 				}
 				programs {
-					id
-					displayID
-					name
+					edges {
+						node {
+							id
+							displayID
+							name
+						}
+					}
 				}
 				editors {
 					id
@@ -60826,15 +65377,23 @@ const GetControlObjectiveByIDDocument = `query GetControlObjectiveByID ($control
 		updatedBy
 		revision
 		controls {
-			id
-			displayID
-			refCode
-			description
+			edges {
+				node {
+					id
+					displayID
+					refCode
+					description
+				}
+			}
 		}
 		programs {
-			id
-			displayID
-			name
+			edges {
+				node {
+					id
+					displayID
+					name
+				}
+			}
 		}
 		editors {
 			id
@@ -60890,15 +65449,23 @@ const GetControlObjectivesDocument = `query GetControlObjectives ($where: Contro
 				updatedBy
 				revision
 				controls {
-					id
-					displayID
-					refCode
-					description
+					edges {
+						node {
+							id
+							displayID
+							refCode
+							description
+						}
+					}
 				}
 				programs {
-					id
-					displayID
-					name
+					edges {
+						node {
+							id
+							displayID
+							name
+						}
+					}
 				}
 				editors {
 					id
@@ -60955,15 +65522,23 @@ const UpdateControlObjectiveDocument = `mutation UpdateControlObjective ($update
 			updatedBy
 			revision
 			controls {
-				id
-				displayID
-				refCode
-				description
+				edges {
+					node {
+						id
+						displayID
+						refCode
+						description
+					}
+				}
 			}
 			programs {
-				id
-				displayID
-				name
+				edges {
+					node {
+						id
+						displayID
+						name
+					}
+				}
 			}
 			editors {
 				id
@@ -61295,9 +65870,13 @@ const CreateBulkCSVEntityDocument = `mutation CreateBulkCSVEntity ($input: Uploa
 			status
 			domains
 			notes {
-				text
-				updatedAt
-				updatedBy
+				edges {
+					node {
+						text
+						updatedAt
+						updatedBy
+					}
+				}
 			}
 			entityType {
 				name
@@ -61340,9 +65919,13 @@ const CreateBulkEntityDocument = `mutation CreateBulkEntity ($input: [CreateEnti
 			status
 			domains
 			notes {
-				text
-				updatedAt
-				updatedBy
+				edges {
+					node {
+						text
+						updatedAt
+						updatedBy
+					}
+				}
 			}
 			entityType {
 				name
@@ -61385,9 +65968,13 @@ const CreateEntityDocument = `mutation CreateEntity ($input: CreateEntityInput!)
 			status
 			domains
 			notes {
-				text
-				updatedAt
-				updatedBy
+				edges {
+					node {
+						text
+						updatedAt
+						updatedBy
+					}
+				}
 			}
 			entityType {
 				name
@@ -61455,9 +66042,13 @@ const GetAllEntitiesDocument = `query GetAllEntities {
 				status
 				domains
 				notes {
-					text
-					updatedAt
-					updatedBy
+					edges {
+						node {
+							text
+							updatedAt
+							updatedBy
+						}
+					}
 				}
 				entityType {
 					name
@@ -61500,9 +66091,13 @@ const GetEntitiesDocument = `query GetEntities ($where: EntityWhereInput) {
 				status
 				domains
 				notes {
-					text
-					updatedAt
-					updatedBy
+					edges {
+						node {
+							text
+							updatedAt
+							updatedBy
+						}
+					}
 				}
 				entityType {
 					name
@@ -61545,9 +66140,13 @@ const GetEntityByIDDocument = `query GetEntityByID ($entityId: ID!) {
 		status
 		domains
 		notes {
-			text
-			updatedAt
-			updatedBy
+			edges {
+				node {
+					text
+					updatedAt
+					updatedBy
+				}
+			}
 		}
 		entityType {
 			name
@@ -61556,13 +66155,17 @@ const GetEntityByIDDocument = `query GetEntityByID ($entityId: ID!) {
 		name
 		ownerID
 		contacts {
-			id
-			fullName
-			email
-			title
-			company
-			address
-			phoneNumber
+			edges {
+				node {
+					id
+					fullName
+					email
+					title
+					company
+					address
+					phoneNumber
+				}
+			}
 		}
 		tags
 		updatedAt
@@ -61598,9 +66201,13 @@ const UpdateEntityDocument = `mutation UpdateEntity ($updateEntityId: ID!, $inpu
 			status
 			domains
 			notes {
-				text
-				updatedAt
-				updatedBy
+				edges {
+					node {
+						text
+						updatedAt
+						updatedBy
+					}
+				}
 			}
 			entityType {
 				name
@@ -62057,31 +66664,67 @@ const CreateBulkCSVEventDocument = `mutation CreateBulkCSVEvent ($input: Upload!
 			eventType
 			metadata
 			user {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			group {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			integration {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			organization {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			invite {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			personalAccessToken {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			hush {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			orgmembership {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			groupmembership {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 		}
 	}
@@ -62114,31 +66757,67 @@ const CreateBulkEventDocument = `mutation CreateBulkEvent ($input: [CreateEventI
 			eventType
 			metadata
 			user {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			group {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			integration {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			organization {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			invite {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			personalAccessToken {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			hush {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			orgmembership {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			groupmembership {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 		}
 	}
@@ -62171,31 +66850,67 @@ const CreateEventDocument = `mutation CreateEvent ($input: CreateEventInput!) {
 			eventType
 			metadata
 			user {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			group {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			integration {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			organization {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			invite {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			personalAccessToken {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			hush {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			orgmembership {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			groupmembership {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 		}
 	}
@@ -62257,31 +66972,67 @@ const GetAllEventsDocument = `query GetAllEvents {
 				eventType
 				metadata
 				user {
-					id
+					edges {
+						node {
+							id
+						}
+					}
 				}
 				group {
-					id
+					edges {
+						node {
+							id
+						}
+					}
 				}
 				integration {
-					id
+					edges {
+						node {
+							id
+						}
+					}
 				}
 				organization {
-					id
+					edges {
+						node {
+							id
+						}
+					}
 				}
 				invite {
-					id
+					edges {
+						node {
+							id
+						}
+					}
 				}
 				personalAccessToken {
-					id
+					edges {
+						node {
+							id
+						}
+					}
 				}
 				hush {
-					id
+					edges {
+						node {
+							id
+						}
+					}
 				}
 				orgmembership {
-					id
+					edges {
+						node {
+							id
+						}
+					}
 				}
 				groupmembership {
-					id
+					edges {
+						node {
+							id
+						}
+					}
 				}
 			}
 		}
@@ -62316,31 +67067,67 @@ const GetEventByIDDocument = `query GetEventByID ($eventId: ID!) {
 		eventType
 		metadata
 		user {
-			id
+			edges {
+				node {
+					id
+				}
+			}
 		}
 		group {
-			id
+			edges {
+				node {
+					id
+				}
+			}
 		}
 		integration {
-			id
+			edges {
+				node {
+					id
+				}
+			}
 		}
 		organization {
-			id
+			edges {
+				node {
+					id
+				}
+			}
 		}
 		invite {
-			id
+			edges {
+				node {
+					id
+				}
+			}
 		}
 		personalAccessToken {
-			id
+			edges {
+				node {
+					id
+				}
+			}
 		}
 		hush {
-			id
+			edges {
+				node {
+					id
+				}
+			}
 		}
 		orgmembership {
-			id
+			edges {
+				node {
+					id
+				}
+			}
 		}
 		groupmembership {
-			id
+			edges {
+				node {
+					id
+				}
+			}
 		}
 	}
 }
@@ -62408,31 +67195,67 @@ const UpdateEventDocument = `mutation UpdateEvent ($updateEventId: ID!, $input: 
 			eventType
 			metadata
 			user {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			group {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			integration {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			organization {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			invite {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			personalAccessToken {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			hush {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			orgmembership {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			groupmembership {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 		}
 	}
@@ -62556,32 +67379,56 @@ const CreateEvidenceDocument = `mutation CreateEvidence ($input: CreateEvidenceI
 			updatedBy
 			url
 			files {
-				id
-				presignedURL
+				edges {
+					node {
+						id
+						presignedURL
+					}
+				}
 			}
 			programs {
-				id
-				displayID
-				name
+				edges {
+					node {
+						id
+						displayID
+						name
+					}
+				}
 			}
 			tasks {
-				id
-				displayID
+				edges {
+					node {
+						id
+						displayID
+					}
+				}
 			}
 			controls {
-				id
-				displayID
-				refCode
+				edges {
+					node {
+						id
+						displayID
+						refCode
+					}
+				}
 			}
 			subcontrols {
-				id
-				displayID
-				refCode
+				edges {
+					node {
+						id
+						displayID
+						refCode
+					}
+				}
 			}
 			controlObjectives {
-				id
-				displayID
-				name
+				edges {
+					node {
+						id
+						displayID
+						name
+					}
+				}
 			}
 		}
 	}
@@ -62652,32 +67499,56 @@ const GetAllEvidencesDocument = `query GetAllEvidences {
 				updatedBy
 				url
 				files {
-					id
-					presignedURL
+					edges {
+						node {
+							id
+							presignedURL
+						}
+					}
 				}
 				programs {
-					id
-					displayID
-					name
+					edges {
+						node {
+							id
+							displayID
+							name
+						}
+					}
 				}
 				tasks {
-					id
-					displayID
+					edges {
+						node {
+							id
+							displayID
+						}
+					}
 				}
 				controls {
-					id
-					displayID
-					refCode
+					edges {
+						node {
+							id
+							displayID
+							refCode
+						}
+					}
 				}
 				subcontrols {
-					id
-					displayID
-					refCode
+					edges {
+						node {
+							id
+							displayID
+							refCode
+						}
+					}
 				}
 				controlObjectives {
-					id
-					displayID
-					name
+					edges {
+						node {
+							id
+							displayID
+							name
+						}
+					}
 				}
 			}
 		}
@@ -62720,32 +67591,56 @@ const GetEvidenceByIDDocument = `query GetEvidenceByID ($evidenceId: ID!) {
 		updatedBy
 		url
 		files {
-			id
-			presignedURL
+			edges {
+				node {
+					id
+					presignedURL
+				}
+			}
 		}
 		programs {
-			id
-			displayID
-			name
+			edges {
+				node {
+					id
+					displayID
+					name
+				}
+			}
 		}
 		tasks {
-			id
-			displayID
+			edges {
+				node {
+					id
+					displayID
+				}
+			}
 		}
 		controls {
-			id
-			displayID
-			refCode
+			edges {
+				node {
+					id
+					displayID
+					refCode
+				}
+			}
 		}
 		subcontrols {
-			id
-			displayID
-			refCode
+			edges {
+				node {
+					id
+					displayID
+					refCode
+				}
+			}
 		}
 		controlObjectives {
-			id
-			displayID
-			name
+			edges {
+				node {
+					id
+					displayID
+					name
+				}
+			}
 		}
 	}
 }
@@ -62790,32 +67685,56 @@ const GetEvidencesDocument = `query GetEvidences ($where: EvidenceWhereInput) {
 				updatedBy
 				url
 				files {
-					id
-					presignedURL
+					edges {
+						node {
+							id
+							presignedURL
+						}
+					}
 				}
 				programs {
-					id
-					displayID
-					name
+					edges {
+						node {
+							id
+							displayID
+							name
+						}
+					}
 				}
 				tasks {
-					id
-					displayID
+					edges {
+						node {
+							id
+							displayID
+						}
+					}
 				}
 				controls {
-					id
-					displayID
-					refCode
+					edges {
+						node {
+							id
+							displayID
+							refCode
+						}
+					}
 				}
 				subcontrols {
-					id
-					displayID
-					refCode
+					edges {
+						node {
+							id
+							displayID
+							refCode
+						}
+					}
 				}
 				controlObjectives {
-					id
-					displayID
-					name
+					edges {
+						node {
+							id
+							displayID
+							name
+						}
+					}
 				}
 			}
 		}
@@ -62861,32 +67780,56 @@ const UpdateEvidenceDocument = `mutation UpdateEvidence ($updateEvidenceId: ID!,
 			updatedBy
 			url
 			files {
-				id
-				presignedURL
+				edges {
+					node {
+						id
+						presignedURL
+					}
+				}
 			}
 			programs {
-				id
-				displayID
-				name
+				edges {
+					node {
+						id
+						displayID
+						name
+					}
+				}
 			}
 			tasks {
-				id
-				displayID
+				edges {
+					node {
+						id
+						displayID
+					}
+				}
 			}
 			controls {
-				id
-				displayID
-				refCode
+				edges {
+					node {
+						id
+						displayID
+						refCode
+					}
+				}
 			}
 			subcontrols {
-				id
-				displayID
-				refCode
+				edges {
+					node {
+						id
+						displayID
+						refCode
+					}
+				}
 			}
 			controlObjectives {
-				id
-				displayID
-				name
+				edges {
+					node {
+						id
+						displayID
+						name
+					}
+				}
 			}
 		}
 	}
@@ -64402,13 +69345,25 @@ const CreateBulkCSVHushDocument = `mutation CreateBulkCSVHush ($input: Upload!) 
 			name
 			secretName
 			integrations {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			organization {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			events {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 		}
 	}
@@ -64441,13 +69396,25 @@ const CreateBulkHushDocument = `mutation CreateBulkHush ($input: [CreateHushInpu
 			name
 			secretName
 			integrations {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			organization {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			events {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 		}
 	}
@@ -64480,13 +69447,25 @@ const CreateHushDocument = `mutation CreateHush ($input: CreateHushInput!) {
 			name
 			secretName
 			integrations {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			organization {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			events {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 		}
 	}
@@ -64520,13 +69499,25 @@ const GetAllHushesDocument = `query GetAllHushes {
 				name
 				secretName
 				integrations {
-					id
+					edges {
+						node {
+							id
+						}
+					}
 				}
 				organization {
-					id
+					edges {
+						node {
+							id
+						}
+					}
 				}
 				events {
-					id
+					edges {
+						node {
+							id
+						}
+					}
 				}
 				createdAt
 				updatedAt
@@ -64561,13 +69552,25 @@ const GetHushByIDDocument = `query GetHushByID ($hushId: ID!) {
 		name
 		secretName
 		integrations {
-			id
+			edges {
+				node {
+					id
+				}
+			}
 		}
 		organization {
-			id
+			edges {
+				node {
+					id
+				}
+			}
 		}
 		events {
-			id
+			edges {
+				node {
+					id
+				}
+			}
 		}
 		createdAt
 		updatedAt
@@ -64604,13 +69607,25 @@ const GetHushesDocument = `query GetHushes ($where: HushWhereInput) {
 				name
 				secretName
 				integrations {
-					id
+					edges {
+						node {
+							id
+						}
+					}
 				}
 				organization {
-					id
+					edges {
+						node {
+							id
+						}
+					}
 				}
 				events {
-					id
+					edges {
+						node {
+							id
+						}
+					}
 				}
 				createdAt
 				updatedAt
@@ -64648,13 +69663,25 @@ const UpdateHushDocument = `mutation UpdateHush ($updateHushId: ID!, $input: Upd
 			name
 			secretName
 			integrations {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			organization {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			events {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 		}
 	}
@@ -64767,10 +69794,18 @@ const CreateBulkCSVIntegrationDocument = `mutation CreateBulkCSVIntegration ($in
 				id
 			}
 			secrets {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			events {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 		}
 	}
@@ -64806,10 +69841,18 @@ const CreateBulkIntegrationDocument = `mutation CreateBulkIntegration ($input: [
 				id
 			}
 			secrets {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			events {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 		}
 	}
@@ -64845,10 +69888,18 @@ const CreateIntegrationDocument = `mutation CreateIntegration ($input: CreateInt
 				id
 			}
 			secrets {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			events {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 		}
 	}
@@ -64909,10 +69960,18 @@ const GetAllIntegrationsDocument = `query GetAllIntegrations {
 					id
 				}
 				secrets {
-					id
+					edges {
+						node {
+							id
+						}
+					}
 				}
 				events {
-					id
+					edges {
+						node {
+							id
+						}
+					}
 				}
 				createdAt
 				createdBy
@@ -64950,10 +70009,18 @@ const GetIntegrationByIDDocument = `query GetIntegrationByID ($integrationId: ID
 			id
 		}
 		secrets {
-			id
+			edges {
+				node {
+					id
+				}
+			}
 		}
 		events {
-			id
+			edges {
+				node {
+					id
+				}
+			}
 		}
 		createdAt
 		createdBy
@@ -64993,10 +70060,18 @@ const GetIntegrationsDocument = `query GetIntegrations ($where: IntegrationWhere
 					id
 				}
 				secrets {
-					id
+					edges {
+						node {
+							id
+						}
+					}
 				}
 				events {
-					id
+					edges {
+						node {
+							id
+						}
+					}
 				}
 				createdAt
 				createdBy
@@ -65037,10 +70112,18 @@ const UpdateIntegrationDocument = `mutation UpdateIntegration ($updateIntegratio
 				id
 			}
 			secrets {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			events {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 		}
 	}
@@ -65781,11 +70864,15 @@ const InvitesByOrgIDDocument = `query InvitesByOrgID ($where: InviteWhereInput) 
 				owner {
 					id
 					invites {
-						recipient
-						requestorID
-						role
-						sendAttempts
-						status
+						edges {
+							node {
+								recipient
+								requestorID
+								role
+								sendAttempts
+								status
+							}
+						}
 					}
 				}
 			}
@@ -65820,14 +70907,22 @@ const CreateBulkCSVMappedControlDocument = `mutation CreateBulkCSVMappedControl 
 			mappingType
 			relation
 			controls {
-				id
-				refCode
-				description
+				edges {
+					node {
+						id
+						refCode
+						description
+					}
+				}
 			}
 			subcontrols {
-				id
-				refCode
-				description
+				edges {
+					node {
+						id
+						refCode
+						description
+					}
+				}
 			}
 			tags
 			updatedAt
@@ -65864,14 +70959,22 @@ const CreateBulkMappedControlDocument = `mutation CreateBulkMappedControl ($inpu
 			relation
 			tags
 			controls {
-				id
-				refCode
-				description
+				edges {
+					node {
+						id
+						refCode
+						description
+					}
+				}
 			}
 			subcontrols {
-				id
-				refCode
-				description
+				edges {
+					node {
+						id
+						refCode
+						description
+					}
+				}
 			}
 			updatedAt
 			updatedBy
@@ -65906,14 +71009,22 @@ const CreateMappedControlDocument = `mutation CreateMappedControl ($input: Creat
 			mappingType
 			relation
 			controls {
-				id
-				refCode
-				description
+				edges {
+					node {
+						id
+						refCode
+						description
+					}
+				}
 			}
 			subcontrols {
-				id
-				refCode
-				description
+				edges {
+					node {
+						id
+						refCode
+						description
+					}
+				}
 			}
 			tags
 			updatedAt
@@ -65974,14 +71085,22 @@ const GetAllMappedControlsDocument = `query GetAllMappedControls {
 				mappingType
 				relation
 				controls {
-					id
-					refCode
-					description
+					edges {
+						node {
+							id
+							refCode
+							description
+						}
+					}
 				}
 				subcontrols {
-					id
-					refCode
-					description
+					edges {
+						node {
+							id
+							refCode
+							description
+						}
+					}
 				}
 				tags
 				updatedAt
@@ -66015,14 +71134,22 @@ const GetMappedControlByIDDocument = `query GetMappedControlByID ($mappedControl
 		mappingType
 		relation
 		controls {
-			id
-			refCode
-			description
+			edges {
+				node {
+					id
+					refCode
+					description
+				}
+			}
 		}
 		subcontrols {
-			id
-			refCode
-			description
+			edges {
+				node {
+					id
+					refCode
+					description
+				}
+			}
 		}
 		tags
 		updatedAt
@@ -66058,14 +71185,22 @@ const GetMappedControlsDocument = `query GetMappedControls ($where: MappedContro
 				mappingType
 				relation
 				controls {
-					id
-					refCode
-					description
+					edges {
+						node {
+							id
+							refCode
+							description
+						}
+					}
 				}
 				subcontrols {
-					id
-					refCode
-					description
+					edges {
+						node {
+							id
+							refCode
+							description
+						}
+					}
 				}
 				tags
 				updatedAt
@@ -66102,14 +71237,22 @@ const UpdateMappedControlDocument = `mutation UpdateMappedControl ($updateMapped
 			mappingType
 			relation
 			controls {
-				id
-				refCode
-				description
+				edges {
+					node {
+						id
+						refCode
+						description
+					}
+				}
 			}
 			subcontrols {
-				id
-				refCode
-				description
+				edges {
+					node {
+						id
+						refCode
+						description
+					}
+				}
 			}
 			tags
 			updatedAt
@@ -66295,8 +71438,12 @@ const CreateNarrativeDocument = `mutation CreateNarrative ($input: CreateNarrati
 			updatedAt
 			updatedBy
 			programs {
-				id
-				name
+				edges {
+					node {
+						id
+						name
+					}
+				}
 			}
 			editors {
 				id
@@ -66371,8 +71518,12 @@ const GetAllNarrativesDocument = `query GetAllNarratives {
 				updatedAt
 				updatedBy
 				programs {
-					id
-					name
+					edges {
+						node {
+							id
+							name
+						}
+					}
 				}
 				editors {
 					id
@@ -66420,8 +71571,12 @@ const GetNarrativeByIDDocument = `query GetNarrativeByID ($narrativeId: ID!) {
 		updatedAt
 		updatedBy
 		programs {
-			id
-			name
+			edges {
+				node {
+					id
+					name
+				}
+			}
 		}
 		editors {
 			id
@@ -66471,8 +71626,12 @@ const GetNarrativesDocument = `query GetNarratives ($where: NarrativeWhereInput)
 				updatedAt
 				updatedBy
 				programs {
-					id
-					name
+					edges {
+						node {
+							id
+							name
+						}
+					}
 				}
 				editors {
 					id
@@ -66523,8 +71682,12 @@ const UpdateNarrativeDocument = `mutation UpdateNarrative ($updateNarrativeId: I
 			updatedAt
 			updatedBy
 			programs {
-				id
-				name
+				edges {
+					node {
+						id
+						name
+					}
+				}
 			}
 			editors {
 				id
@@ -68258,8 +73421,12 @@ const CreatePersonalAccessTokenDocument = `mutation CreatePersonalAccessToken ($
 			updatedAt
 			updatedBy
 			organizations {
-				id
-				name
+				edges {
+					node {
+						id
+						name
+					}
+				}
 			}
 			owner {
 				id
@@ -68331,8 +73498,12 @@ const GetAllPersonalAccessTokensDocument = `query GetAllPersonalAccessTokens {
 				updatedAt
 				updatedBy
 				organizations {
-					id
-					name
+					edges {
+						node {
+							id
+							name
+						}
+					}
 				}
 			}
 		}
@@ -68374,8 +73545,12 @@ const GetPersonalAccessTokenByIDDocument = `query GetPersonalAccessTokenByID ($p
 		updatedAt
 		updatedBy
 		organizations {
-			id
-			name
+			edges {
+				node {
+					id
+					name
+				}
+			}
 		}
 	}
 }
@@ -68419,8 +73594,12 @@ const GetPersonalAccessTokensDocument = `query GetPersonalAccessTokens ($where: 
 				updatedAt
 				updatedBy
 				organizations {
-					id
-					name
+					edges {
+						node {
+							id
+							name
+						}
+					}
 				}
 			}
 		}
@@ -68465,8 +73644,12 @@ const UpdatePersonalAccessTokenDocument = `mutation UpdatePersonalAccessToken ($
 			updatedAt
 			updatedBy
 			organizations {
-				id
-				name
+				edges {
+					node {
+						id
+						name
+					}
+				}
 			}
 			owner {
 				id
@@ -69024,8 +74207,12 @@ const CreateControlWithSubcontrolsDocument = `mutation CreateControlWithSubcontr
 			id
 			refCode
 			subcontrols {
-				id
-				refCode
+				edges {
+					node {
+						id
+						refCode
+					}
+				}
 			}
 		}
 	}
@@ -69056,30 +74243,54 @@ const CreateFullProgramDocument = `mutation CreateFullProgram ($input: CreateFul
 			id
 			displayID
 			members {
-				id
+				edges {
+					node {
+						id
+					}
+				}
 			}
 			controls {
-				id
-				refCode
-				subcontrols {
-					id
-					refCode
+				edges {
+					node {
+						id
+						refCode
+						subcontrols {
+							edges {
+								node {
+									id
+									refCode
+								}
+							}
+						}
+					}
 				}
 			}
 			risks {
-				id
-				displayID
-				name
+				edges {
+					node {
+						id
+						displayID
+						name
+					}
+				}
 			}
 			internalPolicies {
-				id
-				displayID
-				name
+				edges {
+					node {
+						id
+						displayID
+						name
+					}
+				}
 			}
 			procedures {
-				id
-				displayID
-				name
+				edges {
+					node {
+						id
+						displayID
+						name
+					}
+				}
 			}
 		}
 	}
@@ -69123,32 +74334,40 @@ const CreateProgramDocument = `mutation CreateProgram ($input: CreateProgramInpu
 			updatedAt
 			updatedBy
 			procedures {
-				createdAt
-				createdBy
-				details
-				id
-				displayID
-				name
-				procedureType
-				status
-				tags
-				updatedAt
-				updatedBy
-				revision
+				edges {
+					node {
+						createdAt
+						createdBy
+						details
+						id
+						displayID
+						name
+						procedureType
+						status
+						tags
+						updatedAt
+						updatedBy
+						revision
+					}
+				}
 			}
 			internalPolicies {
-				createdAt
-				createdBy
-				details
-				id
-				displayID
-				name
-				policyType
-				status
-				tags
-				updatedAt
-				updatedBy
-				revision
+				edges {
+					node {
+						createdAt
+						createdBy
+						details
+						id
+						displayID
+						name
+						policyType
+						status
+						tags
+						updatedAt
+						updatedBy
+						revision
+					}
+				}
 			}
 			editors {
 				id
@@ -69191,11 +74410,15 @@ const CreateProgramWithMembersDocument = `mutation CreateProgramWithMembers ($in
 			id
 			displayID
 			members {
-				id
-				user {
-					id
-					firstName
-					lastName
+				edges {
+					node {
+						id
+						user {
+							id
+							firstName
+							lastName
+						}
+					}
 				}
 			}
 		}
@@ -69265,32 +74488,40 @@ const GetAllProgramsDocument = `query GetAllPrograms {
 				updatedAt
 				updatedBy
 				procedures {
-					createdAt
-					createdBy
-					details
-					id
-					displayID
-					name
-					procedureType
-					status
-					tags
-					updatedAt
-					updatedBy
-					revision
+					edges {
+						node {
+							createdAt
+							createdBy
+							details
+							id
+							displayID
+							name
+							procedureType
+							status
+							tags
+							updatedAt
+							updatedBy
+							revision
+						}
+					}
 				}
 				internalPolicies {
-					createdAt
-					createdBy
-					details
-					id
-					displayID
-					name
-					policyType
-					status
-					tags
-					updatedAt
-					updatedBy
-					revision
+					edges {
+						node {
+							createdAt
+							createdBy
+							details
+							id
+							displayID
+							name
+							policyType
+							status
+							tags
+							updatedAt
+							updatedBy
+							revision
+						}
+					}
 				}
 				editors {
 					id
@@ -69305,11 +74536,15 @@ const GetAllProgramsDocument = `query GetAllPrograms {
 					name
 				}
 				members {
-					id
-					user {
-						id
-						firstName
-						lastName
+					edges {
+						node {
+							id
+							user {
+								id
+								firstName
+								lastName
+							}
+						}
 					}
 				}
 			}
@@ -69352,32 +74587,40 @@ const GetProgramByIDDocument = `query GetProgramByID ($programId: ID!) {
 		updatedAt
 		updatedBy
 		procedures {
-			createdAt
-			createdBy
-			details
-			id
-			displayID
-			name
-			procedureType
-			status
-			tags
-			updatedAt
-			updatedBy
-			revision
+			edges {
+				node {
+					createdAt
+					createdBy
+					details
+					id
+					displayID
+					name
+					procedureType
+					status
+					tags
+					updatedAt
+					updatedBy
+					revision
+				}
+			}
 		}
 		internalPolicies {
-			createdAt
-			createdBy
-			details
-			id
-			displayID
-			name
-			policyType
-			status
-			tags
-			updatedAt
-			updatedBy
-			revision
+			edges {
+				node {
+					createdAt
+					createdBy
+					details
+					id
+					displayID
+					name
+					policyType
+					status
+					tags
+					updatedAt
+					updatedBy
+					revision
+				}
+			}
 		}
 		editors {
 			id
@@ -69392,11 +74635,15 @@ const GetProgramByIDDocument = `query GetProgramByID ($programId: ID!) {
 			name
 		}
 		members {
-			id
-			user {
-				id
-				firstName
-				lastName
+			edges {
+				node {
+					id
+					user {
+						id
+						firstName
+						lastName
+					}
+				}
 			}
 		}
 	}
@@ -69441,32 +74688,40 @@ const GetProgramsDocument = `query GetPrograms ($where: ProgramWhereInput) {
 				updatedAt
 				updatedBy
 				procedures {
-					createdAt
-					createdBy
-					details
-					id
-					displayID
-					name
-					procedureType
-					status
-					tags
-					updatedAt
-					updatedBy
-					revision
+					edges {
+						node {
+							createdAt
+							createdBy
+							details
+							id
+							displayID
+							name
+							procedureType
+							status
+							tags
+							updatedAt
+							updatedBy
+							revision
+						}
+					}
 				}
 				internalPolicies {
-					createdAt
-					createdBy
-					details
-					id
-					displayID
-					name
-					policyType
-					status
-					tags
-					updatedAt
-					updatedBy
-					revision
+					edges {
+						node {
+							createdAt
+							createdBy
+							details
+							id
+							displayID
+							name
+							policyType
+							status
+							tags
+							updatedAt
+							updatedBy
+							revision
+						}
+					}
 				}
 				editors {
 					id
@@ -69481,11 +74736,15 @@ const GetProgramsDocument = `query GetPrograms ($where: ProgramWhereInput) {
 					name
 				}
 				members {
-					id
-					user {
-						id
-						firstName
-						lastName
+					edges {
+						node {
+							id
+							user {
+								id
+								firstName
+								lastName
+							}
+						}
 					}
 				}
 			}
@@ -69530,30 +74789,40 @@ const UpdateProgramDocument = `mutation UpdateProgram ($updateProgramId: ID!, $i
 			updatedAt
 			updatedBy
 			procedures {
-				createdAt
-				createdBy
-				details
-				id
-				name
-				procedureType
-				status
-				tags
-				updatedAt
-				updatedBy
-				revision
+				edges {
+					node {
+						createdAt
+						createdBy
+						details
+						id
+						displayID
+						name
+						procedureType
+						status
+						tags
+						updatedAt
+						updatedBy
+						revision
+					}
+				}
 			}
 			internalPolicies {
-				createdAt
-				createdBy
-				details
-				id
-				name
-				policyType
-				status
-				tags
-				updatedAt
-				updatedBy
-				revision
+				edges {
+					node {
+						createdAt
+						createdBy
+						details
+						id
+						displayID
+						name
+						policyType
+						status
+						tags
+						updatedAt
+						updatedBy
+						revision
+					}
+				}
 			}
 			editors {
 				id
@@ -69568,11 +74837,15 @@ const UpdateProgramDocument = `mutation UpdateProgram ($updateProgramId: ID!, $i
 				name
 			}
 			members {
-				id
-				user {
-					id
-					firstName
-					lastName
+				edges {
+					node {
+						id
+						user {
+							id
+							firstName
+							lastName
+						}
+					}
 				}
 			}
 		}
@@ -70345,8 +75618,12 @@ const CreateRiskDocument = `mutation CreateRisk ($input: CreateRiskInput!) {
 			updatedAt
 			updatedBy
 			programs {
-				id
-				name
+				edges {
+					node {
+						id
+						name
+					}
+				}
 			}
 			editors {
 				id
@@ -70428,8 +75705,12 @@ const GetAllRisksDocument = `query GetAllRisks {
 				updatedAt
 				updatedBy
 				programs {
-					id
-					name
+					edges {
+						node {
+							id
+							name
+						}
+					}
 				}
 				editors {
 					id
@@ -70484,8 +75765,12 @@ const GetRiskByIDDocument = `query GetRiskByID ($riskId: ID!) {
 		updatedAt
 		updatedBy
 		programs {
-			id
-			name
+			edges {
+				node {
+					id
+					name
+				}
+			}
 		}
 		editors {
 			id
@@ -70542,8 +75827,12 @@ const GetRisksDocument = `query GetRisks ($where: RiskWhereInput) {
 				updatedAt
 				updatedBy
 				programs {
-					id
-					name
+					edges {
+						node {
+							id
+							name
+						}
+					}
 				}
 				editors {
 					id
@@ -70601,8 +75890,12 @@ const UpdateRiskDocument = `mutation UpdateRisk ($updateRiskId: ID!, $input: Upd
 			updatedAt
 			updatedBy
 			programs {
-				id
-				name
+				edges {
+					node {
+						id
+						name
+					}
+				}
 			}
 			editors {
 				id
@@ -70752,6 +76045,7 @@ const GlobalSearchDocument = `query GlobalSearch ($query: String!) {
 			}
 			... on ContactSearchResult {
 				contacts {
+					email
 					fullName
 					id
 					tags
@@ -70816,6 +76110,7 @@ const GlobalSearchDocument = `query GlobalSearch ($query: String!) {
 				evidences {
 					displayID
 					id
+					name
 					tags
 				}
 			}
@@ -70918,6 +76213,9 @@ const GlobalSearchDocument = `query GlobalSearch ($query: String!) {
 			}
 			... on StandardSearchResult {
 				standards {
+					domains
+					framework
+					governingBody
 					id
 					name
 					shortName
@@ -72142,13 +77440,17 @@ const CreateBulkCSVTaskDocument = `mutation CreateBulkCSVTask ($input: Upload!) 
 			details
 			category
 			comments {
-				id
-				displayID
-				text
-				createdAt
-				createdBy
-				updatedAt
-				updatedBy
+				edges {
+					node {
+						id
+						displayID
+						text
+						createdAt
+						createdBy
+						updatedAt
+						updatedBy
+					}
+				}
 			}
 			due
 			id
@@ -72200,13 +77502,17 @@ const CreateBulkTaskDocument = `mutation CreateBulkTask ($input: [CreateTaskInpu
 			details
 			category
 			comments {
-				id
-				displayID
-				text
-				createdAt
-				createdBy
-				updatedAt
-				updatedBy
+				edges {
+					node {
+						id
+						displayID
+						text
+						createdAt
+						createdBy
+						updatedAt
+						updatedBy
+					}
+				}
 			}
 			due
 			id
@@ -72258,13 +77564,17 @@ const CreateTaskDocument = `mutation CreateTask ($input: CreateTaskInput!) {
 			details
 			category
 			comments {
-				id
-				displayID
-				text
-				createdAt
-				createdBy
-				updatedAt
-				updatedBy
+				edges {
+					node {
+						id
+						displayID
+						text
+						createdAt
+						createdBy
+						updatedAt
+						updatedBy
+					}
+				}
 			}
 			due
 			id
@@ -72346,13 +77656,17 @@ const GetAllTasksDocument = `query GetAllTasks {
 				details
 				category
 				comments {
-					id
-					displayID
-					text
-					createdAt
-					createdBy
-					updatedAt
-					updatedBy
+					edges {
+						node {
+							id
+							displayID
+							text
+							createdAt
+							createdBy
+							updatedAt
+							updatedBy
+						}
+					}
 				}
 				due
 				id
@@ -72406,13 +77720,17 @@ const GetTaskByIDDocument = `query GetTaskByID ($taskId: ID!) {
 		details
 		category
 		comments {
-			id
-			displayID
-			text
-			createdAt
-			createdBy
-			updatedAt
-			updatedBy
+			edges {
+				node {
+					id
+					displayID
+					text
+					createdAt
+					createdBy
+					updatedAt
+					updatedBy
+				}
+			}
 		}
 		due
 		id
@@ -72464,13 +77782,17 @@ const GetTasksDocument = `query GetTasks ($where: TaskWhereInput) {
 				details
 				category
 				comments {
-					id
-					displayID
-					text
-					createdAt
-					createdBy
-					updatedAt
-					updatedBy
+					edges {
+						node {
+							id
+							displayID
+							text
+							createdAt
+							createdBy
+							updatedAt
+							updatedBy
+						}
+					}
 				}
 				due
 				id
@@ -72523,13 +77845,17 @@ const UpdateTaskDocument = `mutation UpdateTask ($updateTaskId: ID!, $input: Upd
 			details
 			category
 			comments {
-				id
-				displayID
-				text
-				createdAt
-				createdBy
-				updatedAt
-				updatedBy
+				edges {
+					node {
+						id
+						displayID
+						text
+						createdAt
+						createdBy
+						updatedAt
+						updatedBy
+					}
+				}
 			}
 			due
 			id
@@ -72582,13 +77908,17 @@ const UpdateTaskCommentDocument = `mutation UpdateTaskComment ($updateTaskCommen
 			details
 			category
 			comments {
-				id
-				displayID
-				text
-				createdAt
-				createdBy
-				updatedAt
-				updatedBy
+				edges {
+					node {
+						id
+						displayID
+						text
+						createdAt
+						createdBy
+						updatedAt
+						updatedBy
+					}
+				}
 			}
 			due
 			id
@@ -73280,8 +78610,12 @@ const GetSelfDocument = `query GetSelf {
 			updatedBy
 		}
 		tfaSettings {
-			totpAllowed
-			verified
+			edges {
+				node {
+					totpAllowed
+					verified
+				}
+			}
 		}
 		createdAt
 		createdBy

--- a/pkg/openlaneclient/models.go
+++ b/pkg/openlaneclient/models.go
@@ -339,12 +339,12 @@ type ActionPlan struct {
 	// the group of users who are responsible for approving the action_plan
 	Approver *Group `json:"approver,omitempty"`
 	// temporary delegates for the action_plan, used for temporary approval
-	Delegate *Group        `json:"delegate,omitempty"`
-	Owner    *Organization `json:"owner,omitempty"`
-	Risk     []*Risk       `json:"risk,omitempty"`
-	Control  []*Control    `json:"control,omitempty"`
-	User     []*User       `json:"user,omitempty"`
-	Program  []*Program    `json:"program,omitempty"`
+	Delegate *Group             `json:"delegate,omitempty"`
+	Owner    *Organization      `json:"owner,omitempty"`
+	Risk     *RiskConnection    `json:"risk"`
+	Control  *ControlConnection `json:"control"`
+	User     *UserConnection    `json:"user"`
+	Program  *ProgramConnection `json:"program"`
 }
 
 func (ActionPlan) IsNode() {}
@@ -442,6 +442,14 @@ type ActionPlanHistoryEdge struct {
 	Node *ActionPlanHistory `json:"node,omitempty"`
 	// A cursor for use in pagination.
 	Cursor string `json:"cursor"`
+}
+
+// Ordering options for ActionPlanHistory connections
+type ActionPlanHistoryOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order ActionPlanHistories.
+	Field ActionPlanHistoryOrderField `json:"field"`
 }
 
 // ActionPlanHistoryWhereInput is used for filtering ActionPlanHistory objects.
@@ -714,6 +722,14 @@ type ActionPlanHistoryWhereInput struct {
 	SourceNotNil       *bool    `json:"sourceNotNil,omitempty"`
 	SourceEqualFold    *string  `json:"sourceEqualFold,omitempty"`
 	SourceContainsFold *string  `json:"sourceContainsFold,omitempty"`
+}
+
+// Ordering options for ActionPlan connections
+type ActionPlanOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order ActionPlans.
+	Field ActionPlanOrderField `json:"field"`
 }
 
 type ActionPlanSearchResult struct {
@@ -1054,10 +1070,10 @@ type Contact struct {
 	// the address of the contact
 	Address *string `json:"address,omitempty"`
 	// status of the contact
-	Status   enums.UserStatus `json:"status"`
-	Owner    *Organization    `json:"owner,omitempty"`
-	Entities []*Entity        `json:"entities,omitempty"`
-	Files    []*File          `json:"files,omitempty"`
+	Status   enums.UserStatus  `json:"status"`
+	Owner    *Organization     `json:"owner,omitempty"`
+	Entities *EntityConnection `json:"entities"`
+	Files    *FileConnection   `json:"files"`
 }
 
 func (Contact) IsNode() {}
@@ -1147,6 +1163,14 @@ type ContactHistoryEdge struct {
 	Node *ContactHistory `json:"node,omitempty"`
 	// A cursor for use in pagination.
 	Cursor string `json:"cursor"`
+}
+
+// Ordering options for ContactHistory connections
+type ContactHistoryOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order ContactHistories.
+	Field ContactHistoryOrderField `json:"field"`
 }
 
 // ContactHistoryWhereInput is used for filtering ContactHistory objects.
@@ -1392,6 +1416,14 @@ type ContactHistoryWhereInput struct {
 	StatusNeq   *enums.UserStatus  `json:"statusNEQ,omitempty"`
 	StatusIn    []enums.UserStatus `json:"statusIn,omitempty"`
 	StatusNotIn []enums.UserStatus `json:"statusNotIn,omitempty"`
+}
+
+// Ordering options for Contact connections
+type ContactOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order Contacts.
+	Field ContactOrderField `json:"field"`
 }
 
 type ContactSearchResult struct {
@@ -1682,22 +1714,20 @@ type Control struct {
 	// provides edit access to the risk to members of the group
 	Editors []*Group `json:"editors,omitempty"`
 	// provides view access to the risk to members of the group
-	Viewers  []*Group    `json:"viewers,omitempty"`
-	Standard *Standard   `json:"standard,omitempty"`
-	Programs []*Program  `json:"programs,omitempty"`
-	Evidence []*Evidence `json:"evidence,omitempty"`
-	// the implementation(s) of the control
-	ControlImplementations []*ControlImplementation `json:"controlImplementations,omitempty"`
-	// mapped subcontrols that have a relation to another control or subcontrol
-	MappedControls    []*MappedControl    `json:"mappedControls,omitempty"`
-	ControlObjectives []*ControlObjective `json:"controlObjectives,omitempty"`
-	Subcontrols       []*Subcontrol       `json:"subcontrols,omitempty"`
-	Tasks             []*Task             `json:"tasks,omitempty"`
-	Narratives        []*Narrative        `json:"narratives,omitempty"`
-	Risks             []*Risk             `json:"risks,omitempty"`
-	ActionPlans       []*ActionPlan       `json:"actionPlans,omitempty"`
-	Procedures        []*Procedure        `json:"procedures,omitempty"`
-	InternalPolicies  []*InternalPolicy   `json:"internalPolicies,omitempty"`
+	Viewers                []*Group                         `json:"viewers,omitempty"`
+	Standard               *Standard                        `json:"standard,omitempty"`
+	Programs               *ProgramConnection               `json:"programs"`
+	Evidence               *EvidenceConnection              `json:"evidence"`
+	ControlImplementations *ControlImplementationConnection `json:"controlImplementations"`
+	MappedControls         *MappedControlConnection         `json:"mappedControls"`
+	ControlObjectives      []*ControlObjective              `json:"controlObjectives,omitempty"`
+	Subcontrols            *SubcontrolConnection            `json:"subcontrols"`
+	Tasks                  *TaskConnection                  `json:"tasks"`
+	Narratives             *NarrativeConnection             `json:"narratives"`
+	Risks                  *RiskConnection                  `json:"risks"`
+	ActionPlans            *ActionPlanConnection            `json:"actionPlans"`
+	Procedures             *ProcedureConnection             `json:"procedures"`
+	InternalPolicies       *InternalPolicyConnection        `json:"internalPolicies"`
 	// the group of users who are responsible for the control, will be assigned tasks, approval, etc.
 	ControlOwner *Group `json:"controlOwner,omitempty"`
 	// temporary delegate for the control, used for temporary control ownership
@@ -1811,6 +1841,14 @@ type ControlHistoryEdge struct {
 	Node *ControlHistory `json:"node,omitempty"`
 	// A cursor for use in pagination.
 	Cursor string `json:"cursor"`
+}
+
+// Ordering options for ControlHistory connections
+type ControlHistoryOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order ControlHistories.
+	Field ControlHistoryOrderField `json:"field"`
 }
 
 // ControlHistoryWhereInput is used for filtering ControlHistory objects.
@@ -2116,8 +2154,8 @@ type ControlImplementation struct {
 	// date the control implementation was verified
 	VerificationDate *time.Time `json:"verificationDate,omitempty"`
 	// details of the control implementation
-	Details  *string    `json:"details,omitempty"`
-	Controls []*Control `json:"controls,omitempty"`
+	Details  *string            `json:"details,omitempty"`
+	Controls *ControlConnection `json:"controls"`
 }
 
 func (ControlImplementation) IsNode() {}
@@ -2201,6 +2239,14 @@ type ControlImplementationHistoryEdge struct {
 	Node *ControlImplementationHistory `json:"node,omitempty"`
 	// A cursor for use in pagination.
 	Cursor string `json:"cursor"`
+}
+
+// Ordering options for ControlImplementationHistory connections
+type ControlImplementationHistoryOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order ControlImplementationHistories.
+	Field ControlImplementationHistoryOrderField `json:"field"`
 }
 
 // ControlImplementationHistoryWhereInput is used for filtering ControlImplementationHistory objects.
@@ -2381,6 +2427,14 @@ type ControlImplementationHistoryWhereInput struct {
 	DetailsNotNil       *bool    `json:"detailsNotNil,omitempty"`
 	DetailsEqualFold    *string  `json:"detailsEqualFold,omitempty"`
 	DetailsContainsFold *string  `json:"detailsContainsFold,omitempty"`
+}
+
+// Ordering options for ControlImplementation connections
+type ControlImplementationOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order ControlImplementations.
+	Field ControlImplementationOrderField `json:"field"`
 }
 
 type ControlImplementationSearchResult struct {
@@ -2584,16 +2638,16 @@ type ControlObjective struct {
 	// provides edit access to the risk to members of the group
 	Editors []*Group `json:"editors,omitempty"`
 	// provides view access to the risk to members of the group
-	Viewers          []*Group          `json:"viewers,omitempty"`
-	Programs         []*Program        `json:"programs,omitempty"`
-	Evidence         []*Evidence       `json:"evidence,omitempty"`
-	Controls         []*Control        `json:"controls,omitempty"`
-	Subcontrols      []*Subcontrol     `json:"subcontrols,omitempty"`
-	InternalPolicies []*InternalPolicy `json:"internalPolicies,omitempty"`
-	Procedures       []*Procedure      `json:"procedures,omitempty"`
-	Risks            []*Risk           `json:"risks,omitempty"`
-	Narratives       []*Narrative      `json:"narratives,omitempty"`
-	Tasks            []*Task           `json:"tasks,omitempty"`
+	Viewers          []*Group                  `json:"viewers,omitempty"`
+	Programs         *ProgramConnection        `json:"programs"`
+	Evidence         *EvidenceConnection       `json:"evidence"`
+	Controls         *ControlConnection        `json:"controls"`
+	Subcontrols      *SubcontrolConnection     `json:"subcontrols"`
+	InternalPolicies *InternalPolicyConnection `json:"internalPolicies"`
+	Procedures       *ProcedureConnection      `json:"procedures"`
+	Risks            *RiskConnection           `json:"risks"`
+	Narratives       *NarrativeConnection      `json:"narratives"`
+	Tasks            *TaskConnection           `json:"tasks"`
 }
 
 func (ControlObjective) IsNode() {}
@@ -2687,6 +2741,14 @@ type ControlObjectiveHistoryEdge struct {
 	Node *ControlObjectiveHistory `json:"node,omitempty"`
 	// A cursor for use in pagination.
 	Cursor string `json:"cursor"`
+}
+
+// Ordering options for ControlObjectiveHistory connections
+type ControlObjectiveHistoryOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order ControlObjectiveHistories.
+	Field ControlObjectiveHistoryOrderField `json:"field"`
 }
 
 // ControlObjectiveHistoryWhereInput is used for filtering ControlObjectiveHistory objects.
@@ -2964,6 +3026,14 @@ type ControlObjectiveHistoryWhereInput struct {
 	SubcategoryNotNil       *bool    `json:"subcategoryNotNil,omitempty"`
 	SubcategoryEqualFold    *string  `json:"subcategoryEqualFold,omitempty"`
 	SubcategoryContainsFold *string  `json:"subcategoryContainsFold,omitempty"`
+}
+
+// Ordering options for ControlObjective connections
+type ControlObjectiveOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order ControlObjectives.
+	Field ControlObjectiveOrderField `json:"field"`
 }
 
 type ControlObjectiveSearchResult struct {
@@ -3262,6 +3332,14 @@ type ControlObjectiveWhereInput struct {
 	// tasks edge predicates
 	HasTasks     *bool             `json:"hasTasks,omitempty"`
 	HasTasksWith []*TaskWhereInput `json:"hasTasksWith,omitempty"`
+}
+
+// Ordering options for Control connections
+type ControlOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order Controls.
+	Field ControlOrderField `json:"field"`
 }
 
 type ControlSearchResult struct {
@@ -4644,11 +4722,11 @@ type DocumentData struct {
 	// the template id of the document
 	TemplateID string `json:"templateID"`
 	// the json data of the document
-	Data     map[string]any `json:"data"`
-	Owner    *Organization  `json:"owner,omitempty"`
-	Template *Template      `json:"template"`
-	Entity   []*Entity      `json:"entity,omitempty"`
-	Files    []*File        `json:"files,omitempty"`
+	Data     map[string]any    `json:"data"`
+	Owner    *Organization     `json:"owner,omitempty"`
+	Template *Template         `json:"template"`
+	Entity   *EntityConnection `json:"entity"`
+	Files    *FileConnection   `json:"files"`
 }
 
 func (DocumentData) IsNode() {}
@@ -5067,13 +5145,13 @@ type Entity struct {
 	// The type of the entity
 	EntityTypeID *string `json:"entityTypeID,omitempty"`
 	// status of the entity
-	Status     *string         `json:"status,omitempty"`
-	Owner      *Organization   `json:"owner,omitempty"`
-	Contacts   []*Contact      `json:"contacts,omitempty"`
-	Documents  []*DocumentData `json:"documents,omitempty"`
-	Notes      []*Note         `json:"notes,omitempty"`
-	Files      []*File         `json:"files,omitempty"`
-	EntityType *EntityType     `json:"entityType,omitempty"`
+	Status     *string                 `json:"status,omitempty"`
+	Owner      *Organization           `json:"owner,omitempty"`
+	Contacts   *ContactConnection      `json:"contacts"`
+	Documents  *DocumentDataConnection `json:"documents"`
+	Notes      *NoteConnection         `json:"notes"`
+	Files      *FileConnection         `json:"files"`
+	EntityType *EntityType             `json:"entityType,omitempty"`
 }
 
 func (Entity) IsNode() {}
@@ -5408,9 +5486,9 @@ type EntityType struct {
 	// the organization id that owns the object
 	OwnerID *string `json:"ownerID,omitempty"`
 	// the name of the entity
-	Name     string        `json:"name"`
-	Owner    *Organization `json:"owner,omitempty"`
-	Entities []*Entity     `json:"entities,omitempty"`
+	Name     string            `json:"name"`
+	Owner    *Organization     `json:"owner,omitempty"`
+	Entities *EntityConnection `json:"entities"`
 }
 
 func (EntityType) IsNode() {}
@@ -6025,23 +6103,23 @@ type Event struct {
 	CreatedBy *string    `json:"createdBy,omitempty"`
 	UpdatedBy *string    `json:"updatedBy,omitempty"`
 	// tags associated with the object
-	Tags                []string               `json:"tags,omitempty"`
-	EventID             *string                `json:"eventID,omitempty"`
-	CorrelationID       *string                `json:"correlationID,omitempty"`
-	EventType           string                 `json:"eventType"`
-	Metadata            map[string]any         `json:"metadata,omitempty"`
-	User                []*User                `json:"user,omitempty"`
-	Group               []*Group               `json:"group,omitempty"`
-	Integration         []*Integration         `json:"integration,omitempty"`
-	Organization        []*Organization        `json:"organization,omitempty"`
-	Invite              []*Invite              `json:"invite,omitempty"`
-	PersonalAccessToken []*PersonalAccessToken `json:"personalAccessToken,omitempty"`
-	Hush                []*Hush                `json:"hush,omitempty"`
-	Orgmembership       []*OrgMembership       `json:"orgmembership,omitempty"`
-	Groupmembership     []*GroupMembership     `json:"groupmembership,omitempty"`
-	Subscriber          []*Subscriber          `json:"subscriber,omitempty"`
-	File                []*File                `json:"file,omitempty"`
-	Orgsubscription     []*OrgSubscription     `json:"orgsubscription,omitempty"`
+	Tags                []string                       `json:"tags,omitempty"`
+	EventID             *string                        `json:"eventID,omitempty"`
+	CorrelationID       *string                        `json:"correlationID,omitempty"`
+	EventType           string                         `json:"eventType"`
+	Metadata            map[string]any                 `json:"metadata,omitempty"`
+	User                *UserConnection                `json:"user"`
+	Group               *GroupConnection               `json:"group"`
+	Integration         *IntegrationConnection         `json:"integration"`
+	Organization        *OrganizationConnection        `json:"organization"`
+	Invite              *InviteConnection              `json:"invite"`
+	PersonalAccessToken *PersonalAccessTokenConnection `json:"personalAccessToken"`
+	Hush                *HushConnection                `json:"hush"`
+	Orgmembership       *OrgMembershipConnection       `json:"orgmembership"`
+	Groupmembership     *GroupMembershipConnection     `json:"groupmembership"`
+	Subscriber          *SubscriberConnection          `json:"subscriber"`
+	File                *FileConnection                `json:"file"`
+	Orgsubscription     *OrgSubscriptionConnection     `json:"orgsubscription"`
 }
 
 func (Event) IsNode() {}
@@ -6466,14 +6544,14 @@ type Evidence struct {
 	// the url of the evidence if not uploaded directly to the system
 	URL *string `json:"url,omitempty"`
 	// the status of the evidence, ready, approved, needs renewal, missing artifact, rejected
-	Status            *enums.EvidenceStatus `json:"status,omitempty"`
-	Owner             *Organization         `json:"owner,omitempty"`
-	ControlObjectives []*ControlObjective   `json:"controlObjectives,omitempty"`
-	Controls          []*Control            `json:"controls,omitempty"`
-	Subcontrols       []*Subcontrol         `json:"subcontrols,omitempty"`
-	Files             []*File               `json:"files,omitempty"`
-	Programs          []*Program            `json:"programs,omitempty"`
-	Tasks             []*Task               `json:"tasks,omitempty"`
+	Status            *enums.EvidenceStatus       `json:"status,omitempty"`
+	Owner             *Organization               `json:"owner,omitempty"`
+	ControlObjectives *ControlObjectiveConnection `json:"controlObjectives"`
+	Controls          *ControlConnection          `json:"controls"`
+	Subcontrols       *SubcontrolConnection       `json:"subcontrols"`
+	Files             *FileConnection             `json:"files"`
+	Programs          *ProgramConnection          `json:"programs"`
+	Tasks             *TaskConnection             `json:"tasks"`
 }
 
 func (Evidence) IsNode() {}
@@ -6569,6 +6647,14 @@ type EvidenceHistoryEdge struct {
 	Node *EvidenceHistory `json:"node,omitempty"`
 	// A cursor for use in pagination.
 	Cursor string `json:"cursor"`
+}
+
+// Ordering options for EvidenceHistory connections
+type EvidenceHistoryOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order EvidenceHistories.
+	Field EvidenceHistoryOrderField `json:"field"`
 }
 
 // EvidenceHistoryWhereInput is used for filtering EvidenceHistory objects.
@@ -6839,6 +6925,14 @@ type EvidenceHistoryWhereInput struct {
 	StatusNotIn  []enums.EvidenceStatus `json:"statusNotIn,omitempty"`
 	StatusIsNil  *bool                  `json:"statusIsNil,omitempty"`
 	StatusNotNil *bool                  `json:"statusNotNil,omitempty"`
+}
+
+// Ordering options for Evidence connections
+type EvidenceOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order Evidences.
+	Field EvidenceOrderField `json:"field"`
 }
 
 type EvidenceSearchResult struct {
@@ -7148,20 +7242,20 @@ type File struct {
 	// the storage volume of the file which typically will be the organization ID the file belongs to - this is not a literal volume but the overlay file system mapping
 	StorageVolume *string `json:"storageVolume,omitempty"`
 	// the storage path is the second-level directory of the file path, typically the correlating logical object ID the file is associated with; files can be stand alone objects and not always correlated to a logical one, so this path of the tree may be empty
-	StoragePath         *string                `json:"storagePath,omitempty"`
-	User                []*User                `json:"user,omitempty"`
-	Organization        []*Organization        `json:"organization,omitempty"`
-	Group               []*Group               `json:"group,omitempty"`
-	Contact             []*Contact             `json:"contact,omitempty"`
-	Entity              []*Entity              `json:"entity,omitempty"`
-	UserSetting         []*UserSetting         `json:"userSetting,omitempty"`
-	OrganizationSetting []*OrganizationSetting `json:"organizationSetting,omitempty"`
-	Template            []*Template            `json:"template,omitempty"`
-	DocumentData        []*DocumentData        `json:"documentData,omitempty"`
-	Events              []*Event               `json:"events,omitempty"`
-	Program             []*Program             `json:"program,omitempty"`
-	Evidence            []*Evidence            `json:"evidence,omitempty"`
-	PresignedURL        *string                `json:"presignedURL,omitempty"`
+	StoragePath         *string                        `json:"storagePath,omitempty"`
+	User                *UserConnection                `json:"user"`
+	Organization        *OrganizationConnection        `json:"organization"`
+	Group               *GroupConnection               `json:"group"`
+	Contact             *ContactConnection             `json:"contact"`
+	Entity              *EntityConnection              `json:"entity"`
+	UserSetting         *UserSettingConnection         `json:"userSetting"`
+	OrganizationSetting *OrganizationSettingConnection `json:"organizationSetting"`
+	Template            *TemplateConnection            `json:"template"`
+	DocumentData        *DocumentDataConnection        `json:"documentData"`
+	Events              *EventConnection               `json:"events"`
+	Program             *ProgramConnection             `json:"program"`
+	Evidence            *EvidenceConnection            `json:"evidence"`
+	PresignedURL        *string                        `json:"presignedURL,omitempty"`
 }
 
 func (File) IsNode() {}
@@ -7931,34 +8025,34 @@ type Group struct {
 	// the URL to an image uploaded by the customer for the groups avatar image
 	LogoURL *string `json:"logoURL,omitempty"`
 	// The group's displayed 'friendly' name
-	DisplayName                   string              `json:"displayName"`
-	Owner                         *Organization       `json:"owner,omitempty"`
-	ProcedureEditors              []*Procedure        `json:"procedureEditors,omitempty"`
-	ProcedureBlockedGroups        []*Procedure        `json:"procedureBlockedGroups,omitempty"`
-	InternalPolicyEditors         []*InternalPolicy   `json:"internalPolicyEditors,omitempty"`
-	InternalPolicyBlockedGroups   []*InternalPolicy   `json:"internalPolicyBlockedGroups,omitempty"`
-	ProgramEditors                []*Program          `json:"programEditors,omitempty"`
-	ProgramBlockedGroups          []*Program          `json:"programBlockedGroups,omitempty"`
-	ProgramViewers                []*Program          `json:"programViewers,omitempty"`
-	RiskEditors                   []*Risk             `json:"riskEditors,omitempty"`
-	RiskBlockedGroups             []*Risk             `json:"riskBlockedGroups,omitempty"`
-	RiskViewers                   []*Risk             `json:"riskViewers,omitempty"`
-	ControlObjectiveEditors       []*ControlObjective `json:"controlObjectiveEditors,omitempty"`
-	ControlObjectiveBlockedGroups []*ControlObjective `json:"controlObjectiveBlockedGroups,omitempty"`
-	ControlObjectiveViewers       []*ControlObjective `json:"controlObjectiveViewers,omitempty"`
-	ControlEditors                []*Control          `json:"controlEditors,omitempty"`
-	ControlBlockedGroups          []*Control          `json:"controlBlockedGroups,omitempty"`
-	ControlViewers                []*Control          `json:"controlViewers,omitempty"`
-	NarrativeEditors              []*Narrative        `json:"narrativeEditors,omitempty"`
-	NarrativeBlockedGroups        []*Narrative        `json:"narrativeBlockedGroups,omitempty"`
-	NarrativeViewers              []*Narrative        `json:"narrativeViewers,omitempty"`
-	Setting                       *GroupSetting       `json:"setting,omitempty"`
-	Users                         []*User             `json:"users,omitempty"`
-	Events                        []*Event            `json:"events,omitempty"`
-	Integrations                  []*Integration      `json:"integrations,omitempty"`
-	Files                         []*File             `json:"files,omitempty"`
-	Tasks                         []*Task             `json:"tasks,omitempty"`
-	Members                       []*GroupMembership  `json:"members,omitempty"`
+	DisplayName                   string                 `json:"displayName"`
+	Owner                         *Organization          `json:"owner,omitempty"`
+	ProcedureEditors              []*Procedure           `json:"procedureEditors,omitempty"`
+	ProcedureBlockedGroups        []*Procedure           `json:"procedureBlockedGroups,omitempty"`
+	InternalPolicyEditors         []*InternalPolicy      `json:"internalPolicyEditors,omitempty"`
+	InternalPolicyBlockedGroups   []*InternalPolicy      `json:"internalPolicyBlockedGroups,omitempty"`
+	ProgramEditors                []*Program             `json:"programEditors,omitempty"`
+	ProgramBlockedGroups          []*Program             `json:"programBlockedGroups,omitempty"`
+	ProgramViewers                []*Program             `json:"programViewers,omitempty"`
+	RiskEditors                   []*Risk                `json:"riskEditors,omitempty"`
+	RiskBlockedGroups             []*Risk                `json:"riskBlockedGroups,omitempty"`
+	RiskViewers                   []*Risk                `json:"riskViewers,omitempty"`
+	ControlObjectiveEditors       []*ControlObjective    `json:"controlObjectiveEditors,omitempty"`
+	ControlObjectiveBlockedGroups []*ControlObjective    `json:"controlObjectiveBlockedGroups,omitempty"`
+	ControlObjectiveViewers       []*ControlObjective    `json:"controlObjectiveViewers,omitempty"`
+	ControlEditors                []*Control             `json:"controlEditors,omitempty"`
+	ControlBlockedGroups          []*Control             `json:"controlBlockedGroups,omitempty"`
+	ControlViewers                []*Control             `json:"controlViewers,omitempty"`
+	NarrativeEditors              []*Narrative           `json:"narrativeEditors,omitempty"`
+	NarrativeBlockedGroups        []*Narrative           `json:"narrativeBlockedGroups,omitempty"`
+	NarrativeViewers              []*Narrative           `json:"narrativeViewers,omitempty"`
+	Setting                       *GroupSetting          `json:"setting,omitempty"`
+	Users                         []*User                `json:"users,omitempty"`
+	Events                        *EventConnection       `json:"events"`
+	Integrations                  *IntegrationConnection `json:"integrations"`
+	Files                         *FileConnection        `json:"files"`
+	Tasks                         *TaskConnection        `json:"tasks"`
+	Members                       []*GroupMembership     `json:"members,omitempty"`
 	// permissions the group provides
 	Permissions []*GroupPermissions `json:"permissions,omitempty"`
 }
@@ -8350,6 +8444,14 @@ type GroupMembershipHistoryEdge struct {
 	Cursor string `json:"cursor"`
 }
 
+// Ordering options for GroupMembershipHistory connections
+type GroupMembershipHistoryOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order GroupMembershipHistories.
+	Field GroupMembershipHistoryOrderField `json:"field"`
+}
+
 // GroupMembershipHistoryWhereInput is used for filtering GroupMembershipHistory objects.
 // Input was generated by ent.
 type GroupMembershipHistoryWhereInput struct {
@@ -8511,6 +8613,14 @@ type GroupMembershipHistoryWhereInput struct {
 	UserIDHasSuffix    *string  `json:"userIDHasSuffix,omitempty"`
 	UserIDEqualFold    *string  `json:"userIDEqualFold,omitempty"`
 	UserIDContainsFold *string  `json:"userIDContainsFold,omitempty"`
+}
+
+// Ordering options for GroupMembership connections
+type GroupMembershipOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order GroupMemberships.
+	Field GroupMembershipOrderField `json:"field"`
 }
 
 // Return response for updateGroupMembership mutation
@@ -9329,11 +9439,10 @@ type Hush struct {
 	// the kind of secret, such as sshkey, certificate, api token, etc.
 	Kind *string `json:"kind,omitempty"`
 	// the generic name of a secret associated with the organization
-	SecretName *string `json:"secretName,omitempty"`
-	// the integration associated with the secret
-	Integrations []*Integration  `json:"integrations,omitempty"`
-	Organization []*Organization `json:"organization,omitempty"`
-	Events       []*Event        `json:"events,omitempty"`
+	SecretName   *string                 `json:"secretName,omitempty"`
+	Integrations *IntegrationConnection  `json:"integrations"`
+	Organization *OrganizationConnection `json:"organization"`
+	Events       *EventConnection        `json:"events"`
 }
 
 func (Hush) IsNode() {}
@@ -9783,12 +9892,11 @@ type Integration struct {
 	// the name of the integration - must be unique within the organization
 	Name string `json:"name"`
 	// a description of the integration
-	Description *string       `json:"description,omitempty"`
-	Kind        *string       `json:"kind,omitempty"`
-	Owner       *Organization `json:"owner,omitempty"`
-	// the secrets associated with the integration
-	Secrets []*Hush  `json:"secrets,omitempty"`
-	Events  []*Event `json:"events,omitempty"`
+	Description *string          `json:"description,omitempty"`
+	Kind        *string          `json:"kind,omitempty"`
+	Owner       *Organization    `json:"owner,omitempty"`
+	Secrets     *HushConnection  `json:"secrets"`
+	Events      *EventConnection `json:"events"`
 }
 
 func (Integration) IsNode() {}
@@ -10268,13 +10376,13 @@ type InternalPolicy struct {
 	// the group of users who are responsible for approving the policy
 	Approver *Group `json:"approver,omitempty"`
 	// temporary delegates for the policy, used for temporary approval
-	Delegate          *Group              `json:"delegate,omitempty"`
-	ControlObjectives []*ControlObjective `json:"controlObjectives,omitempty"`
-	Controls          []*Control          `json:"controls,omitempty"`
-	Procedures        []*Procedure        `json:"procedures,omitempty"`
-	Narratives        []*Narrative        `json:"narratives,omitempty"`
-	Tasks             []*Task             `json:"tasks,omitempty"`
-	Programs          []*Program          `json:"programs,omitempty"`
+	Delegate          *Group                      `json:"delegate,omitempty"`
+	ControlObjectives *ControlObjectiveConnection `json:"controlObjectives"`
+	Controls          *ControlConnection          `json:"controls"`
+	Procedures        *ProcedureConnection        `json:"procedures"`
+	Narratives        *NarrativeConnection        `json:"narratives"`
+	Tasks             *TaskConnection             `json:"tasks"`
+	Programs          *ProgramConnection          `json:"programs"`
 }
 
 func (InternalPolicy) IsNode() {}
@@ -10909,9 +11017,9 @@ type Invite struct {
 	// the number of attempts made to perform email send of the invitation, maximum of 5
 	SendAttempts int64 `json:"sendAttempts"`
 	// the user who initiated the invitation
-	RequestorID *string       `json:"requestorID,omitempty"`
-	Owner       *Organization `json:"owner,omitempty"`
-	Events      []*Event      `json:"events,omitempty"`
+	RequestorID *string          `json:"requestorID,omitempty"`
+	Owner       *Organization    `json:"owner,omitempty"`
+	Events      *EventConnection `json:"events"`
 }
 
 func (Invite) IsNode() {}
@@ -10950,6 +11058,14 @@ type InviteEdge struct {
 	Node *Invite `json:"node,omitempty"`
 	// A cursor for use in pagination.
 	Cursor string `json:"cursor"`
+}
+
+// Ordering options for Invite connections
+type InviteOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order Invites.
+	Field InviteOrderField `json:"field"`
 }
 
 // Return response for updateInvite mutation
@@ -11153,11 +11269,9 @@ type MappedControl struct {
 	// the type of mapping between the two controls, e.g. subset, intersect, equal, superset
 	MappingType *string `json:"mappingType,omitempty"`
 	// description of how the two controls are related
-	Relation *string `json:"relation,omitempty"`
-	// mapped controls that have a relation to each other
-	Controls []*Control `json:"controls,omitempty"`
-	// mapped subcontrols that have a relation to each other
-	Subcontrols []*Subcontrol `json:"subcontrols,omitempty"`
+	Relation    *string               `json:"relation,omitempty"`
+	Controls    *ControlConnection    `json:"controls"`
+	Subcontrols *SubcontrolConnection `json:"subcontrols"`
 }
 
 func (MappedControl) IsNode() {}
@@ -11235,6 +11349,14 @@ type MappedControlHistoryEdge struct {
 	Node *MappedControlHistory `json:"node,omitempty"`
 	// A cursor for use in pagination.
 	Cursor string `json:"cursor"`
+}
+
+// Ordering options for MappedControlHistory connections
+type MappedControlHistoryOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order MappedControlHistories.
+	Field MappedControlHistoryOrderField `json:"field"`
 }
 
 // MappedControlHistoryWhereInput is used for filtering MappedControlHistory objects.
@@ -11397,6 +11519,14 @@ type MappedControlHistoryWhereInput struct {
 	RelationNotNil       *bool    `json:"relationNotNil,omitempty"`
 	RelationEqualFold    *string  `json:"relationEqualFold,omitempty"`
 	RelationContainsFold *string  `json:"relationContainsFold,omitempty"`
+}
+
+// Ordering options for MappedControl connections
+type MappedControlOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order MappedControls.
+	Field MappedControlOrderField `json:"field"`
 }
 
 type MappedControlSearchResult struct {
@@ -11578,10 +11708,9 @@ type Narrative struct {
 	// provides edit access to the risk to members of the group
 	Editors []*Group `json:"editors,omitempty"`
 	// provides view access to the risk to members of the group
-	Viewers []*Group `json:"viewers,omitempty"`
-	// which controls are satisfied by the narrative
-	Satisfies []*Control `json:"satisfies,omitempty"`
-	Programs  []*Program `json:"programs,omitempty"`
+	Viewers   []*Group           `json:"viewers,omitempty"`
+	Satisfies *ControlConnection `json:"satisfies"`
+	Programs  *ProgramConnection `json:"programs"`
 }
 
 func (Narrative) IsNode() {}
@@ -11665,6 +11794,14 @@ type NarrativeHistoryEdge struct {
 	Node *NarrativeHistory `json:"node,omitempty"`
 	// A cursor for use in pagination.
 	Cursor string `json:"cursor"`
+}
+
+// Ordering options for NarrativeHistory connections
+type NarrativeHistoryOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order NarrativeHistories.
+	Field NarrativeHistoryOrderField `json:"field"`
 }
 
 // NarrativeHistoryWhereInput is used for filtering NarrativeHistory objects.
@@ -11871,6 +12008,14 @@ type NarrativeHistoryWhereInput struct {
 	DetailsNotNil       *bool    `json:"detailsNotNil,omitempty"`
 	DetailsEqualFold    *string  `json:"detailsEqualFold,omitempty"`
 	DetailsContainsFold *string  `json:"detailsContainsFold,omitempty"`
+}
+
+// Ordering options for Narrative connections
+type NarrativeOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order Narratives.
+	Field NarrativeOrderField `json:"field"`
 }
 
 type NarrativeSearchResult struct {
@@ -12593,19 +12738,19 @@ type OrgMembersInput struct {
 }
 
 type OrgMembership struct {
-	ID             string        `json:"id"`
-	CreatedAt      *time.Time    `json:"createdAt,omitempty"`
-	UpdatedAt      *time.Time    `json:"updatedAt,omitempty"`
-	CreatedBy      *string       `json:"createdBy,omitempty"`
-	UpdatedBy      *string       `json:"updatedBy,omitempty"`
-	DeletedAt      *time.Time    `json:"deletedAt,omitempty"`
-	DeletedBy      *string       `json:"deletedBy,omitempty"`
-	Role           enums.Role    `json:"role"`
-	OrganizationID string        `json:"organizationID"`
-	UserID         string        `json:"userID"`
-	Organization   *Organization `json:"organization"`
-	User           *User         `json:"user"`
-	Events         []*Event      `json:"events,omitempty"`
+	ID             string           `json:"id"`
+	CreatedAt      *time.Time       `json:"createdAt,omitempty"`
+	UpdatedAt      *time.Time       `json:"updatedAt,omitempty"`
+	CreatedBy      *string          `json:"createdBy,omitempty"`
+	UpdatedBy      *string          `json:"updatedBy,omitempty"`
+	DeletedAt      *time.Time       `json:"deletedAt,omitempty"`
+	DeletedBy      *string          `json:"deletedBy,omitempty"`
+	Role           enums.Role       `json:"role"`
+	OrganizationID string           `json:"organizationID"`
+	UserID         string           `json:"userID"`
+	Organization   *Organization    `json:"organization"`
+	User           *User            `json:"user"`
+	Events         *EventConnection `json:"events"`
 }
 
 func (OrgMembership) IsNode() {}
@@ -12680,6 +12825,14 @@ type OrgMembershipHistoryEdge struct {
 	Node *OrgMembershipHistory `json:"node,omitempty"`
 	// A cursor for use in pagination.
 	Cursor string `json:"cursor"`
+}
+
+// Ordering options for OrgMembershipHistory connections
+type OrgMembershipHistoryOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order OrgMembershipHistories.
+	Field OrgMembershipHistoryOrderField `json:"field"`
 }
 
 // OrgMembershipHistoryWhereInput is used for filtering OrgMembershipHistory objects.
@@ -12843,6 +12996,14 @@ type OrgMembershipHistoryWhereInput struct {
 	UserIDHasSuffix    *string  `json:"userIDHasSuffix,omitempty"`
 	UserIDEqualFold    *string  `json:"userIDEqualFold,omitempty"`
 	UserIDContainsFold *string  `json:"userIDContainsFold,omitempty"`
+}
+
+// Ordering options for OrgMembership connections
+type OrgMembershipOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order OrgMemberships.
+	Field OrgMembershipOrderField `json:"field"`
 }
 
 // Return response for updateOrgMembership mutation
@@ -13084,6 +13245,14 @@ type OrgSubscriptionHistoryEdge struct {
 	Node *OrgSubscriptionHistory `json:"node,omitempty"`
 	// A cursor for use in pagination.
 	Cursor string `json:"cursor"`
+}
+
+// Ordering options for OrgSubscriptionHistory connections
+type OrgSubscriptionHistoryOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order OrgSubscriptionHistories.
+	Field OrgSubscriptionHistoryOrderField `json:"field"`
 }
 
 // OrgSubscriptionHistoryWhereInput is used for filtering OrgSubscriptionHistory objects.
@@ -13356,6 +13525,14 @@ type OrgSubscriptionHistoryWhereInput struct {
 	PaymentMethodAddedNeq    *bool `json:"paymentMethodAddedNEQ,omitempty"`
 	PaymentMethodAddedIsNil  *bool `json:"paymentMethodAddedIsNil,omitempty"`
 	PaymentMethodAddedNotNil *bool `json:"paymentMethodAddedNotNil,omitempty"`
+}
+
+// Ordering options for OrgSubscription connections
+type OrgSubscriptionOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order OrgSubscriptions.
+	Field OrgSubscriptionOrderField `json:"field"`
 }
 
 type OrgSubscriptionSearchResult struct {
@@ -13655,41 +13832,41 @@ type Organization struct {
 	// groups that are allowed to create risks
 	RiskCreators []*Group `json:"riskCreators,omitempty"`
 	// groups that are allowed to create templates
-	TemplateCreators     []*Group                `json:"templateCreators,omitempty"`
-	Parent               *Organization           `json:"parent,omitempty"`
-	Children             *OrganizationConnection `json:"children"`
-	Setting              *OrganizationSetting    `json:"setting,omitempty"`
-	PersonalAccessTokens []*PersonalAccessToken  `json:"personalAccessTokens,omitempty"`
-	APITokens            []*APIToken             `json:"apiTokens,omitempty"`
-	Users                []*User                 `json:"users,omitempty"`
-	Files                []*File                 `json:"files,omitempty"`
-	Events               []*Event                `json:"events,omitempty"`
-	Secrets              []*Hush                 `json:"secrets,omitempty"`
-	AvatarFile           *File                   `json:"avatarFile,omitempty"`
-	Groups               []*Group                `json:"groups,omitempty"`
-	Templates            []*Template             `json:"templates,omitempty"`
-	Integrations         []*Integration          `json:"integrations,omitempty"`
-	DocumentData         []*DocumentData         `json:"documentData,omitempty"`
-	OrgSubscriptions     []*OrgSubscription      `json:"orgSubscriptions,omitempty"`
-	Invites              []*Invite               `json:"invites,omitempty"`
-	Subscribers          []*Subscriber           `json:"subscribers,omitempty"`
-	Entities             []*Entity               `json:"entities,omitempty"`
-	EntityTypes          []*EntityType           `json:"entityTypes,omitempty"`
-	Contacts             []*Contact              `json:"contacts,omitempty"`
-	Notes                []*Note                 `json:"notes,omitempty"`
-	Tasks                []*Task                 `json:"tasks,omitempty"`
-	Programs             []*Program              `json:"programs,omitempty"`
-	Procedures           []*Procedure            `json:"procedures,omitempty"`
-	InternalPolicies     []*InternalPolicy       `json:"internalPolicies,omitempty"`
-	Risks                []*Risk                 `json:"risks,omitempty"`
-	ControlObjectives    []*ControlObjective     `json:"controlObjectives,omitempty"`
-	Narratives           []*Narrative            `json:"narratives,omitempty"`
-	Controls             []*Control              `json:"controls,omitempty"`
-	Subcontrols          []*Subcontrol           `json:"subcontrols,omitempty"`
-	Evidence             []*Evidence             `json:"evidence,omitempty"`
-	Standards            []*Standard             `json:"standards,omitempty"`
-	ActionPlans          []*ActionPlan           `json:"actionPlans,omitempty"`
-	Members              []*OrgMembership        `json:"members,omitempty"`
+	TemplateCreators     []*Group                       `json:"templateCreators,omitempty"`
+	Parent               *Organization                  `json:"parent,omitempty"`
+	Children             *OrganizationConnection        `json:"children"`
+	Setting              *OrganizationSetting           `json:"setting,omitempty"`
+	PersonalAccessTokens *PersonalAccessTokenConnection `json:"personalAccessTokens"`
+	APITokens            *APITokenConnection            `json:"apiTokens"`
+	Users                []*User                        `json:"users,omitempty"`
+	Files                *FileConnection                `json:"files"`
+	Events               *EventConnection               `json:"events"`
+	Secrets              *HushConnection                `json:"secrets"`
+	AvatarFile           *File                          `json:"avatarFile,omitempty"`
+	Groups               *GroupConnection               `json:"groups"`
+	Templates            *TemplateConnection            `json:"templates"`
+	Integrations         *IntegrationConnection         `json:"integrations"`
+	DocumentData         *DocumentDataConnection        `json:"documentData"`
+	OrgSubscriptions     []*OrgSubscription             `json:"orgSubscriptions,omitempty"`
+	Invites              *InviteConnection              `json:"invites"`
+	Subscribers          *SubscriberConnection          `json:"subscribers"`
+	Entities             *EntityConnection              `json:"entities"`
+	EntityTypes          *EntityTypeConnection          `json:"entityTypes"`
+	Contacts             *ContactConnection             `json:"contacts"`
+	Notes                *NoteConnection                `json:"notes"`
+	Tasks                *TaskConnection                `json:"tasks"`
+	Programs             *ProgramConnection             `json:"programs"`
+	Procedures           *ProcedureConnection           `json:"procedures"`
+	InternalPolicies     *InternalPolicyConnection      `json:"internalPolicies"`
+	Risks                *RiskConnection                `json:"risks"`
+	ControlObjectives    *ControlObjectiveConnection    `json:"controlObjectives"`
+	Narratives           *NarrativeConnection           `json:"narratives"`
+	Controls             *ControlConnection             `json:"controls"`
+	Subcontrols          *SubcontrolConnection          `json:"subcontrols"`
+	Evidence             *EvidenceConnection            `json:"evidence"`
+	Standards            *StandardConnection            `json:"standards"`
+	ActionPlans          *ActionPlanConnection          `json:"actionPlans"`
+	Members              []*OrgMembership               `json:"members,omitempty"`
 }
 
 func (Organization) IsNode() {}
@@ -14040,9 +14217,9 @@ type OrganizationSetting struct {
 	// should we send email notifications related to billing
 	BillingNotificationsEnabled bool `json:"billingNotificationsEnabled"`
 	// domains allowed to access the organization, if empty all domains are allowed
-	AllowedEmailDomains []string      `json:"allowedEmailDomains,omitempty"`
-	Organization        *Organization `json:"organization,omitempty"`
-	Files               []*File       `json:"files,omitempty"`
+	AllowedEmailDomains []string        `json:"allowedEmailDomains,omitempty"`
+	Organization        *Organization   `json:"organization,omitempty"`
+	Files               *FileConnection `json:"files"`
 }
 
 func (OrganizationSetting) IsNode() {}
@@ -14918,11 +15095,10 @@ type PersonalAccessToken struct {
 	// the user who revoked the token
 	RevokedBy *string `json:"revokedBy,omitempty"`
 	// when the token was revoked
-	RevokedAt *time.Time `json:"revokedAt,omitempty"`
-	Owner     *User      `json:"owner"`
-	// the organization(s) the token is associated with
-	Organizations []*Organization `json:"organizations,omitempty"`
-	Events        []*Event        `json:"events,omitempty"`
+	RevokedAt     *time.Time              `json:"revokedAt,omitempty"`
+	Owner         *User                   `json:"owner"`
+	Organizations *OrganizationConnection `json:"organizations"`
+	Events        *EventConnection        `json:"events"`
 }
 
 func (PersonalAccessToken) IsNode() {}
@@ -15206,13 +15382,13 @@ type Procedure struct {
 	// the group of users who are responsible for approving the procedure
 	Approver *Group `json:"approver,omitempty"`
 	// temporary delegates for the procedure, used for temporary approval
-	Delegate         *Group            `json:"delegate,omitempty"`
-	Controls         []*Control        `json:"controls,omitempty"`
-	InternalPolicies []*InternalPolicy `json:"internalPolicies,omitempty"`
-	Narratives       []*Narrative      `json:"narratives,omitempty"`
-	Risks            []*Risk           `json:"risks,omitempty"`
-	Tasks            []*Task           `json:"tasks,omitempty"`
-	Programs         []*Program        `json:"programs,omitempty"`
+	Delegate         *Group                    `json:"delegate,omitempty"`
+	Controls         *ControlConnection        `json:"controls"`
+	InternalPolicies *InternalPolicyConnection `json:"internalPolicies"`
+	Narratives       *NarrativeConnection      `json:"narratives"`
+	Risks            *RiskConnection           `json:"risks"`
+	Tasks            *TaskConnection           `json:"tasks"`
+	Programs         *ProgramConnection        `json:"programs"`
 }
 
 func (Procedure) IsNode() {}
@@ -15863,21 +16039,21 @@ type Program struct {
 	// provides edit access to the risk to members of the group
 	Editors []*Group `json:"editors,omitempty"`
 	// provides view access to the risk to members of the group
-	Viewers           []*Group             `json:"viewers,omitempty"`
-	Controls          []*Control           `json:"controls,omitempty"`
-	Subcontrols       []*Subcontrol        `json:"subcontrols,omitempty"`
-	ControlObjectives []*ControlObjective  `json:"controlObjectives,omitempty"`
-	InternalPolicies  []*InternalPolicy    `json:"internalPolicies,omitempty"`
-	Procedures        []*Procedure         `json:"procedures,omitempty"`
-	Risks             []*Risk              `json:"risks,omitempty"`
-	Tasks             []*Task              `json:"tasks,omitempty"`
-	Notes             []*Note              `json:"notes,omitempty"`
-	Files             []*File              `json:"files,omitempty"`
-	Evidence          []*Evidence          `json:"evidence,omitempty"`
-	Narratives        []*Narrative         `json:"narratives,omitempty"`
-	ActionPlans       []*ActionPlan        `json:"actionPlans,omitempty"`
-	Users             []*User              `json:"users,omitempty"`
-	Members           []*ProgramMembership `json:"members,omitempty"`
+	Viewers           []*Group                     `json:"viewers,omitempty"`
+	Controls          *ControlConnection           `json:"controls"`
+	Subcontrols       *SubcontrolConnection        `json:"subcontrols"`
+	ControlObjectives *ControlObjectiveConnection  `json:"controlObjectives"`
+	InternalPolicies  *InternalPolicyConnection    `json:"internalPolicies"`
+	Procedures        *ProcedureConnection         `json:"procedures"`
+	Risks             *RiskConnection              `json:"risks"`
+	Tasks             *TaskConnection              `json:"tasks"`
+	Notes             *NoteConnection              `json:"notes"`
+	Files             *FileConnection              `json:"files"`
+	Evidence          *EvidenceConnection          `json:"evidence"`
+	Narratives        *NarrativeConnection         `json:"narratives"`
+	ActionPlans       []*ActionPlan                `json:"actionPlans,omitempty"`
+	Users             *UserConnection              `json:"users"`
+	Members           *ProgramMembershipConnection `json:"members"`
 }
 
 func (Program) IsNode() {}
@@ -15971,6 +16147,14 @@ type ProgramHistoryEdge struct {
 	Node *ProgramHistory `json:"node,omitempty"`
 	// A cursor for use in pagination.
 	Cursor string `json:"cursor"`
+}
+
+// Ordering options for ProgramHistory connections
+type ProgramHistoryOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order ProgramHistories.
+	Field ProgramHistoryOrderField `json:"field"`
 }
 
 // ProgramHistoryWhereInput is used for filtering ProgramHistory objects.
@@ -16288,6 +16472,14 @@ type ProgramMembershipHistoryEdge struct {
 	Cursor string `json:"cursor"`
 }
 
+// Ordering options for ProgramMembershipHistory connections
+type ProgramMembershipHistoryOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order ProgramMembershipHistories.
+	Field ProgramMembershipHistoryOrderField `json:"field"`
+}
+
 // ProgramMembershipHistoryWhereInput is used for filtering ProgramMembershipHistory objects.
 // Input was generated by ent.
 type ProgramMembershipHistoryWhereInput struct {
@@ -16451,6 +16643,14 @@ type ProgramMembershipHistoryWhereInput struct {
 	UserIDContainsFold *string  `json:"userIDContainsFold,omitempty"`
 }
 
+// Ordering options for ProgramMembership connections
+type ProgramMembershipOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order ProgramMemberships.
+	Field ProgramMembershipOrderField `json:"field"`
+}
+
 // Return response for updateProgramMembership mutation
 type ProgramMembershipUpdatePayload struct {
 	// Updated programMembership
@@ -16562,6 +16762,14 @@ type ProgramMembershipWhereInput struct {
 	RoleNotIn []enums.Role `json:"roleNotIn,omitempty"`
 	ProgramID *string      `json:"programID,omitempty"`
 	UserID    *string      `json:"userID,omitempty"`
+}
+
+// Ordering options for Program connections
+type ProgramOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order Programs.
+	Field ProgramOrderField `json:"field"`
 }
 
 type ProgramSearchResult struct {
@@ -16869,11 +17077,11 @@ type Risk struct {
 	// provides edit access to the risk to members of the group
 	Editors []*Group `json:"editors,omitempty"`
 	// provides view access to the risk to members of the group
-	Viewers     []*Group      `json:"viewers,omitempty"`
-	Control     []*Control    `json:"control,omitempty"`
-	Procedure   []*Procedure  `json:"procedure,omitempty"`
-	ActionPlans []*ActionPlan `json:"actionPlans,omitempty"`
-	Programs    []*Program    `json:"programs,omitempty"`
+	Viewers     []*Group              `json:"viewers,omitempty"`
+	Control     *ControlConnection    `json:"control"`
+	Procedure   *ProcedureConnection  `json:"procedure"`
+	ActionPlans *ActionPlanConnection `json:"actionPlans"`
+	Programs    *ProgramConnection    `json:"programs"`
 	// the group of users who are responsible for risk oversight
 	Stakeholder *Group `json:"stakeholder,omitempty"`
 	// temporary delegates for the risk, used for temporary ownership
@@ -16975,6 +17183,14 @@ type RiskHistoryEdge struct {
 	Node *RiskHistory `json:"node,omitempty"`
 	// A cursor for use in pagination.
 	Cursor string `json:"cursor"`
+}
+
+// Ordering options for RiskHistory connections
+type RiskHistoryOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order RiskHistories.
+	Field RiskHistoryOrderField `json:"field"`
 }
 
 // RiskHistoryWhereInput is used for filtering RiskHistory objects.
@@ -17261,6 +17477,14 @@ type RiskHistoryWhereInput struct {
 	BusinessCostsNotNil       *bool    `json:"businessCostsNotNil,omitempty"`
 	BusinessCostsEqualFold    *string  `json:"businessCostsEqualFold,omitempty"`
 	BusinessCostsContainsFold *string  `json:"businessCostsContainsFold,omitempty"`
+}
+
+// Ordering options for Risk connections
+type RiskOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order Risks.
+	Field RiskOrderField `json:"field"`
 }
 
 type RiskSearchResult struct {
@@ -17611,9 +17835,9 @@ type Standard struct {
 	// type of the standard - cybersecurity, healthcare , financial, etc.
 	StandardType *string `json:"standardType,omitempty"`
 	// version of the standard
-	Version  *string       `json:"version,omitempty"`
-	Owner    *Organization `json:"owner,omitempty"`
-	Controls []*Control    `json:"controls,omitempty"`
+	Version  *string            `json:"version,omitempty"`
+	Owner    *Organization      `json:"owner,omitempty"`
+	Controls *ControlConnection `json:"controls"`
 }
 
 func (Standard) IsNode() {}
@@ -17719,6 +17943,14 @@ type StandardHistoryEdge struct {
 	Node *StandardHistory `json:"node,omitempty"`
 	// A cursor for use in pagination.
 	Cursor string `json:"cursor"`
+}
+
+// Ordering options for StandardHistory connections
+type StandardHistoryOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order StandardHistories.
+	Field StandardHistoryOrderField `json:"field"`
 }
 
 // StandardHistoryWhereInput is used for filtering StandardHistory objects.
@@ -18045,6 +18277,14 @@ type StandardHistoryWhereInput struct {
 	VersionNotNil       *bool    `json:"versionNotNil,omitempty"`
 	VersionEqualFold    *string  `json:"versionEqualFold,omitempty"`
 	VersionContainsFold *string  `json:"versionContainsFold,omitempty"`
+}
+
+// Ordering options for Standard connections
+type StandardOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order Standards.
+	Field StandardOrderField `json:"field"`
 }
 
 type StandardSearchResult struct {
@@ -18410,15 +18650,15 @@ type Subcontrol struct {
 	Owner     *Organization `json:"owner,omitempty"`
 	Control   *Control      `json:"control"`
 	// mapped subcontrols that have a relation to another control or subcontrol
-	MappedControls    []*MappedControl    `json:"mappedControls,omitempty"`
-	Evidence          []*Evidence         `json:"evidence,omitempty"`
-	ControlObjectives []*ControlObjective `json:"controlObjectives,omitempty"`
-	Tasks             []*Task             `json:"tasks,omitempty"`
-	Narratives        []*Narrative        `json:"narratives,omitempty"`
-	Risks             []*Risk             `json:"risks,omitempty"`
-	ActionPlans       []*ActionPlan       `json:"actionPlans,omitempty"`
-	Procedures        []*Procedure        `json:"procedures,omitempty"`
-	InternalPolicies  []*InternalPolicy   `json:"internalPolicies,omitempty"`
+	MappedControls    []*MappedControl            `json:"mappedControls,omitempty"`
+	Evidence          *EvidenceConnection         `json:"evidence"`
+	ControlObjectives *ControlObjectiveConnection `json:"controlObjectives"`
+	Tasks             *TaskConnection             `json:"tasks"`
+	Narratives        *NarrativeConnection        `json:"narratives"`
+	Risks             *RiskConnection             `json:"risks"`
+	ActionPlans       *ActionPlanConnection       `json:"actionPlans"`
+	Procedures        *ProcedureConnection        `json:"procedures"`
+	InternalPolicies  *InternalPolicyConnection   `json:"internalPolicies"`
 	// the user who is responsible for the subcontrol, defaults to the parent control owner if not set
 	ControlOwner *Group `json:"controlOwner,omitempty"`
 	// temporary delegate for the control, used for temporary control ownership
@@ -18532,6 +18772,14 @@ type SubcontrolHistoryEdge struct {
 	Node *SubcontrolHistory `json:"node,omitempty"`
 	// A cursor for use in pagination.
 	Cursor string `json:"cursor"`
+}
+
+// Ordering options for SubcontrolHistory connections
+type SubcontrolHistoryOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order SubcontrolHistories.
+	Field SubcontrolHistoryOrderField `json:"field"`
 }
 
 // SubcontrolHistoryWhereInput is used for filtering SubcontrolHistory objects.
@@ -18814,6 +19062,14 @@ type SubcontrolHistoryWhereInput struct {
 	ControlIDHasSuffix    *string  `json:"controlIDHasSuffix,omitempty"`
 	ControlIDEqualFold    *string  `json:"controlIDEqualFold,omitempty"`
 	ControlIDContainsFold *string  `json:"controlIDContainsFold,omitempty"`
+}
+
+// Ordering options for Subcontrol connections
+type SubcontrolOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order Subcontrols.
+	Field SubcontrolOrderField `json:"field"`
 }
 
 type SubcontrolSearchResult struct {
@@ -19140,9 +19396,9 @@ type Subscriber struct {
 	// indicates if the phone number has been verified
 	VerifiedPhone bool `json:"verifiedPhone"`
 	// indicates if the subscriber is active or not, active users will have at least one verified contact method
-	Active bool          `json:"active"`
-	Owner  *Organization `json:"owner,omitempty"`
-	Events []*Event      `json:"events,omitempty"`
+	Active bool             `json:"active"`
+	Owner  *Organization    `json:"owner,omitempty"`
+	Events *EventConnection `json:"events"`
 }
 
 func (Subscriber) IsNode() {}
@@ -19181,6 +19437,14 @@ type SubscriberEdge struct {
 	Node *Subscriber `json:"node,omitempty"`
 	// A cursor for use in pagination.
 	Cursor string `json:"cursor"`
+}
+
+// Ordering options for Subscriber connections
+type SubscriberOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order Subscribers.
+	Field SubscriberOrderField `json:"field"`
 }
 
 type SubscriberSearchResult struct {
@@ -19550,20 +19814,19 @@ type Task struct {
 	// the id of the user who was assigned the task
 	AssigneeID *string `json:"assigneeID,omitempty"`
 	// the id of the user who assigned the task, can be left empty if created by the system or a service token
-	AssignerID *string       `json:"assignerID,omitempty"`
-	Owner      *Organization `json:"owner,omitempty"`
-	Assigner   *User         `json:"assigner,omitempty"`
-	Assignee   *User         `json:"assignee,omitempty"`
-	// conversations related to the task
-	Comments         []*Note             `json:"comments,omitempty"`
-	Group            []*Group            `json:"group,omitempty"`
-	InternalPolicy   []*InternalPolicy   `json:"internalPolicy,omitempty"`
-	Procedure        []*Procedure        `json:"procedure,omitempty"`
-	Control          []*Control          `json:"control,omitempty"`
-	ControlObjective []*ControlObjective `json:"controlObjective,omitempty"`
-	Subcontrol       []*Subcontrol       `json:"subcontrol,omitempty"`
-	Program          []*Program          `json:"program,omitempty"`
-	Evidence         []*Evidence         `json:"evidence,omitempty"`
+	AssignerID       *string                     `json:"assignerID,omitempty"`
+	Owner            *Organization               `json:"owner,omitempty"`
+	Assigner         *User                       `json:"assigner,omitempty"`
+	Assignee         *User                       `json:"assignee,omitempty"`
+	Comments         *NoteConnection             `json:"comments"`
+	Group            *GroupConnection            `json:"group"`
+	InternalPolicy   *InternalPolicyConnection   `json:"internalPolicy"`
+	Procedure        *ProcedureConnection        `json:"procedure"`
+	Control          *ControlConnection          `json:"control"`
+	ControlObjective *ControlObjectiveConnection `json:"controlObjective"`
+	Subcontrol       *SubcontrolConnection       `json:"subcontrol"`
+	Program          *ProgramConnection          `json:"program"`
+	Evidence         *EvidenceConnection         `json:"evidence"`
 }
 
 func (Task) IsNode() {}
@@ -19659,6 +19922,14 @@ type TaskHistoryEdge struct {
 	Node *TaskHistory `json:"node,omitempty"`
 	// A cursor for use in pagination.
 	Cursor string `json:"cursor"`
+}
+
+// Ordering options for TaskHistory connections
+type TaskHistoryOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order TaskHistories.
+	Field TaskHistoryOrderField `json:"field"`
 }
 
 // TaskHistoryWhereInput is used for filtering TaskHistory objects.
@@ -19940,6 +20211,14 @@ type TaskHistoryWhereInput struct {
 	AssignerIDNotNil       *bool    `json:"assignerIDNotNil,omitempty"`
 	AssignerIDEqualFold    *string  `json:"assignerIDEqualFold,omitempty"`
 	AssignerIDContainsFold *string  `json:"assignerIDContainsFold,omitempty"`
+}
+
+// Ordering options for Task connections
+type TaskOrder struct {
+	// The ordering direction.
+	Direction OrderDirection `json:"direction"`
+	// The field by which to order Tasks.
+	Field TaskOrderField `json:"field"`
 }
 
 type TaskSearchResult struct {
@@ -20262,10 +20541,10 @@ type Template struct {
 	// the jsonschema object of the template
 	Jsonconfig map[string]any `json:"jsonconfig"`
 	// the uischema for the template to render in the UI
-	Uischema  map[string]any  `json:"uischema,omitempty"`
-	Owner     *Organization   `json:"owner,omitempty"`
-	Documents []*DocumentData `json:"documents,omitempty"`
-	Files     []*File         `json:"files,omitempty"`
+	Uischema  map[string]any          `json:"uischema,omitempty"`
+	Owner     *Organization           `json:"owner,omitempty"`
+	Documents *DocumentDataConnection `json:"documents"`
+	Files     *FileConnection         `json:"files"`
 }
 
 func (Template) IsNode() {}
@@ -22483,23 +22762,23 @@ type User struct {
 	// auth provider used to register the account
 	AuthProvider enums.AuthProvider `json:"authProvider"`
 	// the user's role
-	Role                 *enums.Role            `json:"role,omitempty"`
-	PersonalAccessTokens []*PersonalAccessToken `json:"personalAccessTokens,omitempty"`
-	TfaSettings          []*TFASetting          `json:"tfaSettings,omitempty"`
-	Setting              *UserSetting           `json:"setting"`
-	Groups               []*Group               `json:"groups,omitempty"`
-	Organizations        []*Organization        `json:"organizations,omitempty"`
-	Files                []*File                `json:"files,omitempty"`
-	AvatarFile           *File                  `json:"avatarFile,omitempty"`
-	Events               []*Event               `json:"events,omitempty"`
-	ActionPlans          []*ActionPlan          `json:"actionPlans,omitempty"`
-	Subcontrols          []*Subcontrol          `json:"subcontrols,omitempty"`
-	AssignerTasks        []*Task                `json:"assignerTasks,omitempty"`
-	AssigneeTasks        []*Task                `json:"assigneeTasks,omitempty"`
-	Programs             []*Program             `json:"programs,omitempty"`
-	GroupMemberships     []*GroupMembership     `json:"groupMemberships,omitempty"`
-	OrgMemberships       []*OrgMembership       `json:"orgMemberships,omitempty"`
-	ProgramMemberships   []*ProgramMembership   `json:"programMemberships,omitempty"`
+	Role                 *enums.Role                    `json:"role,omitempty"`
+	PersonalAccessTokens *PersonalAccessTokenConnection `json:"personalAccessTokens"`
+	TfaSettings          *TFASettingConnection          `json:"tfaSettings"`
+	Setting              *UserSetting                   `json:"setting"`
+	Groups               []*Group                       `json:"groups,omitempty"`
+	Organizations        []*Organization                `json:"organizations,omitempty"`
+	Files                *FileConnection                `json:"files"`
+	AvatarFile           *File                          `json:"avatarFile,omitempty"`
+	Events               *EventConnection               `json:"events"`
+	ActionPlans          *ActionPlanConnection          `json:"actionPlans"`
+	Subcontrols          *SubcontrolConnection          `json:"subcontrols"`
+	AssignerTasks        *TaskConnection                `json:"assignerTasks"`
+	AssigneeTasks        *TaskConnection                `json:"assigneeTasks"`
+	Programs             []*Program                     `json:"programs,omitempty"`
+	GroupMemberships     []*GroupMembership             `json:"groupMemberships,omitempty"`
+	OrgMemberships       []*OrgMembership               `json:"orgMemberships,omitempty"`
+	ProgramMemberships   []*ProgramMembership           `json:"programMemberships,omitempty"`
 }
 
 func (User) IsNode() {}
@@ -22931,8 +23210,8 @@ type UserSetting struct {
 	IsTfaEnabled *bool `json:"isTfaEnabled,omitempty"`
 	User         *User `json:"user,omitempty"`
 	// organization to load on user login
-	DefaultOrg *Organization `json:"defaultOrg,omitempty"`
-	Files      []*File       `json:"files,omitempty"`
+	DefaultOrg *Organization   `json:"defaultOrg,omitempty"`
+	Files      *FileConnection `json:"files"`
 }
 
 func (UserSetting) IsNode() {}
@@ -23696,22 +23975,496 @@ type UserWhereInput struct {
 	HasProgramMembershipsWith []*ProgramMembershipWhereInput `json:"hasProgramMembershipsWith,omitempty"`
 }
 
+// Properties by which ActionPlanHistory connections can be ordered.
+type ActionPlanHistoryOrderField string
+
+const (
+	ActionPlanHistoryOrderFieldDueDate  ActionPlanHistoryOrderField = "due_date"
+	ActionPlanHistoryOrderFieldPriority ActionPlanHistoryOrderField = "PRIORITY"
+	ActionPlanHistoryOrderFieldSource   ActionPlanHistoryOrderField = "source"
+)
+
+var AllActionPlanHistoryOrderField = []ActionPlanHistoryOrderField{
+	ActionPlanHistoryOrderFieldDueDate,
+	ActionPlanHistoryOrderFieldPriority,
+	ActionPlanHistoryOrderFieldSource,
+}
+
+func (e ActionPlanHistoryOrderField) IsValid() bool {
+	switch e {
+	case ActionPlanHistoryOrderFieldDueDate, ActionPlanHistoryOrderFieldPriority, ActionPlanHistoryOrderFieldSource:
+		return true
+	}
+	return false
+}
+
+func (e ActionPlanHistoryOrderField) String() string {
+	return string(e)
+}
+
+func (e *ActionPlanHistoryOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = ActionPlanHistoryOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid ActionPlanHistoryOrderField", str)
+	}
+	return nil
+}
+
+func (e ActionPlanHistoryOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which ActionPlan connections can be ordered.
+type ActionPlanOrderField string
+
+const (
+	ActionPlanOrderFieldDueDate  ActionPlanOrderField = "due_date"
+	ActionPlanOrderFieldPriority ActionPlanOrderField = "PRIORITY"
+	ActionPlanOrderFieldSource   ActionPlanOrderField = "source"
+)
+
+var AllActionPlanOrderField = []ActionPlanOrderField{
+	ActionPlanOrderFieldDueDate,
+	ActionPlanOrderFieldPriority,
+	ActionPlanOrderFieldSource,
+}
+
+func (e ActionPlanOrderField) IsValid() bool {
+	switch e {
+	case ActionPlanOrderFieldDueDate, ActionPlanOrderFieldPriority, ActionPlanOrderFieldSource:
+		return true
+	}
+	return false
+}
+
+func (e ActionPlanOrderField) String() string {
+	return string(e)
+}
+
+func (e *ActionPlanOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = ActionPlanOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid ActionPlanOrderField", str)
+	}
+	return nil
+}
+
+func (e ActionPlanOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which ContactHistory connections can be ordered.
+type ContactHistoryOrderField string
+
+const (
+	ContactHistoryOrderFieldFullName ContactHistoryOrderField = "full_name"
+	ContactHistoryOrderFieldTitle    ContactHistoryOrderField = "title"
+	ContactHistoryOrderFieldCompany  ContactHistoryOrderField = "company"
+	ContactHistoryOrderFieldEmail    ContactHistoryOrderField = "email"
+	ContactHistoryOrderFieldStatus   ContactHistoryOrderField = "STATUS"
+)
+
+var AllContactHistoryOrderField = []ContactHistoryOrderField{
+	ContactHistoryOrderFieldFullName,
+	ContactHistoryOrderFieldTitle,
+	ContactHistoryOrderFieldCompany,
+	ContactHistoryOrderFieldEmail,
+	ContactHistoryOrderFieldStatus,
+}
+
+func (e ContactHistoryOrderField) IsValid() bool {
+	switch e {
+	case ContactHistoryOrderFieldFullName, ContactHistoryOrderFieldTitle, ContactHistoryOrderFieldCompany, ContactHistoryOrderFieldEmail, ContactHistoryOrderFieldStatus:
+		return true
+	}
+	return false
+}
+
+func (e ContactHistoryOrderField) String() string {
+	return string(e)
+}
+
+func (e *ContactHistoryOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = ContactHistoryOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid ContactHistoryOrderField", str)
+	}
+	return nil
+}
+
+func (e ContactHistoryOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which Contact connections can be ordered.
+type ContactOrderField string
+
+const (
+	ContactOrderFieldFullName ContactOrderField = "full_name"
+	ContactOrderFieldTitle    ContactOrderField = "title"
+	ContactOrderFieldCompany  ContactOrderField = "company"
+	ContactOrderFieldEmail    ContactOrderField = "email"
+	ContactOrderFieldStatus   ContactOrderField = "STATUS"
+)
+
+var AllContactOrderField = []ContactOrderField{
+	ContactOrderFieldFullName,
+	ContactOrderFieldTitle,
+	ContactOrderFieldCompany,
+	ContactOrderFieldEmail,
+	ContactOrderFieldStatus,
+}
+
+func (e ContactOrderField) IsValid() bool {
+	switch e {
+	case ContactOrderFieldFullName, ContactOrderFieldTitle, ContactOrderFieldCompany, ContactOrderFieldEmail, ContactOrderFieldStatus:
+		return true
+	}
+	return false
+}
+
+func (e ContactOrderField) String() string {
+	return string(e)
+}
+
+func (e *ContactOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = ContactOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid ContactOrderField", str)
+	}
+	return nil
+}
+
+func (e ContactOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which ControlHistory connections can be ordered.
+type ControlHistoryOrderField string
+
+const (
+	ControlHistoryOrderFieldStatus      ControlHistoryOrderField = "status"
+	ControlHistoryOrderFieldSource      ControlHistoryOrderField = "SOURCE"
+	ControlHistoryOrderFieldControlType ControlHistoryOrderField = "CONTROL_TYPE"
+	ControlHistoryOrderFieldCategory    ControlHistoryOrderField = "category"
+	ControlHistoryOrderFieldSubcategory ControlHistoryOrderField = "subcategory"
+)
+
+var AllControlHistoryOrderField = []ControlHistoryOrderField{
+	ControlHistoryOrderFieldStatus,
+	ControlHistoryOrderFieldSource,
+	ControlHistoryOrderFieldControlType,
+	ControlHistoryOrderFieldCategory,
+	ControlHistoryOrderFieldSubcategory,
+}
+
+func (e ControlHistoryOrderField) IsValid() bool {
+	switch e {
+	case ControlHistoryOrderFieldStatus, ControlHistoryOrderFieldSource, ControlHistoryOrderFieldControlType, ControlHistoryOrderFieldCategory, ControlHistoryOrderFieldSubcategory:
+		return true
+	}
+	return false
+}
+
+func (e ControlHistoryOrderField) String() string {
+	return string(e)
+}
+
+func (e *ControlHistoryOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = ControlHistoryOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid ControlHistoryOrderField", str)
+	}
+	return nil
+}
+
+func (e ControlHistoryOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which ControlImplementationHistory connections can be ordered.
+type ControlImplementationHistoryOrderField string
+
+const (
+	ControlImplementationHistoryOrderFieldStatus             ControlImplementationHistoryOrderField = "STATUS"
+	ControlImplementationHistoryOrderFieldImplementationDate ControlImplementationHistoryOrderField = "implementation_date"
+	ControlImplementationHistoryOrderFieldVerified           ControlImplementationHistoryOrderField = "verified"
+	ControlImplementationHistoryOrderFieldVerificationDate   ControlImplementationHistoryOrderField = "verification_date"
+)
+
+var AllControlImplementationHistoryOrderField = []ControlImplementationHistoryOrderField{
+	ControlImplementationHistoryOrderFieldStatus,
+	ControlImplementationHistoryOrderFieldImplementationDate,
+	ControlImplementationHistoryOrderFieldVerified,
+	ControlImplementationHistoryOrderFieldVerificationDate,
+}
+
+func (e ControlImplementationHistoryOrderField) IsValid() bool {
+	switch e {
+	case ControlImplementationHistoryOrderFieldStatus, ControlImplementationHistoryOrderFieldImplementationDate, ControlImplementationHistoryOrderFieldVerified, ControlImplementationHistoryOrderFieldVerificationDate:
+		return true
+	}
+	return false
+}
+
+func (e ControlImplementationHistoryOrderField) String() string {
+	return string(e)
+}
+
+func (e *ControlImplementationHistoryOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = ControlImplementationHistoryOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid ControlImplementationHistoryOrderField", str)
+	}
+	return nil
+}
+
+func (e ControlImplementationHistoryOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which ControlImplementation connections can be ordered.
+type ControlImplementationOrderField string
+
+const (
+	ControlImplementationOrderFieldStatus             ControlImplementationOrderField = "STATUS"
+	ControlImplementationOrderFieldImplementationDate ControlImplementationOrderField = "implementation_date"
+	ControlImplementationOrderFieldVerified           ControlImplementationOrderField = "verified"
+	ControlImplementationOrderFieldVerificationDate   ControlImplementationOrderField = "verification_date"
+)
+
+var AllControlImplementationOrderField = []ControlImplementationOrderField{
+	ControlImplementationOrderFieldStatus,
+	ControlImplementationOrderFieldImplementationDate,
+	ControlImplementationOrderFieldVerified,
+	ControlImplementationOrderFieldVerificationDate,
+}
+
+func (e ControlImplementationOrderField) IsValid() bool {
+	switch e {
+	case ControlImplementationOrderFieldStatus, ControlImplementationOrderFieldImplementationDate, ControlImplementationOrderFieldVerified, ControlImplementationOrderFieldVerificationDate:
+		return true
+	}
+	return false
+}
+
+func (e ControlImplementationOrderField) String() string {
+	return string(e)
+}
+
+func (e *ControlImplementationOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = ControlImplementationOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid ControlImplementationOrderField", str)
+	}
+	return nil
+}
+
+func (e ControlImplementationOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which ControlObjectiveHistory connections can be ordered.
+type ControlObjectiveHistoryOrderField string
+
+const (
+	ControlObjectiveHistoryOrderFieldName                 ControlObjectiveHistoryOrderField = "name"
+	ControlObjectiveHistoryOrderFieldStatus               ControlObjectiveHistoryOrderField = "status"
+	ControlObjectiveHistoryOrderFieldSource               ControlObjectiveHistoryOrderField = "SOURCE"
+	ControlObjectiveHistoryOrderFieldControlObjectiveType ControlObjectiveHistoryOrderField = "control_objective_type"
+	ControlObjectiveHistoryOrderFieldCategory             ControlObjectiveHistoryOrderField = "category"
+	ControlObjectiveHistoryOrderFieldSubcategory          ControlObjectiveHistoryOrderField = "subcategory"
+)
+
+var AllControlObjectiveHistoryOrderField = []ControlObjectiveHistoryOrderField{
+	ControlObjectiveHistoryOrderFieldName,
+	ControlObjectiveHistoryOrderFieldStatus,
+	ControlObjectiveHistoryOrderFieldSource,
+	ControlObjectiveHistoryOrderFieldControlObjectiveType,
+	ControlObjectiveHistoryOrderFieldCategory,
+	ControlObjectiveHistoryOrderFieldSubcategory,
+}
+
+func (e ControlObjectiveHistoryOrderField) IsValid() bool {
+	switch e {
+	case ControlObjectiveHistoryOrderFieldName, ControlObjectiveHistoryOrderFieldStatus, ControlObjectiveHistoryOrderFieldSource, ControlObjectiveHistoryOrderFieldControlObjectiveType, ControlObjectiveHistoryOrderFieldCategory, ControlObjectiveHistoryOrderFieldSubcategory:
+		return true
+	}
+	return false
+}
+
+func (e ControlObjectiveHistoryOrderField) String() string {
+	return string(e)
+}
+
+func (e *ControlObjectiveHistoryOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = ControlObjectiveHistoryOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid ControlObjectiveHistoryOrderField", str)
+	}
+	return nil
+}
+
+func (e ControlObjectiveHistoryOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which ControlObjective connections can be ordered.
+type ControlObjectiveOrderField string
+
+const (
+	ControlObjectiveOrderFieldName                 ControlObjectiveOrderField = "name"
+	ControlObjectiveOrderFieldStatus               ControlObjectiveOrderField = "status"
+	ControlObjectiveOrderFieldSource               ControlObjectiveOrderField = "SOURCE"
+	ControlObjectiveOrderFieldControlObjectiveType ControlObjectiveOrderField = "control_objective_type"
+	ControlObjectiveOrderFieldCategory             ControlObjectiveOrderField = "category"
+	ControlObjectiveOrderFieldSubcategory          ControlObjectiveOrderField = "subcategory"
+)
+
+var AllControlObjectiveOrderField = []ControlObjectiveOrderField{
+	ControlObjectiveOrderFieldName,
+	ControlObjectiveOrderFieldStatus,
+	ControlObjectiveOrderFieldSource,
+	ControlObjectiveOrderFieldControlObjectiveType,
+	ControlObjectiveOrderFieldCategory,
+	ControlObjectiveOrderFieldSubcategory,
+}
+
+func (e ControlObjectiveOrderField) IsValid() bool {
+	switch e {
+	case ControlObjectiveOrderFieldName, ControlObjectiveOrderFieldStatus, ControlObjectiveOrderFieldSource, ControlObjectiveOrderFieldControlObjectiveType, ControlObjectiveOrderFieldCategory, ControlObjectiveOrderFieldSubcategory:
+		return true
+	}
+	return false
+}
+
+func (e ControlObjectiveOrderField) String() string {
+	return string(e)
+}
+
+func (e *ControlObjectiveOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = ControlObjectiveOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid ControlObjectiveOrderField", str)
+	}
+	return nil
+}
+
+func (e ControlObjectiveOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which Control connections can be ordered.
+type ControlOrderField string
+
+const (
+	ControlOrderFieldStatus      ControlOrderField = "status"
+	ControlOrderFieldSource      ControlOrderField = "SOURCE"
+	ControlOrderFieldControlType ControlOrderField = "CONTROL_TYPE"
+	ControlOrderFieldCategory    ControlOrderField = "category"
+	ControlOrderFieldSubcategory ControlOrderField = "subcategory"
+)
+
+var AllControlOrderField = []ControlOrderField{
+	ControlOrderFieldStatus,
+	ControlOrderFieldSource,
+	ControlOrderFieldControlType,
+	ControlOrderFieldCategory,
+	ControlOrderFieldSubcategory,
+}
+
+func (e ControlOrderField) IsValid() bool {
+	switch e {
+	case ControlOrderFieldStatus, ControlOrderFieldSource, ControlOrderFieldControlType, ControlOrderFieldCategory, ControlOrderFieldSubcategory:
+		return true
+	}
+	return false
+}
+
+func (e ControlOrderField) String() string {
+	return string(e)
+}
+
+func (e *ControlOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = ControlOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid ControlOrderField", str)
+	}
+	return nil
+}
+
+func (e ControlOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
 // Properties by which EntityHistory connections can be ordered.
 type EntityHistoryOrderField string
 
 const (
 	EntityHistoryOrderFieldName        EntityHistoryOrderField = "name"
 	EntityHistoryOrderFieldDisplayName EntityHistoryOrderField = "display_name"
+	EntityHistoryOrderFieldStatus      EntityHistoryOrderField = "status"
 )
 
 var AllEntityHistoryOrderField = []EntityHistoryOrderField{
 	EntityHistoryOrderFieldName,
 	EntityHistoryOrderFieldDisplayName,
+	EntityHistoryOrderFieldStatus,
 }
 
 func (e EntityHistoryOrderField) IsValid() bool {
 	switch e {
-	case EntityHistoryOrderFieldName, EntityHistoryOrderFieldDisplayName:
+	case EntityHistoryOrderFieldName, EntityHistoryOrderFieldDisplayName, EntityHistoryOrderFieldStatus:
 		return true
 	}
 	return false
@@ -23744,16 +24497,18 @@ type EntityOrderField string
 const (
 	EntityOrderFieldName        EntityOrderField = "name"
 	EntityOrderFieldDisplayName EntityOrderField = "display_name"
+	EntityOrderFieldStatus      EntityOrderField = "status"
 )
 
 var AllEntityOrderField = []EntityOrderField{
 	EntityOrderFieldName,
 	EntityOrderFieldDisplayName,
+	EntityOrderFieldStatus,
 }
 
 func (e EntityOrderField) IsValid() bool {
 	switch e {
-	case EntityOrderFieldName, EntityOrderFieldDisplayName:
+	case EntityOrderFieldName, EntityOrderFieldDisplayName, EntityOrderFieldStatus:
 		return true
 	}
 	return false
@@ -23860,6 +24615,98 @@ func (e EntityTypeOrderField) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
+// Properties by which EvidenceHistory connections can be ordered.
+type EvidenceHistoryOrderField string
+
+const (
+	EvidenceHistoryOrderFieldName         EvidenceHistoryOrderField = "name"
+	EvidenceHistoryOrderFieldCreationDate EvidenceHistoryOrderField = "creation_date"
+	EvidenceHistoryOrderFieldRenewalDate  EvidenceHistoryOrderField = "renewal_date"
+	EvidenceHistoryOrderFieldStatus       EvidenceHistoryOrderField = "STATUS"
+)
+
+var AllEvidenceHistoryOrderField = []EvidenceHistoryOrderField{
+	EvidenceHistoryOrderFieldName,
+	EvidenceHistoryOrderFieldCreationDate,
+	EvidenceHistoryOrderFieldRenewalDate,
+	EvidenceHistoryOrderFieldStatus,
+}
+
+func (e EvidenceHistoryOrderField) IsValid() bool {
+	switch e {
+	case EvidenceHistoryOrderFieldName, EvidenceHistoryOrderFieldCreationDate, EvidenceHistoryOrderFieldRenewalDate, EvidenceHistoryOrderFieldStatus:
+		return true
+	}
+	return false
+}
+
+func (e EvidenceHistoryOrderField) String() string {
+	return string(e)
+}
+
+func (e *EvidenceHistoryOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = EvidenceHistoryOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid EvidenceHistoryOrderField", str)
+	}
+	return nil
+}
+
+func (e EvidenceHistoryOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which Evidence connections can be ordered.
+type EvidenceOrderField string
+
+const (
+	EvidenceOrderFieldName         EvidenceOrderField = "name"
+	EvidenceOrderFieldCreationDate EvidenceOrderField = "creation_date"
+	EvidenceOrderFieldRenewalDate  EvidenceOrderField = "renewal_date"
+	EvidenceOrderFieldStatus       EvidenceOrderField = "STATUS"
+)
+
+var AllEvidenceOrderField = []EvidenceOrderField{
+	EvidenceOrderFieldName,
+	EvidenceOrderFieldCreationDate,
+	EvidenceOrderFieldRenewalDate,
+	EvidenceOrderFieldStatus,
+}
+
+func (e EvidenceOrderField) IsValid() bool {
+	switch e {
+	case EvidenceOrderFieldName, EvidenceOrderFieldCreationDate, EvidenceOrderFieldRenewalDate, EvidenceOrderFieldStatus:
+		return true
+	}
+	return false
+}
+
+func (e EvidenceOrderField) String() string {
+	return string(e)
+}
+
+func (e *EvidenceOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = EvidenceOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid EvidenceOrderField", str)
+	}
+	return nil
+}
+
+func (e EvidenceOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
 // Properties by which GroupHistory connections can be ordered.
 type GroupHistoryOrderField string
 
@@ -23899,6 +24746,86 @@ func (e *GroupHistoryOrderField) UnmarshalGQL(v any) error {
 }
 
 func (e GroupHistoryOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which GroupMembershipHistory connections can be ordered.
+type GroupMembershipHistoryOrderField string
+
+const (
+	GroupMembershipHistoryOrderFieldRole GroupMembershipHistoryOrderField = "ROLE"
+)
+
+var AllGroupMembershipHistoryOrderField = []GroupMembershipHistoryOrderField{
+	GroupMembershipHistoryOrderFieldRole,
+}
+
+func (e GroupMembershipHistoryOrderField) IsValid() bool {
+	switch e {
+	case GroupMembershipHistoryOrderFieldRole:
+		return true
+	}
+	return false
+}
+
+func (e GroupMembershipHistoryOrderField) String() string {
+	return string(e)
+}
+
+func (e *GroupMembershipHistoryOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = GroupMembershipHistoryOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid GroupMembershipHistoryOrderField", str)
+	}
+	return nil
+}
+
+func (e GroupMembershipHistoryOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which GroupMembership connections can be ordered.
+type GroupMembershipOrderField string
+
+const (
+	GroupMembershipOrderFieldRole GroupMembershipOrderField = "ROLE"
+)
+
+var AllGroupMembershipOrderField = []GroupMembershipOrderField{
+	GroupMembershipOrderFieldRole,
+}
+
+func (e GroupMembershipOrderField) IsValid() bool {
+	switch e {
+	case GroupMembershipOrderFieldRole:
+		return true
+	}
+	return false
+}
+
+func (e GroupMembershipOrderField) String() string {
+	return string(e)
+}
+
+func (e *GroupMembershipOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = GroupMembershipOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid GroupMembershipOrderField", str)
+	}
+	return nil
+}
+
+func (e GroupMembershipOrderField) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
@@ -24112,6 +25039,210 @@ func (e IntegrationOrderField) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
+// Properties by which Invite connections can be ordered.
+type InviteOrderField string
+
+const (
+	InviteOrderFieldExpires      InviteOrderField = "expires"
+	InviteOrderFieldStatus       InviteOrderField = "STATUS"
+	InviteOrderFieldSendAttempts InviteOrderField = "send_attempts"
+)
+
+var AllInviteOrderField = []InviteOrderField{
+	InviteOrderFieldExpires,
+	InviteOrderFieldStatus,
+	InviteOrderFieldSendAttempts,
+}
+
+func (e InviteOrderField) IsValid() bool {
+	switch e {
+	case InviteOrderFieldExpires, InviteOrderFieldStatus, InviteOrderFieldSendAttempts:
+		return true
+	}
+	return false
+}
+
+func (e InviteOrderField) String() string {
+	return string(e)
+}
+
+func (e *InviteOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = InviteOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid InviteOrderField", str)
+	}
+	return nil
+}
+
+func (e InviteOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which MappedControlHistory connections can be ordered.
+type MappedControlHistoryOrderField string
+
+const (
+	MappedControlHistoryOrderFieldMappingType MappedControlHistoryOrderField = "mapping_type"
+)
+
+var AllMappedControlHistoryOrderField = []MappedControlHistoryOrderField{
+	MappedControlHistoryOrderFieldMappingType,
+}
+
+func (e MappedControlHistoryOrderField) IsValid() bool {
+	switch e {
+	case MappedControlHistoryOrderFieldMappingType:
+		return true
+	}
+	return false
+}
+
+func (e MappedControlHistoryOrderField) String() string {
+	return string(e)
+}
+
+func (e *MappedControlHistoryOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = MappedControlHistoryOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid MappedControlHistoryOrderField", str)
+	}
+	return nil
+}
+
+func (e MappedControlHistoryOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which MappedControl connections can be ordered.
+type MappedControlOrderField string
+
+const (
+	MappedControlOrderFieldMappingType MappedControlOrderField = "mapping_type"
+)
+
+var AllMappedControlOrderField = []MappedControlOrderField{
+	MappedControlOrderFieldMappingType,
+}
+
+func (e MappedControlOrderField) IsValid() bool {
+	switch e {
+	case MappedControlOrderFieldMappingType:
+		return true
+	}
+	return false
+}
+
+func (e MappedControlOrderField) String() string {
+	return string(e)
+}
+
+func (e *MappedControlOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = MappedControlOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid MappedControlOrderField", str)
+	}
+	return nil
+}
+
+func (e MappedControlOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which NarrativeHistory connections can be ordered.
+type NarrativeHistoryOrderField string
+
+const (
+	NarrativeHistoryOrderFieldName NarrativeHistoryOrderField = "name"
+)
+
+var AllNarrativeHistoryOrderField = []NarrativeHistoryOrderField{
+	NarrativeHistoryOrderFieldName,
+}
+
+func (e NarrativeHistoryOrderField) IsValid() bool {
+	switch e {
+	case NarrativeHistoryOrderFieldName:
+		return true
+	}
+	return false
+}
+
+func (e NarrativeHistoryOrderField) String() string {
+	return string(e)
+}
+
+func (e *NarrativeHistoryOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = NarrativeHistoryOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid NarrativeHistoryOrderField", str)
+	}
+	return nil
+}
+
+func (e NarrativeHistoryOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which Narrative connections can be ordered.
+type NarrativeOrderField string
+
+const (
+	NarrativeOrderFieldName NarrativeOrderField = "name"
+)
+
+var AllNarrativeOrderField = []NarrativeOrderField{
+	NarrativeOrderFieldName,
+}
+
+func (e NarrativeOrderField) IsValid() bool {
+	switch e {
+	case NarrativeOrderFieldName:
+		return true
+	}
+	return false
+}
+
+func (e NarrativeOrderField) String() string {
+	return string(e)
+}
+
+func (e *NarrativeOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = NarrativeOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid NarrativeOrderField", str)
+	}
+	return nil
+}
+
+func (e NarrativeOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
 // Possible directions in which to order a list of items when provided an `orderBy` argument.
 type OrderDirection string
 
@@ -24153,6 +25284,186 @@ func (e *OrderDirection) UnmarshalGQL(v any) error {
 }
 
 func (e OrderDirection) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which OrgMembershipHistory connections can be ordered.
+type OrgMembershipHistoryOrderField string
+
+const (
+	OrgMembershipHistoryOrderFieldRole OrgMembershipHistoryOrderField = "ROLE"
+)
+
+var AllOrgMembershipHistoryOrderField = []OrgMembershipHistoryOrderField{
+	OrgMembershipHistoryOrderFieldRole,
+}
+
+func (e OrgMembershipHistoryOrderField) IsValid() bool {
+	switch e {
+	case OrgMembershipHistoryOrderFieldRole:
+		return true
+	}
+	return false
+}
+
+func (e OrgMembershipHistoryOrderField) String() string {
+	return string(e)
+}
+
+func (e *OrgMembershipHistoryOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = OrgMembershipHistoryOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid OrgMembershipHistoryOrderField", str)
+	}
+	return nil
+}
+
+func (e OrgMembershipHistoryOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which OrgMembership connections can be ordered.
+type OrgMembershipOrderField string
+
+const (
+	OrgMembershipOrderFieldRole OrgMembershipOrderField = "ROLE"
+)
+
+var AllOrgMembershipOrderField = []OrgMembershipOrderField{
+	OrgMembershipOrderFieldRole,
+}
+
+func (e OrgMembershipOrderField) IsValid() bool {
+	switch e {
+	case OrgMembershipOrderFieldRole:
+		return true
+	}
+	return false
+}
+
+func (e OrgMembershipOrderField) String() string {
+	return string(e)
+}
+
+func (e *OrgMembershipOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = OrgMembershipOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid OrgMembershipOrderField", str)
+	}
+	return nil
+}
+
+func (e OrgMembershipOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which OrgSubscriptionHistory connections can be ordered.
+type OrgSubscriptionHistoryOrderField string
+
+const (
+	OrgSubscriptionHistoryOrderFieldProductTier              OrgSubscriptionHistoryOrderField = "product_tier"
+	OrgSubscriptionHistoryOrderFieldStripeSubscriptionStatus OrgSubscriptionHistoryOrderField = "stripe_subscription_status"
+	OrgSubscriptionHistoryOrderFieldActive                   OrgSubscriptionHistoryOrderField = "active"
+	OrgSubscriptionHistoryOrderFieldExpiresAt                OrgSubscriptionHistoryOrderField = "expires_at"
+	OrgSubscriptionHistoryOrderFieldTrialExpiresAt           OrgSubscriptionHistoryOrderField = "trial_expires_at"
+	OrgSubscriptionHistoryOrderFieldDaysUntilDue             OrgSubscriptionHistoryOrderField = "days_until_due"
+)
+
+var AllOrgSubscriptionHistoryOrderField = []OrgSubscriptionHistoryOrderField{
+	OrgSubscriptionHistoryOrderFieldProductTier,
+	OrgSubscriptionHistoryOrderFieldStripeSubscriptionStatus,
+	OrgSubscriptionHistoryOrderFieldActive,
+	OrgSubscriptionHistoryOrderFieldExpiresAt,
+	OrgSubscriptionHistoryOrderFieldTrialExpiresAt,
+	OrgSubscriptionHistoryOrderFieldDaysUntilDue,
+}
+
+func (e OrgSubscriptionHistoryOrderField) IsValid() bool {
+	switch e {
+	case OrgSubscriptionHistoryOrderFieldProductTier, OrgSubscriptionHistoryOrderFieldStripeSubscriptionStatus, OrgSubscriptionHistoryOrderFieldActive, OrgSubscriptionHistoryOrderFieldExpiresAt, OrgSubscriptionHistoryOrderFieldTrialExpiresAt, OrgSubscriptionHistoryOrderFieldDaysUntilDue:
+		return true
+	}
+	return false
+}
+
+func (e OrgSubscriptionHistoryOrderField) String() string {
+	return string(e)
+}
+
+func (e *OrgSubscriptionHistoryOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = OrgSubscriptionHistoryOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid OrgSubscriptionHistoryOrderField", str)
+	}
+	return nil
+}
+
+func (e OrgSubscriptionHistoryOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which OrgSubscription connections can be ordered.
+type OrgSubscriptionOrderField string
+
+const (
+	OrgSubscriptionOrderFieldProductTier              OrgSubscriptionOrderField = "product_tier"
+	OrgSubscriptionOrderFieldStripeSubscriptionStatus OrgSubscriptionOrderField = "stripe_subscription_status"
+	OrgSubscriptionOrderFieldActive                   OrgSubscriptionOrderField = "active"
+	OrgSubscriptionOrderFieldExpiresAt                OrgSubscriptionOrderField = "expires_at"
+	OrgSubscriptionOrderFieldTrialExpiresAt           OrgSubscriptionOrderField = "trial_expires_at"
+	OrgSubscriptionOrderFieldDaysUntilDue             OrgSubscriptionOrderField = "days_until_due"
+)
+
+var AllOrgSubscriptionOrderField = []OrgSubscriptionOrderField{
+	OrgSubscriptionOrderFieldProductTier,
+	OrgSubscriptionOrderFieldStripeSubscriptionStatus,
+	OrgSubscriptionOrderFieldActive,
+	OrgSubscriptionOrderFieldExpiresAt,
+	OrgSubscriptionOrderFieldTrialExpiresAt,
+	OrgSubscriptionOrderFieldDaysUntilDue,
+}
+
+func (e OrgSubscriptionOrderField) IsValid() bool {
+	switch e {
+	case OrgSubscriptionOrderFieldProductTier, OrgSubscriptionOrderFieldStripeSubscriptionStatus, OrgSubscriptionOrderFieldActive, OrgSubscriptionOrderFieldExpiresAt, OrgSubscriptionOrderFieldTrialExpiresAt, OrgSubscriptionOrderFieldDaysUntilDue:
+		return true
+	}
+	return false
+}
+
+func (e OrgSubscriptionOrderField) String() string {
+	return string(e)
+}
+
+func (e *OrgSubscriptionOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = OrgSubscriptionOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid OrgSubscriptionOrderField", str)
+	}
+	return nil
+}
+
+func (e OrgSubscriptionOrderField) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
@@ -24240,20 +25551,640 @@ func (e OrganizationOrderField) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
+// Properties by which ProgramHistory connections can be ordered.
+type ProgramHistoryOrderField string
+
+const (
+	ProgramHistoryOrderFieldName      ProgramHistoryOrderField = "name"
+	ProgramHistoryOrderFieldStatus    ProgramHistoryOrderField = "STATUS"
+	ProgramHistoryOrderFieldStartDate ProgramHistoryOrderField = "start_date"
+	ProgramHistoryOrderFieldEndDate   ProgramHistoryOrderField = "end_date"
+)
+
+var AllProgramHistoryOrderField = []ProgramHistoryOrderField{
+	ProgramHistoryOrderFieldName,
+	ProgramHistoryOrderFieldStatus,
+	ProgramHistoryOrderFieldStartDate,
+	ProgramHistoryOrderFieldEndDate,
+}
+
+func (e ProgramHistoryOrderField) IsValid() bool {
+	switch e {
+	case ProgramHistoryOrderFieldName, ProgramHistoryOrderFieldStatus, ProgramHistoryOrderFieldStartDate, ProgramHistoryOrderFieldEndDate:
+		return true
+	}
+	return false
+}
+
+func (e ProgramHistoryOrderField) String() string {
+	return string(e)
+}
+
+func (e *ProgramHistoryOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = ProgramHistoryOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid ProgramHistoryOrderField", str)
+	}
+	return nil
+}
+
+func (e ProgramHistoryOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which ProgramMembershipHistory connections can be ordered.
+type ProgramMembershipHistoryOrderField string
+
+const (
+	ProgramMembershipHistoryOrderFieldRole ProgramMembershipHistoryOrderField = "ROLE"
+)
+
+var AllProgramMembershipHistoryOrderField = []ProgramMembershipHistoryOrderField{
+	ProgramMembershipHistoryOrderFieldRole,
+}
+
+func (e ProgramMembershipHistoryOrderField) IsValid() bool {
+	switch e {
+	case ProgramMembershipHistoryOrderFieldRole:
+		return true
+	}
+	return false
+}
+
+func (e ProgramMembershipHistoryOrderField) String() string {
+	return string(e)
+}
+
+func (e *ProgramMembershipHistoryOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = ProgramMembershipHistoryOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid ProgramMembershipHistoryOrderField", str)
+	}
+	return nil
+}
+
+func (e ProgramMembershipHistoryOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which ProgramMembership connections can be ordered.
+type ProgramMembershipOrderField string
+
+const (
+	ProgramMembershipOrderFieldRole ProgramMembershipOrderField = "ROLE"
+)
+
+var AllProgramMembershipOrderField = []ProgramMembershipOrderField{
+	ProgramMembershipOrderFieldRole,
+}
+
+func (e ProgramMembershipOrderField) IsValid() bool {
+	switch e {
+	case ProgramMembershipOrderFieldRole:
+		return true
+	}
+	return false
+}
+
+func (e ProgramMembershipOrderField) String() string {
+	return string(e)
+}
+
+func (e *ProgramMembershipOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = ProgramMembershipOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid ProgramMembershipOrderField", str)
+	}
+	return nil
+}
+
+func (e ProgramMembershipOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which Program connections can be ordered.
+type ProgramOrderField string
+
+const (
+	ProgramOrderFieldName      ProgramOrderField = "name"
+	ProgramOrderFieldStatus    ProgramOrderField = "STATUS"
+	ProgramOrderFieldStartDate ProgramOrderField = "start_date"
+	ProgramOrderFieldEndDate   ProgramOrderField = "end_date"
+)
+
+var AllProgramOrderField = []ProgramOrderField{
+	ProgramOrderFieldName,
+	ProgramOrderFieldStatus,
+	ProgramOrderFieldStartDate,
+	ProgramOrderFieldEndDate,
+}
+
+func (e ProgramOrderField) IsValid() bool {
+	switch e {
+	case ProgramOrderFieldName, ProgramOrderFieldStatus, ProgramOrderFieldStartDate, ProgramOrderFieldEndDate:
+		return true
+	}
+	return false
+}
+
+func (e ProgramOrderField) String() string {
+	return string(e)
+}
+
+func (e *ProgramOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = ProgramOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid ProgramOrderField", str)
+	}
+	return nil
+}
+
+func (e ProgramOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which RiskHistory connections can be ordered.
+type RiskHistoryOrderField string
+
+const (
+	RiskHistoryOrderFieldName          RiskHistoryOrderField = "name"
+	RiskHistoryOrderFieldStatus        RiskHistoryOrderField = "STATUS"
+	RiskHistoryOrderFieldRiskType      RiskHistoryOrderField = "risk_type"
+	RiskHistoryOrderFieldCategory      RiskHistoryOrderField = "category"
+	RiskHistoryOrderFieldImpact        RiskHistoryOrderField = "IMPACT"
+	RiskHistoryOrderFieldLikelihood    RiskHistoryOrderField = "LIKELIHOOD"
+	RiskHistoryOrderFieldScore         RiskHistoryOrderField = "score"
+	RiskHistoryOrderFieldBusinessCosts RiskHistoryOrderField = "business_costs"
+)
+
+var AllRiskHistoryOrderField = []RiskHistoryOrderField{
+	RiskHistoryOrderFieldName,
+	RiskHistoryOrderFieldStatus,
+	RiskHistoryOrderFieldRiskType,
+	RiskHistoryOrderFieldCategory,
+	RiskHistoryOrderFieldImpact,
+	RiskHistoryOrderFieldLikelihood,
+	RiskHistoryOrderFieldScore,
+	RiskHistoryOrderFieldBusinessCosts,
+}
+
+func (e RiskHistoryOrderField) IsValid() bool {
+	switch e {
+	case RiskHistoryOrderFieldName, RiskHistoryOrderFieldStatus, RiskHistoryOrderFieldRiskType, RiskHistoryOrderFieldCategory, RiskHistoryOrderFieldImpact, RiskHistoryOrderFieldLikelihood, RiskHistoryOrderFieldScore, RiskHistoryOrderFieldBusinessCosts:
+		return true
+	}
+	return false
+}
+
+func (e RiskHistoryOrderField) String() string {
+	return string(e)
+}
+
+func (e *RiskHistoryOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = RiskHistoryOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid RiskHistoryOrderField", str)
+	}
+	return nil
+}
+
+func (e RiskHistoryOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which Risk connections can be ordered.
+type RiskOrderField string
+
+const (
+	RiskOrderFieldName          RiskOrderField = "name"
+	RiskOrderFieldStatus        RiskOrderField = "STATUS"
+	RiskOrderFieldRiskType      RiskOrderField = "risk_type"
+	RiskOrderFieldCategory      RiskOrderField = "category"
+	RiskOrderFieldImpact        RiskOrderField = "IMPACT"
+	RiskOrderFieldLikelihood    RiskOrderField = "LIKELIHOOD"
+	RiskOrderFieldScore         RiskOrderField = "score"
+	RiskOrderFieldBusinessCosts RiskOrderField = "business_costs"
+)
+
+var AllRiskOrderField = []RiskOrderField{
+	RiskOrderFieldName,
+	RiskOrderFieldStatus,
+	RiskOrderFieldRiskType,
+	RiskOrderFieldCategory,
+	RiskOrderFieldImpact,
+	RiskOrderFieldLikelihood,
+	RiskOrderFieldScore,
+	RiskOrderFieldBusinessCosts,
+}
+
+func (e RiskOrderField) IsValid() bool {
+	switch e {
+	case RiskOrderFieldName, RiskOrderFieldStatus, RiskOrderFieldRiskType, RiskOrderFieldCategory, RiskOrderFieldImpact, RiskOrderFieldLikelihood, RiskOrderFieldScore, RiskOrderFieldBusinessCosts:
+		return true
+	}
+	return false
+}
+
+func (e RiskOrderField) String() string {
+	return string(e)
+}
+
+func (e *RiskOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = RiskOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid RiskOrderField", str)
+	}
+	return nil
+}
+
+func (e RiskOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which StandardHistory connections can be ordered.
+type StandardHistoryOrderField string
+
+const (
+	StandardHistoryOrderFieldName          StandardHistoryOrderField = "name"
+	StandardHistoryOrderFieldShortName     StandardHistoryOrderField = "short_name"
+	StandardHistoryOrderFieldFramework     StandardHistoryOrderField = "framework"
+	StandardHistoryOrderFieldGoverningBody StandardHistoryOrderField = "governing_body"
+	StandardHistoryOrderFieldStatus        StandardHistoryOrderField = "STATUS"
+	StandardHistoryOrderFieldStandardType  StandardHistoryOrderField = "standard_type"
+)
+
+var AllStandardHistoryOrderField = []StandardHistoryOrderField{
+	StandardHistoryOrderFieldName,
+	StandardHistoryOrderFieldShortName,
+	StandardHistoryOrderFieldFramework,
+	StandardHistoryOrderFieldGoverningBody,
+	StandardHistoryOrderFieldStatus,
+	StandardHistoryOrderFieldStandardType,
+}
+
+func (e StandardHistoryOrderField) IsValid() bool {
+	switch e {
+	case StandardHistoryOrderFieldName, StandardHistoryOrderFieldShortName, StandardHistoryOrderFieldFramework, StandardHistoryOrderFieldGoverningBody, StandardHistoryOrderFieldStatus, StandardHistoryOrderFieldStandardType:
+		return true
+	}
+	return false
+}
+
+func (e StandardHistoryOrderField) String() string {
+	return string(e)
+}
+
+func (e *StandardHistoryOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = StandardHistoryOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid StandardHistoryOrderField", str)
+	}
+	return nil
+}
+
+func (e StandardHistoryOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which Standard connections can be ordered.
+type StandardOrderField string
+
+const (
+	StandardOrderFieldName          StandardOrderField = "name"
+	StandardOrderFieldShortName     StandardOrderField = "short_name"
+	StandardOrderFieldFramework     StandardOrderField = "framework"
+	StandardOrderFieldGoverningBody StandardOrderField = "governing_body"
+	StandardOrderFieldStatus        StandardOrderField = "STATUS"
+	StandardOrderFieldStandardType  StandardOrderField = "standard_type"
+)
+
+var AllStandardOrderField = []StandardOrderField{
+	StandardOrderFieldName,
+	StandardOrderFieldShortName,
+	StandardOrderFieldFramework,
+	StandardOrderFieldGoverningBody,
+	StandardOrderFieldStatus,
+	StandardOrderFieldStandardType,
+}
+
+func (e StandardOrderField) IsValid() bool {
+	switch e {
+	case StandardOrderFieldName, StandardOrderFieldShortName, StandardOrderFieldFramework, StandardOrderFieldGoverningBody, StandardOrderFieldStatus, StandardOrderFieldStandardType:
+		return true
+	}
+	return false
+}
+
+func (e StandardOrderField) String() string {
+	return string(e)
+}
+
+func (e *StandardOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = StandardOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid StandardOrderField", str)
+	}
+	return nil
+}
+
+func (e StandardOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which SubcontrolHistory connections can be ordered.
+type SubcontrolHistoryOrderField string
+
+const (
+	SubcontrolHistoryOrderFieldStatus      SubcontrolHistoryOrderField = "status"
+	SubcontrolHistoryOrderFieldSource      SubcontrolHistoryOrderField = "SOURCE"
+	SubcontrolHistoryOrderFieldControlType SubcontrolHistoryOrderField = "CONTROL_TYPE"
+	SubcontrolHistoryOrderFieldCategory    SubcontrolHistoryOrderField = "category"
+	SubcontrolHistoryOrderFieldSubcategory SubcontrolHistoryOrderField = "subcategory"
+	SubcontrolHistoryOrderFieldRefCode     SubcontrolHistoryOrderField = "ref_code"
+)
+
+var AllSubcontrolHistoryOrderField = []SubcontrolHistoryOrderField{
+	SubcontrolHistoryOrderFieldStatus,
+	SubcontrolHistoryOrderFieldSource,
+	SubcontrolHistoryOrderFieldControlType,
+	SubcontrolHistoryOrderFieldCategory,
+	SubcontrolHistoryOrderFieldSubcategory,
+	SubcontrolHistoryOrderFieldRefCode,
+}
+
+func (e SubcontrolHistoryOrderField) IsValid() bool {
+	switch e {
+	case SubcontrolHistoryOrderFieldStatus, SubcontrolHistoryOrderFieldSource, SubcontrolHistoryOrderFieldControlType, SubcontrolHistoryOrderFieldCategory, SubcontrolHistoryOrderFieldSubcategory, SubcontrolHistoryOrderFieldRefCode:
+		return true
+	}
+	return false
+}
+
+func (e SubcontrolHistoryOrderField) String() string {
+	return string(e)
+}
+
+func (e *SubcontrolHistoryOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = SubcontrolHistoryOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid SubcontrolHistoryOrderField", str)
+	}
+	return nil
+}
+
+func (e SubcontrolHistoryOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which Subcontrol connections can be ordered.
+type SubcontrolOrderField string
+
+const (
+	SubcontrolOrderFieldStatus      SubcontrolOrderField = "status"
+	SubcontrolOrderFieldSource      SubcontrolOrderField = "SOURCE"
+	SubcontrolOrderFieldControlType SubcontrolOrderField = "CONTROL_TYPE"
+	SubcontrolOrderFieldCategory    SubcontrolOrderField = "category"
+	SubcontrolOrderFieldSubcategory SubcontrolOrderField = "subcategory"
+	SubcontrolOrderFieldRefCode     SubcontrolOrderField = "ref_code"
+)
+
+var AllSubcontrolOrderField = []SubcontrolOrderField{
+	SubcontrolOrderFieldStatus,
+	SubcontrolOrderFieldSource,
+	SubcontrolOrderFieldControlType,
+	SubcontrolOrderFieldCategory,
+	SubcontrolOrderFieldSubcategory,
+	SubcontrolOrderFieldRefCode,
+}
+
+func (e SubcontrolOrderField) IsValid() bool {
+	switch e {
+	case SubcontrolOrderFieldStatus, SubcontrolOrderFieldSource, SubcontrolOrderFieldControlType, SubcontrolOrderFieldCategory, SubcontrolOrderFieldSubcategory, SubcontrolOrderFieldRefCode:
+		return true
+	}
+	return false
+}
+
+func (e SubcontrolOrderField) String() string {
+	return string(e)
+}
+
+func (e *SubcontrolOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = SubcontrolOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid SubcontrolOrderField", str)
+	}
+	return nil
+}
+
+func (e SubcontrolOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which Subscriber connections can be ordered.
+type SubscriberOrderField string
+
+const (
+	SubscriberOrderFieldEmail  SubscriberOrderField = "email"
+	SubscriberOrderFieldActive SubscriberOrderField = "active"
+)
+
+var AllSubscriberOrderField = []SubscriberOrderField{
+	SubscriberOrderFieldEmail,
+	SubscriberOrderFieldActive,
+}
+
+func (e SubscriberOrderField) IsValid() bool {
+	switch e {
+	case SubscriberOrderFieldEmail, SubscriberOrderFieldActive:
+		return true
+	}
+	return false
+}
+
+func (e SubscriberOrderField) String() string {
+	return string(e)
+}
+
+func (e *SubscriberOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = SubscriberOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid SubscriberOrderField", str)
+	}
+	return nil
+}
+
+func (e SubscriberOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which TaskHistory connections can be ordered.
+type TaskHistoryOrderField string
+
+const (
+	TaskHistoryOrderFieldTitle     TaskHistoryOrderField = "title"
+	TaskHistoryOrderFieldStatus    TaskHistoryOrderField = "STATUS"
+	TaskHistoryOrderFieldCategory  TaskHistoryOrderField = "category"
+	TaskHistoryOrderFieldDue       TaskHistoryOrderField = "due"
+	TaskHistoryOrderFieldCompleted TaskHistoryOrderField = "completed"
+)
+
+var AllTaskHistoryOrderField = []TaskHistoryOrderField{
+	TaskHistoryOrderFieldTitle,
+	TaskHistoryOrderFieldStatus,
+	TaskHistoryOrderFieldCategory,
+	TaskHistoryOrderFieldDue,
+	TaskHistoryOrderFieldCompleted,
+}
+
+func (e TaskHistoryOrderField) IsValid() bool {
+	switch e {
+	case TaskHistoryOrderFieldTitle, TaskHistoryOrderFieldStatus, TaskHistoryOrderFieldCategory, TaskHistoryOrderFieldDue, TaskHistoryOrderFieldCompleted:
+		return true
+	}
+	return false
+}
+
+func (e TaskHistoryOrderField) String() string {
+	return string(e)
+}
+
+func (e *TaskHistoryOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = TaskHistoryOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid TaskHistoryOrderField", str)
+	}
+	return nil
+}
+
+func (e TaskHistoryOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Properties by which Task connections can be ordered.
+type TaskOrderField string
+
+const (
+	TaskOrderFieldTitle     TaskOrderField = "title"
+	TaskOrderFieldStatus    TaskOrderField = "STATUS"
+	TaskOrderFieldCategory  TaskOrderField = "category"
+	TaskOrderFieldDue       TaskOrderField = "due"
+	TaskOrderFieldCompleted TaskOrderField = "completed"
+)
+
+var AllTaskOrderField = []TaskOrderField{
+	TaskOrderFieldTitle,
+	TaskOrderFieldStatus,
+	TaskOrderFieldCategory,
+	TaskOrderFieldDue,
+	TaskOrderFieldCompleted,
+}
+
+func (e TaskOrderField) IsValid() bool {
+	switch e {
+	case TaskOrderFieldTitle, TaskOrderFieldStatus, TaskOrderFieldCategory, TaskOrderFieldDue, TaskOrderFieldCompleted:
+		return true
+	}
+	return false
+}
+
+func (e TaskOrderField) String() string {
+	return string(e)
+}
+
+func (e *TaskOrderField) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = TaskOrderField(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid TaskOrderField", str)
+	}
+	return nil
+}
+
+func (e TaskOrderField) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
 // Properties by which TemplateHistory connections can be ordered.
 type TemplateHistoryOrderField string
 
 const (
-	TemplateHistoryOrderFieldName TemplateHistoryOrderField = "name"
+	TemplateHistoryOrderFieldName         TemplateHistoryOrderField = "name"
+	TemplateHistoryOrderFieldTemplateType TemplateHistoryOrderField = "TEMPLATE_TYPE"
 )
 
 var AllTemplateHistoryOrderField = []TemplateHistoryOrderField{
 	TemplateHistoryOrderFieldName,
+	TemplateHistoryOrderFieldTemplateType,
 }
 
 func (e TemplateHistoryOrderField) IsValid() bool {
 	switch e {
-	case TemplateHistoryOrderFieldName:
+	case TemplateHistoryOrderFieldName, TemplateHistoryOrderFieldTemplateType:
 		return true
 	}
 	return false
@@ -24284,16 +26215,18 @@ func (e TemplateHistoryOrderField) MarshalGQL(w io.Writer) {
 type TemplateOrderField string
 
 const (
-	TemplateOrderFieldName TemplateOrderField = "name"
+	TemplateOrderFieldName         TemplateOrderField = "name"
+	TemplateOrderFieldTemplateType TemplateOrderField = "TEMPLATE_TYPE"
 )
 
 var AllTemplateOrderField = []TemplateOrderField{
 	TemplateOrderFieldName,
+	TemplateOrderFieldTemplateType,
 }
 
 func (e TemplateOrderField) IsValid() bool {
 	switch e {
-	case TemplateOrderFieldName:
+	case TemplateOrderFieldName, TemplateOrderFieldTemplateType:
 		return true
 	}
 	return false


### PR DESCRIPTION
- adds OrderBy entgql annotations on fields throughout our schemas which can be sorted
- adds MultiOrder on the schema level for any schema which has more than 1 orderby field
- Adds RelayConnection annotation to all non-unique schema edges on fields which can be compared
- updates CLI commands to include `Edges` and `Node`
- updates graphapi resolver tests to include `Edges` and `Node` where relevant