### PR TITLE
bug: fix bulk create invites for resend

### DIFF
--- a/internal/graphapi/invite.resolvers.go
+++ b/internal/graphapi/invite.resolvers.go
@@ -67,7 +67,6 @@ func (r *mutationResolver) CreateBulkInvite(ctx context.Context, input []*genera
 	return &model.InviteBulkCreatePayload{
 		Invites: results,
 	}, nil
-
 }
 
 // CreateBulkCSVInvite is the resolver for the createBulkCSVInvite field.


### PR DESCRIPTION
We overload the create invite endpoint to do an update if the invitation already exists for the email, this works fine except on the bulk endpoints. Because of how the bulk endpoints work; even though the invites were properly updated; the full mutation wasn't executed so the node didn't have the results returned. 

I tried a few other options
- like attempting to create (instead of get first); but the error results in the transaction being aborted 
- pulling the invites in the resolver if they were nil; this didn't return the correct send attempts; assuming because the transaction wasn't yet committed we didn't have the correct result

This just sends them all in their own mutation - which is the same amount of queries as the bulk result so should be equivalent in performance. 