### PR TITLE
feat: remove validator on display name, default to first and last name if available

### DIFF
--- a/internal/ent/generated/runtime/runtime.go
+++ b/internal/ent/generated/runtime/runtime.go
@@ -3934,7 +3934,6 @@ func init() {
 		fns := [...]func(string) error{
 			validators[0].(func(string) error),
 			validators[1].(func(string) error),
-			validators[2].(func(string) error),
 		}
 		return func(display_name string) error {
 			for _, fn := range fns {

--- a/internal/ent/hooks/user.go
+++ b/internal/ent/hooks/user.go
@@ -58,7 +58,16 @@ func HookUser() ent.Hook {
 				if m.Op().Is(ent.OpCreate) {
 					displayName, _ := m.DisplayName()
 					if displayName == "" {
-						displayName = strings.Split(email, "@")[0]
+						// first try first and last name
+						firstName, _ := m.FirstName()
+						lastName, _ := m.LastName()
+
+						if firstName != "" && lastName != "" {
+							displayName = strings.TrimSpace(fmt.Sprintf("%s %s", firstName, lastName))
+						} else {
+							// if first and last name are not provided, use the email without the domain
+							displayName = strings.Split(email, "@")[0]
+						}
 
 						m.SetDisplayName(displayName)
 					}

--- a/internal/ent/schema/user.go
+++ b/internal/ent/schema/user.go
@@ -3,7 +3,6 @@ package schema
 import (
 	"net/mail"
 	"net/url"
-	"strings"
 	"time"
 
 	"entgo.io/contrib/entgql"
@@ -77,14 +76,6 @@ func (User) Fields() []ent.Field {
 			NotEmpty().
 			Annotations(
 				entgql.OrderField("display_name"),
-			).
-			Validate(
-				func(s string) error {
-					if strings.Contains(s, " ") {
-						return ErrContainsSpaces
-					}
-					return nil
-				},
 			),
 		field.String("avatar_remote_url").
 			Comment("URL of the user's remote avatar").


### PR DESCRIPTION
Validator was preventing setting my display name to "Sarah Funkhouser" - this shouldn't be a slug - but the user's full name ideally. 