### PR TITLE
feat: add ability to run full stack without compiling the server using published image

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -298,6 +298,7 @@ steps:
                 - "${IMAGE_REPO}"
               extra_tags:
                 - "${IMAGE_TAG}"
+                - "latest"
           - theopenlane/container-build#v1.1.1:
               dockerfile: docker/Dockerfile
               push: true

--- a/docker/Taskfile.yaml
+++ b/docker/Taskfile.yaml
@@ -17,31 +17,60 @@ tasks:
     cmds:
       - "docker build -f ./docker/all-in-one/Dockerfile.all-in-one -t core:dev-aio ."
 
-  core:
+  core:local:
+    aliases: ['core:up']
     dir: ..
     desc: brings up the compose environment for the core server
     deps: [build]
     cmds:
       - "docker compose -f ./docker/docker-compose-redis.yml -f ./docker/docker-compose-fga.yml -f ./docker/docker-compose-riverboat.yml -f ./docker/docker-compose.yml -p core up -d"
 
-  core:down:
+  core:local:down:
+    aliases: ['core:down']
     dir: ..
     desc: brings the core compose environment down
     cmds:
       - "docker compose -p core down"
 
-  all:up:
+  core:published:
+    dir: ..
+    desc: brings up the compose environment for the core server using the published docker image. currently this will only work on x86 machines as its built using an x86 server
+    cmds:
+      - "docker compose -f ./docker/docker-compose-redis.yml -f ./docker/docker-compose-fga.yml -f ./docker/docker-compose-riverboat.yml -f ./docker/docker-compose-published.yml -p core up -d"
+
+  core:published:down:
+    dir: ..
+    desc: brings the core compose environment down
+    cmds:
+      - "docker compose -p core down"
+
+  all:local:up:
+    aliases: ['all:up']
     dir: ..
     desc: brings up the full docker compose development environment including core server, fga, and rover
     cmds:
       - task: core
       - task: :rover
 
-  all:down:
+  all:local:down:
+    aliases: ['all:down']
     dir: ..
     desc: brings down both fga and core server compose environments
     cmds:
       - task: core:down
+
+  all:published:up:
+    dir: ..
+    desc: brings up the full docker compose development environment including core server, fga, and rover
+    cmds:
+      - task: core:published
+      - task: :rover
+
+  all:published:down:
+    dir: ..
+    desc: brings down both fga and core server compose environments
+    cmds:
+      - task: core:published:down
 
   redis:
     dir: ..

--- a/docker/docker-compose-published.yml
+++ b/docker/docker-compose-published.yml
@@ -1,0 +1,22 @@
+services:
+  api:
+    image: ghcr.io/theopenlane/core:2830-33bc5a3a
+    depends_on:
+      - openfga
+    command:
+      - serve
+      - --debug
+      - --pretty
+      - --config=/config/.config.yaml
+    volumes:
+      - type: bind
+        source: ../config/.config.yaml
+        target: /config/.config.yaml
+    ports:
+      - "17608:17608"
+    restart: unless-stopped
+    environment:
+      - CORE_REDIS_ADDRESS=redis:6379
+      - CORE_AUTHZ_HOST_URL=openfga:8080
+    networks:
+      - default


### PR DESCRIPTION
- adds a `latest` tag to the published image off main
- adds task command to run the the core server from the published image
- this won't work on arm machines, because the ghcr image is built on x86 machines

To use: 

```
docker login  -u golanglemonade@funkhouse.rs ghcr.io
```
When prompted for a password, enter a github PAT

Start the stack:
```
task docker:core:published
```

To bring it down:
```
core:published:down
```

