### PR TITLE
bug: omit satisfies, just use CollectFields directly

### DIFF
--- a/internal/graphapi/actionplan.resolvers.go
+++ b/internal/graphapi/actionplan.resolvers.go
@@ -19,7 +19,7 @@ import (
 
 // CreateActionPlan is the resolver for the createActionPlan field.
 func (r *mutationResolver) CreateActionPlan(ctx context.Context, input generated.CreateActionPlanInput) (*model.ActionPlanCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set the organization in the auth context if its not done for us
@@ -53,7 +53,7 @@ func (r *mutationResolver) CreateBulkActionPlan(ctx context.Context, input []*ge
 		return nil, rout.NewMissingRequiredFieldError("owner_id")
 	}
 
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	return r.bulkCreateActionPlan(ctx, input)
@@ -61,7 +61,7 @@ func (r *mutationResolver) CreateBulkActionPlan(ctx context.Context, input []*ge
 
 // CreateBulkCSVActionPlan is the resolver for the createBulkCSVActionPlan field.
 func (r *mutationResolver) CreateBulkCSVActionPlan(ctx context.Context, input graphql.Upload) (*model.ActionPlanBulkCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	data, err := unmarshalBulkData[generated.CreateActionPlanInput](input)
@@ -88,7 +88,7 @@ func (r *mutationResolver) CreateBulkCSVActionPlan(ctx context.Context, input gr
 
 // UpdateActionPlan is the resolver for the updateActionPlan field.
 func (r *mutationResolver) UpdateActionPlan(ctx context.Context, id string, input generated.UpdateActionPlanInput) (*model.ActionPlanUpdatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	res, err := withTransactionalMutation(ctx).ActionPlan.Get(ctx, id)
@@ -133,10 +133,10 @@ func (r *mutationResolver) DeleteActionPlan(ctx context.Context, id string) (*mo
 
 // ActionPlan is the resolver for the actionPlan field.
 func (r *queryResolver) ActionPlan(ctx context.Context, id string) (*generated.ActionPlan, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).ActionPlan.Query().Where(actionplan.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).ActionPlan.Query().Where(actionplan.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "actionplan"})
 	}

--- a/internal/graphapi/apitoken.resolvers.go
+++ b/internal/graphapi/apitoken.resolvers.go
@@ -18,7 +18,7 @@ import (
 
 // CreateAPIToken is the resolver for the createAPIToken field.
 func (r *mutationResolver) CreateAPIToken(ctx context.Context, input generated.CreateAPITokenInput) (*model.APITokenCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set the organization in the auth context if its not done for us
@@ -52,7 +52,7 @@ func (r *mutationResolver) CreateBulkAPIToken(ctx context.Context, input []*gene
 		return nil, rout.NewMissingRequiredFieldError("owner_id")
 	}
 
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	return r.bulkCreateAPIToken(ctx, input)
@@ -60,7 +60,7 @@ func (r *mutationResolver) CreateBulkAPIToken(ctx context.Context, input []*gene
 
 // CreateBulkCSVAPIToken is the resolver for the createBulkCSVAPIToken field.
 func (r *mutationResolver) CreateBulkCSVAPIToken(ctx context.Context, input graphql.Upload) (*model.APITokenBulkCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	data, err := unmarshalBulkData[generated.CreateAPITokenInput](input)
@@ -87,7 +87,7 @@ func (r *mutationResolver) CreateBulkCSVAPIToken(ctx context.Context, input grap
 
 // UpdateAPIToken is the resolver for the updateAPIToken field.
 func (r *mutationResolver) UpdateAPIToken(ctx context.Context, id string, input generated.UpdateAPITokenInput) (*model.APITokenUpdatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	res, err := withTransactionalMutation(ctx).APIToken.Get(ctx, id)
@@ -132,10 +132,10 @@ func (r *mutationResolver) DeleteAPIToken(ctx context.Context, id string) (*mode
 
 // APIToken is the resolver for the apiToken field.
 func (r *queryResolver) APIToken(ctx context.Context, id string) (*generated.APIToken, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).APIToken.Query().Where(apitoken.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).APIToken.Query().Where(apitoken.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "apitoken"})
 	}

--- a/internal/graphapi/contact.resolvers.go
+++ b/internal/graphapi/contact.resolvers.go
@@ -18,7 +18,7 @@ import (
 
 // CreateContact is the resolver for the createContact field.
 func (r *mutationResolver) CreateContact(ctx context.Context, input generated.CreateContactInput) (*model.ContactCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set the organization in the auth context if its not done for us
@@ -52,7 +52,7 @@ func (r *mutationResolver) CreateBulkContact(ctx context.Context, input []*gener
 		return nil, rout.NewMissingRequiredFieldError("owner_id")
 	}
 
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	return r.bulkCreateContact(ctx, input)
@@ -60,7 +60,7 @@ func (r *mutationResolver) CreateBulkContact(ctx context.Context, input []*gener
 
 // CreateBulkCSVContact is the resolver for the createBulkCSVContact field.
 func (r *mutationResolver) CreateBulkCSVContact(ctx context.Context, input graphql.Upload) (*model.ContactBulkCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	data, err := unmarshalBulkData[generated.CreateContactInput](input)
@@ -87,7 +87,7 @@ func (r *mutationResolver) CreateBulkCSVContact(ctx context.Context, input graph
 
 // UpdateContact is the resolver for the updateContact field.
 func (r *mutationResolver) UpdateContact(ctx context.Context, id string, input generated.UpdateContactInput) (*model.ContactUpdatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	res, err := withTransactionalMutation(ctx).Contact.Get(ctx, id)
@@ -132,10 +132,10 @@ func (r *mutationResolver) DeleteContact(ctx context.Context, id string) (*model
 
 // Contact is the resolver for the contact field.
 func (r *queryResolver) Contact(ctx context.Context, id string) (*generated.Contact, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Contact.Query().Where(contact.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Contact.Query().Where(contact.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "contact"})
 	}

--- a/internal/graphapi/control.resolvers.go
+++ b/internal/graphapi/control.resolvers.go
@@ -18,7 +18,7 @@ import (
 
 // CreateControl is the resolver for the createControl field.
 func (r *mutationResolver) CreateControl(ctx context.Context, input generated.CreateControlInput) (*model.ControlCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set the organization in the auth context if its not done for us
@@ -52,7 +52,7 @@ func (r *mutationResolver) CreateBulkControl(ctx context.Context, input []*gener
 		return nil, rout.NewMissingRequiredFieldError("owner_id")
 	}
 
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	return r.bulkCreateControl(ctx, input)
@@ -60,7 +60,7 @@ func (r *mutationResolver) CreateBulkControl(ctx context.Context, input []*gener
 
 // CreateBulkCSVControl is the resolver for the createBulkCSVControl field.
 func (r *mutationResolver) CreateBulkCSVControl(ctx context.Context, input graphql.Upload) (*model.ControlBulkCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	data, err := unmarshalBulkData[generated.CreateControlInput](input)
@@ -87,7 +87,7 @@ func (r *mutationResolver) CreateBulkCSVControl(ctx context.Context, input graph
 
 // UpdateControl is the resolver for the updateControl field.
 func (r *mutationResolver) UpdateControl(ctx context.Context, id string, input generated.UpdateControlInput) (*model.ControlUpdatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	res, err := withTransactionalMutation(ctx).Control.Get(ctx, id)
@@ -132,10 +132,10 @@ func (r *mutationResolver) DeleteControl(ctx context.Context, id string) (*model
 
 // Control is the resolver for the control field.
 func (r *queryResolver) Control(ctx context.Context, id string) (*generated.Control, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Control.Query().Where(control.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Control.Query().Where(control.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "control"})
 	}

--- a/internal/graphapi/controlimplementation.resolvers.go
+++ b/internal/graphapi/controlimplementation.resolvers.go
@@ -18,7 +18,7 @@ import (
 
 // CreateControlImplementation is the resolver for the createControlImplementation field.
 func (r *mutationResolver) CreateControlImplementation(ctx context.Context, input generated.CreateControlImplementationInput) (*model.ControlImplementationCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	res, err := withTransactionalMutation(ctx).ControlImplementation.Create().SetInput(input).Save(ctx)
@@ -37,7 +37,7 @@ func (r *mutationResolver) CreateBulkControlImplementation(ctx context.Context, 
 		return nil, rout.NewMissingRequiredFieldError("input")
 	}
 
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	return r.bulkCreateControlImplementation(ctx, input)
@@ -45,7 +45,7 @@ func (r *mutationResolver) CreateBulkControlImplementation(ctx context.Context, 
 
 // CreateBulkCSVControlImplementation is the resolver for the createBulkCSVControlImplementation field.
 func (r *mutationResolver) CreateBulkCSVControlImplementation(ctx context.Context, input graphql.Upload) (*model.ControlImplementationBulkCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	data, err := unmarshalBulkData[generated.CreateControlImplementationInput](input)
@@ -64,7 +64,7 @@ func (r *mutationResolver) CreateBulkCSVControlImplementation(ctx context.Contex
 
 // UpdateControlImplementation is the resolver for the updateControlImplementation field.
 func (r *mutationResolver) UpdateControlImplementation(ctx context.Context, id string, input generated.UpdateControlImplementationInput) (*model.ControlImplementationUpdatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	res, err := withTransactionalMutation(ctx).ControlImplementation.Get(ctx, id)
@@ -102,10 +102,10 @@ func (r *mutationResolver) DeleteControlImplementation(ctx context.Context, id s
 
 // ControlImplementation is the resolver for the controlImplementation field.
 func (r *queryResolver) ControlImplementation(ctx context.Context, id string) (*generated.ControlImplementation, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).ControlImplementation.Query().Where(controlimplementation.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).ControlImplementation.Query().Where(controlimplementation.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "controlimplementation"})
 	}

--- a/internal/graphapi/controlobjective.resolvers.go
+++ b/internal/graphapi/controlobjective.resolvers.go
@@ -18,7 +18,7 @@ import (
 
 // CreateControlObjective is the resolver for the createControlObjective field.
 func (r *mutationResolver) CreateControlObjective(ctx context.Context, input generated.CreateControlObjectiveInput) (*model.ControlObjectiveCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set the organization in the auth context if its not done for us
@@ -52,7 +52,7 @@ func (r *mutationResolver) CreateBulkControlObjective(ctx context.Context, input
 		return nil, rout.NewMissingRequiredFieldError("owner_id")
 	}
 
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	return r.bulkCreateControlObjective(ctx, input)
@@ -60,7 +60,7 @@ func (r *mutationResolver) CreateBulkControlObjective(ctx context.Context, input
 
 // CreateBulkCSVControlObjective is the resolver for the createBulkCSVControlObjective field.
 func (r *mutationResolver) CreateBulkCSVControlObjective(ctx context.Context, input graphql.Upload) (*model.ControlObjectiveBulkCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	data, err := unmarshalBulkData[generated.CreateControlObjectiveInput](input)
@@ -87,7 +87,7 @@ func (r *mutationResolver) CreateBulkCSVControlObjective(ctx context.Context, in
 
 // UpdateControlObjective is the resolver for the updateControlObjective field.
 func (r *mutationResolver) UpdateControlObjective(ctx context.Context, id string, input generated.UpdateControlObjectiveInput) (*model.ControlObjectiveUpdatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	res, err := withTransactionalMutation(ctx).ControlObjective.Get(ctx, id)
@@ -132,10 +132,10 @@ func (r *mutationResolver) DeleteControlObjective(ctx context.Context, id string
 
 // ControlObjective is the resolver for the controlObjective field.
 func (r *queryResolver) ControlObjective(ctx context.Context, id string) (*generated.ControlObjective, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).ControlObjective.Query().Where(controlobjective.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).ControlObjective.Query().Where(controlobjective.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "controlobjective"})
 	}

--- a/internal/graphapi/documentdata.resolvers.go
+++ b/internal/graphapi/documentdata.resolvers.go
@@ -18,7 +18,7 @@ import (
 
 // CreateDocumentData is the resolver for the createDocumentData field.
 func (r *mutationResolver) CreateDocumentData(ctx context.Context, input generated.CreateDocumentDataInput) (*model.DocumentDataCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set the organization in the auth context if its not done for us
@@ -52,7 +52,7 @@ func (r *mutationResolver) CreateBulkDocumentData(ctx context.Context, input []*
 		return nil, rout.NewMissingRequiredFieldError("owner_id")
 	}
 
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	return r.bulkCreateDocumentData(ctx, input)
@@ -60,7 +60,7 @@ func (r *mutationResolver) CreateBulkDocumentData(ctx context.Context, input []*
 
 // CreateBulkCSVDocumentData is the resolver for the createBulkCSVDocumentData field.
 func (r *mutationResolver) CreateBulkCSVDocumentData(ctx context.Context, input graphql.Upload) (*model.DocumentDataBulkCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	data, err := unmarshalBulkData[generated.CreateDocumentDataInput](input)
@@ -87,7 +87,7 @@ func (r *mutationResolver) CreateBulkCSVDocumentData(ctx context.Context, input 
 
 // UpdateDocumentData is the resolver for the updateDocumentData field.
 func (r *mutationResolver) UpdateDocumentData(ctx context.Context, id string, input generated.UpdateDocumentDataInput) (*model.DocumentDataUpdatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	res, err := withTransactionalMutation(ctx).DocumentData.Get(ctx, id)
@@ -132,10 +132,10 @@ func (r *mutationResolver) DeleteDocumentData(ctx context.Context, id string) (*
 
 // DocumentData is the resolver for the documentData field.
 func (r *queryResolver) DocumentData(ctx context.Context, id string) (*generated.DocumentData, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).DocumentData.Query().Where(documentdata.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).DocumentData.Query().Where(documentdata.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "documentdata"})
 	}

--- a/internal/graphapi/ent.resolvers.go
+++ b/internal/graphapi/ent.resolvers.go
@@ -35,7 +35,7 @@ func (r *queryResolver) Nodes(ctx context.Context, ids []string) ([]generated.No
 
 // APITokens is the resolver for the apiTokens field.
 func (r *queryResolver) APITokens(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.APITokenOrder, where *generated.APITokenWhereInput) (*generated.APITokenConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -52,6 +52,7 @@ func (r *queryResolver) APITokens(ctx context.Context, after *entgql.Cursor[stri
 		first,
 		before,
 		last,
+		generated.WithAPITokenOrder(orderBy),
 		generated.WithAPITokenFilter(where.Filter))
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "apitoken"})
@@ -62,7 +63,7 @@ func (r *queryResolver) APITokens(ctx context.Context, after *entgql.Cursor[stri
 
 // ActionPlans is the resolver for the actionPlans field.
 func (r *queryResolver) ActionPlans(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ActionPlanOrder, where *generated.ActionPlanWhereInput) (*generated.ActionPlanConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -90,7 +91,7 @@ func (r *queryResolver) ActionPlans(ctx context.Context, after *entgql.Cursor[st
 
 // ActionPlanHistories is the resolver for the actionPlanHistories field.
 func (r *queryResolver) ActionPlanHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ActionPlanHistoryOrder, where *generated.ActionPlanHistoryWhereInput) (*generated.ActionPlanHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -118,7 +119,7 @@ func (r *queryResolver) ActionPlanHistories(ctx context.Context, after *entgql.C
 
 // Contacts is the resolver for the contacts field.
 func (r *queryResolver) Contacts(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ContactOrder, where *generated.ContactWhereInput) (*generated.ContactConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -146,7 +147,7 @@ func (r *queryResolver) Contacts(ctx context.Context, after *entgql.Cursor[strin
 
 // ContactHistories is the resolver for the contactHistories field.
 func (r *queryResolver) ContactHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ContactHistoryOrder, where *generated.ContactHistoryWhereInput) (*generated.ContactHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -174,7 +175,7 @@ func (r *queryResolver) ContactHistories(ctx context.Context, after *entgql.Curs
 
 // Controls is the resolver for the controls field.
 func (r *queryResolver) Controls(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlOrder, where *generated.ControlWhereInput) (*generated.ControlConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -202,7 +203,7 @@ func (r *queryResolver) Controls(ctx context.Context, after *entgql.Cursor[strin
 
 // ControlHistories is the resolver for the controlHistories field.
 func (r *queryResolver) ControlHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ControlHistoryOrder, where *generated.ControlHistoryWhereInput) (*generated.ControlHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -230,7 +231,7 @@ func (r *queryResolver) ControlHistories(ctx context.Context, after *entgql.Curs
 
 // ControlImplementations is the resolver for the controlImplementations field.
 func (r *queryResolver) ControlImplementations(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlImplementationOrder, where *generated.ControlImplementationWhereInput) (*generated.ControlImplementationConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -258,7 +259,7 @@ func (r *queryResolver) ControlImplementations(ctx context.Context, after *entgq
 
 // ControlImplementationHistories is the resolver for the controlImplementationHistories field.
 func (r *queryResolver) ControlImplementationHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ControlImplementationHistoryOrder, where *generated.ControlImplementationHistoryWhereInput) (*generated.ControlImplementationHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -286,7 +287,7 @@ func (r *queryResolver) ControlImplementationHistories(ctx context.Context, afte
 
 // ControlObjectives is the resolver for the controlObjectives field.
 func (r *queryResolver) ControlObjectives(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlObjectiveOrder, where *generated.ControlObjectiveWhereInput) (*generated.ControlObjectiveConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -314,7 +315,7 @@ func (r *queryResolver) ControlObjectives(ctx context.Context, after *entgql.Cur
 
 // ControlObjectiveHistories is the resolver for the controlObjectiveHistories field.
 func (r *queryResolver) ControlObjectiveHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ControlObjectiveHistoryOrder, where *generated.ControlObjectiveHistoryWhereInput) (*generated.ControlObjectiveHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -342,7 +343,7 @@ func (r *queryResolver) ControlObjectiveHistories(ctx context.Context, after *en
 
 // DocumentDataSlice is the resolver for the documentDataSlice field.
 func (r *queryResolver) DocumentDataSlice(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.DocumentDataOrder, where *generated.DocumentDataWhereInput) (*generated.DocumentDataConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -359,6 +360,7 @@ func (r *queryResolver) DocumentDataSlice(ctx context.Context, after *entgql.Cur
 		first,
 		before,
 		last,
+		generated.WithDocumentDataOrder(orderBy),
 		generated.WithDocumentDataFilter(where.Filter))
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "documentdata"})
@@ -369,7 +371,7 @@ func (r *queryResolver) DocumentDataSlice(ctx context.Context, after *entgql.Cur
 
 // DocumentDataHistories is the resolver for the documentDataHistories field.
 func (r *queryResolver) DocumentDataHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.DocumentDataHistoryOrder, where *generated.DocumentDataHistoryWhereInput) (*generated.DocumentDataHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -386,6 +388,7 @@ func (r *queryResolver) DocumentDataHistories(ctx context.Context, after *entgql
 		first,
 		before,
 		last,
+		generated.WithDocumentDataHistoryOrder(orderBy),
 		generated.WithDocumentDataHistoryFilter(where.Filter))
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "documentdatahistory"})
@@ -396,7 +399,7 @@ func (r *queryResolver) DocumentDataHistories(ctx context.Context, after *entgql
 
 // Entities is the resolver for the entities field.
 func (r *queryResolver) Entities(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.EntityOrder, where *generated.EntityWhereInput) (*generated.EntityConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -424,7 +427,7 @@ func (r *queryResolver) Entities(ctx context.Context, after *entgql.Cursor[strin
 
 // EntityHistories is the resolver for the entityHistories field.
 func (r *queryResolver) EntityHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.EntityHistoryOrder, where *generated.EntityHistoryWhereInput) (*generated.EntityHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -452,7 +455,7 @@ func (r *queryResolver) EntityHistories(ctx context.Context, after *entgql.Curso
 
 // EntityTypes is the resolver for the entityTypes field.
 func (r *queryResolver) EntityTypes(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.EntityTypeOrder, where *generated.EntityTypeWhereInput) (*generated.EntityTypeConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -480,7 +483,7 @@ func (r *queryResolver) EntityTypes(ctx context.Context, after *entgql.Cursor[st
 
 // EntityTypeHistories is the resolver for the entityTypeHistories field.
 func (r *queryResolver) EntityTypeHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.EntityTypeHistoryOrder, where *generated.EntityTypeHistoryWhereInput) (*generated.EntityTypeHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -508,7 +511,7 @@ func (r *queryResolver) EntityTypeHistories(ctx context.Context, after *entgql.C
 
 // Events is the resolver for the events field.
 func (r *queryResolver) Events(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.EventOrder, where *generated.EventWhereInput) (*generated.EventConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -525,6 +528,7 @@ func (r *queryResolver) Events(ctx context.Context, after *entgql.Cursor[string]
 		first,
 		before,
 		last,
+		generated.WithEventOrder(orderBy),
 		generated.WithEventFilter(where.Filter))
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "event"})
@@ -535,7 +539,7 @@ func (r *queryResolver) Events(ctx context.Context, after *entgql.Cursor[string]
 
 // EventHistories is the resolver for the eventHistories field.
 func (r *queryResolver) EventHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.EventHistoryOrder, where *generated.EventHistoryWhereInput) (*generated.EventHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -552,6 +556,7 @@ func (r *queryResolver) EventHistories(ctx context.Context, after *entgql.Cursor
 		first,
 		before,
 		last,
+		generated.WithEventHistoryOrder(orderBy),
 		generated.WithEventHistoryFilter(where.Filter))
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "eventhistory"})
@@ -562,7 +567,7 @@ func (r *queryResolver) EventHistories(ctx context.Context, after *entgql.Cursor
 
 // Evidences is the resolver for the evidences field.
 func (r *queryResolver) Evidences(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.EvidenceOrder, where *generated.EvidenceWhereInput) (*generated.EvidenceConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -590,7 +595,7 @@ func (r *queryResolver) Evidences(ctx context.Context, after *entgql.Cursor[stri
 
 // EvidenceHistories is the resolver for the evidenceHistories field.
 func (r *queryResolver) EvidenceHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.EvidenceHistoryOrder, where *generated.EvidenceHistoryWhereInput) (*generated.EvidenceHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -618,7 +623,7 @@ func (r *queryResolver) EvidenceHistories(ctx context.Context, after *entgql.Cur
 
 // Files is the resolver for the files field.
 func (r *queryResolver) Files(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.FileOrder, where *generated.FileWhereInput) (*generated.FileConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -635,6 +640,7 @@ func (r *queryResolver) Files(ctx context.Context, after *entgql.Cursor[string],
 		first,
 		before,
 		last,
+		generated.WithFileOrder(orderBy),
 		generated.WithFileFilter(where.Filter))
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "file"})
@@ -645,7 +651,7 @@ func (r *queryResolver) Files(ctx context.Context, after *entgql.Cursor[string],
 
 // FileHistories is the resolver for the fileHistories field.
 func (r *queryResolver) FileHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.FileHistoryOrder, where *generated.FileHistoryWhereInput) (*generated.FileHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -662,6 +668,7 @@ func (r *queryResolver) FileHistories(ctx context.Context, after *entgql.Cursor[
 		first,
 		before,
 		last,
+		generated.WithFileHistoryOrder(orderBy),
 		generated.WithFileHistoryFilter(where.Filter))
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "filehistory"})
@@ -672,7 +679,7 @@ func (r *queryResolver) FileHistories(ctx context.Context, after *entgql.Cursor[
 
 // Groups is the resolver for the groups field.
 func (r *queryResolver) Groups(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.GroupOrder, where *generated.GroupWhereInput) (*generated.GroupConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -700,7 +707,7 @@ func (r *queryResolver) Groups(ctx context.Context, after *entgql.Cursor[string]
 
 // GroupHistories is the resolver for the groupHistories field.
 func (r *queryResolver) GroupHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.GroupHistoryOrder, where *generated.GroupHistoryWhereInput) (*generated.GroupHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -728,7 +735,7 @@ func (r *queryResolver) GroupHistories(ctx context.Context, after *entgql.Cursor
 
 // GroupMemberships is the resolver for the groupMemberships field.
 func (r *queryResolver) GroupMemberships(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.GroupMembershipOrder, where *generated.GroupMembershipWhereInput) (*generated.GroupMembershipConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -756,7 +763,7 @@ func (r *queryResolver) GroupMemberships(ctx context.Context, after *entgql.Curs
 
 // GroupMembershipHistories is the resolver for the groupMembershipHistories field.
 func (r *queryResolver) GroupMembershipHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.GroupMembershipHistoryOrder, where *generated.GroupMembershipHistoryWhereInput) (*generated.GroupMembershipHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -784,7 +791,7 @@ func (r *queryResolver) GroupMembershipHistories(ctx context.Context, after *ent
 
 // GroupSettings is the resolver for the groupSettings field.
 func (r *queryResolver) GroupSettings(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.GroupSettingOrder, where *generated.GroupSettingWhereInput) (*generated.GroupSettingConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -801,6 +808,7 @@ func (r *queryResolver) GroupSettings(ctx context.Context, after *entgql.Cursor[
 		first,
 		before,
 		last,
+		generated.WithGroupSettingOrder(orderBy),
 		generated.WithGroupSettingFilter(where.Filter))
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "groupsetting"})
@@ -811,7 +819,7 @@ func (r *queryResolver) GroupSettings(ctx context.Context, after *entgql.Cursor[
 
 // GroupSettingHistories is the resolver for the groupSettingHistories field.
 func (r *queryResolver) GroupSettingHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.GroupSettingHistoryOrder, where *generated.GroupSettingHistoryWhereInput) (*generated.GroupSettingHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -828,6 +836,7 @@ func (r *queryResolver) GroupSettingHistories(ctx context.Context, after *entgql
 		first,
 		before,
 		last,
+		generated.WithGroupSettingHistoryOrder(orderBy),
 		generated.WithGroupSettingHistoryFilter(where.Filter))
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "groupsettinghistory"})
@@ -838,7 +847,7 @@ func (r *queryResolver) GroupSettingHistories(ctx context.Context, after *entgql
 
 // Hushes is the resolver for the hushes field.
 func (r *queryResolver) Hushes(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.HushOrder, where *generated.HushWhereInput) (*generated.HushConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -866,7 +875,7 @@ func (r *queryResolver) Hushes(ctx context.Context, after *entgql.Cursor[string]
 
 // HushHistories is the resolver for the hushHistories field.
 func (r *queryResolver) HushHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.HushHistoryOrder, where *generated.HushHistoryWhereInput) (*generated.HushHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -894,7 +903,7 @@ func (r *queryResolver) HushHistories(ctx context.Context, after *entgql.Cursor[
 
 // Integrations is the resolver for the integrations field.
 func (r *queryResolver) Integrations(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.IntegrationOrder, where *generated.IntegrationWhereInput) (*generated.IntegrationConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -922,7 +931,7 @@ func (r *queryResolver) Integrations(ctx context.Context, after *entgql.Cursor[s
 
 // IntegrationHistories is the resolver for the integrationHistories field.
 func (r *queryResolver) IntegrationHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.IntegrationHistoryOrder, where *generated.IntegrationHistoryWhereInput) (*generated.IntegrationHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -950,7 +959,7 @@ func (r *queryResolver) IntegrationHistories(ctx context.Context, after *entgql.
 
 // InternalPolicies is the resolver for the internalPolicies field.
 func (r *queryResolver) InternalPolicies(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.InternalPolicyOrder, where *generated.InternalPolicyWhereInput) (*generated.InternalPolicyConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -967,6 +976,7 @@ func (r *queryResolver) InternalPolicies(ctx context.Context, after *entgql.Curs
 		first,
 		before,
 		last,
+		generated.WithInternalPolicyOrder(orderBy),
 		generated.WithInternalPolicyFilter(where.Filter))
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "internalpolicy"})
@@ -977,7 +987,7 @@ func (r *queryResolver) InternalPolicies(ctx context.Context, after *entgql.Curs
 
 // InternalPolicyHistories is the resolver for the internalPolicyHistories field.
 func (r *queryResolver) InternalPolicyHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.InternalPolicyHistoryOrder, where *generated.InternalPolicyHistoryWhereInput) (*generated.InternalPolicyHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -994,6 +1004,7 @@ func (r *queryResolver) InternalPolicyHistories(ctx context.Context, after *entg
 		first,
 		before,
 		last,
+		generated.WithInternalPolicyHistoryOrder(orderBy),
 		generated.WithInternalPolicyHistoryFilter(where.Filter))
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "internalpolicyhistory"})
@@ -1004,7 +1015,7 @@ func (r *queryResolver) InternalPolicyHistories(ctx context.Context, after *entg
 
 // Invites is the resolver for the invites field.
 func (r *queryResolver) Invites(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.InviteOrder, where *generated.InviteWhereInput) (*generated.InviteConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1032,7 +1043,7 @@ func (r *queryResolver) Invites(ctx context.Context, after *entgql.Cursor[string
 
 // MappedControls is the resolver for the mappedControls field.
 func (r *queryResolver) MappedControls(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.MappedControlOrder, where *generated.MappedControlWhereInput) (*generated.MappedControlConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1060,7 +1071,7 @@ func (r *queryResolver) MappedControls(ctx context.Context, after *entgql.Cursor
 
 // MappedControlHistories is the resolver for the mappedControlHistories field.
 func (r *queryResolver) MappedControlHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.MappedControlHistoryOrder, where *generated.MappedControlHistoryWhereInput) (*generated.MappedControlHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1088,7 +1099,7 @@ func (r *queryResolver) MappedControlHistories(ctx context.Context, after *entgq
 
 // Narratives is the resolver for the narratives field.
 func (r *queryResolver) Narratives(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.NarrativeOrder, where *generated.NarrativeWhereInput) (*generated.NarrativeConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1116,7 +1127,7 @@ func (r *queryResolver) Narratives(ctx context.Context, after *entgql.Cursor[str
 
 // NarrativeHistories is the resolver for the narrativeHistories field.
 func (r *queryResolver) NarrativeHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.NarrativeHistoryOrder, where *generated.NarrativeHistoryWhereInput) (*generated.NarrativeHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1144,7 +1155,7 @@ func (r *queryResolver) NarrativeHistories(ctx context.Context, after *entgql.Cu
 
 // Notes is the resolver for the notes field.
 func (r *queryResolver) Notes(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.NoteOrder, where *generated.NoteWhereInput) (*generated.NoteConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1161,6 +1172,7 @@ func (r *queryResolver) Notes(ctx context.Context, after *entgql.Cursor[string],
 		first,
 		before,
 		last,
+		generated.WithNoteOrder(orderBy),
 		generated.WithNoteFilter(where.Filter))
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "note"})
@@ -1171,7 +1183,7 @@ func (r *queryResolver) Notes(ctx context.Context, after *entgql.Cursor[string],
 
 // NoteHistories is the resolver for the noteHistories field.
 func (r *queryResolver) NoteHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.NoteHistoryOrder, where *generated.NoteHistoryWhereInput) (*generated.NoteHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1188,6 +1200,7 @@ func (r *queryResolver) NoteHistories(ctx context.Context, after *entgql.Cursor[
 		first,
 		before,
 		last,
+		generated.WithNoteHistoryOrder(orderBy),
 		generated.WithNoteHistoryFilter(where.Filter))
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "notehistory"})
@@ -1198,7 +1211,7 @@ func (r *queryResolver) NoteHistories(ctx context.Context, after *entgql.Cursor[
 
 // OrgMemberships is the resolver for the orgMemberships field.
 func (r *queryResolver) OrgMemberships(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.OrgMembershipOrder, where *generated.OrgMembershipWhereInput) (*generated.OrgMembershipConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1226,7 +1239,7 @@ func (r *queryResolver) OrgMemberships(ctx context.Context, after *entgql.Cursor
 
 // OrgMembershipHistories is the resolver for the orgMembershipHistories field.
 func (r *queryResolver) OrgMembershipHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.OrgMembershipHistoryOrder, where *generated.OrgMembershipHistoryWhereInput) (*generated.OrgMembershipHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1254,7 +1267,7 @@ func (r *queryResolver) OrgMembershipHistories(ctx context.Context, after *entgq
 
 // OrgSubscriptions is the resolver for the orgSubscriptions field.
 func (r *queryResolver) OrgSubscriptions(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.OrgSubscriptionOrder, where *generated.OrgSubscriptionWhereInput) (*generated.OrgSubscriptionConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1282,7 +1295,7 @@ func (r *queryResolver) OrgSubscriptions(ctx context.Context, after *entgql.Curs
 
 // OrgSubscriptionHistories is the resolver for the orgSubscriptionHistories field.
 func (r *queryResolver) OrgSubscriptionHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.OrgSubscriptionHistoryOrder, where *generated.OrgSubscriptionHistoryWhereInput) (*generated.OrgSubscriptionHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1310,7 +1323,7 @@ func (r *queryResolver) OrgSubscriptionHistories(ctx context.Context, after *ent
 
 // Organizations is the resolver for the organizations field.
 func (r *queryResolver) Organizations(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.OrganizationOrder, where *generated.OrganizationWhereInput) (*generated.OrganizationConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1338,7 +1351,7 @@ func (r *queryResolver) Organizations(ctx context.Context, after *entgql.Cursor[
 
 // OrganizationHistories is the resolver for the organizationHistories field.
 func (r *queryResolver) OrganizationHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.OrganizationHistoryOrder, where *generated.OrganizationHistoryWhereInput) (*generated.OrganizationHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1366,7 +1379,7 @@ func (r *queryResolver) OrganizationHistories(ctx context.Context, after *entgql
 
 // OrganizationSettings is the resolver for the organizationSettings field.
 func (r *queryResolver) OrganizationSettings(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.OrganizationSettingOrder, where *generated.OrganizationSettingWhereInput) (*generated.OrganizationSettingConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1383,6 +1396,7 @@ func (r *queryResolver) OrganizationSettings(ctx context.Context, after *entgql.
 		first,
 		before,
 		last,
+		generated.WithOrganizationSettingOrder(orderBy),
 		generated.WithOrganizationSettingFilter(where.Filter))
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "organizationsetting"})
@@ -1393,7 +1407,7 @@ func (r *queryResolver) OrganizationSettings(ctx context.Context, after *entgql.
 
 // OrganizationSettingHistories is the resolver for the organizationSettingHistories field.
 func (r *queryResolver) OrganizationSettingHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.OrganizationSettingHistoryOrder, where *generated.OrganizationSettingHistoryWhereInput) (*generated.OrganizationSettingHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1410,6 +1424,7 @@ func (r *queryResolver) OrganizationSettingHistories(ctx context.Context, after 
 		first,
 		before,
 		last,
+		generated.WithOrganizationSettingHistoryOrder(orderBy),
 		generated.WithOrganizationSettingHistoryFilter(where.Filter))
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "organizationsettinghistory"})
@@ -1420,7 +1435,7 @@ func (r *queryResolver) OrganizationSettingHistories(ctx context.Context, after 
 
 // PersonalAccessTokens is the resolver for the personalAccessTokens field.
 func (r *queryResolver) PersonalAccessTokens(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.PersonalAccessTokenOrder, where *generated.PersonalAccessTokenWhereInput) (*generated.PersonalAccessTokenConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1437,6 +1452,7 @@ func (r *queryResolver) PersonalAccessTokens(ctx context.Context, after *entgql.
 		first,
 		before,
 		last,
+		generated.WithPersonalAccessTokenOrder(orderBy),
 		generated.WithPersonalAccessTokenFilter(where.Filter))
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "personalaccesstoken"})
@@ -1447,7 +1463,7 @@ func (r *queryResolver) PersonalAccessTokens(ctx context.Context, after *entgql.
 
 // Procedures is the resolver for the procedures field.
 func (r *queryResolver) Procedures(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ProcedureOrder, where *generated.ProcedureWhereInput) (*generated.ProcedureConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1464,6 +1480,7 @@ func (r *queryResolver) Procedures(ctx context.Context, after *entgql.Cursor[str
 		first,
 		before,
 		last,
+		generated.WithProcedureOrder(orderBy),
 		generated.WithProcedureFilter(where.Filter))
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "procedure"})
@@ -1474,7 +1491,7 @@ func (r *queryResolver) Procedures(ctx context.Context, after *entgql.Cursor[str
 
 // ProcedureHistories is the resolver for the procedureHistories field.
 func (r *queryResolver) ProcedureHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ProcedureHistoryOrder, where *generated.ProcedureHistoryWhereInput) (*generated.ProcedureHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1491,6 +1508,7 @@ func (r *queryResolver) ProcedureHistories(ctx context.Context, after *entgql.Cu
 		first,
 		before,
 		last,
+		generated.WithProcedureHistoryOrder(orderBy),
 		generated.WithProcedureHistoryFilter(where.Filter))
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "procedurehistory"})
@@ -1501,7 +1519,7 @@ func (r *queryResolver) ProcedureHistories(ctx context.Context, after *entgql.Cu
 
 // Programs is the resolver for the programs field.
 func (r *queryResolver) Programs(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ProgramOrder, where *generated.ProgramWhereInput) (*generated.ProgramConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1529,7 +1547,7 @@ func (r *queryResolver) Programs(ctx context.Context, after *entgql.Cursor[strin
 
 // ProgramHistories is the resolver for the programHistories field.
 func (r *queryResolver) ProgramHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ProgramHistoryOrder, where *generated.ProgramHistoryWhereInput) (*generated.ProgramHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1557,7 +1575,7 @@ func (r *queryResolver) ProgramHistories(ctx context.Context, after *entgql.Curs
 
 // ProgramMemberships is the resolver for the programMemberships field.
 func (r *queryResolver) ProgramMemberships(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ProgramMembershipOrder, where *generated.ProgramMembershipWhereInput) (*generated.ProgramMembershipConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1585,7 +1603,7 @@ func (r *queryResolver) ProgramMemberships(ctx context.Context, after *entgql.Cu
 
 // ProgramMembershipHistories is the resolver for the programMembershipHistories field.
 func (r *queryResolver) ProgramMembershipHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ProgramMembershipHistoryOrder, where *generated.ProgramMembershipHistoryWhereInput) (*generated.ProgramMembershipHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1613,7 +1631,7 @@ func (r *queryResolver) ProgramMembershipHistories(ctx context.Context, after *e
 
 // Risks is the resolver for the risks field.
 func (r *queryResolver) Risks(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.RiskOrder, where *generated.RiskWhereInput) (*generated.RiskConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1641,7 +1659,7 @@ func (r *queryResolver) Risks(ctx context.Context, after *entgql.Cursor[string],
 
 // RiskHistories is the resolver for the riskHistories field.
 func (r *queryResolver) RiskHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.RiskHistoryOrder, where *generated.RiskHistoryWhereInput) (*generated.RiskHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1669,7 +1687,7 @@ func (r *queryResolver) RiskHistories(ctx context.Context, after *entgql.Cursor[
 
 // Standards is the resolver for the standards field.
 func (r *queryResolver) Standards(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.StandardOrder, where *generated.StandardWhereInput) (*generated.StandardConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1697,7 +1715,7 @@ func (r *queryResolver) Standards(ctx context.Context, after *entgql.Cursor[stri
 
 // StandardHistories is the resolver for the standardHistories field.
 func (r *queryResolver) StandardHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.StandardHistoryOrder, where *generated.StandardHistoryWhereInput) (*generated.StandardHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1725,7 +1743,7 @@ func (r *queryResolver) StandardHistories(ctx context.Context, after *entgql.Cur
 
 // Subcontrols is the resolver for the subcontrols field.
 func (r *queryResolver) Subcontrols(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.SubcontrolOrder, where *generated.SubcontrolWhereInput) (*generated.SubcontrolConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1753,7 +1771,7 @@ func (r *queryResolver) Subcontrols(ctx context.Context, after *entgql.Cursor[st
 
 // SubcontrolHistories is the resolver for the subcontrolHistories field.
 func (r *queryResolver) SubcontrolHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.SubcontrolHistoryOrder, where *generated.SubcontrolHistoryWhereInput) (*generated.SubcontrolHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1781,7 +1799,7 @@ func (r *queryResolver) SubcontrolHistories(ctx context.Context, after *entgql.C
 
 // Subscribers is the resolver for the subscribers field.
 func (r *queryResolver) Subscribers(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.SubscriberOrder, where *generated.SubscriberWhereInput) (*generated.SubscriberConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1809,7 +1827,7 @@ func (r *queryResolver) Subscribers(ctx context.Context, after *entgql.Cursor[st
 
 // TfaSettings is the resolver for the tfaSettings field.
 func (r *queryResolver) TfaSettings(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.TFASettingOrder, where *generated.TFASettingWhereInput) (*generated.TFASettingConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1826,6 +1844,7 @@ func (r *queryResolver) TfaSettings(ctx context.Context, after *entgql.Cursor[st
 		first,
 		before,
 		last,
+		generated.WithTFASettingOrder(orderBy),
 		generated.WithTFASettingFilter(where.Filter))
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "tfasetting"})
@@ -1836,7 +1855,7 @@ func (r *queryResolver) TfaSettings(ctx context.Context, after *entgql.Cursor[st
 
 // Tasks is the resolver for the tasks field.
 func (r *queryResolver) Tasks(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.TaskOrder, where *generated.TaskWhereInput) (*generated.TaskConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1864,7 +1883,7 @@ func (r *queryResolver) Tasks(ctx context.Context, after *entgql.Cursor[string],
 
 // TaskHistories is the resolver for the taskHistories field.
 func (r *queryResolver) TaskHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.TaskHistoryOrder, where *generated.TaskHistoryWhereInput) (*generated.TaskHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1892,7 +1911,7 @@ func (r *queryResolver) TaskHistories(ctx context.Context, after *entgql.Cursor[
 
 // Templates is the resolver for the templates field.
 func (r *queryResolver) Templates(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.TemplateOrder, where *generated.TemplateWhereInput) (*generated.TemplateConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1920,7 +1939,7 @@ func (r *queryResolver) Templates(ctx context.Context, after *entgql.Cursor[stri
 
 // TemplateHistories is the resolver for the templateHistories field.
 func (r *queryResolver) TemplateHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.TemplateHistoryOrder, where *generated.TemplateHistoryWhereInput) (*generated.TemplateHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1948,7 +1967,7 @@ func (r *queryResolver) TemplateHistories(ctx context.Context, after *entgql.Cur
 
 // Users is the resolver for the users field.
 func (r *queryResolver) Users(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.UserOrder, where *generated.UserWhereInput) (*generated.UserConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -1976,7 +1995,7 @@ func (r *queryResolver) Users(ctx context.Context, after *entgql.Cursor[string],
 
 // UserHistories is the resolver for the userHistories field.
 func (r *queryResolver) UserHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.UserHistoryOrder, where *generated.UserHistoryWhereInput) (*generated.UserHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -2004,7 +2023,7 @@ func (r *queryResolver) UserHistories(ctx context.Context, after *entgql.Cursor[
 
 // UserSettings is the resolver for the userSettings field.
 func (r *queryResolver) UserSettings(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.UserSettingOrder, where *generated.UserSettingWhereInput) (*generated.UserSettingConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -2021,6 +2040,7 @@ func (r *queryResolver) UserSettings(ctx context.Context, after *entgql.Cursor[s
 		first,
 		before,
 		last,
+		generated.WithUserSettingOrder(orderBy),
 		generated.WithUserSettingFilter(where.Filter))
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "usersetting"})
@@ -2031,7 +2051,7 @@ func (r *queryResolver) UserSettings(ctx context.Context, after *entgql.Cursor[s
 
 // UserSettingHistories is the resolver for the userSettingHistories field.
 func (r *queryResolver) UserSettingHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.UserSettingHistoryOrder, where *generated.UserSettingHistoryWhereInput) (*generated.UserSettingHistoryConnection, error) {
-	// get preloads to set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
@@ -2048,6 +2068,7 @@ func (r *queryResolver) UserSettingHistories(ctx context.Context, after *entgql.
 		first,
 		before,
 		last,
+		generated.WithUserSettingHistoryOrder(orderBy),
 		generated.WithUserSettingHistoryFilter(where.Filter))
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "usersettinghistory"})

--- a/internal/graphapi/ent.resolvers.go
+++ b/internal/graphapi/ent.resolvers.go
@@ -35,13 +35,13 @@ func (r *queryResolver) Nodes(ctx context.Context, ids []string) ([]generated.No
 
 // APITokens is the resolver for the apiTokens field.
 func (r *queryResolver) APITokens(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.APITokenOrder, where *generated.APITokenWhereInput) (*generated.APITokenConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).APIToken.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).APIToken.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "apitoken"})
 	}
@@ -62,13 +62,13 @@ func (r *queryResolver) APITokens(ctx context.Context, after *entgql.Cursor[stri
 
 // ActionPlans is the resolver for the actionPlans field.
 func (r *queryResolver) ActionPlans(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ActionPlanOrder, where *generated.ActionPlanWhereInput) (*generated.ActionPlanConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).ActionPlan.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).ActionPlan.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "actionplan"})
 	}
@@ -90,13 +90,13 @@ func (r *queryResolver) ActionPlans(ctx context.Context, after *entgql.Cursor[st
 
 // ActionPlanHistories is the resolver for the actionPlanHistories field.
 func (r *queryResolver) ActionPlanHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ActionPlanHistoryOrder, where *generated.ActionPlanHistoryWhereInput) (*generated.ActionPlanHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).ActionPlanHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).ActionPlanHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "actionplanhistory"})
 	}
@@ -118,13 +118,13 @@ func (r *queryResolver) ActionPlanHistories(ctx context.Context, after *entgql.C
 
 // Contacts is the resolver for the contacts field.
 func (r *queryResolver) Contacts(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ContactOrder, where *generated.ContactWhereInput) (*generated.ContactConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Contact.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Contact.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "contact"})
 	}
@@ -146,13 +146,13 @@ func (r *queryResolver) Contacts(ctx context.Context, after *entgql.Cursor[strin
 
 // ContactHistories is the resolver for the contactHistories field.
 func (r *queryResolver) ContactHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ContactHistoryOrder, where *generated.ContactHistoryWhereInput) (*generated.ContactHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).ContactHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).ContactHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "contacthistory"})
 	}
@@ -174,13 +174,13 @@ func (r *queryResolver) ContactHistories(ctx context.Context, after *entgql.Curs
 
 // Controls is the resolver for the controls field.
 func (r *queryResolver) Controls(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlOrder, where *generated.ControlWhereInput) (*generated.ControlConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Control.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Control.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "control"})
 	}
@@ -202,13 +202,13 @@ func (r *queryResolver) Controls(ctx context.Context, after *entgql.Cursor[strin
 
 // ControlHistories is the resolver for the controlHistories field.
 func (r *queryResolver) ControlHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ControlHistoryOrder, where *generated.ControlHistoryWhereInput) (*generated.ControlHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).ControlHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).ControlHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "controlhistory"})
 	}
@@ -230,13 +230,13 @@ func (r *queryResolver) ControlHistories(ctx context.Context, after *entgql.Curs
 
 // ControlImplementations is the resolver for the controlImplementations field.
 func (r *queryResolver) ControlImplementations(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlImplementationOrder, where *generated.ControlImplementationWhereInput) (*generated.ControlImplementationConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).ControlImplementation.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).ControlImplementation.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "controlimplementation"})
 	}
@@ -258,13 +258,13 @@ func (r *queryResolver) ControlImplementations(ctx context.Context, after *entgq
 
 // ControlImplementationHistories is the resolver for the controlImplementationHistories field.
 func (r *queryResolver) ControlImplementationHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ControlImplementationHistoryOrder, where *generated.ControlImplementationHistoryWhereInput) (*generated.ControlImplementationHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).ControlImplementationHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).ControlImplementationHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "controlimplementationhistory"})
 	}
@@ -286,13 +286,13 @@ func (r *queryResolver) ControlImplementationHistories(ctx context.Context, afte
 
 // ControlObjectives is the resolver for the controlObjectives field.
 func (r *queryResolver) ControlObjectives(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ControlObjectiveOrder, where *generated.ControlObjectiveWhereInput) (*generated.ControlObjectiveConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).ControlObjective.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).ControlObjective.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "controlobjective"})
 	}
@@ -314,13 +314,13 @@ func (r *queryResolver) ControlObjectives(ctx context.Context, after *entgql.Cur
 
 // ControlObjectiveHistories is the resolver for the controlObjectiveHistories field.
 func (r *queryResolver) ControlObjectiveHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ControlObjectiveHistoryOrder, where *generated.ControlObjectiveHistoryWhereInput) (*generated.ControlObjectiveHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).ControlObjectiveHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).ControlObjectiveHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "controlobjectivehistory"})
 	}
@@ -342,13 +342,13 @@ func (r *queryResolver) ControlObjectiveHistories(ctx context.Context, after *en
 
 // DocumentDataSlice is the resolver for the documentDataSlice field.
 func (r *queryResolver) DocumentDataSlice(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.DocumentDataOrder, where *generated.DocumentDataWhereInput) (*generated.DocumentDataConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).DocumentData.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).DocumentData.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "documentdata"})
 	}
@@ -369,13 +369,13 @@ func (r *queryResolver) DocumentDataSlice(ctx context.Context, after *entgql.Cur
 
 // DocumentDataHistories is the resolver for the documentDataHistories field.
 func (r *queryResolver) DocumentDataHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.DocumentDataHistoryOrder, where *generated.DocumentDataHistoryWhereInput) (*generated.DocumentDataHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).DocumentDataHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).DocumentDataHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "documentdatahistory"})
 	}
@@ -396,13 +396,13 @@ func (r *queryResolver) DocumentDataHistories(ctx context.Context, after *entgql
 
 // Entities is the resolver for the entities field.
 func (r *queryResolver) Entities(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.EntityOrder, where *generated.EntityWhereInput) (*generated.EntityConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Entity.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Entity.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "entity"})
 	}
@@ -424,13 +424,13 @@ func (r *queryResolver) Entities(ctx context.Context, after *entgql.Cursor[strin
 
 // EntityHistories is the resolver for the entityHistories field.
 func (r *queryResolver) EntityHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.EntityHistoryOrder, where *generated.EntityHistoryWhereInput) (*generated.EntityHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).EntityHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).EntityHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "entityhistory"})
 	}
@@ -452,13 +452,13 @@ func (r *queryResolver) EntityHistories(ctx context.Context, after *entgql.Curso
 
 // EntityTypes is the resolver for the entityTypes field.
 func (r *queryResolver) EntityTypes(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.EntityTypeOrder, where *generated.EntityTypeWhereInput) (*generated.EntityTypeConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).EntityType.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).EntityType.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "entitytype"})
 	}
@@ -480,13 +480,13 @@ func (r *queryResolver) EntityTypes(ctx context.Context, after *entgql.Cursor[st
 
 // EntityTypeHistories is the resolver for the entityTypeHistories field.
 func (r *queryResolver) EntityTypeHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.EntityTypeHistoryOrder, where *generated.EntityTypeHistoryWhereInput) (*generated.EntityTypeHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).EntityTypeHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).EntityTypeHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "entitytypehistory"})
 	}
@@ -508,13 +508,13 @@ func (r *queryResolver) EntityTypeHistories(ctx context.Context, after *entgql.C
 
 // Events is the resolver for the events field.
 func (r *queryResolver) Events(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.EventOrder, where *generated.EventWhereInput) (*generated.EventConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Event.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Event.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "event"})
 	}
@@ -535,13 +535,13 @@ func (r *queryResolver) Events(ctx context.Context, after *entgql.Cursor[string]
 
 // EventHistories is the resolver for the eventHistories field.
 func (r *queryResolver) EventHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.EventHistoryOrder, where *generated.EventHistoryWhereInput) (*generated.EventHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).EventHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).EventHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "eventhistory"})
 	}
@@ -562,13 +562,13 @@ func (r *queryResolver) EventHistories(ctx context.Context, after *entgql.Cursor
 
 // Evidences is the resolver for the evidences field.
 func (r *queryResolver) Evidences(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.EvidenceOrder, where *generated.EvidenceWhereInput) (*generated.EvidenceConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Evidence.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Evidence.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "evidence"})
 	}
@@ -590,13 +590,13 @@ func (r *queryResolver) Evidences(ctx context.Context, after *entgql.Cursor[stri
 
 // EvidenceHistories is the resolver for the evidenceHistories field.
 func (r *queryResolver) EvidenceHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.EvidenceHistoryOrder, where *generated.EvidenceHistoryWhereInput) (*generated.EvidenceHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).EvidenceHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).EvidenceHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "evidencehistory"})
 	}
@@ -618,13 +618,13 @@ func (r *queryResolver) EvidenceHistories(ctx context.Context, after *entgql.Cur
 
 // Files is the resolver for the files field.
 func (r *queryResolver) Files(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.FileOrder, where *generated.FileWhereInput) (*generated.FileConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).File.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).File.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "file"})
 	}
@@ -645,13 +645,13 @@ func (r *queryResolver) Files(ctx context.Context, after *entgql.Cursor[string],
 
 // FileHistories is the resolver for the fileHistories field.
 func (r *queryResolver) FileHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.FileHistoryOrder, where *generated.FileHistoryWhereInput) (*generated.FileHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).FileHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).FileHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "filehistory"})
 	}
@@ -672,13 +672,13 @@ func (r *queryResolver) FileHistories(ctx context.Context, after *entgql.Cursor[
 
 // Groups is the resolver for the groups field.
 func (r *queryResolver) Groups(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.GroupOrder, where *generated.GroupWhereInput) (*generated.GroupConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Group.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Group.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "group"})
 	}
@@ -700,13 +700,13 @@ func (r *queryResolver) Groups(ctx context.Context, after *entgql.Cursor[string]
 
 // GroupHistories is the resolver for the groupHistories field.
 func (r *queryResolver) GroupHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.GroupHistoryOrder, where *generated.GroupHistoryWhereInput) (*generated.GroupHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).GroupHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).GroupHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "grouphistory"})
 	}
@@ -728,13 +728,13 @@ func (r *queryResolver) GroupHistories(ctx context.Context, after *entgql.Cursor
 
 // GroupMemberships is the resolver for the groupMemberships field.
 func (r *queryResolver) GroupMemberships(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.GroupMembershipOrder, where *generated.GroupMembershipWhereInput) (*generated.GroupMembershipConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).GroupMembership.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).GroupMembership.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "groupmembership"})
 	}
@@ -756,13 +756,13 @@ func (r *queryResolver) GroupMemberships(ctx context.Context, after *entgql.Curs
 
 // GroupMembershipHistories is the resolver for the groupMembershipHistories field.
 func (r *queryResolver) GroupMembershipHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.GroupMembershipHistoryOrder, where *generated.GroupMembershipHistoryWhereInput) (*generated.GroupMembershipHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).GroupMembershipHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).GroupMembershipHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "groupmembershiphistory"})
 	}
@@ -784,13 +784,13 @@ func (r *queryResolver) GroupMembershipHistories(ctx context.Context, after *ent
 
 // GroupSettings is the resolver for the groupSettings field.
 func (r *queryResolver) GroupSettings(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.GroupSettingOrder, where *generated.GroupSettingWhereInput) (*generated.GroupSettingConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).GroupSetting.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).GroupSetting.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "groupsetting"})
 	}
@@ -811,13 +811,13 @@ func (r *queryResolver) GroupSettings(ctx context.Context, after *entgql.Cursor[
 
 // GroupSettingHistories is the resolver for the groupSettingHistories field.
 func (r *queryResolver) GroupSettingHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.GroupSettingHistoryOrder, where *generated.GroupSettingHistoryWhereInput) (*generated.GroupSettingHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).GroupSettingHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).GroupSettingHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "groupsettinghistory"})
 	}
@@ -838,13 +838,13 @@ func (r *queryResolver) GroupSettingHistories(ctx context.Context, after *entgql
 
 // Hushes is the resolver for the hushes field.
 func (r *queryResolver) Hushes(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.HushOrder, where *generated.HushWhereInput) (*generated.HushConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Hush.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Hush.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "hush"})
 	}
@@ -866,13 +866,13 @@ func (r *queryResolver) Hushes(ctx context.Context, after *entgql.Cursor[string]
 
 // HushHistories is the resolver for the hushHistories field.
 func (r *queryResolver) HushHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.HushHistoryOrder, where *generated.HushHistoryWhereInput) (*generated.HushHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).HushHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).HushHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "hushhistory"})
 	}
@@ -894,13 +894,13 @@ func (r *queryResolver) HushHistories(ctx context.Context, after *entgql.Cursor[
 
 // Integrations is the resolver for the integrations field.
 func (r *queryResolver) Integrations(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.IntegrationOrder, where *generated.IntegrationWhereInput) (*generated.IntegrationConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Integration.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Integration.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "integration"})
 	}
@@ -922,13 +922,13 @@ func (r *queryResolver) Integrations(ctx context.Context, after *entgql.Cursor[s
 
 // IntegrationHistories is the resolver for the integrationHistories field.
 func (r *queryResolver) IntegrationHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.IntegrationHistoryOrder, where *generated.IntegrationHistoryWhereInput) (*generated.IntegrationHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).IntegrationHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).IntegrationHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "integrationhistory"})
 	}
@@ -950,13 +950,13 @@ func (r *queryResolver) IntegrationHistories(ctx context.Context, after *entgql.
 
 // InternalPolicies is the resolver for the internalPolicies field.
 func (r *queryResolver) InternalPolicies(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.InternalPolicyOrder, where *generated.InternalPolicyWhereInput) (*generated.InternalPolicyConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).InternalPolicy.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).InternalPolicy.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "internalpolicy"})
 	}
@@ -977,13 +977,13 @@ func (r *queryResolver) InternalPolicies(ctx context.Context, after *entgql.Curs
 
 // InternalPolicyHistories is the resolver for the internalPolicyHistories field.
 func (r *queryResolver) InternalPolicyHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.InternalPolicyHistoryOrder, where *generated.InternalPolicyHistoryWhereInput) (*generated.InternalPolicyHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).InternalPolicyHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).InternalPolicyHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "internalpolicyhistory"})
 	}
@@ -1004,13 +1004,13 @@ func (r *queryResolver) InternalPolicyHistories(ctx context.Context, after *entg
 
 // Invites is the resolver for the invites field.
 func (r *queryResolver) Invites(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.InviteOrder, where *generated.InviteWhereInput) (*generated.InviteConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Invite.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Invite.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "invite"})
 	}
@@ -1032,13 +1032,13 @@ func (r *queryResolver) Invites(ctx context.Context, after *entgql.Cursor[string
 
 // MappedControls is the resolver for the mappedControls field.
 func (r *queryResolver) MappedControls(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.MappedControlOrder, where *generated.MappedControlWhereInput) (*generated.MappedControlConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).MappedControl.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).MappedControl.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "mappedcontrol"})
 	}
@@ -1060,13 +1060,13 @@ func (r *queryResolver) MappedControls(ctx context.Context, after *entgql.Cursor
 
 // MappedControlHistories is the resolver for the mappedControlHistories field.
 func (r *queryResolver) MappedControlHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.MappedControlHistoryOrder, where *generated.MappedControlHistoryWhereInput) (*generated.MappedControlHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).MappedControlHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).MappedControlHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "mappedcontrolhistory"})
 	}
@@ -1088,13 +1088,13 @@ func (r *queryResolver) MappedControlHistories(ctx context.Context, after *entgq
 
 // Narratives is the resolver for the narratives field.
 func (r *queryResolver) Narratives(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.NarrativeOrder, where *generated.NarrativeWhereInput) (*generated.NarrativeConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Narrative.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Narrative.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "narrative"})
 	}
@@ -1116,13 +1116,13 @@ func (r *queryResolver) Narratives(ctx context.Context, after *entgql.Cursor[str
 
 // NarrativeHistories is the resolver for the narrativeHistories field.
 func (r *queryResolver) NarrativeHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.NarrativeHistoryOrder, where *generated.NarrativeHistoryWhereInput) (*generated.NarrativeHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).NarrativeHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).NarrativeHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "narrativehistory"})
 	}
@@ -1144,13 +1144,13 @@ func (r *queryResolver) NarrativeHistories(ctx context.Context, after *entgql.Cu
 
 // Notes is the resolver for the notes field.
 func (r *queryResolver) Notes(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.NoteOrder, where *generated.NoteWhereInput) (*generated.NoteConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Note.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Note.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "note"})
 	}
@@ -1171,13 +1171,13 @@ func (r *queryResolver) Notes(ctx context.Context, after *entgql.Cursor[string],
 
 // NoteHistories is the resolver for the noteHistories field.
 func (r *queryResolver) NoteHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.NoteHistoryOrder, where *generated.NoteHistoryWhereInput) (*generated.NoteHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).NoteHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).NoteHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "notehistory"})
 	}
@@ -1198,13 +1198,13 @@ func (r *queryResolver) NoteHistories(ctx context.Context, after *entgql.Cursor[
 
 // OrgMemberships is the resolver for the orgMemberships field.
 func (r *queryResolver) OrgMemberships(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.OrgMembershipOrder, where *generated.OrgMembershipWhereInput) (*generated.OrgMembershipConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).OrgMembership.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).OrgMembership.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "orgmembership"})
 	}
@@ -1226,13 +1226,13 @@ func (r *queryResolver) OrgMemberships(ctx context.Context, after *entgql.Cursor
 
 // OrgMembershipHistories is the resolver for the orgMembershipHistories field.
 func (r *queryResolver) OrgMembershipHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.OrgMembershipHistoryOrder, where *generated.OrgMembershipHistoryWhereInput) (*generated.OrgMembershipHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).OrgMembershipHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).OrgMembershipHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "orgmembershiphistory"})
 	}
@@ -1254,13 +1254,13 @@ func (r *queryResolver) OrgMembershipHistories(ctx context.Context, after *entgq
 
 // OrgSubscriptions is the resolver for the orgSubscriptions field.
 func (r *queryResolver) OrgSubscriptions(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.OrgSubscriptionOrder, where *generated.OrgSubscriptionWhereInput) (*generated.OrgSubscriptionConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).OrgSubscription.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).OrgSubscription.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "orgsubscription"})
 	}
@@ -1282,13 +1282,13 @@ func (r *queryResolver) OrgSubscriptions(ctx context.Context, after *entgql.Curs
 
 // OrgSubscriptionHistories is the resolver for the orgSubscriptionHistories field.
 func (r *queryResolver) OrgSubscriptionHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.OrgSubscriptionHistoryOrder, where *generated.OrgSubscriptionHistoryWhereInput) (*generated.OrgSubscriptionHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).OrgSubscriptionHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).OrgSubscriptionHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "orgsubscriptionhistory"})
 	}
@@ -1310,13 +1310,13 @@ func (r *queryResolver) OrgSubscriptionHistories(ctx context.Context, after *ent
 
 // Organizations is the resolver for the organizations field.
 func (r *queryResolver) Organizations(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.OrganizationOrder, where *generated.OrganizationWhereInput) (*generated.OrganizationConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Organization.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Organization.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "organization"})
 	}
@@ -1338,13 +1338,13 @@ func (r *queryResolver) Organizations(ctx context.Context, after *entgql.Cursor[
 
 // OrganizationHistories is the resolver for the organizationHistories field.
 func (r *queryResolver) OrganizationHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.OrganizationHistoryOrder, where *generated.OrganizationHistoryWhereInput) (*generated.OrganizationHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).OrganizationHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).OrganizationHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "organizationhistory"})
 	}
@@ -1366,13 +1366,13 @@ func (r *queryResolver) OrganizationHistories(ctx context.Context, after *entgql
 
 // OrganizationSettings is the resolver for the organizationSettings field.
 func (r *queryResolver) OrganizationSettings(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.OrganizationSettingOrder, where *generated.OrganizationSettingWhereInput) (*generated.OrganizationSettingConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).OrganizationSetting.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).OrganizationSetting.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "organizationsetting"})
 	}
@@ -1393,13 +1393,13 @@ func (r *queryResolver) OrganizationSettings(ctx context.Context, after *entgql.
 
 // OrganizationSettingHistories is the resolver for the organizationSettingHistories field.
 func (r *queryResolver) OrganizationSettingHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.OrganizationSettingHistoryOrder, where *generated.OrganizationSettingHistoryWhereInput) (*generated.OrganizationSettingHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).OrganizationSettingHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).OrganizationSettingHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "organizationsettinghistory"})
 	}
@@ -1420,13 +1420,13 @@ func (r *queryResolver) OrganizationSettingHistories(ctx context.Context, after 
 
 // PersonalAccessTokens is the resolver for the personalAccessTokens field.
 func (r *queryResolver) PersonalAccessTokens(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.PersonalAccessTokenOrder, where *generated.PersonalAccessTokenWhereInput) (*generated.PersonalAccessTokenConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).PersonalAccessToken.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).PersonalAccessToken.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "personalaccesstoken"})
 	}
@@ -1447,13 +1447,13 @@ func (r *queryResolver) PersonalAccessTokens(ctx context.Context, after *entgql.
 
 // Procedures is the resolver for the procedures field.
 func (r *queryResolver) Procedures(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ProcedureOrder, where *generated.ProcedureWhereInput) (*generated.ProcedureConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Procedure.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Procedure.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "procedure"})
 	}
@@ -1474,13 +1474,13 @@ func (r *queryResolver) Procedures(ctx context.Context, after *entgql.Cursor[str
 
 // ProcedureHistories is the resolver for the procedureHistories field.
 func (r *queryResolver) ProcedureHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ProcedureHistoryOrder, where *generated.ProcedureHistoryWhereInput) (*generated.ProcedureHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).ProcedureHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).ProcedureHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "procedurehistory"})
 	}
@@ -1501,13 +1501,13 @@ func (r *queryResolver) ProcedureHistories(ctx context.Context, after *entgql.Cu
 
 // Programs is the resolver for the programs field.
 func (r *queryResolver) Programs(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ProgramOrder, where *generated.ProgramWhereInput) (*generated.ProgramConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Program.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Program.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "program"})
 	}
@@ -1529,13 +1529,13 @@ func (r *queryResolver) Programs(ctx context.Context, after *entgql.Cursor[strin
 
 // ProgramHistories is the resolver for the programHistories field.
 func (r *queryResolver) ProgramHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ProgramHistoryOrder, where *generated.ProgramHistoryWhereInput) (*generated.ProgramHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).ProgramHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).ProgramHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "programhistory"})
 	}
@@ -1557,13 +1557,13 @@ func (r *queryResolver) ProgramHistories(ctx context.Context, after *entgql.Curs
 
 // ProgramMemberships is the resolver for the programMemberships field.
 func (r *queryResolver) ProgramMemberships(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.ProgramMembershipOrder, where *generated.ProgramMembershipWhereInput) (*generated.ProgramMembershipConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).ProgramMembership.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).ProgramMembership.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "programmembership"})
 	}
@@ -1585,13 +1585,13 @@ func (r *queryResolver) ProgramMemberships(ctx context.Context, after *entgql.Cu
 
 // ProgramMembershipHistories is the resolver for the programMembershipHistories field.
 func (r *queryResolver) ProgramMembershipHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.ProgramMembershipHistoryOrder, where *generated.ProgramMembershipHistoryWhereInput) (*generated.ProgramMembershipHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).ProgramMembershipHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).ProgramMembershipHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "programmembershiphistory"})
 	}
@@ -1613,13 +1613,13 @@ func (r *queryResolver) ProgramMembershipHistories(ctx context.Context, after *e
 
 // Risks is the resolver for the risks field.
 func (r *queryResolver) Risks(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.RiskOrder, where *generated.RiskWhereInput) (*generated.RiskConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Risk.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Risk.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "risk"})
 	}
@@ -1641,13 +1641,13 @@ func (r *queryResolver) Risks(ctx context.Context, after *entgql.Cursor[string],
 
 // RiskHistories is the resolver for the riskHistories field.
 func (r *queryResolver) RiskHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.RiskHistoryOrder, where *generated.RiskHistoryWhereInput) (*generated.RiskHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).RiskHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).RiskHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "riskhistory"})
 	}
@@ -1669,13 +1669,13 @@ func (r *queryResolver) RiskHistories(ctx context.Context, after *entgql.Cursor[
 
 // Standards is the resolver for the standards field.
 func (r *queryResolver) Standards(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.StandardOrder, where *generated.StandardWhereInput) (*generated.StandardConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Standard.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Standard.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "standard"})
 	}
@@ -1697,13 +1697,13 @@ func (r *queryResolver) Standards(ctx context.Context, after *entgql.Cursor[stri
 
 // StandardHistories is the resolver for the standardHistories field.
 func (r *queryResolver) StandardHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.StandardHistoryOrder, where *generated.StandardHistoryWhereInput) (*generated.StandardHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).StandardHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).StandardHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "standardhistory"})
 	}
@@ -1725,13 +1725,13 @@ func (r *queryResolver) StandardHistories(ctx context.Context, after *entgql.Cur
 
 // Subcontrols is the resolver for the subcontrols field.
 func (r *queryResolver) Subcontrols(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.SubcontrolOrder, where *generated.SubcontrolWhereInput) (*generated.SubcontrolConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Subcontrol.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Subcontrol.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "subcontrol"})
 	}
@@ -1753,13 +1753,13 @@ func (r *queryResolver) Subcontrols(ctx context.Context, after *entgql.Cursor[st
 
 // SubcontrolHistories is the resolver for the subcontrolHistories field.
 func (r *queryResolver) SubcontrolHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.SubcontrolHistoryOrder, where *generated.SubcontrolHistoryWhereInput) (*generated.SubcontrolHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).SubcontrolHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).SubcontrolHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "subcontrolhistory"})
 	}
@@ -1781,13 +1781,13 @@ func (r *queryResolver) SubcontrolHistories(ctx context.Context, after *entgql.C
 
 // Subscribers is the resolver for the subscribers field.
 func (r *queryResolver) Subscribers(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.SubscriberOrder, where *generated.SubscriberWhereInput) (*generated.SubscriberConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Subscriber.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Subscriber.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "subscriber"})
 	}
@@ -1809,13 +1809,13 @@ func (r *queryResolver) Subscribers(ctx context.Context, after *entgql.Cursor[st
 
 // TfaSettings is the resolver for the tfaSettings field.
 func (r *queryResolver) TfaSettings(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.TFASettingOrder, where *generated.TFASettingWhereInput) (*generated.TFASettingConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).TFASetting.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).TFASetting.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "tfasetting"})
 	}
@@ -1836,13 +1836,13 @@ func (r *queryResolver) TfaSettings(ctx context.Context, after *entgql.Cursor[st
 
 // Tasks is the resolver for the tasks field.
 func (r *queryResolver) Tasks(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.TaskOrder, where *generated.TaskWhereInput) (*generated.TaskConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Task.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Task.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "task"})
 	}
@@ -1864,13 +1864,13 @@ func (r *queryResolver) Tasks(ctx context.Context, after *entgql.Cursor[string],
 
 // TaskHistories is the resolver for the taskHistories field.
 func (r *queryResolver) TaskHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.TaskHistoryOrder, where *generated.TaskHistoryWhereInput) (*generated.TaskHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).TaskHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).TaskHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "taskhistory"})
 	}
@@ -1892,13 +1892,13 @@ func (r *queryResolver) TaskHistories(ctx context.Context, after *entgql.Cursor[
 
 // Templates is the resolver for the templates field.
 func (r *queryResolver) Templates(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.TemplateOrder, where *generated.TemplateWhereInput) (*generated.TemplateConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Template.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Template.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "template"})
 	}
@@ -1920,13 +1920,13 @@ func (r *queryResolver) Templates(ctx context.Context, after *entgql.Cursor[stri
 
 // TemplateHistories is the resolver for the templateHistories field.
 func (r *queryResolver) TemplateHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.TemplateHistoryOrder, where *generated.TemplateHistoryWhereInput) (*generated.TemplateHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).TemplateHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).TemplateHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "templatehistory"})
 	}
@@ -1948,13 +1948,13 @@ func (r *queryResolver) TemplateHistories(ctx context.Context, after *entgql.Cur
 
 // Users is the resolver for the users field.
 func (r *queryResolver) Users(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.UserOrder, where *generated.UserWhereInput) (*generated.UserConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).User.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).User.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "user"})
 	}
@@ -1976,13 +1976,13 @@ func (r *queryResolver) Users(ctx context.Context, after *entgql.Cursor[string],
 
 // UserHistories is the resolver for the userHistories field.
 func (r *queryResolver) UserHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.UserHistoryOrder, where *generated.UserHistoryWhereInput) (*generated.UserHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).UserHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).UserHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "userhistory"})
 	}
@@ -2004,13 +2004,13 @@ func (r *queryResolver) UserHistories(ctx context.Context, after *entgql.Cursor[
 
 // UserSettings is the resolver for the userSettings field.
 func (r *queryResolver) UserSettings(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.UserSettingOrder, where *generated.UserSettingWhereInput) (*generated.UserSettingConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).UserSetting.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).UserSetting.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "usersetting"})
 	}
@@ -2031,13 +2031,13 @@ func (r *queryResolver) UserSettings(ctx context.Context, after *entgql.Cursor[s
 
 // UserSettingHistories is the resolver for the userSettingHistories field.
 func (r *queryResolver) UserSettingHistories(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.UserSettingHistoryOrder, where *generated.UserSettingHistoryWhereInput) (*generated.UserSettingHistoryConnection, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set page limit if nothing was set
 	first, last = graphutils.SetFirstLastDefaults(first, last, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).UserSettingHistory.Query().CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).UserSettingHistory.Query().CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "usersettinghistory"})
 	}

--- a/internal/graphapi/entity.resolvers.go
+++ b/internal/graphapi/entity.resolvers.go
@@ -18,7 +18,7 @@ import (
 
 // CreateEntity is the resolver for the createEntity field.
 func (r *mutationResolver) CreateEntity(ctx context.Context, input generated.CreateEntityInput) (*model.EntityCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set the organization in the auth context if its not done for us
@@ -52,7 +52,7 @@ func (r *mutationResolver) CreateBulkEntity(ctx context.Context, input []*genera
 		return nil, rout.NewMissingRequiredFieldError("owner_id")
 	}
 
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	return r.bulkCreateEntity(ctx, input)
@@ -60,7 +60,7 @@ func (r *mutationResolver) CreateBulkEntity(ctx context.Context, input []*genera
 
 // CreateBulkCSVEntity is the resolver for the createBulkCSVEntity field.
 func (r *mutationResolver) CreateBulkCSVEntity(ctx context.Context, input graphql.Upload) (*model.EntityBulkCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	data, err := unmarshalBulkData[generated.CreateEntityInput](input)
@@ -87,7 +87,7 @@ func (r *mutationResolver) CreateBulkCSVEntity(ctx context.Context, input graphq
 
 // UpdateEntity is the resolver for the updateEntity field.
 func (r *mutationResolver) UpdateEntity(ctx context.Context, id string, input generated.UpdateEntityInput) (*model.EntityUpdatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	res, err := withTransactionalMutation(ctx).Entity.Get(ctx, id)
@@ -132,10 +132,10 @@ func (r *mutationResolver) DeleteEntity(ctx context.Context, id string) (*model.
 
 // Entity is the resolver for the entity field.
 func (r *queryResolver) Entity(ctx context.Context, id string) (*generated.Entity, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Entity.Query().Where(entity.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Entity.Query().Where(entity.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "entity"})
 	}

--- a/internal/graphapi/entitytype.resolvers.go
+++ b/internal/graphapi/entitytype.resolvers.go
@@ -18,7 +18,7 @@ import (
 
 // CreateEntityType is the resolver for the createEntityType field.
 func (r *mutationResolver) CreateEntityType(ctx context.Context, input generated.CreateEntityTypeInput) (*model.EntityTypeCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set the organization in the auth context if its not done for us
@@ -52,7 +52,7 @@ func (r *mutationResolver) CreateBulkEntityType(ctx context.Context, input []*ge
 		return nil, rout.NewMissingRequiredFieldError("owner_id")
 	}
 
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	return r.bulkCreateEntityType(ctx, input)
@@ -60,7 +60,7 @@ func (r *mutationResolver) CreateBulkEntityType(ctx context.Context, input []*ge
 
 // CreateBulkCSVEntityType is the resolver for the createBulkCSVEntityType field.
 func (r *mutationResolver) CreateBulkCSVEntityType(ctx context.Context, input graphql.Upload) (*model.EntityTypeBulkCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	data, err := unmarshalBulkData[generated.CreateEntityTypeInput](input)
@@ -87,7 +87,7 @@ func (r *mutationResolver) CreateBulkCSVEntityType(ctx context.Context, input gr
 
 // UpdateEntityType is the resolver for the updateEntityType field.
 func (r *mutationResolver) UpdateEntityType(ctx context.Context, id string, input generated.UpdateEntityTypeInput) (*model.EntityTypeUpdatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	res, err := withTransactionalMutation(ctx).EntityType.Get(ctx, id)
@@ -132,10 +132,10 @@ func (r *mutationResolver) DeleteEntityType(ctx context.Context, id string) (*mo
 
 // EntityType is the resolver for the entityType field.
 func (r *queryResolver) EntityType(ctx context.Context, id string) (*generated.EntityType, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).EntityType.Query().Where(entitytype.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).EntityType.Query().Where(entitytype.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "entitytype"})
 	}

--- a/internal/graphapi/event.resolvers.go
+++ b/internal/graphapi/event.resolvers.go
@@ -18,7 +18,7 @@ import (
 
 // CreateEvent is the resolver for the createEvent field.
 func (r *mutationResolver) CreateEvent(ctx context.Context, input generated.CreateEventInput) (*model.EventCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	res, err := withTransactionalMutation(ctx).Event.Create().SetInput(input).Save(ctx)
@@ -37,7 +37,7 @@ func (r *mutationResolver) CreateBulkEvent(ctx context.Context, input []*generat
 		return nil, rout.NewMissingRequiredFieldError("input")
 	}
 
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	return r.bulkCreateEvent(ctx, input)
@@ -45,7 +45,7 @@ func (r *mutationResolver) CreateBulkEvent(ctx context.Context, input []*generat
 
 // CreateBulkCSVEvent is the resolver for the createBulkCSVEvent field.
 func (r *mutationResolver) CreateBulkCSVEvent(ctx context.Context, input graphql.Upload) (*model.EventBulkCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	data, err := unmarshalBulkData[generated.CreateEventInput](input)
@@ -64,7 +64,7 @@ func (r *mutationResolver) CreateBulkCSVEvent(ctx context.Context, input graphql
 
 // UpdateEvent is the resolver for the updateEvent field.
 func (r *mutationResolver) UpdateEvent(ctx context.Context, id string, input generated.UpdateEventInput) (*model.EventUpdatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	res, err := withTransactionalMutation(ctx).Event.Get(ctx, id)
@@ -102,10 +102,10 @@ func (r *mutationResolver) DeleteEvent(ctx context.Context, id string) (*model.E
 
 // Event is the resolver for the event field.
 func (r *queryResolver) Event(ctx context.Context, id string) (*generated.Event, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Event.Query().Where(event.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Event.Query().Where(event.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "event"})
 	}

--- a/internal/graphapi/evidence.resolvers.go
+++ b/internal/graphapi/evidence.resolvers.go
@@ -18,7 +18,7 @@ import (
 
 // CreateEvidence is the resolver for the createEvidence field.
 func (r *mutationResolver) CreateEvidence(ctx context.Context, input generated.CreateEvidenceInput, evidenceFiles []*graphql.Upload) (*model.EvidenceCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set the organization in the auth context if its not done for us
@@ -40,7 +40,7 @@ func (r *mutationResolver) CreateEvidence(ctx context.Context, input generated.C
 
 // UpdateEvidence is the resolver for the updateEvidence field.
 func (r *mutationResolver) UpdateEvidence(ctx context.Context, id string, input generated.UpdateEvidenceInput, evidenceFiles []*graphql.Upload) (*model.EvidenceUpdatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	res, err := withTransactionalMutation(ctx).Evidence.Get(ctx, id)
@@ -85,10 +85,10 @@ func (r *mutationResolver) DeleteEvidence(ctx context.Context, id string) (*mode
 
 // Evidence is the resolver for the evidence field.
 func (r *queryResolver) Evidence(ctx context.Context, id string) (*generated.Evidence, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Evidence.Query().Where(evidence.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Evidence.Query().Where(evidence.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "evidence"})
 	}

--- a/internal/graphapi/file.resolvers.go
+++ b/internal/graphapi/file.resolvers.go
@@ -30,10 +30,10 @@ func (r *mutationResolver) DeleteFile(ctx context.Context, id string) (*model.Fi
 
 // File is the resolver for the file field.
 func (r *queryResolver) File(ctx context.Context, id string) (*generated.File, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).File.Query().Where(file.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).File.Query().Where(file.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "file"})
 	}

--- a/internal/graphapi/group.resolvers.go
+++ b/internal/graphapi/group.resolvers.go
@@ -18,7 +18,7 @@ import (
 
 // CreateGroup is the resolver for the createGroup field.
 func (r *mutationResolver) CreateGroup(ctx context.Context, input generated.CreateGroupInput) (*model.GroupCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set the organization in the auth context if its not done for us
@@ -52,7 +52,7 @@ func (r *mutationResolver) CreateBulkGroup(ctx context.Context, input []*generat
 		return nil, rout.NewMissingRequiredFieldError("owner_id")
 	}
 
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	return r.bulkCreateGroup(ctx, input)
@@ -60,7 +60,7 @@ func (r *mutationResolver) CreateBulkGroup(ctx context.Context, input []*generat
 
 // CreateBulkCSVGroup is the resolver for the createBulkCSVGroup field.
 func (r *mutationResolver) CreateBulkCSVGroup(ctx context.Context, input graphql.Upload) (*model.GroupBulkCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	data, err := unmarshalBulkData[generated.CreateGroupInput](input)
@@ -87,7 +87,7 @@ func (r *mutationResolver) CreateBulkCSVGroup(ctx context.Context, input graphql
 
 // UpdateGroup is the resolver for the updateGroup field.
 func (r *mutationResolver) UpdateGroup(ctx context.Context, id string, input generated.UpdateGroupInput) (*model.GroupUpdatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	res, err := withTransactionalMutation(ctx).Group.Get(ctx, id)
@@ -132,10 +132,10 @@ func (r *mutationResolver) DeleteGroup(ctx context.Context, id string) (*model.G
 
 // Group is the resolver for the group field.
 func (r *queryResolver) Group(ctx context.Context, id string) (*generated.Group, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Group.Query().Where(group.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Group.Query().Where(group.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "group"})
 	}

--- a/internal/graphapi/groupextended.resolvers.go
+++ b/internal/graphapi/groupextended.resolvers.go
@@ -92,8 +92,8 @@ func (r *groupResolver) Permissions(ctx context.Context, obj *generated.Group) (
 
 // CreateGroupWithMembers is the resolver for the createGroupWithMembers field.
 func (r *mutationResolver) CreateGroupWithMembers(ctx context.Context, groupInput generated.CreateGroupInput, members []*model.GroupMembersInput) (*model.GroupCreatePayload, error) {
-	// grab preloads and set max result limits
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// grab preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set the organization in the auth context if its not done for us
 	if err := setOrganizationInAuthContext(ctx, groupInput.OwnerID); err != nil {
@@ -125,7 +125,7 @@ func (r *mutationResolver) CreateGroupWithMembers(ctx context.Context, groupInpu
 		Query().
 		WithMembers().
 		Where(group.IDEQ(res.Group.ID)).
-		CollectFields(ctx, preloads...)
+		CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionCreate, object: "group"})
 	}
@@ -142,8 +142,8 @@ func (r *mutationResolver) CreateGroupWithMembers(ctx context.Context, groupInpu
 
 // CreateGroupByClone is the resolver for the createGroupByClone field.
 func (r *mutationResolver) CreateGroupByClone(ctx context.Context, groupInput generated.CreateGroupInput, members []*model.GroupMembersInput, inheritGroupPermissions *string, cloneGroupMembers *string) (*model.GroupCreatePayload, error) {
-	// grab preloads and set max result limits
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// grab preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set the organization in the auth context if its not done for us
 	if err := setOrganizationInAuthContext(ctx, groupInput.OwnerID); err != nil {
@@ -254,7 +254,7 @@ func (r *mutationResolver) CreateGroupByClone(ctx context.Context, groupInput ge
 	query, err := withTransactionalMutation(ctx).Group.Query().
 		Where(group.IDEQ(res.ID)).
 		WithMembers().
-		CollectFields(ctx, preloads...)
+		CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionCreate, object: "group"})
 	}
@@ -271,7 +271,7 @@ func (r *mutationResolver) CreateGroupByClone(ctx context.Context, groupInput ge
 
 // CreateGroupSettings is the resolver for the createGroupSettings field.
 func (r *createGroupInputResolver) CreateGroupSettings(ctx context.Context, obj *generated.CreateGroupInput, data *generated.CreateGroupSettingInput) error {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set the organization in the auth context if its not done for us
@@ -348,7 +348,7 @@ func (r *updateGroupInputResolver) RemoveGroupMembers(ctx context.Context, obj *
 
 // UpdateGroupSettings is the resolver for the updateGroupSettings field.
 func (r *updateGroupInputResolver) UpdateGroupSettings(ctx context.Context, obj *generated.UpdateGroupInput, data *generated.UpdateGroupSettingInput) error {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	groupID := graphutils.GetStringInputVariableByName(ctx, "id")

--- a/internal/graphapi/groupmembership.resolvers.go
+++ b/internal/graphapi/groupmembership.resolvers.go
@@ -18,7 +18,7 @@ import (
 
 // CreateGroupMembership is the resolver for the createGroupMembership field.
 func (r *mutationResolver) CreateGroupMembership(ctx context.Context, input generated.CreateGroupMembershipInput) (*model.GroupMembershipCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	res, err := withTransactionalMutation(ctx).GroupMembership.Create().SetInput(input).Save(ctx)
@@ -44,7 +44,7 @@ func (r *mutationResolver) CreateBulkGroupMembership(ctx context.Context, input 
 		return nil, rout.NewMissingRequiredFieldError("owner_id")
 	}
 
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	return r.bulkCreateGroupMembership(ctx, input)
@@ -52,7 +52,7 @@ func (r *mutationResolver) CreateBulkGroupMembership(ctx context.Context, input 
 
 // CreateBulkCSVGroupMembership is the resolver for the createBulkCSVGroupMembership field.
 func (r *mutationResolver) CreateBulkCSVGroupMembership(ctx context.Context, input graphql.Upload) (*model.GroupMembershipBulkCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	data, err := unmarshalBulkData[generated.CreateGroupMembershipInput](input)
@@ -71,7 +71,7 @@ func (r *mutationResolver) CreateBulkCSVGroupMembership(ctx context.Context, inp
 
 // UpdateGroupMembership is the resolver for the updateGroupMembership field.
 func (r *mutationResolver) UpdateGroupMembership(ctx context.Context, id string, input generated.UpdateGroupMembershipInput) (*model.GroupMembershipUpdatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	res, err := withTransactionalMutation(ctx).GroupMembership.Get(ctx, id)
@@ -109,10 +109,10 @@ func (r *mutationResolver) DeleteGroupMembership(ctx context.Context, id string)
 
 // GroupMembership is the resolver for the groupMembership field.
 func (r *queryResolver) GroupMembership(ctx context.Context, id string) (*generated.GroupMembership, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).GroupMembership.Query().Where(groupmembership.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).GroupMembership.Query().Where(groupmembership.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "groupmembership"})
 	}

--- a/internal/graphapi/groupsetting.resolvers.go
+++ b/internal/graphapi/groupsetting.resolvers.go
@@ -18,7 +18,7 @@ import (
 
 // CreateGroupSetting is the resolver for the createGroupSetting field.
 func (r *mutationResolver) CreateGroupSetting(ctx context.Context, input generated.CreateGroupSettingInput) (*model.GroupSettingCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	res, err := withTransactionalMutation(ctx).GroupSetting.Create().SetInput(input).Save(ctx)
@@ -44,7 +44,7 @@ func (r *mutationResolver) CreateBulkGroupSetting(ctx context.Context, input []*
 		return nil, rout.NewMissingRequiredFieldError("owner_id")
 	}
 
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	return r.bulkCreateGroupSetting(ctx, input)
@@ -52,7 +52,7 @@ func (r *mutationResolver) CreateBulkGroupSetting(ctx context.Context, input []*
 
 // CreateBulkCSVGroupSetting is the resolver for the createBulkCSVGroupSetting field.
 func (r *mutationResolver) CreateBulkCSVGroupSetting(ctx context.Context, input graphql.Upload) (*model.GroupSettingBulkCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	data, err := unmarshalBulkData[generated.CreateGroupSettingInput](input)
@@ -71,7 +71,7 @@ func (r *mutationResolver) CreateBulkCSVGroupSetting(ctx context.Context, input 
 
 // UpdateGroupSetting is the resolver for the updateGroupSetting field.
 func (r *mutationResolver) UpdateGroupSetting(ctx context.Context, id string, input generated.UpdateGroupSettingInput) (*model.GroupSettingUpdatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	res, err := withTransactionalMutation(ctx).GroupSetting.Get(ctx, id)
@@ -109,10 +109,10 @@ func (r *mutationResolver) DeleteGroupSetting(ctx context.Context, id string) (*
 
 // GroupSetting is the resolver for the groupSetting field.
 func (r *queryResolver) GroupSetting(ctx context.Context, id string) (*generated.GroupSetting, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).GroupSetting.Query().Where(groupsetting.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).GroupSetting.Query().Where(groupsetting.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "groupsetting"})
 	}

--- a/internal/graphapi/hush.resolvers.go
+++ b/internal/graphapi/hush.resolvers.go
@@ -18,7 +18,7 @@ import (
 
 // CreateHush is the resolver for the createHush field.
 func (r *mutationResolver) CreateHush(ctx context.Context, input generated.CreateHushInput) (*model.HushCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	res, err := withTransactionalMutation(ctx).Hush.Create().SetInput(input).Save(ctx)
@@ -37,7 +37,7 @@ func (r *mutationResolver) CreateBulkHush(ctx context.Context, input []*generate
 		return nil, rout.NewMissingRequiredFieldError("input")
 	}
 
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	return r.bulkCreateHush(ctx, input)
@@ -45,7 +45,7 @@ func (r *mutationResolver) CreateBulkHush(ctx context.Context, input []*generate
 
 // CreateBulkCSVHush is the resolver for the createBulkCSVHush field.
 func (r *mutationResolver) CreateBulkCSVHush(ctx context.Context, input graphql.Upload) (*model.HushBulkCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	data, err := unmarshalBulkData[generated.CreateHushInput](input)
@@ -64,7 +64,7 @@ func (r *mutationResolver) CreateBulkCSVHush(ctx context.Context, input graphql.
 
 // UpdateHush is the resolver for the updateHush field.
 func (r *mutationResolver) UpdateHush(ctx context.Context, id string, input generated.UpdateHushInput) (*model.HushUpdatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	res, err := withTransactionalMutation(ctx).Hush.Get(ctx, id)
@@ -102,10 +102,10 @@ func (r *mutationResolver) DeleteHush(ctx context.Context, id string) (*model.Hu
 
 // Hush is the resolver for the hush field.
 func (r *queryResolver) Hush(ctx context.Context, id string) (*generated.Hush, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Hush.Query().Where(hush.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Hush.Query().Where(hush.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "hush"})
 	}

--- a/internal/graphapi/integration.resolvers.go
+++ b/internal/graphapi/integration.resolvers.go
@@ -18,7 +18,7 @@ import (
 
 // CreateIntegration is the resolver for the createIntegration field.
 func (r *mutationResolver) CreateIntegration(ctx context.Context, input generated.CreateIntegrationInput) (*model.IntegrationCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set the organization in the auth context if its not done for us
@@ -52,7 +52,7 @@ func (r *mutationResolver) CreateBulkIntegration(ctx context.Context, input []*g
 		return nil, rout.NewMissingRequiredFieldError("owner_id")
 	}
 
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	return r.bulkCreateIntegration(ctx, input)
@@ -60,7 +60,7 @@ func (r *mutationResolver) CreateBulkIntegration(ctx context.Context, input []*g
 
 // CreateBulkCSVIntegration is the resolver for the createBulkCSVIntegration field.
 func (r *mutationResolver) CreateBulkCSVIntegration(ctx context.Context, input graphql.Upload) (*model.IntegrationBulkCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	data, err := unmarshalBulkData[generated.CreateIntegrationInput](input)
@@ -87,7 +87,7 @@ func (r *mutationResolver) CreateBulkCSVIntegration(ctx context.Context, input g
 
 // UpdateIntegration is the resolver for the updateIntegration field.
 func (r *mutationResolver) UpdateIntegration(ctx context.Context, id string, input generated.UpdateIntegrationInput) (*model.IntegrationUpdatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	res, err := withTransactionalMutation(ctx).Integration.Get(ctx, id)
@@ -132,10 +132,10 @@ func (r *mutationResolver) DeleteIntegration(ctx context.Context, id string) (*m
 
 // Integration is the resolver for the integration field.
 func (r *queryResolver) Integration(ctx context.Context, id string) (*generated.Integration, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Integration.Query().Where(integration.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Integration.Query().Where(integration.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "integration"})
 	}

--- a/internal/graphapi/internalpolicy.resolvers.go
+++ b/internal/graphapi/internalpolicy.resolvers.go
@@ -18,7 +18,7 @@ import (
 
 // CreateInternalPolicy is the resolver for the createInternalPolicy field.
 func (r *mutationResolver) CreateInternalPolicy(ctx context.Context, input generated.CreateInternalPolicyInput) (*model.InternalPolicyCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set the organization in the auth context if its not done for us
@@ -52,7 +52,7 @@ func (r *mutationResolver) CreateBulkInternalPolicy(ctx context.Context, input [
 		return nil, rout.NewMissingRequiredFieldError("owner_id")
 	}
 
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	return r.bulkCreateInternalPolicy(ctx, input)
@@ -60,7 +60,7 @@ func (r *mutationResolver) CreateBulkInternalPolicy(ctx context.Context, input [
 
 // CreateBulkCSVInternalPolicy is the resolver for the createBulkCSVInternalPolicy field.
 func (r *mutationResolver) CreateBulkCSVInternalPolicy(ctx context.Context, input graphql.Upload) (*model.InternalPolicyBulkCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	data, err := unmarshalBulkData[generated.CreateInternalPolicyInput](input)
@@ -87,7 +87,7 @@ func (r *mutationResolver) CreateBulkCSVInternalPolicy(ctx context.Context, inpu
 
 // UpdateInternalPolicy is the resolver for the updateInternalPolicy field.
 func (r *mutationResolver) UpdateInternalPolicy(ctx context.Context, id string, input generated.UpdateInternalPolicyInput) (*model.InternalPolicyUpdatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	res, err := withTransactionalMutation(ctx).InternalPolicy.Get(ctx, id)
@@ -132,10 +132,10 @@ func (r *mutationResolver) DeleteInternalPolicy(ctx context.Context, id string) 
 
 // InternalPolicy is the resolver for the internalPolicy field.
 func (r *queryResolver) InternalPolicy(ctx context.Context, id string) (*generated.InternalPolicy, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).InternalPolicy.Query().Where(internalpolicy.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).InternalPolicy.Query().Where(internalpolicy.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "internalpolicy"})
 	}

--- a/internal/graphapi/invite.resolvers.go
+++ b/internal/graphapi/invite.resolvers.go
@@ -18,7 +18,7 @@ import (
 
 // CreateInvite is the resolver for the createInvite field.
 func (r *mutationResolver) CreateInvite(ctx context.Context, input generated.CreateInviteInput) (*model.InviteCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set the organization in the auth context if its not done for us
@@ -71,7 +71,7 @@ func (r *mutationResolver) CreateBulkInvite(ctx context.Context, input []*genera
 
 // CreateBulkCSVInvite is the resolver for the createBulkCSVInvite field.
 func (r *mutationResolver) CreateBulkCSVInvite(ctx context.Context, input graphql.Upload) (*model.InviteBulkCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	data, err := unmarshalBulkData[generated.CreateInviteInput](input)
@@ -86,7 +86,7 @@ func (r *mutationResolver) CreateBulkCSVInvite(ctx context.Context, input graphq
 
 // UpdateInvite is the resolver for the updateInvite field.
 func (r *mutationResolver) UpdateInvite(ctx context.Context, id string, input generated.UpdateInviteInput) (*model.InviteUpdatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	res, err := withTransactionalMutation(ctx).Invite.Get(ctx, id)
@@ -131,10 +131,10 @@ func (r *mutationResolver) DeleteInvite(ctx context.Context, id string) (*model.
 
 // Invite is the resolver for the invite field.
 func (r *queryResolver) Invite(ctx context.Context, id string) (*generated.Invite, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// get preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Invite.Query().Where(invite.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Invite.Query().Where(invite.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "invite"})
 	}

--- a/internal/graphapi/mappedcontrol.resolvers.go
+++ b/internal/graphapi/mappedcontrol.resolvers.go
@@ -12,15 +12,11 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/mappedcontrol"
 	"github.com/theopenlane/core/internal/graphapi/model"
-	"github.com/theopenlane/gqlgen-plugins/graphutils"
 	"github.com/theopenlane/utils/rout"
 )
 
 // CreateMappedControl is the resolver for the createMappedControl field.
 func (r *mutationResolver) CreateMappedControl(ctx context.Context, input generated.CreateMappedControlInput) (*model.MappedControlCreatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	res, err := withTransactionalMutation(ctx).MappedControl.Create().SetInput(input).Save(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionCreate, object: "mappedcontrol"})
@@ -37,17 +33,11 @@ func (r *mutationResolver) CreateBulkMappedControl(ctx context.Context, input []
 		return nil, rout.NewMissingRequiredFieldError("input")
 	}
 
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	return r.bulkCreateMappedControl(ctx, input)
 }
 
 // CreateBulkCSVMappedControl is the resolver for the createBulkCSVMappedControl field.
 func (r *mutationResolver) CreateBulkCSVMappedControl(ctx context.Context, input graphql.Upload) (*model.MappedControlBulkCreatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	data, err := unmarshalBulkData[generated.CreateMappedControlInput](input)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to unmarshal bulk data")
@@ -64,9 +54,6 @@ func (r *mutationResolver) CreateBulkCSVMappedControl(ctx context.Context, input
 
 // UpdateMappedControl is the resolver for the updateMappedControl field.
 func (r *mutationResolver) UpdateMappedControl(ctx context.Context, id string, input generated.UpdateMappedControlInput) (*model.MappedControlUpdatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	res, err := withTransactionalMutation(ctx).MappedControl.Get(ctx, id)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionUpdate, object: "mappedcontrol"})
@@ -102,10 +89,7 @@ func (r *mutationResolver) DeleteMappedControl(ctx context.Context, id string) (
 
 // MappedControl is the resolver for the mappedControl field.
 func (r *queryResolver) MappedControl(ctx context.Context, id string) (*generated.MappedControl, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
-
-	query, err := withTransactionalMutation(ctx).MappedControl.Query().Where(mappedcontrol.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).MappedControl.Query().Where(mappedcontrol.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "mappedcontrol"})
 	}

--- a/internal/graphapi/narrative.resolvers.go
+++ b/internal/graphapi/narrative.resolvers.go
@@ -12,15 +12,11 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/narrative"
 	"github.com/theopenlane/core/internal/graphapi/model"
-	"github.com/theopenlane/gqlgen-plugins/graphutils"
 	"github.com/theopenlane/utils/rout"
 )
 
 // CreateNarrative is the resolver for the createNarrative field.
 func (r *mutationResolver) CreateNarrative(ctx context.Context, input generated.CreateNarrativeInput) (*model.NarrativeCreatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	// set the organization in the auth context if its not done for us
 	if err := setOrganizationInAuthContext(ctx, input.OwnerID); err != nil {
 		log.Error().Err(err).Msg("failed to set organization in auth context")
@@ -52,17 +48,11 @@ func (r *mutationResolver) CreateBulkNarrative(ctx context.Context, input []*gen
 		return nil, rout.NewMissingRequiredFieldError("owner_id")
 	}
 
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	return r.bulkCreateNarrative(ctx, input)
 }
 
 // CreateBulkCSVNarrative is the resolver for the createBulkCSVNarrative field.
 func (r *mutationResolver) CreateBulkCSVNarrative(ctx context.Context, input graphql.Upload) (*model.NarrativeBulkCreatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	data, err := unmarshalBulkData[generated.CreateNarrativeInput](input)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to unmarshal bulk data")
@@ -87,9 +77,6 @@ func (r *mutationResolver) CreateBulkCSVNarrative(ctx context.Context, input gra
 
 // UpdateNarrative is the resolver for the updateNarrative field.
 func (r *mutationResolver) UpdateNarrative(ctx context.Context, id string, input generated.UpdateNarrativeInput) (*model.NarrativeUpdatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	res, err := withTransactionalMutation(ctx).Narrative.Get(ctx, id)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionUpdate, object: "narrative"})
@@ -132,10 +119,7 @@ func (r *mutationResolver) DeleteNarrative(ctx context.Context, id string) (*mod
 
 // Narrative is the resolver for the narrative field.
 func (r *queryResolver) Narrative(ctx context.Context, id string) (*generated.Narrative, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
-
-	query, err := withTransactionalMutation(ctx).Narrative.Query().Where(narrative.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Narrative.Query().Where(narrative.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "narrative"})
 	}

--- a/internal/graphapi/note.resolvers.go
+++ b/internal/graphapi/note.resolvers.go
@@ -30,9 +30,6 @@ func (r *mutationResolver) UpdateTaskComment(ctx context.Context, id string, inp
 		return nil, parseRequestError(err, action{action: ActionUpdate, object: "task"})
 	}
 
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	objectRes, err := withTransactionalMutation(ctx).Task.Query().Where(task.HasCommentsWith(note.ID(id))).Only(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionUpdate, object: "task"})
@@ -45,10 +42,7 @@ func (r *mutationResolver) UpdateTaskComment(ctx context.Context, id string, inp
 
 // Note is the resolver for the note field.
 func (r *queryResolver) Note(ctx context.Context, id string) (*generated.Note, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
-
-	query, err := withTransactionalMutation(ctx).Note.Query().Where(note.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Note.Query().Where(note.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "note"})
 	}

--- a/internal/graphapi/onboarding.resolvers.go
+++ b/internal/graphapi/onboarding.resolvers.go
@@ -10,7 +10,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/graphapi/model"
-	"github.com/theopenlane/gqlgen-plugins/graphutils"
 	"github.com/theopenlane/iam/auth"
 )
 
@@ -21,9 +20,6 @@ func (r *mutationResolver) CreateOnboarding(ctx context.Context, input generated
 
 		return nil, ErrResourceNotAccessibleWithToken
 	}
-
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	res, err := withTransactionalMutation(ctx).Onboarding.Create().SetInput(input).Save(ctx)
 	if err != nil {

--- a/internal/graphapi/organization.resolvers.go
+++ b/internal/graphapi/organization.resolvers.go
@@ -12,7 +12,6 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/organization"
 	"github.com/theopenlane/core/internal/graphapi/model"
-	"github.com/theopenlane/gqlgen-plugins/graphutils"
 	"github.com/theopenlane/iam/auth"
 )
 
@@ -33,9 +32,6 @@ func (r *mutationResolver) CreateOrganization(ctx context.Context, input generat
 		}
 	}
 
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	res, err := withTransactionalMutation(ctx).Organization.Create().SetInput(input).Save(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionCreate, object: "organization"})
@@ -48,9 +44,6 @@ func (r *mutationResolver) CreateOrganization(ctx context.Context, input generat
 
 // UpdateOrganization is the resolver for the updateOrganization field.
 func (r *mutationResolver) UpdateOrganization(ctx context.Context, id string, input generated.UpdateOrganizationInput, avatarFile *graphql.Upload) (*model.OrganizationUpdatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	res, err := withTransactionalMutation(ctx).Organization.Get(ctx, id)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionUpdate, object: "organization"})
@@ -98,10 +91,7 @@ func (r *queryResolver) Organization(ctx context.Context, id string) (*generated
 		return nil, newNotFoundError("id")
 	}
 
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
-
-	query, err := withTransactionalMutation(ctx).Organization.Query().Where(organization.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Organization.Query().Where(organization.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "organization"})
 	}

--- a/internal/graphapi/organizationsetting.resolvers.go
+++ b/internal/graphapi/organizationsetting.resolvers.go
@@ -12,15 +12,11 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/organizationsetting"
 	"github.com/theopenlane/core/internal/graphapi/model"
-	"github.com/theopenlane/gqlgen-plugins/graphutils"
 	"github.com/theopenlane/utils/rout"
 )
 
 // CreateOrganizationSetting is the resolver for the createOrganizationSetting field.
 func (r *mutationResolver) CreateOrganizationSetting(ctx context.Context, input generated.CreateOrganizationSettingInput) (*model.OrganizationSettingCreatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	res, err := withTransactionalMutation(ctx).OrganizationSetting.Create().SetInput(input).Save(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionCreate, object: "organizationsetting"})
@@ -37,17 +33,11 @@ func (r *mutationResolver) CreateBulkOrganizationSetting(ctx context.Context, in
 		return nil, rout.NewMissingRequiredFieldError("input")
 	}
 
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	return r.bulkCreateOrganizationSetting(ctx, input)
 }
 
 // CreateBulkCSVOrganizationSetting is the resolver for the createBulkCSVOrganizationSetting field.
 func (r *mutationResolver) CreateBulkCSVOrganizationSetting(ctx context.Context, input graphql.Upload) (*model.OrganizationSettingBulkCreatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	data, err := unmarshalBulkData[generated.CreateOrganizationSettingInput](input)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to unmarshal bulk data")
@@ -64,9 +54,6 @@ func (r *mutationResolver) CreateBulkCSVOrganizationSetting(ctx context.Context,
 
 // UpdateOrganizationSetting is the resolver for the updateOrganizationSetting field.
 func (r *mutationResolver) UpdateOrganizationSetting(ctx context.Context, id string, input generated.UpdateOrganizationSettingInput) (*model.OrganizationSettingUpdatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	res, err := withTransactionalMutation(ctx).OrganizationSetting.Get(ctx, id)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionUpdate, object: "organizationsetting"})
@@ -102,10 +89,7 @@ func (r *mutationResolver) DeleteOrganizationSetting(ctx context.Context, id str
 
 // OrganizationSetting is the resolver for the organizationSetting field.
 func (r *queryResolver) OrganizationSetting(ctx context.Context, id string) (*generated.OrganizationSetting, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
-
-	query, err := withTransactionalMutation(ctx).OrganizationSetting.Query().Where(organizationsetting.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).OrganizationSetting.Query().Where(organizationsetting.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "organizationsetting"})
 	}

--- a/internal/graphapi/orgextended.resolvers.go
+++ b/internal/graphapi/orgextended.resolvers.go
@@ -18,9 +18,6 @@ import (
 
 // CreateOrganizationWithMembers is the resolver for the createOrganizationWithMembers field.
 func (r *mutationResolver) CreateOrganizationWithMembers(ctx context.Context, organizationInput generated.CreateOrganizationInput, avatarFile *graphql.Upload, members []*model.OrgMembersInput) (*model.OrganizationCreatePayload, error) {
-	// grab preloads and set max result limits
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	res, err := r.CreateOrganization(ctx, organizationInput, nil)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionCreate, object: "organization"})
@@ -44,7 +41,7 @@ func (r *mutationResolver) CreateOrganizationWithMembers(ctx context.Context, or
 		Query().
 		WithMembers().
 		Where(entorg.IDEQ(res.Organization.ID)).
-		CollectFields(ctx, preloads...)
+		CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionCreate, object: "group"})
 	}
@@ -61,9 +58,6 @@ func (r *mutationResolver) CreateOrganizationWithMembers(ctx context.Context, or
 
 // CreateOrgSettings is the resolver for the createOrgSettings field.
 func (r *createOrganizationInputResolver) CreateOrgSettings(ctx context.Context, obj *generated.CreateOrganizationInput, data *generated.CreateOrganizationSettingInput) error {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	c := withTransactionalMutation(ctx)
 
 	orgSettings, err := c.OrganizationSetting.Create().SetInput(*data).Save(ctx)
@@ -78,9 +72,6 @@ func (r *createOrganizationInputResolver) CreateOrgSettings(ctx context.Context,
 
 // AddOrgMembers is the resolver for the addOrgMembers field.
 func (r *updateOrganizationInputResolver) AddOrgMembers(ctx context.Context, obj *generated.UpdateOrganizationInput, data []*generated.CreateOrgMembershipInput) error {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	orgID := graphutils.GetStringInputVariableByName(ctx, "id")
 	if orgID == nil {
 		log.Error().Msg("unable to get org from context")

--- a/internal/graphapi/orgmembership.resolvers.go
+++ b/internal/graphapi/orgmembership.resolvers.go
@@ -12,15 +12,11 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/orgmembership"
 	"github.com/theopenlane/core/internal/graphapi/model"
-	"github.com/theopenlane/gqlgen-plugins/graphutils"
 	"github.com/theopenlane/utils/rout"
 )
 
 // CreateOrgMembership is the resolver for the createOrgMembership field.
 func (r *mutationResolver) CreateOrgMembership(ctx context.Context, input generated.CreateOrgMembershipInput) (*model.OrgMembershipCreatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	res, err := withTransactionalMutation(ctx).OrgMembership.Create().SetInput(input).Save(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionCreate, object: "orgmembership"})
@@ -37,17 +33,11 @@ func (r *mutationResolver) CreateBulkOrgMembership(ctx context.Context, input []
 		return nil, rout.NewMissingRequiredFieldError("input")
 	}
 
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	return r.bulkCreateOrgMembership(ctx, input)
 }
 
 // CreateBulkCSVOrgMembership is the resolver for the createBulkCSVOrgMembership field.
 func (r *mutationResolver) CreateBulkCSVOrgMembership(ctx context.Context, input graphql.Upload) (*model.OrgMembershipBulkCreatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	data, err := unmarshalBulkData[generated.CreateOrgMembershipInput](input)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to unmarshal bulk data")
@@ -64,9 +54,6 @@ func (r *mutationResolver) CreateBulkCSVOrgMembership(ctx context.Context, input
 
 // UpdateOrgMembership is the resolver for the updateOrgMembership field.
 func (r *mutationResolver) UpdateOrgMembership(ctx context.Context, id string, input generated.UpdateOrgMembershipInput) (*model.OrgMembershipUpdatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	res, err := withTransactionalMutation(ctx).OrgMembership.Get(ctx, id)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionUpdate, object: "orgmembership"})
@@ -102,10 +89,7 @@ func (r *mutationResolver) DeleteOrgMembership(ctx context.Context, id string) (
 
 // OrgMembership is the resolver for the orgMembership field.
 func (r *queryResolver) OrgMembership(ctx context.Context, id string) (*generated.OrgMembership, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
-
-	query, err := withTransactionalMutation(ctx).OrgMembership.Query().Where(orgmembership.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).OrgMembership.Query().Where(orgmembership.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "orgmembership"})
 	}

--- a/internal/graphapi/orgsubscription.resolvers.go
+++ b/internal/graphapi/orgsubscription.resolvers.go
@@ -9,15 +9,11 @@ import (
 
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/orgsubscription"
-	"github.com/theopenlane/gqlgen-plugins/graphutils"
 )
 
 // OrgSubscription is the resolver for the orgSubscription field.
 func (r *queryResolver) OrgSubscription(ctx context.Context, id string) (*generated.OrgSubscription, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
-
-	query, err := withTransactionalMutation(ctx).OrgSubscription.Query().Where(orgsubscription.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).OrgSubscription.Query().Where(orgsubscription.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "orgsubscription"})
 	}

--- a/internal/graphapi/personalaccesstoken.resolvers.go
+++ b/internal/graphapi/personalaccesstoken.resolvers.go
@@ -10,14 +10,10 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/personalaccesstoken"
 	"github.com/theopenlane/core/internal/graphapi/model"
-	"github.com/theopenlane/gqlgen-plugins/graphutils"
 )
 
 // CreatePersonalAccessToken is the resolver for the createPersonalAccessToken field.
 func (r *mutationResolver) CreatePersonalAccessToken(ctx context.Context, input generated.CreatePersonalAccessTokenInput) (*model.PersonalAccessTokenCreatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	res, err := withTransactionalMutation(ctx).PersonalAccessToken.Create().SetInput(input).Save(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionCreate, object: "personalaccesstoken"})
@@ -30,9 +26,6 @@ func (r *mutationResolver) CreatePersonalAccessToken(ctx context.Context, input 
 
 // UpdatePersonalAccessToken is the resolver for the updatePersonalAccessToken field.
 func (r *mutationResolver) UpdatePersonalAccessToken(ctx context.Context, id string, input generated.UpdatePersonalAccessTokenInput) (*model.PersonalAccessTokenUpdatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	res, err := withTransactionalMutation(ctx).PersonalAccessToken.Get(ctx, id)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionUpdate, object: "personalaccesstoken"})
@@ -68,10 +61,7 @@ func (r *mutationResolver) DeletePersonalAccessToken(ctx context.Context, id str
 
 // PersonalAccessToken is the resolver for the personalAccessToken field.
 func (r *queryResolver) PersonalAccessToken(ctx context.Context, id string) (*generated.PersonalAccessToken, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
-
-	query, err := withTransactionalMutation(ctx).PersonalAccessToken.Query().Where(personalaccesstoken.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).PersonalAccessToken.Query().Where(personalaccesstoken.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "personalaccesstoken"})
 	}

--- a/internal/graphapi/procedure.resolvers.go
+++ b/internal/graphapi/procedure.resolvers.go
@@ -18,7 +18,7 @@ import (
 
 // CreateProcedure is the resolver for the createProcedure field.
 func (r *mutationResolver) CreateProcedure(ctx context.Context, input generated.CreateProcedureInput) (*model.ProcedureCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// set the organization in the auth context if its not done for us
@@ -52,7 +52,7 @@ func (r *mutationResolver) CreateBulkProcedure(ctx context.Context, input []*gen
 		return nil, rout.NewMissingRequiredFieldError("owner_id")
 	}
 
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	return r.bulkCreateProcedure(ctx, input)
@@ -60,7 +60,7 @@ func (r *mutationResolver) CreateBulkProcedure(ctx context.Context, input []*gen
 
 // CreateBulkCSVProcedure is the resolver for the createBulkCSVProcedure field.
 func (r *mutationResolver) CreateBulkCSVProcedure(ctx context.Context, input graphql.Upload) (*model.ProcedureBulkCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	data, err := unmarshalBulkData[generated.CreateProcedureInput](input)
@@ -87,7 +87,7 @@ func (r *mutationResolver) CreateBulkCSVProcedure(ctx context.Context, input gra
 
 // UpdateProcedure is the resolver for the updateProcedure field.
 func (r *mutationResolver) UpdateProcedure(ctx context.Context, id string, input generated.UpdateProcedureInput) (*model.ProcedureUpdatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	res, err := withTransactionalMutation(ctx).Procedure.Get(ctx, id)
@@ -132,10 +132,9 @@ func (r *mutationResolver) DeleteProcedure(ctx context.Context, id string) (*mod
 
 // Procedure is the resolver for the procedure field.
 func (r *queryResolver) Procedure(ctx context.Context, id string) (*generated.Procedure, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
-	query, err := withTransactionalMutation(ctx).Procedure.Query().Where(procedure.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Procedure.Query().Where(procedure.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "procedure"})
 	}

--- a/internal/graphapi/program.resolvers.go
+++ b/internal/graphapi/program.resolvers.go
@@ -12,15 +12,11 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/program"
 	"github.com/theopenlane/core/internal/graphapi/model"
-	"github.com/theopenlane/gqlgen-plugins/graphutils"
 	"github.com/theopenlane/utils/rout"
 )
 
 // CreateProgram is the resolver for the createProgram field.
 func (r *mutationResolver) CreateProgram(ctx context.Context, input generated.CreateProgramInput) (*model.ProgramCreatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	// set the organization in the auth context if its not done for us
 	if err := setOrganizationInAuthContext(ctx, input.OwnerID); err != nil {
 		log.Error().Err(err).Msg("failed to set organization in auth context")
@@ -52,17 +48,11 @@ func (r *mutationResolver) CreateBulkProgram(ctx context.Context, input []*gener
 		return nil, rout.NewMissingRequiredFieldError("owner_id")
 	}
 
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	return r.bulkCreateProgram(ctx, input)
 }
 
 // CreateBulkCSVProgram is the resolver for the createBulkCSVProgram field.
 func (r *mutationResolver) CreateBulkCSVProgram(ctx context.Context, input graphql.Upload) (*model.ProgramBulkCreatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	data, err := unmarshalBulkData[generated.CreateProgramInput](input)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to unmarshal bulk data")
@@ -87,9 +77,6 @@ func (r *mutationResolver) CreateBulkCSVProgram(ctx context.Context, input graph
 
 // UpdateProgram is the resolver for the updateProgram field.
 func (r *mutationResolver) UpdateProgram(ctx context.Context, id string, input generated.UpdateProgramInput) (*model.ProgramUpdatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	res, err := withTransactionalMutation(ctx).Program.Get(ctx, id)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionUpdate, object: "program"})
@@ -132,10 +119,7 @@ func (r *mutationResolver) DeleteProgram(ctx context.Context, id string) (*model
 
 // Program is the resolver for the program field.
 func (r *queryResolver) Program(ctx context.Context, id string) (*generated.Program, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
-
-	query, err := withTransactionalMutation(ctx).Program.Query().Where(program.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Program.Query().Where(program.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "program"})
 	}

--- a/internal/graphapi/programextended.resolvers.go
+++ b/internal/graphapi/programextended.resolvers.go
@@ -19,9 +19,6 @@ import (
 
 // CreateProgramWithMembers is the resolver for the createProgramWithMembers field.
 func (r *mutationResolver) CreateProgramWithMembers(ctx context.Context, input model.CreateProgramWithMembersInput) (*model.ProgramCreatePayload, error) {
-	// grab preloads and set max result limits
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	// set the organization in the auth context if its not done for us
 	if err := setOrganizationInAuthContext(ctx, input.Program.OwnerID); err != nil {
 		log.Error().Err(err).Msg("failed to set organization in auth context")
@@ -52,7 +49,7 @@ func (r *mutationResolver) CreateProgramWithMembers(ctx context.Context, input m
 	query, err := withTransactionalMutation(ctx).Program.
 		Query().
 		Where(program.ID(res.ID)).
-		CollectFields(ctx, preloads...)
+		CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionCreate, object: "program"})
 	}
@@ -69,9 +66,6 @@ func (r *mutationResolver) CreateProgramWithMembers(ctx context.Context, input m
 
 // CreateFullProgram is the resolver for the createFullProgram field.
 func (r *mutationResolver) CreateFullProgram(ctx context.Context, input model.CreateFullProgramInput) (*model.ProgramCreatePayload, error) {
-	// grab preloads and set max result limits
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	// set the organization in the auth context if its not done for us
 	if err := setOrganizationInAuthContext(ctx, input.Program.OwnerID); err != nil {
 		log.Error().Err(err).Msg("failed to set organization in auth context")
@@ -160,7 +154,7 @@ func (r *mutationResolver) CreateFullProgram(ctx context.Context, input model.Cr
 	query, err := withTransactionalMutation(ctx).Program.
 		Query().
 		Where(program.ID(res.ID)).
-		CollectFields(ctx, preloads...)
+		CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionCreate, object: "program"})
 	}
@@ -177,8 +171,8 @@ func (r *mutationResolver) CreateFullProgram(ctx context.Context, input model.Cr
 
 // CreateControlWithSubcontrols is the resolver for the createControlWithSubcontrols field.
 func (r *mutationResolver) CreateControlWithSubcontrols(ctx context.Context, input model.CreateControlWithSubcontrolsInput) (*model.ControlCreatePayload, error) {
-	// grab preloads and set max result limits
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
+	// grab preloads to set max result limits
+	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	res, err := withTransactionalMutation(ctx).Control.Create().SetInput(*input.Control).Save(ctx)
 	if err != nil {
@@ -203,7 +197,7 @@ func (r *mutationResolver) CreateControlWithSubcontrols(ctx context.Context, inp
 	query, err := withTransactionalMutation(ctx).Control.
 		Query().
 		Where(control.ID(res.ID)).
-		CollectFields(ctx, preloads...)
+		CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionCreate, object: "control"})
 

--- a/internal/graphapi/programmembership.resolvers.go
+++ b/internal/graphapi/programmembership.resolvers.go
@@ -12,15 +12,11 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/programmembership"
 	"github.com/theopenlane/core/internal/graphapi/model"
-	"github.com/theopenlane/gqlgen-plugins/graphutils"
 	"github.com/theopenlane/utils/rout"
 )
 
 // CreateProgramMembership is the resolver for the createProgramMembership field.
 func (r *mutationResolver) CreateProgramMembership(ctx context.Context, input generated.CreateProgramMembershipInput) (*model.ProgramMembershipCreatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	res, err := withTransactionalMutation(ctx).ProgramMembership.Create().SetInput(input).Save(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionCreate, object: "programmembership"})
@@ -37,17 +33,11 @@ func (r *mutationResolver) CreateBulkProgramMembership(ctx context.Context, inpu
 		return nil, rout.NewMissingRequiredFieldError("input")
 	}
 
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	return r.bulkCreateProgramMembership(ctx, input)
 }
 
 // CreateBulkCSVProgramMembership is the resolver for the createBulkCSVProgramMembership field.
 func (r *mutationResolver) CreateBulkCSVProgramMembership(ctx context.Context, input graphql.Upload) (*model.ProgramMembershipBulkCreatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	data, err := unmarshalBulkData[generated.CreateProgramMembershipInput](input)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to unmarshal bulk data")
@@ -64,9 +54,6 @@ func (r *mutationResolver) CreateBulkCSVProgramMembership(ctx context.Context, i
 
 // UpdateProgramMembership is the resolver for the updateProgramMembership field.
 func (r *mutationResolver) UpdateProgramMembership(ctx context.Context, id string, input generated.UpdateProgramMembershipInput) (*model.ProgramMembershipUpdatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	res, err := withTransactionalMutation(ctx).ProgramMembership.Get(ctx, id)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionUpdate, object: "programmembership"})
@@ -102,10 +89,7 @@ func (r *mutationResolver) DeleteProgramMembership(ctx context.Context, id strin
 
 // ProgramMembership is the resolver for the programMembership field.
 func (r *queryResolver) ProgramMembership(ctx context.Context, id string) (*generated.ProgramMembership, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
-
-	query, err := withTransactionalMutation(ctx).ProgramMembership.Query().Where(programmembership.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).ProgramMembership.Query().Where(programmembership.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "programmembership"})
 	}

--- a/internal/graphapi/risk.resolvers.go
+++ b/internal/graphapi/risk.resolvers.go
@@ -12,15 +12,11 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/risk"
 	"github.com/theopenlane/core/internal/graphapi/model"
-	"github.com/theopenlane/gqlgen-plugins/graphutils"
 	"github.com/theopenlane/utils/rout"
 )
 
 // CreateRisk is the resolver for the createRisk field.
 func (r *mutationResolver) CreateRisk(ctx context.Context, input generated.CreateRiskInput) (*model.RiskCreatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	// set the organization in the auth context if its not done for us
 	if err := setOrganizationInAuthContext(ctx, input.OwnerID); err != nil {
 		log.Error().Err(err).Msg("failed to set organization in auth context")
@@ -52,17 +48,11 @@ func (r *mutationResolver) CreateBulkRisk(ctx context.Context, input []*generate
 		return nil, rout.NewMissingRequiredFieldError("owner_id")
 	}
 
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	return r.bulkCreateRisk(ctx, input)
 }
 
 // CreateBulkCSVRisk is the resolver for the createBulkCSVRisk field.
 func (r *mutationResolver) CreateBulkCSVRisk(ctx context.Context, input graphql.Upload) (*model.RiskBulkCreatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	data, err := unmarshalBulkData[generated.CreateRiskInput](input)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to unmarshal bulk data")
@@ -87,9 +77,6 @@ func (r *mutationResolver) CreateBulkCSVRisk(ctx context.Context, input graphql.
 
 // UpdateRisk is the resolver for the updateRisk field.
 func (r *mutationResolver) UpdateRisk(ctx context.Context, id string, input generated.UpdateRiskInput) (*model.RiskUpdatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	res, err := withTransactionalMutation(ctx).Risk.Get(ctx, id)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionUpdate, object: "risk"})
@@ -132,10 +119,7 @@ func (r *mutationResolver) DeleteRisk(ctx context.Context, id string) (*model.Ri
 
 // Risk is the resolver for the risk field.
 func (r *queryResolver) Risk(ctx context.Context, id string) (*generated.Risk, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
-
-	query, err := withTransactionalMutation(ctx).Risk.Query().Where(risk.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Risk.Query().Where(risk.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "risk"})
 	}

--- a/internal/graphapi/standard.resolvers.go
+++ b/internal/graphapi/standard.resolvers.go
@@ -13,15 +13,11 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated/standard"
 	"github.com/theopenlane/core/internal/ent/privacy/rule"
 	"github.com/theopenlane/core/internal/graphapi/model"
-	"github.com/theopenlane/gqlgen-plugins/graphutils"
 	"github.com/theopenlane/utils/rout"
 )
 
 // CreateStandard is the resolver for the createStandard field.
 func (r *mutationResolver) CreateStandard(ctx context.Context, input generated.CreateStandardInput) (*model.StandardCreatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	// set the organization in the auth context if its not done for us
 	if err := setOrganizationInAuthContext(ctx, input.OwnerID); err != nil {
 		log.Error().Err(err).Msg("failed to set organization in auth context")
@@ -46,9 +42,6 @@ func (r *mutationResolver) CreateStandard(ctx context.Context, input generated.C
 
 // UpdateStandard is the resolver for the updateStandard field.
 func (r *mutationResolver) UpdateStandard(ctx context.Context, id string, input generated.UpdateStandardInput) (*model.StandardUpdatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	res, err := withTransactionalMutation(ctx).Standard.Get(ctx, id)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionUpdate, object: "standard"})
@@ -96,10 +89,7 @@ func (r *mutationResolver) DeleteStandard(ctx context.Context, id string) (*mode
 
 // Standard is the resolver for the standard field.
 func (r *queryResolver) Standard(ctx context.Context, id string) (*generated.Standard, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
-
-	query, err := withTransactionalMutation(ctx).Standard.Query().Where(standard.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Standard.Query().Where(standard.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "standard"})
 	}

--- a/internal/graphapi/standard_test.go
+++ b/internal/graphapi/standard_test.go
@@ -237,7 +237,7 @@ func (suite *GraphTestSuite) TestQueryStandards() {
 	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, IDs: orgOwnedStandardIDs}).MustDelete(testUser1.UserCtx, suite)
 }
 
-func (suite *GraphTestSuite) TestMutationCreateStandard() {
+func (suite *GraphTestSuite) v() {
 	t := suite.T()
 
 	numControls := 20

--- a/internal/graphapi/subcontrol.resolvers.go
+++ b/internal/graphapi/subcontrol.resolvers.go
@@ -12,15 +12,11 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/subcontrol"
 	"github.com/theopenlane/core/internal/graphapi/model"
-	"github.com/theopenlane/gqlgen-plugins/graphutils"
 	"github.com/theopenlane/utils/rout"
 )
 
 // CreateSubcontrol is the resolver for the createSubcontrol field.
 func (r *mutationResolver) CreateSubcontrol(ctx context.Context, input generated.CreateSubcontrolInput) (*model.SubcontrolCreatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	// set the organization in the auth context if its not done for us
 	if err := setOrganizationInAuthContext(ctx, input.OwnerID); err != nil {
 		log.Error().Err(err).Msg("failed to set organization in auth context")
@@ -52,17 +48,11 @@ func (r *mutationResolver) CreateBulkSubcontrol(ctx context.Context, input []*ge
 		return nil, rout.NewMissingRequiredFieldError("owner_id")
 	}
 
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	return r.bulkCreateSubcontrol(ctx, input)
 }
 
 // CreateBulkCSVSubcontrol is the resolver for the createBulkCSVSubcontrol field.
 func (r *mutationResolver) CreateBulkCSVSubcontrol(ctx context.Context, input graphql.Upload) (*model.SubcontrolBulkCreatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	data, err := unmarshalBulkData[generated.CreateSubcontrolInput](input)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to unmarshal bulk data")
@@ -87,9 +77,6 @@ func (r *mutationResolver) CreateBulkCSVSubcontrol(ctx context.Context, input gr
 
 // UpdateSubcontrol is the resolver for the updateSubcontrol field.
 func (r *mutationResolver) UpdateSubcontrol(ctx context.Context, id string, input generated.UpdateSubcontrolInput) (*model.SubcontrolUpdatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	res, err := withTransactionalMutation(ctx).Subcontrol.Get(ctx, id)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionUpdate, object: "subcontrol"})
@@ -132,10 +119,7 @@ func (r *mutationResolver) DeleteSubcontrol(ctx context.Context, id string) (*mo
 
 // Subcontrol is the resolver for the subcontrol field.
 func (r *queryResolver) Subcontrol(ctx context.Context, id string) (*generated.Subcontrol, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
-
-	query, err := withTransactionalMutation(ctx).Subcontrol.Query().Where(subcontrol.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Subcontrol.Query().Where(subcontrol.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "subcontrol"})
 	}

--- a/internal/graphapi/subscriber.resolvers.go
+++ b/internal/graphapi/subscriber.resolvers.go
@@ -18,7 +18,7 @@ import (
 
 // CreateSubscriber is the resolver for the createSubscriber field.
 func (r *mutationResolver) CreateSubscriber(ctx context.Context, input generated.CreateSubscriberInput) (*model.SubscriberCreatePayload, error) {
-	// grab preloads and set max result limits
+	// grab preloads to set max result limits
 	graphutils.GetPreloads(ctx, r.maxResultLimit)
 	// set the organization in the auth context if its not done for us
 	if err := setOrganizationInAuthContext(ctx, input.OwnerID); err != nil {
@@ -39,17 +39,11 @@ func (r *mutationResolver) CreateSubscriber(ctx context.Context, input generated
 
 // CreateBulkSubscriber is the resolver for the createBulkSubscriber field.
 func (r *mutationResolver) CreateBulkSubscriber(ctx context.Context, input []*generated.CreateSubscriberInput) (*model.SubscriberBulkCreatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	return r.bulkCreateSubscriber(ctx, input)
 }
 
 // CreateBulkCSVSubscriber is the resolver for the createBulkCSVSubscriber field.
 func (r *mutationResolver) CreateBulkCSVSubscriber(ctx context.Context, input graphql.Upload) (*model.SubscriberBulkCreatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	data, err := unmarshalBulkData[generated.CreateSubscriberInput](input)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to unmarshal bulk data")
@@ -62,9 +56,6 @@ func (r *mutationResolver) CreateBulkCSVSubscriber(ctx context.Context, input gr
 
 // UpdateSubscriber is the resolver for the updateSubscriber field.
 func (r *mutationResolver) UpdateSubscriber(ctx context.Context, email string, input generated.UpdateSubscriberInput) (*model.SubscriberUpdatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	res, err := withTransactionalMutation(ctx).Subscriber.Query().
 		Where(
 			subscriber.EmailEQ(email),
@@ -124,10 +115,7 @@ func (r *mutationResolver) DeleteSubscriber(ctx context.Context, email string, o
 
 // Subscriber is the resolver for the subscriber field.
 func (r *queryResolver) Subscriber(ctx context.Context, email string) (*generated.Subscriber, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
-
-	query, err := withTransactionalMutation(ctx).Subscriber.Query().Where(subscriber.EmailEQ(email)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Subscriber.Query().Where(subscriber.EmailEQ(email)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "subscriber"})
 	}

--- a/internal/graphapi/template.resolvers.go
+++ b/internal/graphapi/template.resolvers.go
@@ -12,15 +12,11 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/template"
 	"github.com/theopenlane/core/internal/graphapi/model"
-	"github.com/theopenlane/gqlgen-plugins/graphutils"
 	"github.com/theopenlane/utils/rout"
 )
 
 // CreateTemplate is the resolver for the createTemplate field.
 func (r *mutationResolver) CreateTemplate(ctx context.Context, input generated.CreateTemplateInput) (*model.TemplateCreatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	// set the organization in the auth context if its not done for us
 	if err := setOrganizationInAuthContext(ctx, input.OwnerID); err != nil {
 		log.Error().Err(err).Msg("failed to set organization in auth context")
@@ -52,17 +48,11 @@ func (r *mutationResolver) CreateBulkTemplate(ctx context.Context, input []*gene
 		return nil, rout.NewMissingRequiredFieldError("owner_id")
 	}
 
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	return r.bulkCreateTemplate(ctx, input)
 }
 
 // CreateBulkCSVTemplate is the resolver for the createBulkCSVTemplate field.
 func (r *mutationResolver) CreateBulkCSVTemplate(ctx context.Context, input graphql.Upload) (*model.TemplateBulkCreatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	data, err := unmarshalBulkData[generated.CreateTemplateInput](input)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to unmarshal bulk data")
@@ -87,9 +77,6 @@ func (r *mutationResolver) CreateBulkCSVTemplate(ctx context.Context, input grap
 
 // UpdateTemplate is the resolver for the updateTemplate field.
 func (r *mutationResolver) UpdateTemplate(ctx context.Context, id string, input generated.UpdateTemplateInput) (*model.TemplateUpdatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	res, err := withTransactionalMutation(ctx).Template.Get(ctx, id)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionUpdate, object: "template"})
@@ -132,10 +119,7 @@ func (r *mutationResolver) DeleteTemplate(ctx context.Context, id string) (*mode
 
 // Template is the resolver for the template field.
 func (r *queryResolver) Template(ctx context.Context, id string) (*generated.Template, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
-
-	query, err := withTransactionalMutation(ctx).Template.Query().Where(template.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).Template.Query().Where(template.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "template"})
 	}

--- a/internal/graphapi/tfasetting.resolvers.go
+++ b/internal/graphapi/tfasetting.resolvers.go
@@ -20,9 +20,6 @@ func (r *mutationResolver) CreateTFASetting(ctx context.Context, input generated
 		return nil, err
 	}
 
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	// get the userID from the context
 	userID, err := auth.GetSubjectIDFromContext(ctx)
 	if err != nil {
@@ -61,9 +58,6 @@ func (r *mutationResolver) UpdateTFASetting(ctx context.Context, input generated
 	if err := checkAllowedAuthType(ctx); err != nil {
 		return nil, err
 	}
-
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
 
 	// get the userID from the context
 	userID, err := auth.GetSubjectIDFromContext(ctx)
@@ -118,9 +112,6 @@ func (r *mutationResolver) UpdateTFASetting(ctx context.Context, input generated
 
 // TfaSetting is the resolver for the tfaSettings field.
 func (r *queryResolver) TfaSetting(ctx context.Context, id *string) (*generated.TFASetting, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	if err := checkAllowedAuthType(ctx); err != nil {
 		return nil, err
 	}
@@ -132,7 +123,7 @@ func (r *queryResolver) TfaSetting(ctx context.Context, id *string) (*generated.
 	}
 
 	if id != nil && *id != "" {
-		query, err := withTransactionalMutation(ctx).TFASetting.Query().Where(tfasetting.ID(*id)).CollectFields(ctx, preloads...)
+		query, err := withTransactionalMutation(ctx).TFASetting.Query().Where(tfasetting.ID(*id)).CollectFields(ctx)
 		if err != nil {
 			return nil, parseRequestError(err, action{action: ActionGet, object: "tfasetting"})
 		}
@@ -145,7 +136,7 @@ func (r *queryResolver) TfaSetting(ctx context.Context, id *string) (*generated.
 		return settings, nil
 	}
 
-	query, err := withTransactionalMutation(ctx).TFASetting.Query().Where(tfasetting.OwnerID(userID)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).TFASetting.Query().Where(tfasetting.OwnerID(userID)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "tfasetting"})
 	}

--- a/internal/graphapi/user.resolvers.go
+++ b/internal/graphapi/user.resolvers.go
@@ -11,7 +11,6 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/user"
 	"github.com/theopenlane/core/internal/graphapi/model"
-	"github.com/theopenlane/gqlgen-plugins/graphutils"
 	"github.com/theopenlane/iam/auth"
 	"github.com/theopenlane/utils/rout"
 )
@@ -25,9 +24,6 @@ func (r *mutationResolver) CreateUser(ctx context.Context, input generated.Creat
 
 // UpdateUser is the resolver for the updateUser field.
 func (r *mutationResolver) UpdateUser(ctx context.Context, id string, input generated.UpdateUserInput, avatarFile *graphql.Upload) (*model.UserUpdatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	res, err := withTransactionalMutation(ctx).User.Get(ctx, id)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionUpdate, object: "user"})
@@ -63,10 +59,7 @@ func (r *mutationResolver) DeleteUser(ctx context.Context, id string) (*model.Us
 
 // User is the resolver for the user field.
 func (r *queryResolver) User(ctx context.Context, id string) (*generated.User, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
-
-	query, err := withTransactionalMutation(ctx).User.Query().Where(user.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).User.Query().Where(user.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "user"})
 	}
@@ -86,10 +79,7 @@ func (r *queryResolver) Self(ctx context.Context) (*generated.User, error) {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "user"})
 	}
 
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
-
-	query, err := withTransactionalMutation(ctx).User.Query().Where(user.ID(userID)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).User.Query().Where(user.ID(userID)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "user"})
 	}

--- a/internal/graphapi/usersetting.resolvers.go
+++ b/internal/graphapi/usersetting.resolvers.go
@@ -12,15 +12,11 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/usersetting"
 	"github.com/theopenlane/core/internal/graphapi/model"
-	"github.com/theopenlane/gqlgen-plugins/graphutils"
 	"github.com/theopenlane/utils/rout"
 )
 
 // CreateUserSetting is the resolver for the createUserSetting field.
 func (r *mutationResolver) CreateUserSetting(ctx context.Context, input generated.CreateUserSettingInput) (*model.UserSettingCreatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	res, err := withTransactionalMutation(ctx).UserSetting.Create().SetInput(input).Save(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionCreate, object: "usersetting"})
@@ -37,17 +33,11 @@ func (r *mutationResolver) CreateBulkUserSetting(ctx context.Context, input []*g
 		return nil, rout.NewMissingRequiredFieldError("input")
 	}
 
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	return r.bulkCreateUserSetting(ctx, input)
 }
 
 // CreateBulkCSVUserSetting is the resolver for the createBulkCSVUserSetting field.
 func (r *mutationResolver) CreateBulkCSVUserSetting(ctx context.Context, input graphql.Upload) (*model.UserSettingBulkCreatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	data, err := unmarshalBulkData[generated.CreateUserSettingInput](input)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to unmarshal bulk data")
@@ -64,9 +54,6 @@ func (r *mutationResolver) CreateBulkCSVUserSetting(ctx context.Context, input g
 
 // UpdateUserSetting is the resolver for the updateUserSetting field.
 func (r *mutationResolver) UpdateUserSetting(ctx context.Context, id string, input generated.UpdateUserSettingInput) (*model.UserSettingUpdatePayload, error) {
-	// grab preloads and set max result limits
-	graphutils.GetPreloads(ctx, r.maxResultLimit)
-
 	res, err := withTransactionalMutation(ctx).UserSetting.Get(ctx, id)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionUpdate, object: "usersetting"})
@@ -87,10 +74,7 @@ func (r *mutationResolver) UpdateUserSetting(ctx context.Context, id string, inp
 
 // UserSetting is the resolver for the userSetting field.
 func (r *queryResolver) UserSetting(ctx context.Context, id string) (*generated.UserSetting, error) {
-	// determine all fields that were requested
-	preloads := graphutils.GetPreloads(ctx, r.maxResultLimit)
-
-	query, err := withTransactionalMutation(ctx).UserSetting.Query().Where(usersetting.ID(id)).CollectFields(ctx, preloads...)
+	query, err := withTransactionalMutation(ctx).UserSetting.Query().Where(usersetting.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "usersetting"})
 	}


### PR DESCRIPTION
- removes preloads filter, this was causing a conflict when using fragments.  After more debugging, I realized the `CollectField` function grabs these automatically anyways, so should keep only pulling required fields + eager loads edges. We still need to call the function because this is what we use to set the max results on edges if there is none set on the request
- Regenerates ent resolvers to pull in new order by fields, tested with the updated templates: https://github.com/theopenlane/gqlgen-plugins/pull/85