### PR TITLE
feat: edge cleanup updates

### DIFF
--- a/db/migrations-goose-postgres/20250405232726_hush.sql
+++ b/db/migrations-goose-postgres/20250405232726_hush.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- modify "hush_history" table
+ALTER TABLE "hush_history" ADD COLUMN "owner_id" character varying NULL;
+-- modify "hushes" table
+ALTER TABLE "hushes" ADD COLUMN "owner_id" character varying NULL, ADD CONSTRAINT "hushes_organizations_secrets" FOREIGN KEY ("owner_id") REFERENCES "organizations" ("id") ON UPDATE NO ACTION ON DELETE SET NULL;
+
+-- +goose Down
+-- reverse: modify "hushes" table
+ALTER TABLE "hushes" DROP CONSTRAINT "hushes_organizations_secrets", DROP COLUMN "owner_id";
+-- reverse: modify "hush_history" table
+ALTER TABLE "hush_history" DROP COLUMN "owner_id";

--- a/db/migrations-goose-postgres/atlas.sum
+++ b/db/migrations-goose-postgres/atlas.sum
@@ -1,4 +1,4 @@
-h1:n1us1BfbmI1ZusDWONGTwmta9aAkqFPpFcijPDa0irM=
+h1:Zq+nutxn1DN9TELp/DBiD75oGZPoQm6K17gEmJa9/Ow=
 20241211231032_init.sql h1:Cj6GduEDECy6Y+8DfI6767WosqG2AKWybIyJJ6AgKqA=
 20241212223714_consistent_naming.sql h1:RvnNmsStlHkmAdSCnX1fFh/KYgfj1RMYYEc4iCN9JcQ=
 20250109002850_billing_address.sql h1:m0ek3WXqRgS3+ZbSa/DcIMB16vb8Tjm2MgNqyRll3rU=
@@ -27,3 +27,4 @@ h1:n1us1BfbmI1ZusDWONGTwmta9aAkqFPpFcijPDa0irM=
 20250401045540_control_fields.sql h1:7xbJhSJj04STItmwk+vTH3QK2rsY6eCvKWuu4mwKUXI=
 20250401232813_notes_to_files.sql h1:8KlSgy0zOl0/GlZLnEdKarT4P/i6Y7FCZ2VSNJtQ45M=
 20250403043329_control_fields.sql h1:2sj8IpqNtHsvUhXVMdTV/LEWXPZ6z/6aUVN8iZ9txZ0=
+20250405232726_hush.sql h1:Ndu5HeHihu0dd+mwjxMKbeG7uPvdBtKzQJlVw8UfMPU=

--- a/db/migrations/20250405232724_hush.sql
+++ b/db/migrations/20250405232724_hush.sql
@@ -1,0 +1,4 @@
+-- Modify "hush_history" table
+ALTER TABLE "hush_history" ADD COLUMN "owner_id" character varying NULL;
+-- Modify "hushes" table
+ALTER TABLE "hushes" ADD COLUMN "owner_id" character varying NULL, ADD CONSTRAINT "hushes_organizations_secrets" FOREIGN KEY ("owner_id") REFERENCES "organizations" ("id") ON UPDATE NO ACTION ON DELETE SET NULL;

--- a/db/migrations/atlas.sum
+++ b/db/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:eP4BUcmpubCDm6OF2x074hRZkWl9Lfbjf/BxPl/gRm0=
+h1:Ep2T8FbDX4pa82dvwuUiPBK8IibILqXSH0Zm/wvxRts=
 20241211231032_init.sql h1:TxjpHzKPB/5L2i7V2JfO1y+Cep/AyQN5wGjhY7saCeE=
 20241212223712_consistent_naming.sql h1:tbdYOtixhW66Jmvy3aCm+X6neI/SRVvItKM0Bdn26TA=
 20250109002849_billing_address.sql h1:mspCGbJ6HVmx3r4j+d/WvruzirJdJ8u5x18WF9R9ESE=
@@ -27,3 +27,4 @@ h1:eP4BUcmpubCDm6OF2x074hRZkWl9Lfbjf/BxPl/gRm0=
 20250401045537_control_fields.sql h1:j96qYq+ZPcH4lSWsdPeUmKNrovk2elPixxS+muYLe8I=
 20250401232810_notes_to_files.sql h1:5fRX3o+vDAAiJZNhOK+oVvrRUvbsQO/eW1xPKWwnxsA=
 20250403043327_control_fields.sql h1:PhfsedkilzUwiio9epF9xlq5VXjOHSTtT2h1FgRCvCk=
+20250405232724_hush.sql h1:yPo8aJD7ZgZVaGM6zvdttgxWYHAmmJpFw4brAjbi82E=

--- a/internal/ent/generated/auditing.go
+++ b/internal/ent/generated/auditing.go
@@ -1102,6 +1102,9 @@ func (hh *HushHistory) changes(new *HushHistory) []Change {
 	if !reflect.DeepEqual(hh.DeletedBy, new.DeletedBy) {
 		changes = append(changes, NewChange(hushhistory.FieldDeletedBy, hh.DeletedBy, new.DeletedBy))
 	}
+	if !reflect.DeepEqual(hh.OwnerID, new.OwnerID) {
+		changes = append(changes, NewChange(hushhistory.FieldOwnerID, hh.OwnerID, new.OwnerID))
+	}
 	if !reflect.DeepEqual(hh.Name, new.Name) {
 		changes = append(changes, NewChange(hushhistory.FieldName, hh.Name, new.Name))
 	}

--- a/internal/ent/generated/edge_cleanup.go
+++ b/internal/ent/generated/edge_cleanup.go
@@ -8,6 +8,7 @@ import (
 	"entgo.io/ent/privacy"
 	"github.com/rs/zerolog/log"
 	"github.com/theopenlane/core/internal/ent/generated/actionplan"
+	"github.com/theopenlane/core/internal/ent/generated/apitoken"
 	"github.com/theopenlane/core/internal/ent/generated/contact"
 	"github.com/theopenlane/core/internal/ent/generated/control"
 	"github.com/theopenlane/core/internal/ent/generated/controlimplementation"
@@ -21,6 +22,7 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated/group"
 	"github.com/theopenlane/core/internal/ent/generated/groupmembership"
 	"github.com/theopenlane/core/internal/ent/generated/groupsetting"
+	"github.com/theopenlane/core/internal/ent/generated/hush"
 	"github.com/theopenlane/core/internal/ent/generated/integration"
 	"github.com/theopenlane/core/internal/ent/generated/internalpolicy"
 	"github.com/theopenlane/core/internal/ent/generated/invite"
@@ -81,13 +83,6 @@ func ContactHistoryEdgeCleanup(ctx context.Context, id string) error {
 
 func ControlEdgeCleanup(ctx context.Context, id string) error {
 	ctx = contextx.With(privacy.DecisionContext(ctx, privacy.Allowf("cleanup control edge")), entfga.DeleteTuplesFirstKey{})
-
-	if exists, err := FromContext(ctx).ControlImplementation.Query().Where((controlimplementation.HasControlsWith(control.ID(id)))).Exist(ctx); err == nil && exists {
-		if controlimplementationCount, err := FromContext(ctx).ControlImplementation.Delete().Where(controlimplementation.HasControlsWith(control.ID(id))).Exec(ctx); err != nil {
-			log.Debug().Err(err).Int("count", controlimplementationCount).Msg("deleting controlimplementation")
-			return err
-		}
-	}
 
 	if exists, err := FromContext(ctx).Subcontrol.Query().Where((subcontrol.HasControlWith(control.ID(id)))).Exist(ctx); err == nil && exists {
 		if subcontrolCount, err := FromContext(ctx).Subcontrol.Delete().Where(subcontrol.HasControlWith(control.ID(id))).Exec(ctx); err != nil {
@@ -396,9 +391,23 @@ func OrganizationEdgeCleanup(ctx context.Context, id string) error {
 		}
 	}
 
+	if exists, err := FromContext(ctx).APIToken.Query().Where((apitoken.HasOwnerWith(organization.ID(id)))).Exist(ctx); err == nil && exists {
+		if apitokenCount, err := FromContext(ctx).APIToken.Delete().Where(apitoken.HasOwnerWith(organization.ID(id))).Exec(ctx); err != nil {
+			log.Debug().Err(err).Int("count", apitokenCount).Msg("deleting apitoken")
+			return err
+		}
+	}
+
 	if exists, err := FromContext(ctx).File.Query().Where((file.HasOrganizationWith(organization.ID(id)))).Exist(ctx); err == nil && exists {
 		if fileCount, err := FromContext(ctx).File.Delete().Where(file.HasOrganizationWith(organization.ID(id))).Exec(ctx); err != nil {
 			log.Debug().Err(err).Int("count", fileCount).Msg("deleting file")
+			return err
+		}
+	}
+
+	if exists, err := FromContext(ctx).Hush.Query().Where((hush.HasOwnerWith(organization.ID(id)))).Exist(ctx); err == nil && exists {
+		if hushCount, err := FromContext(ctx).Hush.Delete().Where(hush.HasOwnerWith(organization.ID(id))).Exec(ctx); err != nil {
+			log.Debug().Err(err).Int("count", hushCount).Msg("deleting hush")
 			return err
 		}
 	}
@@ -669,13 +678,6 @@ func RiskHistoryEdgeCleanup(ctx context.Context, id string) error {
 func StandardEdgeCleanup(ctx context.Context, id string) error {
 	ctx = contextx.With(privacy.DecisionContext(ctx, privacy.Allowf("cleanup standard edge")), entfga.DeleteTuplesFirstKey{})
 
-	if exists, err := FromContext(ctx).Control.Query().Where((control.HasStandardWith(standard.ID(id)))).Exist(ctx); err == nil && exists {
-		if controlCount, err := FromContext(ctx).Control.Delete().Where(control.HasStandardWith(standard.ID(id))).Exec(ctx); err != nil {
-			log.Debug().Err(err).Int("count", controlCount).Msg("deleting control")
-			return err
-		}
-	}
-
 	return nil
 }
 
@@ -687,13 +689,6 @@ func StandardHistoryEdgeCleanup(ctx context.Context, id string) error {
 
 func SubcontrolEdgeCleanup(ctx context.Context, id string) error {
 	ctx = contextx.With(privacy.DecisionContext(ctx, privacy.Allowf("cleanup subcontrol edge")), entfga.DeleteTuplesFirstKey{})
-
-	if exists, err := FromContext(ctx).ControlImplementation.Query().Where((controlimplementation.HasSubcontrolsWith(subcontrol.ID(id)))).Exist(ctx); err == nil && exists {
-		if controlimplementationCount, err := FromContext(ctx).ControlImplementation.Delete().Where(controlimplementation.HasSubcontrolsWith(subcontrol.ID(id))).Exec(ctx); err != nil {
-			log.Debug().Err(err).Int("count", controlimplementationCount).Msg("deleting controlimplementation")
-			return err
-		}
-	}
 
 	return nil
 }

--- a/internal/ent/generated/gql_mutation_input.go
+++ b/internal/ent/generated/gql_mutation_input.go
@@ -3547,14 +3547,14 @@ func (c *GroupSettingUpdateOne) SetInput(i UpdateGroupSettingInput) *GroupSettin
 
 // CreateHushInput represents a mutation input for creating hushes.
 type CreateHushInput struct {
-	Name            string
-	Description     *string
-	Kind            *string
-	SecretName      *string
-	SecretValue     *string
-	IntegrationIDs  []string
-	OrganizationIDs []string
-	EventIDs        []string
+	Name           string
+	Description    *string
+	Kind           *string
+	SecretName     *string
+	SecretValue    *string
+	OwnerID        *string
+	IntegrationIDs []string
+	EventIDs       []string
 }
 
 // Mutate applies the CreateHushInput on the HushMutation builder.
@@ -3572,11 +3572,11 @@ func (i *CreateHushInput) Mutate(m *HushMutation) {
 	if v := i.SecretValue; v != nil {
 		m.SetSecretValue(*v)
 	}
+	if v := i.OwnerID; v != nil {
+		m.SetOwnerID(*v)
+	}
 	if v := i.IntegrationIDs; len(v) > 0 {
 		m.AddIntegrationIDs(v...)
-	}
-	if v := i.OrganizationIDs; len(v) > 0 {
-		m.AddOrganizationIDs(v...)
 	}
 	if v := i.EventIDs; len(v) > 0 {
 		m.AddEventIDs(v...)
@@ -3591,20 +3591,19 @@ func (c *HushCreate) SetInput(i CreateHushInput) *HushCreate {
 
 // UpdateHushInput represents a mutation input for updating hushes.
 type UpdateHushInput struct {
-	Name                  *string
-	ClearDescription      bool
-	Description           *string
-	ClearKind             bool
-	Kind                  *string
-	ClearIntegrations     bool
-	AddIntegrationIDs     []string
-	RemoveIntegrationIDs  []string
-	ClearOrganization     bool
-	AddOrganizationIDs    []string
-	RemoveOrganizationIDs []string
-	ClearEvents           bool
-	AddEventIDs           []string
-	RemoveEventIDs        []string
+	Name                 *string
+	ClearDescription     bool
+	Description          *string
+	ClearKind            bool
+	Kind                 *string
+	ClearOwner           bool
+	OwnerID              *string
+	ClearIntegrations    bool
+	AddIntegrationIDs    []string
+	RemoveIntegrationIDs []string
+	ClearEvents          bool
+	AddEventIDs          []string
+	RemoveEventIDs       []string
 }
 
 // Mutate applies the UpdateHushInput on the HushMutation builder.
@@ -3624,6 +3623,12 @@ func (i *UpdateHushInput) Mutate(m *HushMutation) {
 	if v := i.Kind; v != nil {
 		m.SetKind(*v)
 	}
+	if i.ClearOwner {
+		m.ClearOwner()
+	}
+	if v := i.OwnerID; v != nil {
+		m.SetOwnerID(*v)
+	}
 	if i.ClearIntegrations {
 		m.ClearIntegrations()
 	}
@@ -3632,15 +3637,6 @@ func (i *UpdateHushInput) Mutate(m *HushMutation) {
 	}
 	if v := i.RemoveIntegrationIDs; len(v) > 0 {
 		m.RemoveIntegrationIDs(v...)
-	}
-	if i.ClearOrganization {
-		m.ClearOrganization()
-	}
-	if v := i.AddOrganizationIDs; len(v) > 0 {
-		m.AddOrganizationIDs(v...)
-	}
-	if v := i.RemoveOrganizationIDs; len(v) > 0 {
-		m.RemoveOrganizationIDs(v...)
 	}
 	if i.ClearEvents {
 		m.ClearEvents()

--- a/internal/ent/generated/gql_where_input.go
+++ b/internal/ent/generated/gql_where_input.go
@@ -27960,6 +27960,23 @@ type HushWhereInput struct {
 	DeletedByEqualFold    *string  `json:"deletedByEqualFold,omitempty"`
 	DeletedByContainsFold *string  `json:"deletedByContainsFold,omitempty"`
 
+	// "owner_id" field predicates.
+	OwnerID             *string  `json:"ownerID,omitempty"`
+	OwnerIDNEQ          *string  `json:"ownerIDNEQ,omitempty"`
+	OwnerIDIn           []string `json:"ownerIDIn,omitempty"`
+	OwnerIDNotIn        []string `json:"ownerIDNotIn,omitempty"`
+	OwnerIDGT           *string  `json:"ownerIDGT,omitempty"`
+	OwnerIDGTE          *string  `json:"ownerIDGTE,omitempty"`
+	OwnerIDLT           *string  `json:"ownerIDLT,omitempty"`
+	OwnerIDLTE          *string  `json:"ownerIDLTE,omitempty"`
+	OwnerIDContains     *string  `json:"ownerIDContains,omitempty"`
+	OwnerIDHasPrefix    *string  `json:"ownerIDHasPrefix,omitempty"`
+	OwnerIDHasSuffix    *string  `json:"ownerIDHasSuffix,omitempty"`
+	OwnerIDIsNil        bool     `json:"ownerIDIsNil,omitempty"`
+	OwnerIDNotNil       bool     `json:"ownerIDNotNil,omitempty"`
+	OwnerIDEqualFold    *string  `json:"ownerIDEqualFold,omitempty"`
+	OwnerIDContainsFold *string  `json:"ownerIDContainsFold,omitempty"`
+
 	// "name" field predicates.
 	Name             *string  `json:"name,omitempty"`
 	NameNEQ          *string  `json:"nameNEQ,omitempty"`
@@ -28009,13 +28026,13 @@ type HushWhereInput struct {
 	SecretNameEqualFold    *string  `json:"secretNameEqualFold,omitempty"`
 	SecretNameContainsFold *string  `json:"secretNameContainsFold,omitempty"`
 
+	// "owner" edge predicates.
+	HasOwner     *bool                     `json:"hasOwner,omitempty"`
+	HasOwnerWith []*OrganizationWhereInput `json:"hasOwnerWith,omitempty"`
+
 	// "integrations" edge predicates.
 	HasIntegrations     *bool                    `json:"hasIntegrations,omitempty"`
 	HasIntegrationsWith []*IntegrationWhereInput `json:"hasIntegrationsWith,omitempty"`
-
-	// "organization" edge predicates.
-	HasOrganization     *bool                     `json:"hasOrganization,omitempty"`
-	HasOrganizationWith []*OrganizationWhereInput `json:"hasOrganizationWith,omitempty"`
 
 	// "events" edge predicates.
 	HasEvents     *bool              `json:"hasEvents,omitempty"`
@@ -28348,6 +28365,51 @@ func (i *HushWhereInput) P() (predicate.Hush, error) {
 	if i.DeletedByContainsFold != nil {
 		predicates = append(predicates, hush.DeletedByContainsFold(*i.DeletedByContainsFold))
 	}
+	if i.OwnerID != nil {
+		predicates = append(predicates, hush.OwnerIDEQ(*i.OwnerID))
+	}
+	if i.OwnerIDNEQ != nil {
+		predicates = append(predicates, hush.OwnerIDNEQ(*i.OwnerIDNEQ))
+	}
+	if len(i.OwnerIDIn) > 0 {
+		predicates = append(predicates, hush.OwnerIDIn(i.OwnerIDIn...))
+	}
+	if len(i.OwnerIDNotIn) > 0 {
+		predicates = append(predicates, hush.OwnerIDNotIn(i.OwnerIDNotIn...))
+	}
+	if i.OwnerIDGT != nil {
+		predicates = append(predicates, hush.OwnerIDGT(*i.OwnerIDGT))
+	}
+	if i.OwnerIDGTE != nil {
+		predicates = append(predicates, hush.OwnerIDGTE(*i.OwnerIDGTE))
+	}
+	if i.OwnerIDLT != nil {
+		predicates = append(predicates, hush.OwnerIDLT(*i.OwnerIDLT))
+	}
+	if i.OwnerIDLTE != nil {
+		predicates = append(predicates, hush.OwnerIDLTE(*i.OwnerIDLTE))
+	}
+	if i.OwnerIDContains != nil {
+		predicates = append(predicates, hush.OwnerIDContains(*i.OwnerIDContains))
+	}
+	if i.OwnerIDHasPrefix != nil {
+		predicates = append(predicates, hush.OwnerIDHasPrefix(*i.OwnerIDHasPrefix))
+	}
+	if i.OwnerIDHasSuffix != nil {
+		predicates = append(predicates, hush.OwnerIDHasSuffix(*i.OwnerIDHasSuffix))
+	}
+	if i.OwnerIDIsNil {
+		predicates = append(predicates, hush.OwnerIDIsNil())
+	}
+	if i.OwnerIDNotNil {
+		predicates = append(predicates, hush.OwnerIDNotNil())
+	}
+	if i.OwnerIDEqualFold != nil {
+		predicates = append(predicates, hush.OwnerIDEqualFold(*i.OwnerIDEqualFold))
+	}
+	if i.OwnerIDContainsFold != nil {
+		predicates = append(predicates, hush.OwnerIDContainsFold(*i.OwnerIDContainsFold))
+	}
 	if i.Name != nil {
 		predicates = append(predicates, hush.NameEQ(*i.Name))
 	}
@@ -28478,6 +28540,24 @@ func (i *HushWhereInput) P() (predicate.Hush, error) {
 		predicates = append(predicates, hush.SecretNameContainsFold(*i.SecretNameContainsFold))
 	}
 
+	if i.HasOwner != nil {
+		p := hush.HasOwner()
+		if !*i.HasOwner {
+			p = hush.Not(p)
+		}
+		predicates = append(predicates, p)
+	}
+	if len(i.HasOwnerWith) > 0 {
+		with := make([]predicate.Organization, 0, len(i.HasOwnerWith))
+		for _, w := range i.HasOwnerWith {
+			p, err := w.P()
+			if err != nil {
+				return nil, fmt.Errorf("%w: field 'HasOwnerWith'", err)
+			}
+			with = append(with, p)
+		}
+		predicates = append(predicates, hush.HasOwnerWith(with...))
+	}
 	if i.HasIntegrations != nil {
 		p := hush.HasIntegrations()
 		if !*i.HasIntegrations {
@@ -28495,24 +28575,6 @@ func (i *HushWhereInput) P() (predicate.Hush, error) {
 			with = append(with, p)
 		}
 		predicates = append(predicates, hush.HasIntegrationsWith(with...))
-	}
-	if i.HasOrganization != nil {
-		p := hush.HasOrganization()
-		if !*i.HasOrganization {
-			p = hush.Not(p)
-		}
-		predicates = append(predicates, p)
-	}
-	if len(i.HasOrganizationWith) > 0 {
-		with := make([]predicate.Organization, 0, len(i.HasOrganizationWith))
-		for _, w := range i.HasOrganizationWith {
-			p, err := w.P()
-			if err != nil {
-				return nil, fmt.Errorf("%w: field 'HasOrganizationWith'", err)
-			}
-			with = append(with, p)
-		}
-		predicates = append(predicates, hush.HasOrganizationWith(with...))
 	}
 	if i.HasEvents != nil {
 		p := hush.HasEvents()
@@ -28680,6 +28742,23 @@ type HushHistoryWhereInput struct {
 	DeletedByNotNil       bool     `json:"deletedByNotNil,omitempty"`
 	DeletedByEqualFold    *string  `json:"deletedByEqualFold,omitempty"`
 	DeletedByContainsFold *string  `json:"deletedByContainsFold,omitempty"`
+
+	// "owner_id" field predicates.
+	OwnerID             *string  `json:"ownerID,omitempty"`
+	OwnerIDNEQ          *string  `json:"ownerIDNEQ,omitempty"`
+	OwnerIDIn           []string `json:"ownerIDIn,omitempty"`
+	OwnerIDNotIn        []string `json:"ownerIDNotIn,omitempty"`
+	OwnerIDGT           *string  `json:"ownerIDGT,omitempty"`
+	OwnerIDGTE          *string  `json:"ownerIDGTE,omitempty"`
+	OwnerIDLT           *string  `json:"ownerIDLT,omitempty"`
+	OwnerIDLTE          *string  `json:"ownerIDLTE,omitempty"`
+	OwnerIDContains     *string  `json:"ownerIDContains,omitempty"`
+	OwnerIDHasPrefix    *string  `json:"ownerIDHasPrefix,omitempty"`
+	OwnerIDHasSuffix    *string  `json:"ownerIDHasSuffix,omitempty"`
+	OwnerIDIsNil        bool     `json:"ownerIDIsNil,omitempty"`
+	OwnerIDNotNil       bool     `json:"ownerIDNotNil,omitempty"`
+	OwnerIDEqualFold    *string  `json:"ownerIDEqualFold,omitempty"`
+	OwnerIDContainsFold *string  `json:"ownerIDContainsFold,omitempty"`
 
 	// "name" field predicates.
 	Name             *string  `json:"name,omitempty"`
@@ -29137,6 +29216,51 @@ func (i *HushHistoryWhereInput) P() (predicate.HushHistory, error) {
 	}
 	if i.DeletedByContainsFold != nil {
 		predicates = append(predicates, hushhistory.DeletedByContainsFold(*i.DeletedByContainsFold))
+	}
+	if i.OwnerID != nil {
+		predicates = append(predicates, hushhistory.OwnerIDEQ(*i.OwnerID))
+	}
+	if i.OwnerIDNEQ != nil {
+		predicates = append(predicates, hushhistory.OwnerIDNEQ(*i.OwnerIDNEQ))
+	}
+	if len(i.OwnerIDIn) > 0 {
+		predicates = append(predicates, hushhistory.OwnerIDIn(i.OwnerIDIn...))
+	}
+	if len(i.OwnerIDNotIn) > 0 {
+		predicates = append(predicates, hushhistory.OwnerIDNotIn(i.OwnerIDNotIn...))
+	}
+	if i.OwnerIDGT != nil {
+		predicates = append(predicates, hushhistory.OwnerIDGT(*i.OwnerIDGT))
+	}
+	if i.OwnerIDGTE != nil {
+		predicates = append(predicates, hushhistory.OwnerIDGTE(*i.OwnerIDGTE))
+	}
+	if i.OwnerIDLT != nil {
+		predicates = append(predicates, hushhistory.OwnerIDLT(*i.OwnerIDLT))
+	}
+	if i.OwnerIDLTE != nil {
+		predicates = append(predicates, hushhistory.OwnerIDLTE(*i.OwnerIDLTE))
+	}
+	if i.OwnerIDContains != nil {
+		predicates = append(predicates, hushhistory.OwnerIDContains(*i.OwnerIDContains))
+	}
+	if i.OwnerIDHasPrefix != nil {
+		predicates = append(predicates, hushhistory.OwnerIDHasPrefix(*i.OwnerIDHasPrefix))
+	}
+	if i.OwnerIDHasSuffix != nil {
+		predicates = append(predicates, hushhistory.OwnerIDHasSuffix(*i.OwnerIDHasSuffix))
+	}
+	if i.OwnerIDIsNil {
+		predicates = append(predicates, hushhistory.OwnerIDIsNil())
+	}
+	if i.OwnerIDNotNil {
+		predicates = append(predicates, hushhistory.OwnerIDNotNil())
+	}
+	if i.OwnerIDEqualFold != nil {
+		predicates = append(predicates, hushhistory.OwnerIDEqualFold(*i.OwnerIDEqualFold))
+	}
+	if i.OwnerIDContainsFold != nil {
+		predicates = append(predicates, hushhistory.OwnerIDContainsFold(*i.OwnerIDContainsFold))
 	}
 	if i.Name != nil {
 		predicates = append(predicates, hushhistory.NameEQ(*i.Name))

--- a/internal/ent/generated/history_from_mutation.go
+++ b/internal/ent/generated/history_from_mutation.go
@@ -3594,6 +3594,10 @@ func (m *HushMutation) CreateHistoryFromCreate(ctx context.Context) error {
 		create = create.SetDeletedBy(deletedBy)
 	}
 
+	if ownerID, exists := m.OwnerID(); exists {
+		create = create.SetOwnerID(ownerID)
+	}
+
 	if name, exists := m.Name(); exists {
 		create = create.SetName(name)
 	}
@@ -3680,6 +3684,12 @@ func (m *HushMutation) CreateHistoryFromUpdate(ctx context.Context) error {
 			create = create.SetDeletedBy(hush.DeletedBy)
 		}
 
+		if ownerID, exists := m.OwnerID(); exists {
+			create = create.SetOwnerID(ownerID)
+		} else {
+			create = create.SetOwnerID(hush.OwnerID)
+		}
+
 		if name, exists := m.Name(); exists {
 			create = create.SetName(name)
 		} else {
@@ -3748,6 +3758,7 @@ func (m *HushMutation) CreateHistoryFromDelete(ctx context.Context) error {
 			SetUpdatedBy(hush.UpdatedBy).
 			SetDeletedAt(hush.DeletedAt).
 			SetDeletedBy(hush.DeletedBy).
+			SetOwnerID(hush.OwnerID).
 			SetName(hush.Name).
 			SetDescription(hush.Description).
 			SetKind(hush.Kind).

--- a/internal/ent/generated/hush/where.go
+++ b/internal/ent/generated/hush/where.go
@@ -97,6 +97,11 @@ func DeletedBy(v string) predicate.Hush {
 	return predicate.Hush(sql.FieldEQ(FieldDeletedBy, v))
 }
 
+// OwnerID applies equality check predicate on the "owner_id" field. It's identical to OwnerIDEQ.
+func OwnerID(v string) predicate.Hush {
+	return predicate.Hush(sql.FieldEQ(FieldOwnerID, v))
+}
+
 // Name applies equality check predicate on the "name" field. It's identical to NameEQ.
 func Name(v string) predicate.Hush {
 	return predicate.Hush(sql.FieldEQ(FieldName, v))
@@ -497,6 +502,81 @@ func DeletedByContainsFold(v string) predicate.Hush {
 	return predicate.Hush(sql.FieldContainsFold(FieldDeletedBy, v))
 }
 
+// OwnerIDEQ applies the EQ predicate on the "owner_id" field.
+func OwnerIDEQ(v string) predicate.Hush {
+	return predicate.Hush(sql.FieldEQ(FieldOwnerID, v))
+}
+
+// OwnerIDNEQ applies the NEQ predicate on the "owner_id" field.
+func OwnerIDNEQ(v string) predicate.Hush {
+	return predicate.Hush(sql.FieldNEQ(FieldOwnerID, v))
+}
+
+// OwnerIDIn applies the In predicate on the "owner_id" field.
+func OwnerIDIn(vs ...string) predicate.Hush {
+	return predicate.Hush(sql.FieldIn(FieldOwnerID, vs...))
+}
+
+// OwnerIDNotIn applies the NotIn predicate on the "owner_id" field.
+func OwnerIDNotIn(vs ...string) predicate.Hush {
+	return predicate.Hush(sql.FieldNotIn(FieldOwnerID, vs...))
+}
+
+// OwnerIDGT applies the GT predicate on the "owner_id" field.
+func OwnerIDGT(v string) predicate.Hush {
+	return predicate.Hush(sql.FieldGT(FieldOwnerID, v))
+}
+
+// OwnerIDGTE applies the GTE predicate on the "owner_id" field.
+func OwnerIDGTE(v string) predicate.Hush {
+	return predicate.Hush(sql.FieldGTE(FieldOwnerID, v))
+}
+
+// OwnerIDLT applies the LT predicate on the "owner_id" field.
+func OwnerIDLT(v string) predicate.Hush {
+	return predicate.Hush(sql.FieldLT(FieldOwnerID, v))
+}
+
+// OwnerIDLTE applies the LTE predicate on the "owner_id" field.
+func OwnerIDLTE(v string) predicate.Hush {
+	return predicate.Hush(sql.FieldLTE(FieldOwnerID, v))
+}
+
+// OwnerIDContains applies the Contains predicate on the "owner_id" field.
+func OwnerIDContains(v string) predicate.Hush {
+	return predicate.Hush(sql.FieldContains(FieldOwnerID, v))
+}
+
+// OwnerIDHasPrefix applies the HasPrefix predicate on the "owner_id" field.
+func OwnerIDHasPrefix(v string) predicate.Hush {
+	return predicate.Hush(sql.FieldHasPrefix(FieldOwnerID, v))
+}
+
+// OwnerIDHasSuffix applies the HasSuffix predicate on the "owner_id" field.
+func OwnerIDHasSuffix(v string) predicate.Hush {
+	return predicate.Hush(sql.FieldHasSuffix(FieldOwnerID, v))
+}
+
+// OwnerIDIsNil applies the IsNil predicate on the "owner_id" field.
+func OwnerIDIsNil() predicate.Hush {
+	return predicate.Hush(sql.FieldIsNull(FieldOwnerID))
+}
+
+// OwnerIDNotNil applies the NotNil predicate on the "owner_id" field.
+func OwnerIDNotNil() predicate.Hush {
+	return predicate.Hush(sql.FieldNotNull(FieldOwnerID))
+}
+
+// OwnerIDEqualFold applies the EqualFold predicate on the "owner_id" field.
+func OwnerIDEqualFold(v string) predicate.Hush {
+	return predicate.Hush(sql.FieldEqualFold(FieldOwnerID, v))
+}
+
+// OwnerIDContainsFold applies the ContainsFold predicate on the "owner_id" field.
+func OwnerIDContainsFold(v string) predicate.Hush {
+	return predicate.Hush(sql.FieldContainsFold(FieldOwnerID, v))
+}
+
 // NameEQ applies the EQ predicate on the "name" field.
 func NameEQ(v string) predicate.Hush {
 	return predicate.Hush(sql.FieldEQ(FieldName, v))
@@ -862,6 +942,35 @@ func SecretValueContainsFold(v string) predicate.Hush {
 	return predicate.Hush(sql.FieldContainsFold(FieldSecretValue, v))
 }
 
+// HasOwner applies the HasEdge predicate on the "owner" edge.
+func HasOwner() predicate.Hush {
+	return predicate.Hush(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, OwnerTable, OwnerColumn),
+		)
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Organization
+		step.Edge.Schema = schemaConfig.Hush
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasOwnerWith applies the HasEdge predicate on the "owner" edge with a given conditions (other predicates).
+func HasOwnerWith(preds ...predicate.Organization) predicate.Hush {
+	return predicate.Hush(func(s *sql.Selector) {
+		step := newOwnerStep()
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.Organization
+		step.Edge.Schema = schemaConfig.Hush
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
 // HasIntegrations applies the HasEdge predicate on the "integrations" edge.
 func HasIntegrations() predicate.Hush {
 	return predicate.Hush(func(s *sql.Selector) {
@@ -883,35 +992,6 @@ func HasIntegrationsWith(preds ...predicate.Integration) predicate.Hush {
 		schemaConfig := internal.SchemaConfigFromContext(s.Context())
 		step.To.Schema = schemaConfig.Integration
 		step.Edge.Schema = schemaConfig.IntegrationSecrets
-		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
-			for _, p := range preds {
-				p(s)
-			}
-		})
-	})
-}
-
-// HasOrganization applies the HasEdge predicate on the "organization" edge.
-func HasOrganization() predicate.Hush {
-	return predicate.Hush(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, true, OrganizationTable, OrganizationPrimaryKey...),
-		)
-		schemaConfig := internal.SchemaConfigFromContext(s.Context())
-		step.To.Schema = schemaConfig.Organization
-		step.Edge.Schema = schemaConfig.OrganizationSecrets
-		sqlgraph.HasNeighbors(s, step)
-	})
-}
-
-// HasOrganizationWith applies the HasEdge predicate on the "organization" edge with a given conditions (other predicates).
-func HasOrganizationWith(preds ...predicate.Organization) predicate.Hush {
-	return predicate.Hush(func(s *sql.Selector) {
-		step := newOrganizationStep()
-		schemaConfig := internal.SchemaConfigFromContext(s.Context())
-		step.To.Schema = schemaConfig.Organization
-		step.Edge.Schema = schemaConfig.OrganizationSecrets
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/internal/ent/generated/hush_query.go
+++ b/internal/ent/generated/hush_query.go
@@ -28,13 +28,12 @@ type HushQuery struct {
 	order                 []hush.OrderOption
 	inters                []Interceptor
 	predicates            []predicate.Hush
+	withOwner             *OrganizationQuery
 	withIntegrations      *IntegrationQuery
-	withOrganization      *OrganizationQuery
 	withEvents            *EventQuery
 	loadTotal             []func(context.Context, []*Hush) error
 	modifiers             []func(*sql.Selector)
 	withNamedIntegrations map[string]*IntegrationQuery
-	withNamedOrganization map[string]*OrganizationQuery
 	withNamedEvents       map[string]*EventQuery
 	// intermediate query (i.e. traversal path).
 	sql  *sql.Selector
@@ -72,6 +71,31 @@ func (hq *HushQuery) Order(o ...hush.OrderOption) *HushQuery {
 	return hq
 }
 
+// QueryOwner chains the current query on the "owner" edge.
+func (hq *HushQuery) QueryOwner() *OrganizationQuery {
+	query := (&OrganizationClient{config: hq.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := hq.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := hq.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(hush.Table, hush.FieldID, selector),
+			sqlgraph.To(organization.Table, organization.FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, hush.OwnerTable, hush.OwnerColumn),
+		)
+		schemaConfig := hq.schemaConfig
+		step.To.Schema = schemaConfig.Organization
+		step.Edge.Schema = schemaConfig.Hush
+		fromU = sqlgraph.SetNeighbors(hq.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
 // QueryIntegrations chains the current query on the "integrations" edge.
 func (hq *HushQuery) QueryIntegrations() *IntegrationQuery {
 	query := (&IntegrationClient{config: hq.config}).Query()
@@ -91,31 +115,6 @@ func (hq *HushQuery) QueryIntegrations() *IntegrationQuery {
 		schemaConfig := hq.schemaConfig
 		step.To.Schema = schemaConfig.Integration
 		step.Edge.Schema = schemaConfig.IntegrationSecrets
-		fromU = sqlgraph.SetNeighbors(hq.driver.Dialect(), step)
-		return fromU, nil
-	}
-	return query
-}
-
-// QueryOrganization chains the current query on the "organization" edge.
-func (hq *HushQuery) QueryOrganization() *OrganizationQuery {
-	query := (&OrganizationClient{config: hq.config}).Query()
-	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
-		if err := hq.prepareQuery(ctx); err != nil {
-			return nil, err
-		}
-		selector := hq.sqlQuery(ctx)
-		if err := selector.Err(); err != nil {
-			return nil, err
-		}
-		step := sqlgraph.NewStep(
-			sqlgraph.From(hush.Table, hush.FieldID, selector),
-			sqlgraph.To(organization.Table, organization.FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, true, hush.OrganizationTable, hush.OrganizationPrimaryKey...),
-		)
-		schemaConfig := hq.schemaConfig
-		step.To.Schema = schemaConfig.Organization
-		step.Edge.Schema = schemaConfig.OrganizationSecrets
 		fromU = sqlgraph.SetNeighbors(hq.driver.Dialect(), step)
 		return fromU, nil
 	}
@@ -339,14 +338,25 @@ func (hq *HushQuery) Clone() *HushQuery {
 		order:            append([]hush.OrderOption{}, hq.order...),
 		inters:           append([]Interceptor{}, hq.inters...),
 		predicates:       append([]predicate.Hush{}, hq.predicates...),
+		withOwner:        hq.withOwner.Clone(),
 		withIntegrations: hq.withIntegrations.Clone(),
-		withOrganization: hq.withOrganization.Clone(),
 		withEvents:       hq.withEvents.Clone(),
 		// clone intermediate query.
 		sql:       hq.sql.Clone(),
 		path:      hq.path,
 		modifiers: append([]func(*sql.Selector){}, hq.modifiers...),
 	}
+}
+
+// WithOwner tells the query-builder to eager-load the nodes that are connected to
+// the "owner" edge. The optional arguments are used to configure the query builder of the edge.
+func (hq *HushQuery) WithOwner(opts ...func(*OrganizationQuery)) *HushQuery {
+	query := (&OrganizationClient{config: hq.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	hq.withOwner = query
+	return hq
 }
 
 // WithIntegrations tells the query-builder to eager-load the nodes that are connected to
@@ -357,17 +367,6 @@ func (hq *HushQuery) WithIntegrations(opts ...func(*IntegrationQuery)) *HushQuer
 		opt(query)
 	}
 	hq.withIntegrations = query
-	return hq
-}
-
-// WithOrganization tells the query-builder to eager-load the nodes that are connected to
-// the "organization" edge. The optional arguments are used to configure the query builder of the edge.
-func (hq *HushQuery) WithOrganization(opts ...func(*OrganizationQuery)) *HushQuery {
-	query := (&OrganizationClient{config: hq.config}).Query()
-	for _, opt := range opts {
-		opt(query)
-	}
-	hq.withOrganization = query
 	return hq
 }
 
@@ -461,8 +460,8 @@ func (hq *HushQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Hush, e
 		nodes       = []*Hush{}
 		_spec       = hq.querySpec()
 		loadedTypes = [3]bool{
+			hq.withOwner != nil,
 			hq.withIntegrations != nil,
-			hq.withOrganization != nil,
 			hq.withEvents != nil,
 		}
 	)
@@ -489,17 +488,16 @@ func (hq *HushQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Hush, e
 	if len(nodes) == 0 {
 		return nodes, nil
 	}
+	if query := hq.withOwner; query != nil {
+		if err := hq.loadOwner(ctx, query, nodes, nil,
+			func(n *Hush, e *Organization) { n.Edges.Owner = e }); err != nil {
+			return nil, err
+		}
+	}
 	if query := hq.withIntegrations; query != nil {
 		if err := hq.loadIntegrations(ctx, query, nodes,
 			func(n *Hush) { n.Edges.Integrations = []*Integration{} },
 			func(n *Hush, e *Integration) { n.Edges.Integrations = append(n.Edges.Integrations, e) }); err != nil {
-			return nil, err
-		}
-	}
-	if query := hq.withOrganization; query != nil {
-		if err := hq.loadOrganization(ctx, query, nodes,
-			func(n *Hush) { n.Edges.Organization = []*Organization{} },
-			func(n *Hush, e *Organization) { n.Edges.Organization = append(n.Edges.Organization, e) }); err != nil {
 			return nil, err
 		}
 	}
@@ -514,13 +512,6 @@ func (hq *HushQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Hush, e
 		if err := hq.loadIntegrations(ctx, query, nodes,
 			func(n *Hush) { n.appendNamedIntegrations(name) },
 			func(n *Hush, e *Integration) { n.appendNamedIntegrations(name, e) }); err != nil {
-			return nil, err
-		}
-	}
-	for name, query := range hq.withNamedOrganization {
-		if err := hq.loadOrganization(ctx, query, nodes,
-			func(n *Hush) { n.appendNamedOrganization(name) },
-			func(n *Hush, e *Organization) { n.appendNamedOrganization(name, e) }); err != nil {
 			return nil, err
 		}
 	}
@@ -539,6 +530,35 @@ func (hq *HushQuery) sqlAll(ctx context.Context, hooks ...queryHook) ([]*Hush, e
 	return nodes, nil
 }
 
+func (hq *HushQuery) loadOwner(ctx context.Context, query *OrganizationQuery, nodes []*Hush, init func(*Hush), assign func(*Hush, *Organization)) error {
+	ids := make([]string, 0, len(nodes))
+	nodeids := make(map[string][]*Hush)
+	for i := range nodes {
+		fk := nodes[i].OwnerID
+		if _, ok := nodeids[fk]; !ok {
+			ids = append(ids, fk)
+		}
+		nodeids[fk] = append(nodeids[fk], nodes[i])
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	query.Where(organization.IDIn(ids...))
+	neighbors, err := query.All(ctx)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		nodes, ok := nodeids[n.ID]
+		if !ok {
+			return fmt.Errorf(`unexpected foreign-key "owner_id" returned %v`, n.ID)
+		}
+		for i := range nodes {
+			assign(nodes[i], n)
+		}
+	}
+	return nil
+}
 func (hq *HushQuery) loadIntegrations(ctx context.Context, query *IntegrationQuery, nodes []*Hush, init func(*Hush), assign func(*Hush, *Integration)) error {
 	edgeIDs := make([]driver.Value, len(nodes))
 	byID := make(map[string]*Hush)
@@ -594,68 +614,6 @@ func (hq *HushQuery) loadIntegrations(ctx context.Context, query *IntegrationQue
 		nodes, ok := nids[n.ID]
 		if !ok {
 			return fmt.Errorf(`unexpected "integrations" node returned %v`, n.ID)
-		}
-		for kn := range nodes {
-			assign(kn, n)
-		}
-	}
-	return nil
-}
-func (hq *HushQuery) loadOrganization(ctx context.Context, query *OrganizationQuery, nodes []*Hush, init func(*Hush), assign func(*Hush, *Organization)) error {
-	edgeIDs := make([]driver.Value, len(nodes))
-	byID := make(map[string]*Hush)
-	nids := make(map[string]map[*Hush]struct{})
-	for i, node := range nodes {
-		edgeIDs[i] = node.ID
-		byID[node.ID] = node
-		if init != nil {
-			init(node)
-		}
-	}
-	query.Where(func(s *sql.Selector) {
-		joinT := sql.Table(hush.OrganizationTable)
-		joinT.Schema(hq.schemaConfig.OrganizationSecrets)
-		s.Join(joinT).On(s.C(organization.FieldID), joinT.C(hush.OrganizationPrimaryKey[0]))
-		s.Where(sql.InValues(joinT.C(hush.OrganizationPrimaryKey[1]), edgeIDs...))
-		columns := s.SelectedColumns()
-		s.Select(joinT.C(hush.OrganizationPrimaryKey[1]))
-		s.AppendSelect(columns...)
-		s.SetDistinct(false)
-	})
-	if err := query.prepareQuery(ctx); err != nil {
-		return err
-	}
-	qr := QuerierFunc(func(ctx context.Context, q Query) (Value, error) {
-		return query.sqlAll(ctx, func(_ context.Context, spec *sqlgraph.QuerySpec) {
-			assign := spec.Assign
-			values := spec.ScanValues
-			spec.ScanValues = func(columns []string) ([]any, error) {
-				values, err := values(columns[1:])
-				if err != nil {
-					return nil, err
-				}
-				return append([]any{new(sql.NullString)}, values...), nil
-			}
-			spec.Assign = func(columns []string, values []any) error {
-				outValue := values[0].(*sql.NullString).String
-				inValue := values[1].(*sql.NullString).String
-				if nids[inValue] == nil {
-					nids[inValue] = map[*Hush]struct{}{byID[outValue]: {}}
-					return assign(columns[1:], values[1:])
-				}
-				nids[inValue][byID[outValue]] = struct{}{}
-				return nil
-			}
-		})
-	})
-	neighbors, err := withInterceptors[[]*Organization](ctx, query, qr, query.inters)
-	if err != nil {
-		return err
-	}
-	for _, n := range neighbors {
-		nodes, ok := nids[n.ID]
-		if !ok {
-			return fmt.Errorf(`unexpected "organization" node returned %v`, n.ID)
 		}
 		for kn := range nodes {
 			assign(kn, n)
@@ -756,6 +714,9 @@ func (hq *HushQuery) querySpec() *sqlgraph.QuerySpec {
 				_spec.Node.Columns = append(_spec.Node.Columns, fields[i])
 			}
 		}
+		if hq.withOwner != nil {
+			_spec.Node.AddColumnOnce(hush.FieldOwnerID)
+		}
 	}
 	if ps := hq.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
@@ -835,20 +796,6 @@ func (hq *HushQuery) WithNamedIntegrations(name string, opts ...func(*Integratio
 		hq.withNamedIntegrations = make(map[string]*IntegrationQuery)
 	}
 	hq.withNamedIntegrations[name] = query
-	return hq
-}
-
-// WithNamedOrganization tells the query-builder to eager-load the nodes that are connected to the "organization"
-// edge with the given name. The optional arguments are used to configure the query builder of the edge.
-func (hq *HushQuery) WithNamedOrganization(name string, opts ...func(*OrganizationQuery)) *HushQuery {
-	query := (&OrganizationClient{config: hq.config}).Query()
-	for _, opt := range opts {
-		opt(query)
-	}
-	if hq.withNamedOrganization == nil {
-		hq.withNamedOrganization = make(map[string]*OrganizationQuery)
-	}
-	hq.withNamedOrganization[name] = query
 	return hq
 }
 

--- a/internal/ent/generated/hushhistory.go
+++ b/internal/ent/generated/hushhistory.go
@@ -36,6 +36,8 @@ type HushHistory struct {
 	DeletedAt time.Time `json:"deleted_at,omitempty"`
 	// DeletedBy holds the value of the "deleted_by" field.
 	DeletedBy string `json:"deleted_by,omitempty"`
+	// the organization id that owns the object
+	OwnerID string `json:"owner_id,omitempty"`
 	// the logical name of the corresponding hush secret or it's general grouping
 	Name string `json:"name,omitempty"`
 	// a description of the hush value or purpose, such as github PAT
@@ -56,7 +58,7 @@ func (*HushHistory) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case hushhistory.FieldOperation:
 			values[i] = new(history.OpType)
-		case hushhistory.FieldID, hushhistory.FieldRef, hushhistory.FieldCreatedBy, hushhistory.FieldUpdatedBy, hushhistory.FieldDeletedBy, hushhistory.FieldName, hushhistory.FieldDescription, hushhistory.FieldKind, hushhistory.FieldSecretName, hushhistory.FieldSecretValue:
+		case hushhistory.FieldID, hushhistory.FieldRef, hushhistory.FieldCreatedBy, hushhistory.FieldUpdatedBy, hushhistory.FieldDeletedBy, hushhistory.FieldOwnerID, hushhistory.FieldName, hushhistory.FieldDescription, hushhistory.FieldKind, hushhistory.FieldSecretName, hushhistory.FieldSecretValue:
 			values[i] = new(sql.NullString)
 		case hushhistory.FieldHistoryTime, hushhistory.FieldCreatedAt, hushhistory.FieldUpdatedAt, hushhistory.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
@@ -134,6 +136,12 @@ func (hh *HushHistory) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field deleted_by", values[i])
 			} else if value.Valid {
 				hh.DeletedBy = value.String
+			}
+		case hushhistory.FieldOwnerID:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field owner_id", values[i])
+			} else if value.Valid {
+				hh.OwnerID = value.String
 			}
 		case hushhistory.FieldName:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -227,6 +235,9 @@ func (hh *HushHistory) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("deleted_by=")
 	builder.WriteString(hh.DeletedBy)
+	builder.WriteString(", ")
+	builder.WriteString("owner_id=")
+	builder.WriteString(hh.OwnerID)
 	builder.WriteString(", ")
 	builder.WriteString("name=")
 	builder.WriteString(hh.Name)

--- a/internal/ent/generated/hushhistory/hushhistory.go
+++ b/internal/ent/generated/hushhistory/hushhistory.go
@@ -34,6 +34,8 @@ const (
 	FieldDeletedAt = "deleted_at"
 	// FieldDeletedBy holds the string denoting the deleted_by field in the database.
 	FieldDeletedBy = "deleted_by"
+	// FieldOwnerID holds the string denoting the owner_id field in the database.
+	FieldOwnerID = "owner_id"
 	// FieldName holds the string denoting the name field in the database.
 	FieldName = "name"
 	// FieldDescription holds the string denoting the description field in the database.
@@ -60,6 +62,7 @@ var Columns = []string{
 	FieldUpdatedBy,
 	FieldDeletedAt,
 	FieldDeletedBy,
+	FieldOwnerID,
 	FieldName,
 	FieldDescription,
 	FieldKind,
@@ -151,6 +154,11 @@ func ByDeletedAt(opts ...sql.OrderTermOption) OrderOption {
 // ByDeletedBy orders the results by the deleted_by field.
 func ByDeletedBy(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDeletedBy, opts...).ToFunc()
+}
+
+// ByOwnerID orders the results by the owner_id field.
+func ByOwnerID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldOwnerID, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.

--- a/internal/ent/generated/hushhistory/where.go
+++ b/internal/ent/generated/hushhistory/where.go
@@ -105,6 +105,11 @@ func DeletedBy(v string) predicate.HushHistory {
 	return predicate.HushHistory(sql.FieldEQ(FieldDeletedBy, v))
 }
 
+// OwnerID applies equality check predicate on the "owner_id" field. It's identical to OwnerIDEQ.
+func OwnerID(v string) predicate.HushHistory {
+	return predicate.HushHistory(sql.FieldEQ(FieldOwnerID, v))
+}
+
 // Name applies equality check predicate on the "name" field. It's identical to NameEQ.
 func Name(v string) predicate.HushHistory {
 	return predicate.HushHistory(sql.FieldEQ(FieldName, v))
@@ -638,6 +643,81 @@ func DeletedByEqualFold(v string) predicate.HushHistory {
 // DeletedByContainsFold applies the ContainsFold predicate on the "deleted_by" field.
 func DeletedByContainsFold(v string) predicate.HushHistory {
 	return predicate.HushHistory(sql.FieldContainsFold(FieldDeletedBy, v))
+}
+
+// OwnerIDEQ applies the EQ predicate on the "owner_id" field.
+func OwnerIDEQ(v string) predicate.HushHistory {
+	return predicate.HushHistory(sql.FieldEQ(FieldOwnerID, v))
+}
+
+// OwnerIDNEQ applies the NEQ predicate on the "owner_id" field.
+func OwnerIDNEQ(v string) predicate.HushHistory {
+	return predicate.HushHistory(sql.FieldNEQ(FieldOwnerID, v))
+}
+
+// OwnerIDIn applies the In predicate on the "owner_id" field.
+func OwnerIDIn(vs ...string) predicate.HushHistory {
+	return predicate.HushHistory(sql.FieldIn(FieldOwnerID, vs...))
+}
+
+// OwnerIDNotIn applies the NotIn predicate on the "owner_id" field.
+func OwnerIDNotIn(vs ...string) predicate.HushHistory {
+	return predicate.HushHistory(sql.FieldNotIn(FieldOwnerID, vs...))
+}
+
+// OwnerIDGT applies the GT predicate on the "owner_id" field.
+func OwnerIDGT(v string) predicate.HushHistory {
+	return predicate.HushHistory(sql.FieldGT(FieldOwnerID, v))
+}
+
+// OwnerIDGTE applies the GTE predicate on the "owner_id" field.
+func OwnerIDGTE(v string) predicate.HushHistory {
+	return predicate.HushHistory(sql.FieldGTE(FieldOwnerID, v))
+}
+
+// OwnerIDLT applies the LT predicate on the "owner_id" field.
+func OwnerIDLT(v string) predicate.HushHistory {
+	return predicate.HushHistory(sql.FieldLT(FieldOwnerID, v))
+}
+
+// OwnerIDLTE applies the LTE predicate on the "owner_id" field.
+func OwnerIDLTE(v string) predicate.HushHistory {
+	return predicate.HushHistory(sql.FieldLTE(FieldOwnerID, v))
+}
+
+// OwnerIDContains applies the Contains predicate on the "owner_id" field.
+func OwnerIDContains(v string) predicate.HushHistory {
+	return predicate.HushHistory(sql.FieldContains(FieldOwnerID, v))
+}
+
+// OwnerIDHasPrefix applies the HasPrefix predicate on the "owner_id" field.
+func OwnerIDHasPrefix(v string) predicate.HushHistory {
+	return predicate.HushHistory(sql.FieldHasPrefix(FieldOwnerID, v))
+}
+
+// OwnerIDHasSuffix applies the HasSuffix predicate on the "owner_id" field.
+func OwnerIDHasSuffix(v string) predicate.HushHistory {
+	return predicate.HushHistory(sql.FieldHasSuffix(FieldOwnerID, v))
+}
+
+// OwnerIDIsNil applies the IsNil predicate on the "owner_id" field.
+func OwnerIDIsNil() predicate.HushHistory {
+	return predicate.HushHistory(sql.FieldIsNull(FieldOwnerID))
+}
+
+// OwnerIDNotNil applies the NotNil predicate on the "owner_id" field.
+func OwnerIDNotNil() predicate.HushHistory {
+	return predicate.HushHistory(sql.FieldNotNull(FieldOwnerID))
+}
+
+// OwnerIDEqualFold applies the EqualFold predicate on the "owner_id" field.
+func OwnerIDEqualFold(v string) predicate.HushHistory {
+	return predicate.HushHistory(sql.FieldEqualFold(FieldOwnerID, v))
+}
+
+// OwnerIDContainsFold applies the ContainsFold predicate on the "owner_id" field.
+func OwnerIDContainsFold(v string) predicate.HushHistory {
+	return predicate.HushHistory(sql.FieldContainsFold(FieldOwnerID, v))
 }
 
 // NameEQ applies the EQ predicate on the "name" field.

--- a/internal/ent/generated/hushhistory_create.go
+++ b/internal/ent/generated/hushhistory_create.go
@@ -139,6 +139,20 @@ func (hhc *HushHistoryCreate) SetNillableDeletedBy(s *string) *HushHistoryCreate
 	return hhc
 }
 
+// SetOwnerID sets the "owner_id" field.
+func (hhc *HushHistoryCreate) SetOwnerID(s string) *HushHistoryCreate {
+	hhc.mutation.SetOwnerID(s)
+	return hhc
+}
+
+// SetNillableOwnerID sets the "owner_id" field if the given value is not nil.
+func (hhc *HushHistoryCreate) SetNillableOwnerID(s *string) *HushHistoryCreate {
+	if s != nil {
+		hhc.SetOwnerID(*s)
+	}
+	return hhc
+}
+
 // SetName sets the "name" field.
 func (hhc *HushHistoryCreate) SetName(s string) *HushHistoryCreate {
 	hhc.mutation.SetName(s)
@@ -355,6 +369,10 @@ func (hhc *HushHistoryCreate) createSpec() (*HushHistory, *sqlgraph.CreateSpec) 
 	if value, ok := hhc.mutation.DeletedBy(); ok {
 		_spec.SetField(hushhistory.FieldDeletedBy, field.TypeString, value)
 		_node.DeletedBy = value
+	}
+	if value, ok := hhc.mutation.OwnerID(); ok {
+		_spec.SetField(hushhistory.FieldOwnerID, field.TypeString, value)
+		_node.OwnerID = value
 	}
 	if value, ok := hhc.mutation.Name(); ok {
 		_spec.SetField(hushhistory.FieldName, field.TypeString, value)

--- a/internal/ent/generated/hushhistory_update.go
+++ b/internal/ent/generated/hushhistory_update.go
@@ -103,6 +103,26 @@ func (hhu *HushHistoryUpdate) ClearDeletedBy() *HushHistoryUpdate {
 	return hhu
 }
 
+// SetOwnerID sets the "owner_id" field.
+func (hhu *HushHistoryUpdate) SetOwnerID(s string) *HushHistoryUpdate {
+	hhu.mutation.SetOwnerID(s)
+	return hhu
+}
+
+// SetNillableOwnerID sets the "owner_id" field if the given value is not nil.
+func (hhu *HushHistoryUpdate) SetNillableOwnerID(s *string) *HushHistoryUpdate {
+	if s != nil {
+		hhu.SetOwnerID(*s)
+	}
+	return hhu
+}
+
+// ClearOwnerID clears the value of the "owner_id" field.
+func (hhu *HushHistoryUpdate) ClearOwnerID() *HushHistoryUpdate {
+	hhu.mutation.ClearOwnerID()
+	return hhu
+}
+
 // SetName sets the "name" field.
 func (hhu *HushHistoryUpdate) SetName(s string) *HushHistoryUpdate {
 	hhu.mutation.SetName(s)
@@ -246,6 +266,12 @@ func (hhu *HushHistoryUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	if hhu.mutation.DeletedByCleared() {
 		_spec.ClearField(hushhistory.FieldDeletedBy, field.TypeString)
 	}
+	if value, ok := hhu.mutation.OwnerID(); ok {
+		_spec.SetField(hushhistory.FieldOwnerID, field.TypeString, value)
+	}
+	if hhu.mutation.OwnerIDCleared() {
+		_spec.ClearField(hushhistory.FieldOwnerID, field.TypeString)
+	}
 	if value, ok := hhu.mutation.Name(); ok {
 		_spec.SetField(hushhistory.FieldName, field.TypeString, value)
 	}
@@ -360,6 +386,26 @@ func (hhuo *HushHistoryUpdateOne) SetNillableDeletedBy(s *string) *HushHistoryUp
 // ClearDeletedBy clears the value of the "deleted_by" field.
 func (hhuo *HushHistoryUpdateOne) ClearDeletedBy() *HushHistoryUpdateOne {
 	hhuo.mutation.ClearDeletedBy()
+	return hhuo
+}
+
+// SetOwnerID sets the "owner_id" field.
+func (hhuo *HushHistoryUpdateOne) SetOwnerID(s string) *HushHistoryUpdateOne {
+	hhuo.mutation.SetOwnerID(s)
+	return hhuo
+}
+
+// SetNillableOwnerID sets the "owner_id" field if the given value is not nil.
+func (hhuo *HushHistoryUpdateOne) SetNillableOwnerID(s *string) *HushHistoryUpdateOne {
+	if s != nil {
+		hhuo.SetOwnerID(*s)
+	}
+	return hhuo
+}
+
+// ClearOwnerID clears the value of the "owner_id" field.
+func (hhuo *HushHistoryUpdateOne) ClearOwnerID() *HushHistoryUpdateOne {
+	hhuo.mutation.ClearOwnerID()
 	return hhuo
 }
 
@@ -535,6 +581,12 @@ func (hhuo *HushHistoryUpdateOne) sqlSave(ctx context.Context) (_node *HushHisto
 	}
 	if hhuo.mutation.DeletedByCleared() {
 		_spec.ClearField(hushhistory.FieldDeletedBy, field.TypeString)
+	}
+	if value, ok := hhuo.mutation.OwnerID(); ok {
+		_spec.SetField(hushhistory.FieldOwnerID, field.TypeString, value)
+	}
+	if hhuo.mutation.OwnerIDCleared() {
+		_spec.ClearField(hushhistory.FieldOwnerID, field.TypeString)
 	}
 	if value, ok := hhuo.mutation.Name(); ok {
 		_spec.SetField(hushhistory.FieldName, field.TypeString, value)

--- a/internal/ent/generated/internal/schemaconfig.go
+++ b/internal/ent/generated/internal/schemaconfig.go
@@ -103,7 +103,6 @@ type SchemaConfig struct {
 	OrganizationPersonalAccessTokens string // Organization-personal_access_tokens->PersonalAccessToken table.
 	OrganizationFiles                string // Organization-files->File table.
 	OrganizationEvents               string // Organization-events->Event table.
-	OrganizationSecrets              string // Organization-secrets->Hush table.
 	OrganizationHistory              string // OrganizationHistory table.
 	OrganizationSetting              string // OrganizationSetting table.
 	OrganizationSettingFiles         string // OrganizationSetting-files->File table.

--- a/internal/ent/generated/migrate/schema.go
+++ b/internal/ent/generated/migrate/schema.go
@@ -1265,12 +1265,21 @@ var (
 		{Name: "kind", Type: field.TypeString, Nullable: true},
 		{Name: "secret_name", Type: field.TypeString, Nullable: true},
 		{Name: "secret_value", Type: field.TypeString, Nullable: true},
+		{Name: "owner_id", Type: field.TypeString, Nullable: true},
 	}
 	// HushesTable holds the schema information for the "hushes" table.
 	HushesTable = &schema.Table{
 		Name:       "hushes",
 		Columns:    HushesColumns,
 		PrimaryKey: []*schema.Column{HushesColumns[0]},
+		ForeignKeys: []*schema.ForeignKey{
+			{
+				Symbol:     "hushes_organizations_secrets",
+				Columns:    []*schema.Column{HushesColumns[12]},
+				RefColumns: []*schema.Column{OrganizationsColumns[0]},
+				OnDelete:   schema.SetNull,
+			},
+		},
 	}
 	// HushHistoryColumns holds the columns for the "hush_history" table.
 	HushHistoryColumns = []*schema.Column{
@@ -1284,6 +1293,7 @@ var (
 		{Name: "updated_by", Type: field.TypeString, Nullable: true},
 		{Name: "deleted_at", Type: field.TypeTime, Nullable: true},
 		{Name: "deleted_by", Type: field.TypeString, Nullable: true},
+		{Name: "owner_id", Type: field.TypeString, Nullable: true},
 		{Name: "name", Type: field.TypeString},
 		{Name: "description", Type: field.TypeString, Nullable: true},
 		{Name: "kind", Type: field.TypeString, Nullable: true},
@@ -4408,31 +4418,6 @@ var (
 			},
 		},
 	}
-	// OrganizationSecretsColumns holds the columns for the "organization_secrets" table.
-	OrganizationSecretsColumns = []*schema.Column{
-		{Name: "organization_id", Type: field.TypeString},
-		{Name: "hush_id", Type: field.TypeString},
-	}
-	// OrganizationSecretsTable holds the schema information for the "organization_secrets" table.
-	OrganizationSecretsTable = &schema.Table{
-		Name:       "organization_secrets",
-		Columns:    OrganizationSecretsColumns,
-		PrimaryKey: []*schema.Column{OrganizationSecretsColumns[0], OrganizationSecretsColumns[1]},
-		ForeignKeys: []*schema.ForeignKey{
-			{
-				Symbol:     "organization_secrets_organization_id",
-				Columns:    []*schema.Column{OrganizationSecretsColumns[0]},
-				RefColumns: []*schema.Column{OrganizationsColumns[0]},
-				OnDelete:   schema.Cascade,
-			},
-			{
-				Symbol:     "organization_secrets_hush_id",
-				Columns:    []*schema.Column{OrganizationSecretsColumns[1]},
-				RefColumns: []*schema.Column{HushesColumns[0]},
-				OnDelete:   schema.Cascade,
-			},
-		},
-	}
 	// OrganizationSettingFilesColumns holds the columns for the "organization_setting_files" table.
 	OrganizationSettingFilesColumns = []*schema.Column{
 		{Name: "organization_setting_id", Type: field.TypeString},
@@ -5384,7 +5369,6 @@ var (
 		OrganizationPersonalAccessTokensTable,
 		OrganizationFilesTable,
 		OrganizationEventsTable,
-		OrganizationSecretsTable,
 		OrganizationSettingFilesTable,
 		PersonalAccessTokenEventsTable,
 		ProcedureBlockedGroupsTable,
@@ -5500,6 +5484,7 @@ func init() {
 	GroupSettingHistoryTable.Annotation = &entsql.Annotation{
 		Table: "group_setting_history",
 	}
+	HushesTable.ForeignKeys[0].RefTable = OrganizationsTable
 	HushHistoryTable.Annotation = &entsql.Annotation{
 		Table: "hush_history",
 	}
@@ -5711,8 +5696,6 @@ func init() {
 	OrganizationFilesTable.ForeignKeys[1].RefTable = FilesTable
 	OrganizationEventsTable.ForeignKeys[0].RefTable = OrganizationsTable
 	OrganizationEventsTable.ForeignKeys[1].RefTable = EventsTable
-	OrganizationSecretsTable.ForeignKeys[0].RefTable = OrganizationsTable
-	OrganizationSecretsTable.ForeignKeys[1].RefTable = HushesTable
 	OrganizationSettingFilesTable.ForeignKeys[0].RefTable = OrganizationSettingsTable
 	OrganizationSettingFilesTable.ForeignKeys[1].RefTable = FilesTable
 	PersonalAccessTokenEventsTable.ForeignKeys[0].RefTable = PersonalAccessTokensTable

--- a/internal/ent/generated/organization/organization.go
+++ b/internal/ent/generated/organization/organization.go
@@ -242,11 +242,13 @@ const (
 	// EventsInverseTable is the table name for the Event entity.
 	// It exists in this package in order to avoid circular dependency with the "event" package.
 	EventsInverseTable = "events"
-	// SecretsTable is the table that holds the secrets relation/edge. The primary key declared below.
-	SecretsTable = "organization_secrets"
+	// SecretsTable is the table that holds the secrets relation/edge.
+	SecretsTable = "hushes"
 	// SecretsInverseTable is the table name for the Hush entity.
 	// It exists in this package in order to avoid circular dependency with the "hush" package.
 	SecretsInverseTable = "hushes"
+	// SecretsColumn is the table column denoting the secrets relation/edge.
+	SecretsColumn = "owner_id"
 	// AvatarFileTable is the table that holds the avatar_file relation/edge.
 	AvatarFileTable = "organizations"
 	// AvatarFileInverseTable is the table name for the File entity.
@@ -465,9 +467,6 @@ var (
 	// EventsPrimaryKey and EventsColumn2 are the table columns denoting the
 	// primary key for the events relation (M2M).
 	EventsPrimaryKey = []string{"organization_id", "event_id"}
-	// SecretsPrimaryKey and SecretsColumn2 are the table columns denoting the
-	// primary key for the secrets relation (M2M).
-	SecretsPrimaryKey = []string{"organization_id", "hush_id"}
 )
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -1317,7 +1316,7 @@ func newSecretsStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(SecretsInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.M2M, false, SecretsTable, SecretsPrimaryKey...),
+		sqlgraph.Edge(sqlgraph.O2M, false, SecretsTable, SecretsColumn),
 	)
 }
 func newAvatarFileStep() *sqlgraph.Step {

--- a/internal/ent/generated/organization/where.go
+++ b/internal/ent/generated/organization/where.go
@@ -1535,11 +1535,11 @@ func HasSecrets() predicate.Organization {
 	return predicate.Organization(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, SecretsTable, SecretsPrimaryKey...),
+			sqlgraph.Edge(sqlgraph.O2M, false, SecretsTable, SecretsColumn),
 		)
 		schemaConfig := internal.SchemaConfigFromContext(s.Context())
 		step.To.Schema = schemaConfig.Hush
-		step.Edge.Schema = schemaConfig.OrganizationSecrets
+		step.Edge.Schema = schemaConfig.Hush
 		sqlgraph.HasNeighbors(s, step)
 	})
 }
@@ -1550,7 +1550,7 @@ func HasSecretsWith(preds ...predicate.Hush) predicate.Organization {
 		step := newSecretsStep()
 		schemaConfig := internal.SchemaConfigFromContext(s.Context())
 		step.To.Schema = schemaConfig.Hush
-		step.Edge.Schema = schemaConfig.OrganizationSecrets
+		step.Edge.Schema = schemaConfig.Hush
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/internal/ent/generated/organization_create.go
+++ b/internal/ent/generated/organization_create.go
@@ -1447,16 +1447,16 @@ func (oc *OrganizationCreate) createSpec() (*Organization, *sqlgraph.CreateSpec)
 	}
 	if nodes := oc.mutation.SecretsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
+			Rel:     sqlgraph.O2M,
 			Inverse: false,
 			Table:   organization.SecretsTable,
-			Columns: organization.SecretsPrimaryKey,
+			Columns: []string{organization.SecretsColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(hush.FieldID, field.TypeString),
 			},
 		}
-		edge.Schema = oc.schemaConfig.OrganizationSecrets
+		edge.Schema = oc.schemaConfig.Hush
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}

--- a/internal/ent/generated/organization_query.go
+++ b/internal/ent/generated/organization_query.go
@@ -620,11 +620,11 @@ func (oq *OrganizationQuery) QuerySecrets() *HushQuery {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(organization.Table, organization.FieldID, selector),
 			sqlgraph.To(hush.Table, hush.FieldID),
-			sqlgraph.Edge(sqlgraph.M2M, false, organization.SecretsTable, organization.SecretsPrimaryKey...),
+			sqlgraph.Edge(sqlgraph.O2M, false, organization.SecretsTable, organization.SecretsColumn),
 		)
 		schemaConfig := oq.schemaConfig
 		step.To.Schema = schemaConfig.Hush
-		step.Edge.Schema = schemaConfig.OrganizationSecrets
+		step.Edge.Schema = schemaConfig.Hush
 		fromU = sqlgraph.SetNeighbors(oq.driver.Dialect(), step)
 		return fromU, nil
 	}
@@ -3420,64 +3420,32 @@ func (oq *OrganizationQuery) loadEvents(ctx context.Context, query *EventQuery, 
 	return nil
 }
 func (oq *OrganizationQuery) loadSecrets(ctx context.Context, query *HushQuery, nodes []*Organization, init func(*Organization), assign func(*Organization, *Hush)) error {
-	edgeIDs := make([]driver.Value, len(nodes))
-	byID := make(map[string]*Organization)
-	nids := make(map[string]map[*Organization]struct{})
-	for i, node := range nodes {
-		edgeIDs[i] = node.ID
-		byID[node.ID] = node
+	fks := make([]driver.Value, 0, len(nodes))
+	nodeids := make(map[string]*Organization)
+	for i := range nodes {
+		fks = append(fks, nodes[i].ID)
+		nodeids[nodes[i].ID] = nodes[i]
 		if init != nil {
-			init(node)
+			init(nodes[i])
 		}
 	}
-	query.Where(func(s *sql.Selector) {
-		joinT := sql.Table(organization.SecretsTable)
-		joinT.Schema(oq.schemaConfig.OrganizationSecrets)
-		s.Join(joinT).On(s.C(hush.FieldID), joinT.C(organization.SecretsPrimaryKey[1]))
-		s.Where(sql.InValues(joinT.C(organization.SecretsPrimaryKey[0]), edgeIDs...))
-		columns := s.SelectedColumns()
-		s.Select(joinT.C(organization.SecretsPrimaryKey[0]))
-		s.AppendSelect(columns...)
-		s.SetDistinct(false)
-	})
-	if err := query.prepareQuery(ctx); err != nil {
-		return err
+	if len(query.ctx.Fields) > 0 {
+		query.ctx.AppendFieldOnce(hush.FieldOwnerID)
 	}
-	qr := QuerierFunc(func(ctx context.Context, q Query) (Value, error) {
-		return query.sqlAll(ctx, func(_ context.Context, spec *sqlgraph.QuerySpec) {
-			assign := spec.Assign
-			values := spec.ScanValues
-			spec.ScanValues = func(columns []string) ([]any, error) {
-				values, err := values(columns[1:])
-				if err != nil {
-					return nil, err
-				}
-				return append([]any{new(sql.NullString)}, values...), nil
-			}
-			spec.Assign = func(columns []string, values []any) error {
-				outValue := values[0].(*sql.NullString).String
-				inValue := values[1].(*sql.NullString).String
-				if nids[inValue] == nil {
-					nids[inValue] = map[*Organization]struct{}{byID[outValue]: {}}
-					return assign(columns[1:], values[1:])
-				}
-				nids[inValue][byID[outValue]] = struct{}{}
-				return nil
-			}
-		})
-	})
-	neighbors, err := withInterceptors[[]*Hush](ctx, query, qr, query.inters)
+	query.Where(predicate.Hush(func(s *sql.Selector) {
+		s.Where(sql.InValues(s.C(organization.SecretsColumn), fks...))
+	}))
+	neighbors, err := query.All(ctx)
 	if err != nil {
 		return err
 	}
 	for _, n := range neighbors {
-		nodes, ok := nids[n.ID]
+		fk := n.OwnerID
+		node, ok := nodeids[fk]
 		if !ok {
-			return fmt.Errorf(`unexpected "secrets" node returned %v`, n.ID)
+			return fmt.Errorf(`unexpected referenced foreign-key "owner_id" returned %v for node %v`, fk, n.ID)
 		}
-		for kn := range nodes {
-			assign(kn, n)
-		}
+		assign(node, n)
 	}
 	return nil
 }

--- a/internal/ent/generated/organization_update.go
+++ b/internal/ent/generated/organization_update.go
@@ -2731,30 +2731,30 @@ func (ou *OrganizationUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if ou.mutation.SecretsCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
+			Rel:     sqlgraph.O2M,
 			Inverse: false,
 			Table:   organization.SecretsTable,
-			Columns: organization.SecretsPrimaryKey,
+			Columns: []string{organization.SecretsColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(hush.FieldID, field.TypeString),
 			},
 		}
-		edge.Schema = ou.schemaConfig.OrganizationSecrets
+		edge.Schema = ou.schemaConfig.Hush
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := ou.mutation.RemovedSecretsIDs(); len(nodes) > 0 && !ou.mutation.SecretsCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
+			Rel:     sqlgraph.O2M,
 			Inverse: false,
 			Table:   organization.SecretsTable,
-			Columns: organization.SecretsPrimaryKey,
+			Columns: []string{organization.SecretsColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(hush.FieldID, field.TypeString),
 			},
 		}
-		edge.Schema = ou.schemaConfig.OrganizationSecrets
+		edge.Schema = ou.schemaConfig.Hush
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
@@ -2762,16 +2762,16 @@ func (ou *OrganizationUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if nodes := ou.mutation.SecretsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
+			Rel:     sqlgraph.O2M,
 			Inverse: false,
 			Table:   organization.SecretsTable,
-			Columns: organization.SecretsPrimaryKey,
+			Columns: []string{organization.SecretsColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(hush.FieldID, field.TypeString),
 			},
 		}
-		edge.Schema = ou.schemaConfig.OrganizationSecrets
+		edge.Schema = ou.schemaConfig.Hush
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
@@ -6729,30 +6729,30 @@ func (ouo *OrganizationUpdateOne) sqlSave(ctx context.Context) (_node *Organizat
 	}
 	if ouo.mutation.SecretsCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
+			Rel:     sqlgraph.O2M,
 			Inverse: false,
 			Table:   organization.SecretsTable,
-			Columns: organization.SecretsPrimaryKey,
+			Columns: []string{organization.SecretsColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(hush.FieldID, field.TypeString),
 			},
 		}
-		edge.Schema = ouo.schemaConfig.OrganizationSecrets
+		edge.Schema = ouo.schemaConfig.Hush
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
 	if nodes := ouo.mutation.RemovedSecretsIDs(); len(nodes) > 0 && !ouo.mutation.SecretsCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
+			Rel:     sqlgraph.O2M,
 			Inverse: false,
 			Table:   organization.SecretsTable,
-			Columns: organization.SecretsPrimaryKey,
+			Columns: []string{organization.SecretsColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(hush.FieldID, field.TypeString),
 			},
 		}
-		edge.Schema = ouo.schemaConfig.OrganizationSecrets
+		edge.Schema = ouo.schemaConfig.Hush
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
@@ -6760,16 +6760,16 @@ func (ouo *OrganizationUpdateOne) sqlSave(ctx context.Context) (_node *Organizat
 	}
 	if nodes := ouo.mutation.SecretsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2M,
+			Rel:     sqlgraph.O2M,
 			Inverse: false,
 			Table:   organization.SecretsTable,
-			Columns: organization.SecretsPrimaryKey,
+			Columns: []string{organization.SecretsColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(hush.FieldID, field.TypeString),
 			},
 		}
-		edge.Schema = ouo.schemaConfig.OrganizationSecrets
+		edge.Schema = ouo.schemaConfig.Hush
 		for _, k := range nodes {
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}

--- a/internal/ent/generated/runtime/runtime.go
+++ b/internal/ent/generated/runtime/runtime.go
@@ -1664,18 +1664,24 @@ func init() {
 	hushMixin := schema.Hush{}.Mixin()
 	hushMixinHooks0 := hushMixin[0].Hooks()
 	hushMixinHooks1 := hushMixin[1].Hooks()
+	hushMixinHooks4 := hushMixin[4].Hooks()
 	hushHooks := schema.Hush{}.Hooks()
 	hush.Hooks[0] = hushMixinHooks0[0]
 	hush.Hooks[1] = hushMixinHooks1[0]
-	hush.Hooks[2] = hushHooks[0]
+	hush.Hooks[2] = hushMixinHooks4[0]
+	hush.Hooks[3] = hushHooks[0]
 	hushMixinInters1 := hushMixin[1].Interceptors()
+	hushMixinInters4 := hushMixin[4].Interceptors()
 	hushInters := schema.Hush{}.Interceptors()
 	hush.Interceptors[0] = hushMixinInters1[0]
-	hush.Interceptors[1] = hushInters[0]
+	hush.Interceptors[1] = hushMixinInters4[0]
+	hush.Interceptors[2] = hushInters[0]
 	hushMixinFields0 := hushMixin[0].Fields()
 	_ = hushMixinFields0
 	hushMixinFields2 := hushMixin[2].Fields()
 	_ = hushMixinFields2
+	hushMixinFields4 := hushMixin[4].Fields()
+	_ = hushMixinFields4
 	hushFields := schema.Hush{}.Fields()
 	_ = hushFields
 	// hushDescCreatedAt is the schema descriptor for created_at field.
@@ -1688,6 +1694,10 @@ func init() {
 	hush.DefaultUpdatedAt = hushDescUpdatedAt.Default.(func() time.Time)
 	// hush.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.
 	hush.UpdateDefaultUpdatedAt = hushDescUpdatedAt.UpdateDefault.(func() time.Time)
+	// hushDescOwnerID is the schema descriptor for owner_id field.
+	hushDescOwnerID := hushMixinFields4[0].Descriptor()
+	// hush.OwnerIDValidator is a validator for the "owner_id" field. It is called by the builders before save.
+	hush.OwnerIDValidator = hushDescOwnerID.Validators[0].(func(string) error)
 	// hushDescName is the schema descriptor for name field.
 	hushDescName := hushFields[0].Descriptor()
 	// hush.NameValidator is a validator for the "name" field. It is called by the builders before save.

--- a/internal/ent/schema/control.go
+++ b/internal/ent/schema/control.go
@@ -68,10 +68,9 @@ func (c Control) Edges() []ent.Edge {
 		defaultEdgeFromWithPagination(c, Program{}),
 
 		edgeToWithPagination(&edgeDefinition{
-			fromSchema:    c,
-			edgeSchema:    ControlImplementation{},
-			cascadeDelete: "Controls",
-			comment:       "the implementation(s) of the control",
+			fromSchema: c,
+			edgeSchema: ControlImplementation{},
+			comment:    "the implementation(s) of the control",
 		}),
 		// controls have control objectives and subcontrols
 		edgeToWithPagination(&edgeDefinition{

--- a/internal/ent/schema/hush.go
+++ b/internal/ent/schema/hush.go
@@ -77,7 +77,6 @@ func (h Hush) Edges() []ent.Edge {
 			edgeSchema: Integration{},
 			comment:    "the integration associated with the secret",
 		}),
-		defaultEdgeFrom(h, Organization{}),
 		defaultEdgeToWithPagination(h, Event{}),
 	}
 }
@@ -88,8 +87,13 @@ func (Hush) Annotations() []schema.Annotation {
 }
 
 // Mixin of the Hush shhhh
-func (Hush) Mixin() []ent.Mixin {
-	return mixinConfig{excludeTags: true}.getMixins()
+func (h Hush) Mixin() []ent.Mixin {
+	return mixinConfig{
+		excludeTags: true,
+		additionalMixins: []ent.Mixin{
+			newOrgOwnedMixin(h),
+		},
+	}.getMixins()
 }
 
 // Hooks of the Hush

--- a/internal/ent/schema/organization.go
+++ b/internal/ent/schema/organization.go
@@ -148,7 +148,11 @@ func (o Organization) Edges() []ent.Edge {
 			cascadeDelete: "Organization",
 		}),
 		defaultEdgeToWithPagination(o, PersonalAccessToken{}),
-		defaultEdgeToWithPagination(o, APIToken{}),
+		edgeToWithPagination(&edgeDefinition{
+			fromSchema:         o,
+			edgeSchema:         APIToken{},
+			cascadeDeleteOwner: true,
+		}),
 
 		edge.From("users", User.Type).
 			Ref("organizations").
@@ -165,10 +169,14 @@ func (o Organization) Edges() []ent.Edge {
 			annotations: []schema.Annotation{
 				entx.CascadeAnnotationField("Organization"), // 1:m so we override the default
 			},
+			cascadeDeleteOwner: true,
 		}),
-
 		defaultEdgeToWithPagination(o, Event{}),
-		defaultEdgeToWithPagination(o, Hush{}),
+		edgeToWithPagination(&edgeDefinition{
+			fromSchema:         o,
+			edgeSchema:         Hush{},
+			cascadeDeleteOwner: true,
+		}),
 		uniqueEdgeTo(&edgeDefinition{
 			fromSchema: o,
 			name:       "avatar_file",

--- a/internal/ent/schema/standard.go
+++ b/internal/ent/schema/standard.go
@@ -122,9 +122,8 @@ func (Standard) Fields() []ent.Field {
 func (s Standard) Edges() []ent.Edge {
 	return []ent.Edge{
 		edgeToWithPagination(&edgeDefinition{
-			fromSchema:    s,
-			edgeSchema:    Control{},
-			cascadeDelete: "Standard",
+			fromSchema: s,
+			edgeSchema: Control{},
 			annotations: []schema.Annotation{
 				// skip the ability to create and update controls via the standard
 				// TODO: (sfunk) implement permissions on parent edge to allow children to be created

--- a/internal/ent/schema/subcontrol.go
+++ b/internal/ent/schema/subcontrol.go
@@ -69,10 +69,9 @@ func (s Subcontrol) Edges() []ent.Edge {
 			required:   true,
 		}),
 		edgeToWithPagination(&edgeDefinition{
-			fromSchema:    s,
-			edgeSchema:    ControlImplementation{},
-			cascadeDelete: "Subcontrols",
-			comment:       "the implementation(s) of the subcontrol",
+			fromSchema: s,
+			edgeSchema: ControlImplementation{},
+			comment:    "the implementation(s) of the subcontrol",
 		}),
 	}
 }

--- a/internal/graphapi/clientschema/schema.graphql
+++ b/internal/graphapi/clientschema/schema.graphql
@@ -6843,8 +6843,8 @@ input CreateHushInput {
 	the secret value
 	"""
 	secretValue: String
+	ownerID: ID
 	integrationIDs: [ID!]
-	organizationIDs: [ID!]
 	eventIDs: [ID!]
 }
 """
@@ -15018,6 +15018,10 @@ type Hush implements Node {
 	deletedAt: Time
 	deletedBy: String
 	"""
+	the organization id that owns the object
+	"""
+	ownerID: ID
+	"""
 	the logical name of the corresponding hush secret or it's general grouping
 	"""
 	name: String!
@@ -15033,6 +15037,7 @@ type Hush implements Node {
 	the generic name of a secret associated with the organization
 	"""
 	secretName: String
+	owner: Organization
 	integrations(
 		"""
 		Returns the elements in the list that come after the specified cursor.
@@ -15064,7 +15069,6 @@ type Hush implements Node {
 		"""
 		where: IntegrationWhereInput
 	): IntegrationConnection!
-	organization: [Organization!]
 	events(
 		"""
 		Returns the elements in the list that come after the specified cursor.
@@ -15165,6 +15169,10 @@ type HushHistory implements Node {
 	updatedBy: String
 	deletedAt: Time
 	deletedBy: String
+	"""
+	the organization id that owns the object
+	"""
+	ownerID: String
 	"""
 	the logical name of the corresponding hush secret or it's general grouping
 	"""
@@ -15393,6 +15401,24 @@ input HushHistoryWhereInput {
 	deletedByEqualFold: String
 	deletedByContainsFold: String
 	"""
+	owner_id field predicates
+	"""
+	ownerID: String
+	ownerIDNEQ: String
+	ownerIDIn: [String!]
+	ownerIDNotIn: [String!]
+	ownerIDGT: String
+	ownerIDGTE: String
+	ownerIDLT: String
+	ownerIDLTE: String
+	ownerIDContains: String
+	ownerIDHasPrefix: String
+	ownerIDHasSuffix: String
+	ownerIDIsNil: Boolean
+	ownerIDNotNil: Boolean
+	ownerIDEqualFold: String
+	ownerIDContainsFold: String
+	"""
 	name field predicates
 	"""
 	name: String
@@ -15591,6 +15617,24 @@ input HushWhereInput {
 	deletedByEqualFold: String
 	deletedByContainsFold: String
 	"""
+	owner_id field predicates
+	"""
+	ownerID: ID
+	ownerIDNEQ: ID
+	ownerIDIn: [ID!]
+	ownerIDNotIn: [ID!]
+	ownerIDGT: ID
+	ownerIDGTE: ID
+	ownerIDLT: ID
+	ownerIDLTE: ID
+	ownerIDContains: ID
+	ownerIDHasPrefix: ID
+	ownerIDHasSuffix: ID
+	ownerIDIsNil: Boolean
+	ownerIDNotNil: Boolean
+	ownerIDEqualFold: ID
+	ownerIDContainsFold: ID
+	"""
 	name field predicates
 	"""
 	name: String
@@ -15643,15 +15687,15 @@ input HushWhereInput {
 	secretNameEqualFold: String
 	secretNameContainsFold: String
 	"""
+	owner edge predicates
+	"""
+	hasOwner: Boolean
+	hasOwnerWith: [OrganizationWhereInput!]
+	"""
 	integrations edge predicates
 	"""
 	hasIntegrations: Boolean
 	hasIntegrationsWith: [IntegrationWhereInput!]
-	"""
-	organization edge predicates
-	"""
-	hasOrganization: Boolean
-	hasOrganizationWith: [OrganizationWhereInput!]
 	"""
 	events edge predicates
 	"""
@@ -40024,12 +40068,11 @@ input UpdateHushInput {
 	"""
 	kind: String
 	clearKind: Boolean
+	ownerID: ID
+	clearOwner: Boolean
 	addIntegrationIDs: [ID!]
 	removeIntegrationIDs: [ID!]
 	clearIntegrations: Boolean
-	addOrganizationIDs: [ID!]
-	removeOrganizationIDs: [ID!]
-	clearOrganization: Boolean
 	addEventIDs: [ID!]
 	removeEventIDs: [ID!]
 	clearEvents: Boolean

--- a/internal/graphapi/generated/hush.generated.go
+++ b/internal/graphapi/generated/hush.generated.go
@@ -79,6 +79,8 @@ func (ec *executionContext) fieldContext_HushBulkCreatePayload_hushes(_ context.
 				return ec.fieldContext_Hush_deletedAt(ctx, field)
 			case "deletedBy":
 				return ec.fieldContext_Hush_deletedBy(ctx, field)
+			case "ownerID":
+				return ec.fieldContext_Hush_ownerID(ctx, field)
 			case "name":
 				return ec.fieldContext_Hush_name(ctx, field)
 			case "description":
@@ -87,10 +89,10 @@ func (ec *executionContext) fieldContext_HushBulkCreatePayload_hushes(_ context.
 				return ec.fieldContext_Hush_kind(ctx, field)
 			case "secretName":
 				return ec.fieldContext_Hush_secretName(ctx, field)
+			case "owner":
+				return ec.fieldContext_Hush_owner(ctx, field)
 			case "integrations":
 				return ec.fieldContext_Hush_integrations(ctx, field)
-			case "organization":
-				return ec.fieldContext_Hush_organization(ctx, field)
 			case "events":
 				return ec.fieldContext_Hush_events(ctx, field)
 			}
@@ -153,6 +155,8 @@ func (ec *executionContext) fieldContext_HushCreatePayload_hush(_ context.Contex
 				return ec.fieldContext_Hush_deletedAt(ctx, field)
 			case "deletedBy":
 				return ec.fieldContext_Hush_deletedBy(ctx, field)
+			case "ownerID":
+				return ec.fieldContext_Hush_ownerID(ctx, field)
 			case "name":
 				return ec.fieldContext_Hush_name(ctx, field)
 			case "description":
@@ -161,10 +165,10 @@ func (ec *executionContext) fieldContext_HushCreatePayload_hush(_ context.Contex
 				return ec.fieldContext_Hush_kind(ctx, field)
 			case "secretName":
 				return ec.fieldContext_Hush_secretName(ctx, field)
+			case "owner":
+				return ec.fieldContext_Hush_owner(ctx, field)
 			case "integrations":
 				return ec.fieldContext_Hush_integrations(ctx, field)
-			case "organization":
-				return ec.fieldContext_Hush_organization(ctx, field)
 			case "events":
 				return ec.fieldContext_Hush_events(ctx, field)
 			}
@@ -271,6 +275,8 @@ func (ec *executionContext) fieldContext_HushUpdatePayload_hush(_ context.Contex
 				return ec.fieldContext_Hush_deletedAt(ctx, field)
 			case "deletedBy":
 				return ec.fieldContext_Hush_deletedBy(ctx, field)
+			case "ownerID":
+				return ec.fieldContext_Hush_ownerID(ctx, field)
 			case "name":
 				return ec.fieldContext_Hush_name(ctx, field)
 			case "description":
@@ -279,10 +285,10 @@ func (ec *executionContext) fieldContext_HushUpdatePayload_hush(_ context.Contex
 				return ec.fieldContext_Hush_kind(ctx, field)
 			case "secretName":
 				return ec.fieldContext_Hush_secretName(ctx, field)
+			case "owner":
+				return ec.fieldContext_Hush_owner(ctx, field)
 			case "integrations":
 				return ec.fieldContext_Hush_integrations(ctx, field)
-			case "organization":
-				return ec.fieldContext_Hush_organization(ctx, field)
 			case "events":
 				return ec.fieldContext_Hush_events(ctx, field)
 			}

--- a/internal/graphapi/generated/root_.generated.go
+++ b/internal/graphapi/generated/root_.generated.go
@@ -1415,7 +1415,8 @@ type ComplexityRoot struct {
 		Integrations func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.IntegrationOrder, where *generated.IntegrationWhereInput) int
 		Kind         func(childComplexity int) int
 		Name         func(childComplexity int) int
-		Organization func(childComplexity int) int
+		Owner        func(childComplexity int) int
+		OwnerID      func(childComplexity int) int
 		SecretName   func(childComplexity int) int
 		UpdatedAt    func(childComplexity int) int
 		UpdatedBy    func(childComplexity int) int
@@ -1455,6 +1456,7 @@ type ComplexityRoot struct {
 		Kind        func(childComplexity int) int
 		Name        func(childComplexity int) int
 		Operation   func(childComplexity int) int
+		OwnerID     func(childComplexity int) int
 		Ref         func(childComplexity int) int
 		SecretName  func(childComplexity int) int
 		UpdatedAt   func(childComplexity int) int
@@ -10235,12 +10237,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Hush.Name(childComplexity), true
 
-	case "Hush.organization":
-		if e.complexity.Hush.Organization == nil {
+	case "Hush.owner":
+		if e.complexity.Hush.Owner == nil {
 			break
 		}
 
-		return e.complexity.Hush.Organization(childComplexity), true
+		return e.complexity.Hush.Owner(childComplexity), true
+
+	case "Hush.ownerID":
+		if e.complexity.Hush.OwnerID == nil {
+			break
+		}
+
+		return e.complexity.Hush.OwnerID(childComplexity), true
 
 	case "Hush.secretName":
 		if e.complexity.Hush.SecretName == nil {
@@ -10388,6 +10397,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.HushHistory.Operation(childComplexity), true
+
+	case "HushHistory.ownerID":
+		if e.complexity.HushHistory.OwnerID == nil {
+			break
+		}
+
+		return e.complexity.HushHistory.OwnerID(childComplexity), true
 
 	case "HushHistory.ref":
 		if e.complexity.HushHistory.Ref == nil {
@@ -32127,8 +32143,8 @@ input CreateHushInput {
   the secret value
   """
   secretValue: String
+  ownerID: ID
   integrationIDs: [ID!]
-  organizationIDs: [ID!]
   eventIDs: [ID!]
 }
 """
@@ -39944,6 +39960,10 @@ type Hush implements Node {
   deletedAt: Time
   deletedBy: String
   """
+  the organization id that owns the object
+  """
+  ownerID: ID
+  """
   the logical name of the corresponding hush secret or it's general grouping
   """
   name: String!
@@ -39959,6 +39979,7 @@ type Hush implements Node {
   the generic name of a secret associated with the organization
   """
   secretName: String
+  owner: Organization
   integrations(
     """
     Returns the elements in the list that come after the specified cursor.
@@ -39990,7 +40011,6 @@ type Hush implements Node {
     """
     where: IntegrationWhereInput
   ): IntegrationConnection!
-  organization: [Organization!]
   events(
     """
     Returns the elements in the list that come after the specified cursor.
@@ -40064,6 +40084,10 @@ type HushHistory implements Node {
   updatedBy: String
   deletedAt: Time
   deletedBy: String
+  """
+  the organization id that owns the object
+  """
+  ownerID: String
   """
   the logical name of the corresponding hush secret or it's general grouping
   """
@@ -40292,6 +40316,24 @@ input HushHistoryWhereInput {
   deletedByEqualFold: String
   deletedByContainsFold: String
   """
+  owner_id field predicates
+  """
+  ownerID: String
+  ownerIDNEQ: String
+  ownerIDIn: [String!]
+  ownerIDNotIn: [String!]
+  ownerIDGT: String
+  ownerIDGTE: String
+  ownerIDLT: String
+  ownerIDLTE: String
+  ownerIDContains: String
+  ownerIDHasPrefix: String
+  ownerIDHasSuffix: String
+  ownerIDIsNil: Boolean
+  ownerIDNotNil: Boolean
+  ownerIDEqualFold: String
+  ownerIDContainsFold: String
+  """
   name field predicates
   """
   name: String
@@ -40481,6 +40523,24 @@ input HushWhereInput {
   deletedByEqualFold: String
   deletedByContainsFold: String
   """
+  owner_id field predicates
+  """
+  ownerID: ID
+  ownerIDNEQ: ID
+  ownerIDIn: [ID!]
+  ownerIDNotIn: [ID!]
+  ownerIDGT: ID
+  ownerIDGTE: ID
+  ownerIDLT: ID
+  ownerIDLTE: ID
+  ownerIDContains: ID
+  ownerIDHasPrefix: ID
+  ownerIDHasSuffix: ID
+  ownerIDIsNil: Boolean
+  ownerIDNotNil: Boolean
+  ownerIDEqualFold: ID
+  ownerIDContainsFold: ID
+  """
   name field predicates
   """
   name: String
@@ -40533,15 +40593,15 @@ input HushWhereInput {
   secretNameEqualFold: String
   secretNameContainsFold: String
   """
+  owner edge predicates
+  """
+  hasOwner: Boolean
+  hasOwnerWith: [OrganizationWhereInput!]
+  """
   integrations edge predicates
   """
   hasIntegrations: Boolean
   hasIntegrationsWith: [IntegrationWhereInput!]
-  """
-  organization edge predicates
-  """
-  hasOrganization: Boolean
-  hasOrganizationWith: [OrganizationWhereInput!]
   """
   events edge predicates
   """
@@ -61369,12 +61429,11 @@ input UpdateHushInput {
   """
   kind: String
   clearKind: Boolean
+  ownerID: ID
+  clearOwner: Boolean
   addIntegrationIDs: [ID!]
   removeIntegrationIDs: [ID!]
   clearIntegrations: Boolean
-  addOrganizationIDs: [ID!]
-  removeOrganizationIDs: [ID!]
-  clearOrganization: Boolean
   addEventIDs: [ID!]
   removeEventIDs: [ID!]
   clearEvents: Boolean

--- a/internal/graphapi/query/hush.graphql
+++ b/internal/graphapi/query/hush.graphql
@@ -13,9 +13,7 @@ mutation CreateBulkCSVHush($input: Upload!) {
           }
         }
       }
-      organization {
-        id
-      }
+      ownerID
       events {
         edges {
           node {
@@ -42,9 +40,7 @@ mutation CreateBulkHush($input: [CreateHushInput!]) {
           }
         }
       }
-      organization {
-        id
-      }
+      ownerID
       events {
         edges {
           node {
@@ -71,9 +67,7 @@ mutation CreateHush($input: CreateHushInput!) {
           }
         }
       }
-      organization {
-        id
-      }
+      ownerID
       events {
         edges {
           node {
@@ -101,9 +95,7 @@ query GetAllHushes {
             }
           }
         }
-        organization {
-          id
-        }
+        ownerID
         events {
           edges {
             node {
@@ -134,9 +126,7 @@ query GetHushByID($hushId: ID!) {
         }
       }
     }
-    organization {
-      id
-    }
+    ownerID
     events {
       edges {
         node {
@@ -167,9 +157,7 @@ query GetHushes($where: HushWhereInput) {
             }
           }
         }
-        organization {
-          id
-        }
+        ownerID
         events {
           edges {
             node {
@@ -201,9 +189,7 @@ mutation UpdateHush($updateHushId: ID!, $input: UpdateHushInput!) {
           }
         }
       }
-      organization {
-        id
-      }
+      ownerID
       events {
         edges {
           node {

--- a/internal/graphapi/schema/ent.graphql
+++ b/internal/graphapi/schema/ent.graphql
@@ -6525,8 +6525,8 @@ input CreateHushInput {
   the secret value
   """
   secretValue: String
+  ownerID: ID
   integrationIDs: [ID!]
-  organizationIDs: [ID!]
   eventIDs: [ID!]
 }
 """
@@ -14342,6 +14342,10 @@ type Hush implements Node {
   deletedAt: Time
   deletedBy: String
   """
+  the organization id that owns the object
+  """
+  ownerID: ID
+  """
   the logical name of the corresponding hush secret or it's general grouping
   """
   name: String!
@@ -14357,6 +14361,7 @@ type Hush implements Node {
   the generic name of a secret associated with the organization
   """
   secretName: String
+  owner: Organization
   integrations(
     """
     Returns the elements in the list that come after the specified cursor.
@@ -14388,7 +14393,6 @@ type Hush implements Node {
     """
     where: IntegrationWhereInput
   ): IntegrationConnection!
-  organization: [Organization!]
   events(
     """
     Returns the elements in the list that come after the specified cursor.
@@ -14462,6 +14466,10 @@ type HushHistory implements Node {
   updatedBy: String
   deletedAt: Time
   deletedBy: String
+  """
+  the organization id that owns the object
+  """
+  ownerID: String
   """
   the logical name of the corresponding hush secret or it's general grouping
   """
@@ -14690,6 +14698,24 @@ input HushHistoryWhereInput {
   deletedByEqualFold: String
   deletedByContainsFold: String
   """
+  owner_id field predicates
+  """
+  ownerID: String
+  ownerIDNEQ: String
+  ownerIDIn: [String!]
+  ownerIDNotIn: [String!]
+  ownerIDGT: String
+  ownerIDGTE: String
+  ownerIDLT: String
+  ownerIDLTE: String
+  ownerIDContains: String
+  ownerIDHasPrefix: String
+  ownerIDHasSuffix: String
+  ownerIDIsNil: Boolean
+  ownerIDNotNil: Boolean
+  ownerIDEqualFold: String
+  ownerIDContainsFold: String
+  """
   name field predicates
   """
   name: String
@@ -14879,6 +14905,24 @@ input HushWhereInput {
   deletedByEqualFold: String
   deletedByContainsFold: String
   """
+  owner_id field predicates
+  """
+  ownerID: ID
+  ownerIDNEQ: ID
+  ownerIDIn: [ID!]
+  ownerIDNotIn: [ID!]
+  ownerIDGT: ID
+  ownerIDGTE: ID
+  ownerIDLT: ID
+  ownerIDLTE: ID
+  ownerIDContains: ID
+  ownerIDHasPrefix: ID
+  ownerIDHasSuffix: ID
+  ownerIDIsNil: Boolean
+  ownerIDNotNil: Boolean
+  ownerIDEqualFold: ID
+  ownerIDContainsFold: ID
+  """
   name field predicates
   """
   name: String
@@ -14931,15 +14975,15 @@ input HushWhereInput {
   secretNameEqualFold: String
   secretNameContainsFold: String
   """
+  owner edge predicates
+  """
+  hasOwner: Boolean
+  hasOwnerWith: [OrganizationWhereInput!]
+  """
   integrations edge predicates
   """
   hasIntegrations: Boolean
   hasIntegrationsWith: [IntegrationWhereInput!]
-  """
-  organization edge predicates
-  """
-  hasOrganization: Boolean
-  hasOrganizationWith: [OrganizationWhereInput!]
   """
   events edge predicates
   """
@@ -35767,12 +35811,11 @@ input UpdateHushInput {
   """
   kind: String
   clearKind: Boolean
+  ownerID: ID
+  clearOwner: Boolean
   addIntegrationIDs: [ID!]
   removeIntegrationIDs: [ID!]
   clearIntegrations: Boolean
-  addOrganizationIDs: [ID!]
-  removeOrganizationIDs: [ID!]
-  clearOrganization: Boolean
   addEventIDs: [ID!]
   removeEventIDs: [ID!]
   clearEvents: Boolean

--- a/internal/httpserve/handlers/csv/sample_hush.csv
+++ b/internal/httpserve/handlers/csv/sample_hush.csv
@@ -1,2 +1,2 @@
-Name,Description,Kind,SecretName,SecretValue,IntegrationIDs,OrganizationIDs,EventIDs
-example_name,example_description,example_kind,example_secretname,example_secretvalue,example_integrationids,example_organizationids,example_eventids
+Name,Description,Kind,SecretName,SecretValue,OwnerId,IntegrationIDs,EventIDs
+example_name,example_description,example_kind,example_secretname,example_secretvalue,example_ownerid,example_integrationids,example_eventids

--- a/pkg/openlaneclient/graphclient.go
+++ b/pkg/openlaneclient/graphclient.go
@@ -24415,17 +24415,6 @@ func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Integrations) GetEdges() []*
 	return t.Edges
 }
 
-type CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Organization struct {
-	ID string "json:\"id\" graphql:\"id\""
-}
-
-func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Organization) GetID() string {
-	if t == nil {
-		t = &CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Organization{}
-	}
-	return t.ID
-}
-
 type CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Events_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
@@ -24460,14 +24449,14 @@ func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Events) GetEdges() []*Create
 }
 
 type CreateBulkCSVHush_CreateBulkCSVHush_Hushes struct {
-	Description  *string                                                    "json:\"description,omitempty\" graphql:\"description\""
-	Events       CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Events          "json:\"events\" graphql:\"events\""
-	ID           string                                                     "json:\"id\" graphql:\"id\""
-	Integrations CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Integrations    "json:\"integrations\" graphql:\"integrations\""
-	Kind         *string                                                    "json:\"kind,omitempty\" graphql:\"kind\""
-	Name         string                                                     "json:\"name\" graphql:\"name\""
-	Organization []*CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Organization "json:\"organization,omitempty\" graphql:\"organization\""
-	SecretName   *string                                                    "json:\"secretName,omitempty\" graphql:\"secretName\""
+	Description  *string                                                 "json:\"description,omitempty\" graphql:\"description\""
+	Events       CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Events       "json:\"events\" graphql:\"events\""
+	ID           string                                                  "json:\"id\" graphql:\"id\""
+	Integrations CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Integrations "json:\"integrations\" graphql:\"integrations\""
+	Kind         *string                                                 "json:\"kind,omitempty\" graphql:\"kind\""
+	Name         string                                                  "json:\"name\" graphql:\"name\""
+	OwnerID      *string                                                 "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	SecretName   *string                                                 "json:\"secretName,omitempty\" graphql:\"secretName\""
 }
 
 func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes) GetDescription() *string {
@@ -24506,11 +24495,11 @@ func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes) GetName() string {
 	}
 	return t.Name
 }
-func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes) GetOrganization() []*CreateBulkCSVHush_CreateBulkCSVHush_Hushes_Organization {
+func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes) GetOwnerID() *string {
 	if t == nil {
 		t = &CreateBulkCSVHush_CreateBulkCSVHush_Hushes{}
 	}
-	return t.Organization
+	return t.OwnerID
 }
 func (t *CreateBulkCSVHush_CreateBulkCSVHush_Hushes) GetSecretName() *string {
 	if t == nil {
@@ -24563,17 +24552,6 @@ func (t *CreateBulkHush_CreateBulkHush_Hushes_Integrations) GetEdges() []*Create
 	return t.Edges
 }
 
-type CreateBulkHush_CreateBulkHush_Hushes_Organization struct {
-	ID string "json:\"id\" graphql:\"id\""
-}
-
-func (t *CreateBulkHush_CreateBulkHush_Hushes_Organization) GetID() string {
-	if t == nil {
-		t = &CreateBulkHush_CreateBulkHush_Hushes_Organization{}
-	}
-	return t.ID
-}
-
 type CreateBulkHush_CreateBulkHush_Hushes_Events_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
@@ -24608,14 +24586,14 @@ func (t *CreateBulkHush_CreateBulkHush_Hushes_Events) GetEdges() []*CreateBulkHu
 }
 
 type CreateBulkHush_CreateBulkHush_Hushes struct {
-	Description  *string                                              "json:\"description,omitempty\" graphql:\"description\""
-	Events       CreateBulkHush_CreateBulkHush_Hushes_Events          "json:\"events\" graphql:\"events\""
-	ID           string                                               "json:\"id\" graphql:\"id\""
-	Integrations CreateBulkHush_CreateBulkHush_Hushes_Integrations    "json:\"integrations\" graphql:\"integrations\""
-	Kind         *string                                              "json:\"kind,omitempty\" graphql:\"kind\""
-	Name         string                                               "json:\"name\" graphql:\"name\""
-	Organization []*CreateBulkHush_CreateBulkHush_Hushes_Organization "json:\"organization,omitempty\" graphql:\"organization\""
-	SecretName   *string                                              "json:\"secretName,omitempty\" graphql:\"secretName\""
+	Description  *string                                           "json:\"description,omitempty\" graphql:\"description\""
+	Events       CreateBulkHush_CreateBulkHush_Hushes_Events       "json:\"events\" graphql:\"events\""
+	ID           string                                            "json:\"id\" graphql:\"id\""
+	Integrations CreateBulkHush_CreateBulkHush_Hushes_Integrations "json:\"integrations\" graphql:\"integrations\""
+	Kind         *string                                           "json:\"kind,omitempty\" graphql:\"kind\""
+	Name         string                                            "json:\"name\" graphql:\"name\""
+	OwnerID      *string                                           "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	SecretName   *string                                           "json:\"secretName,omitempty\" graphql:\"secretName\""
 }
 
 func (t *CreateBulkHush_CreateBulkHush_Hushes) GetDescription() *string {
@@ -24654,11 +24632,11 @@ func (t *CreateBulkHush_CreateBulkHush_Hushes) GetName() string {
 	}
 	return t.Name
 }
-func (t *CreateBulkHush_CreateBulkHush_Hushes) GetOrganization() []*CreateBulkHush_CreateBulkHush_Hushes_Organization {
+func (t *CreateBulkHush_CreateBulkHush_Hushes) GetOwnerID() *string {
 	if t == nil {
 		t = &CreateBulkHush_CreateBulkHush_Hushes{}
 	}
-	return t.Organization
+	return t.OwnerID
 }
 func (t *CreateBulkHush_CreateBulkHush_Hushes) GetSecretName() *string {
 	if t == nil {
@@ -24711,17 +24689,6 @@ func (t *CreateHush_CreateHush_Hush_Integrations) GetEdges() []*CreateHush_Creat
 	return t.Edges
 }
 
-type CreateHush_CreateHush_Hush_Organization struct {
-	ID string "json:\"id\" graphql:\"id\""
-}
-
-func (t *CreateHush_CreateHush_Hush_Organization) GetID() string {
-	if t == nil {
-		t = &CreateHush_CreateHush_Hush_Organization{}
-	}
-	return t.ID
-}
-
 type CreateHush_CreateHush_Hush_Events_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
@@ -24756,14 +24723,14 @@ func (t *CreateHush_CreateHush_Hush_Events) GetEdges() []*CreateHush_CreateHush_
 }
 
 type CreateHush_CreateHush_Hush struct {
-	Description  *string                                    "json:\"description,omitempty\" graphql:\"description\""
-	Events       CreateHush_CreateHush_Hush_Events          "json:\"events\" graphql:\"events\""
-	ID           string                                     "json:\"id\" graphql:\"id\""
-	Integrations CreateHush_CreateHush_Hush_Integrations    "json:\"integrations\" graphql:\"integrations\""
-	Kind         *string                                    "json:\"kind,omitempty\" graphql:\"kind\""
-	Name         string                                     "json:\"name\" graphql:\"name\""
-	Organization []*CreateHush_CreateHush_Hush_Organization "json:\"organization,omitempty\" graphql:\"organization\""
-	SecretName   *string                                    "json:\"secretName,omitempty\" graphql:\"secretName\""
+	Description  *string                                 "json:\"description,omitempty\" graphql:\"description\""
+	Events       CreateHush_CreateHush_Hush_Events       "json:\"events\" graphql:\"events\""
+	ID           string                                  "json:\"id\" graphql:\"id\""
+	Integrations CreateHush_CreateHush_Hush_Integrations "json:\"integrations\" graphql:\"integrations\""
+	Kind         *string                                 "json:\"kind,omitempty\" graphql:\"kind\""
+	Name         string                                  "json:\"name\" graphql:\"name\""
+	OwnerID      *string                                 "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	SecretName   *string                                 "json:\"secretName,omitempty\" graphql:\"secretName\""
 }
 
 func (t *CreateHush_CreateHush_Hush) GetDescription() *string {
@@ -24802,11 +24769,11 @@ func (t *CreateHush_CreateHush_Hush) GetName() string {
 	}
 	return t.Name
 }
-func (t *CreateHush_CreateHush_Hush) GetOrganization() []*CreateHush_CreateHush_Hush_Organization {
+func (t *CreateHush_CreateHush_Hush) GetOwnerID() *string {
 	if t == nil {
 		t = &CreateHush_CreateHush_Hush{}
 	}
-	return t.Organization
+	return t.OwnerID
 }
 func (t *CreateHush_CreateHush_Hush) GetSecretName() *string {
 	if t == nil {
@@ -24859,17 +24826,6 @@ func (t *GetAllHushes_Hushes_Edges_Node_Integrations) GetEdges() []*GetAllHushes
 	return t.Edges
 }
 
-type GetAllHushes_Hushes_Edges_Node_Organization struct {
-	ID string "json:\"id\" graphql:\"id\""
-}
-
-func (t *GetAllHushes_Hushes_Edges_Node_Organization) GetID() string {
-	if t == nil {
-		t = &GetAllHushes_Hushes_Edges_Node_Organization{}
-	}
-	return t.ID
-}
-
 type GetAllHushes_Hushes_Edges_Node_Events_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
@@ -24904,18 +24860,18 @@ func (t *GetAllHushes_Hushes_Edges_Node_Events) GetEdges() []*GetAllHushes_Hushe
 }
 
 type GetAllHushes_Hushes_Edges_Node struct {
-	CreatedAt    *time.Time                                     "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy    *string                                        "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description  *string                                        "json:\"description,omitempty\" graphql:\"description\""
-	Events       GetAllHushes_Hushes_Edges_Node_Events          "json:\"events\" graphql:\"events\""
-	ID           string                                         "json:\"id\" graphql:\"id\""
-	Integrations GetAllHushes_Hushes_Edges_Node_Integrations    "json:\"integrations\" graphql:\"integrations\""
-	Kind         *string                                        "json:\"kind,omitempty\" graphql:\"kind\""
-	Name         string                                         "json:\"name\" graphql:\"name\""
-	Organization []*GetAllHushes_Hushes_Edges_Node_Organization "json:\"organization,omitempty\" graphql:\"organization\""
-	SecretName   *string                                        "json:\"secretName,omitempty\" graphql:\"secretName\""
-	UpdatedAt    *time.Time                                     "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy    *string                                        "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	CreatedAt    *time.Time                                  "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy    *string                                     "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description  *string                                     "json:\"description,omitempty\" graphql:\"description\""
+	Events       GetAllHushes_Hushes_Edges_Node_Events       "json:\"events\" graphql:\"events\""
+	ID           string                                      "json:\"id\" graphql:\"id\""
+	Integrations GetAllHushes_Hushes_Edges_Node_Integrations "json:\"integrations\" graphql:\"integrations\""
+	Kind         *string                                     "json:\"kind,omitempty\" graphql:\"kind\""
+	Name         string                                      "json:\"name\" graphql:\"name\""
+	OwnerID      *string                                     "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	SecretName   *string                                     "json:\"secretName,omitempty\" graphql:\"secretName\""
+	UpdatedAt    *time.Time                                  "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy    *string                                     "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *GetAllHushes_Hushes_Edges_Node) GetCreatedAt() *time.Time {
@@ -24966,11 +24922,11 @@ func (t *GetAllHushes_Hushes_Edges_Node) GetName() string {
 	}
 	return t.Name
 }
-func (t *GetAllHushes_Hushes_Edges_Node) GetOrganization() []*GetAllHushes_Hushes_Edges_Node_Organization {
+func (t *GetAllHushes_Hushes_Edges_Node) GetOwnerID() *string {
 	if t == nil {
 		t = &GetAllHushes_Hushes_Edges_Node{}
 	}
-	return t.Organization
+	return t.OwnerID
 }
 func (t *GetAllHushes_Hushes_Edges_Node) GetSecretName() *string {
 	if t == nil {
@@ -25046,17 +25002,6 @@ func (t *GetHushByID_Hush_Integrations) GetEdges() []*GetHushByID_Hush_Integrati
 	return t.Edges
 }
 
-type GetHushByID_Hush_Organization struct {
-	ID string "json:\"id\" graphql:\"id\""
-}
-
-func (t *GetHushByID_Hush_Organization) GetID() string {
-	if t == nil {
-		t = &GetHushByID_Hush_Organization{}
-	}
-	return t.ID
-}
-
 type GetHushByID_Hush_Events_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
@@ -25091,18 +25036,18 @@ func (t *GetHushByID_Hush_Events) GetEdges() []*GetHushByID_Hush_Events_Edges {
 }
 
 type GetHushByID_Hush struct {
-	CreatedAt    *time.Time                       "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy    *string                          "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description  *string                          "json:\"description,omitempty\" graphql:\"description\""
-	Events       GetHushByID_Hush_Events          "json:\"events\" graphql:\"events\""
-	ID           string                           "json:\"id\" graphql:\"id\""
-	Integrations GetHushByID_Hush_Integrations    "json:\"integrations\" graphql:\"integrations\""
-	Kind         *string                          "json:\"kind,omitempty\" graphql:\"kind\""
-	Name         string                           "json:\"name\" graphql:\"name\""
-	Organization []*GetHushByID_Hush_Organization "json:\"organization,omitempty\" graphql:\"organization\""
-	SecretName   *string                          "json:\"secretName,omitempty\" graphql:\"secretName\""
-	UpdatedAt    *time.Time                       "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy    *string                          "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	CreatedAt    *time.Time                    "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy    *string                       "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description  *string                       "json:\"description,omitempty\" graphql:\"description\""
+	Events       GetHushByID_Hush_Events       "json:\"events\" graphql:\"events\""
+	ID           string                        "json:\"id\" graphql:\"id\""
+	Integrations GetHushByID_Hush_Integrations "json:\"integrations\" graphql:\"integrations\""
+	Kind         *string                       "json:\"kind,omitempty\" graphql:\"kind\""
+	Name         string                        "json:\"name\" graphql:\"name\""
+	OwnerID      *string                       "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	SecretName   *string                       "json:\"secretName,omitempty\" graphql:\"secretName\""
+	UpdatedAt    *time.Time                    "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy    *string                       "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *GetHushByID_Hush) GetCreatedAt() *time.Time {
@@ -25153,11 +25098,11 @@ func (t *GetHushByID_Hush) GetName() string {
 	}
 	return t.Name
 }
-func (t *GetHushByID_Hush) GetOrganization() []*GetHushByID_Hush_Organization {
+func (t *GetHushByID_Hush) GetOwnerID() *string {
 	if t == nil {
 		t = &GetHushByID_Hush{}
 	}
-	return t.Organization
+	return t.OwnerID
 }
 func (t *GetHushByID_Hush) GetSecretName() *string {
 	if t == nil {
@@ -25211,17 +25156,6 @@ func (t *GetHushes_Hushes_Edges_Node_Integrations) GetEdges() []*GetHushes_Hushe
 	return t.Edges
 }
 
-type GetHushes_Hushes_Edges_Node_Organization struct {
-	ID string "json:\"id\" graphql:\"id\""
-}
-
-func (t *GetHushes_Hushes_Edges_Node_Organization) GetID() string {
-	if t == nil {
-		t = &GetHushes_Hushes_Edges_Node_Organization{}
-	}
-	return t.ID
-}
-
 type GetHushes_Hushes_Edges_Node_Events_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
@@ -25256,18 +25190,18 @@ func (t *GetHushes_Hushes_Edges_Node_Events) GetEdges() []*GetHushes_Hushes_Edge
 }
 
 type GetHushes_Hushes_Edges_Node struct {
-	CreatedAt    *time.Time                                  "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy    *string                                     "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	Description  *string                                     "json:\"description,omitempty\" graphql:\"description\""
-	Events       GetHushes_Hushes_Edges_Node_Events          "json:\"events\" graphql:\"events\""
-	ID           string                                      "json:\"id\" graphql:\"id\""
-	Integrations GetHushes_Hushes_Edges_Node_Integrations    "json:\"integrations\" graphql:\"integrations\""
-	Kind         *string                                     "json:\"kind,omitempty\" graphql:\"kind\""
-	Name         string                                      "json:\"name\" graphql:\"name\""
-	Organization []*GetHushes_Hushes_Edges_Node_Organization "json:\"organization,omitempty\" graphql:\"organization\""
-	SecretName   *string                                     "json:\"secretName,omitempty\" graphql:\"secretName\""
-	UpdatedAt    *time.Time                                  "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy    *string                                     "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	CreatedAt    *time.Time                               "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy    *string                                  "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description  *string                                  "json:\"description,omitempty\" graphql:\"description\""
+	Events       GetHushes_Hushes_Edges_Node_Events       "json:\"events\" graphql:\"events\""
+	ID           string                                   "json:\"id\" graphql:\"id\""
+	Integrations GetHushes_Hushes_Edges_Node_Integrations "json:\"integrations\" graphql:\"integrations\""
+	Kind         *string                                  "json:\"kind,omitempty\" graphql:\"kind\""
+	Name         string                                   "json:\"name\" graphql:\"name\""
+	OwnerID      *string                                  "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	SecretName   *string                                  "json:\"secretName,omitempty\" graphql:\"secretName\""
+	UpdatedAt    *time.Time                               "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy    *string                                  "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *GetHushes_Hushes_Edges_Node) GetCreatedAt() *time.Time {
@@ -25318,11 +25252,11 @@ func (t *GetHushes_Hushes_Edges_Node) GetName() string {
 	}
 	return t.Name
 }
-func (t *GetHushes_Hushes_Edges_Node) GetOrganization() []*GetHushes_Hushes_Edges_Node_Organization {
+func (t *GetHushes_Hushes_Edges_Node) GetOwnerID() *string {
 	if t == nil {
 		t = &GetHushes_Hushes_Edges_Node{}
 	}
-	return t.Organization
+	return t.OwnerID
 }
 func (t *GetHushes_Hushes_Edges_Node) GetSecretName() *string {
 	if t == nil {
@@ -25398,17 +25332,6 @@ func (t *UpdateHush_UpdateHush_Hush_Integrations) GetEdges() []*UpdateHush_Updat
 	return t.Edges
 }
 
-type UpdateHush_UpdateHush_Hush_Organization struct {
-	ID string "json:\"id\" graphql:\"id\""
-}
-
-func (t *UpdateHush_UpdateHush_Hush_Organization) GetID() string {
-	if t == nil {
-		t = &UpdateHush_UpdateHush_Hush_Organization{}
-	}
-	return t.ID
-}
-
 type UpdateHush_UpdateHush_Hush_Events_Edges_Node struct {
 	ID string "json:\"id\" graphql:\"id\""
 }
@@ -25443,14 +25366,14 @@ func (t *UpdateHush_UpdateHush_Hush_Events) GetEdges() []*UpdateHush_UpdateHush_
 }
 
 type UpdateHush_UpdateHush_Hush struct {
-	Description  *string                                    "json:\"description,omitempty\" graphql:\"description\""
-	Events       UpdateHush_UpdateHush_Hush_Events          "json:\"events\" graphql:\"events\""
-	ID           string                                     "json:\"id\" graphql:\"id\""
-	Integrations UpdateHush_UpdateHush_Hush_Integrations    "json:\"integrations\" graphql:\"integrations\""
-	Kind         *string                                    "json:\"kind,omitempty\" graphql:\"kind\""
-	Name         string                                     "json:\"name\" graphql:\"name\""
-	Organization []*UpdateHush_UpdateHush_Hush_Organization "json:\"organization,omitempty\" graphql:\"organization\""
-	SecretName   *string                                    "json:\"secretName,omitempty\" graphql:\"secretName\""
+	Description  *string                                 "json:\"description,omitempty\" graphql:\"description\""
+	Events       UpdateHush_UpdateHush_Hush_Events       "json:\"events\" graphql:\"events\""
+	ID           string                                  "json:\"id\" graphql:\"id\""
+	Integrations UpdateHush_UpdateHush_Hush_Integrations "json:\"integrations\" graphql:\"integrations\""
+	Kind         *string                                 "json:\"kind,omitempty\" graphql:\"kind\""
+	Name         string                                  "json:\"name\" graphql:\"name\""
+	OwnerID      *string                                 "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	SecretName   *string                                 "json:\"secretName,omitempty\" graphql:\"secretName\""
 }
 
 func (t *UpdateHush_UpdateHush_Hush) GetDescription() *string {
@@ -25489,11 +25412,11 @@ func (t *UpdateHush_UpdateHush_Hush) GetName() string {
 	}
 	return t.Name
 }
-func (t *UpdateHush_UpdateHush_Hush) GetOrganization() []*UpdateHush_UpdateHush_Hush_Organization {
+func (t *UpdateHush_UpdateHush_Hush) GetOwnerID() *string {
 	if t == nil {
 		t = &UpdateHush_UpdateHush_Hush{}
 	}
-	return t.Organization
+	return t.OwnerID
 }
 func (t *UpdateHush_UpdateHush_Hush) GetSecretName() *string {
 	if t == nil {
@@ -71152,9 +71075,7 @@ const CreateBulkCSVHushDocument = `mutation CreateBulkCSVHush ($input: Upload!) 
 					}
 				}
 			}
-			organization {
-				id
-			}
+			ownerID
 			events {
 				edges {
 					node {
@@ -71199,9 +71120,7 @@ const CreateBulkHushDocument = `mutation CreateBulkHush ($input: [CreateHushInpu
 					}
 				}
 			}
-			organization {
-				id
-			}
+			ownerID
 			events {
 				edges {
 					node {
@@ -71246,9 +71165,7 @@ const CreateHushDocument = `mutation CreateHush ($input: CreateHushInput!) {
 					}
 				}
 			}
-			organization {
-				id
-			}
+			ownerID
 			events {
 				edges {
 					node {
@@ -71294,9 +71211,7 @@ const GetAllHushesDocument = `query GetAllHushes {
 						}
 					}
 				}
-				organization {
-					id
-				}
+				ownerID
 				events {
 					edges {
 						node {
@@ -71343,9 +71258,7 @@ const GetHushByIDDocument = `query GetHushByID ($hushId: ID!) {
 				}
 			}
 		}
-		organization {
-			id
-		}
+		ownerID
 		events {
 			edges {
 				node {
@@ -71394,9 +71307,7 @@ const GetHushesDocument = `query GetHushes ($where: HushWhereInput) {
 						}
 					}
 				}
-				organization {
-					id
-				}
+				ownerID
 				events {
 					edges {
 						node {
@@ -71446,9 +71357,7 @@ const UpdateHushDocument = `mutation UpdateHush ($updateHushId: ID!, $input: Upd
 					}
 				}
 			}
-			organization {
-				id
-			}
+			ownerID
 			events {
 				edges {
 					node {

--- a/pkg/openlaneclient/models.go
+++ b/pkg/openlaneclient/models.go
@@ -4358,10 +4358,10 @@ type CreateHushInput struct {
 	// the generic name of a secret associated with the organization
 	SecretName *string `json:"secretName,omitempty"`
 	// the secret value
-	SecretValue     *string  `json:"secretValue,omitempty"`
-	IntegrationIDs  []string `json:"integrationIDs,omitempty"`
-	OrganizationIDs []string `json:"organizationIDs,omitempty"`
-	EventIDs        []string `json:"eventIDs,omitempty"`
+	SecretValue    *string  `json:"secretValue,omitempty"`
+	OwnerID        *string  `json:"ownerID,omitempty"`
+	IntegrationIDs []string `json:"integrationIDs,omitempty"`
+	EventIDs       []string `json:"eventIDs,omitempty"`
 }
 
 // CreateIntegrationInput is used for create Integration object.
@@ -9754,6 +9754,8 @@ type Hush struct {
 	UpdatedBy *string    `json:"updatedBy,omitempty"`
 	DeletedAt *time.Time `json:"deletedAt,omitempty"`
 	DeletedBy *string    `json:"deletedBy,omitempty"`
+	// the organization id that owns the object
+	OwnerID *string `json:"ownerID,omitempty"`
 	// the logical name of the corresponding hush secret or it's general grouping
 	Name string `json:"name"`
 	// a description of the hush value or purpose, such as github PAT
@@ -9762,8 +9764,8 @@ type Hush struct {
 	Kind *string `json:"kind,omitempty"`
 	// the generic name of a secret associated with the organization
 	SecretName   *string                `json:"secretName,omitempty"`
+	Owner        *Organization          `json:"owner,omitempty"`
 	Integrations *IntegrationConnection `json:"integrations"`
-	Organization []*Organization        `json:"organization,omitempty"`
 	Events       *EventConnection       `json:"events"`
 }
 
@@ -9816,6 +9818,8 @@ type HushHistory struct {
 	UpdatedBy   *string        `json:"updatedBy,omitempty"`
 	DeletedAt   *time.Time     `json:"deletedAt,omitempty"`
 	DeletedBy   *string        `json:"deletedBy,omitempty"`
+	// the organization id that owns the object
+	OwnerID *string `json:"ownerID,omitempty"`
 	// the logical name of the corresponding hush secret or it's general grouping
 	Name string `json:"name"`
 	// a description of the hush value or purpose, such as github PAT
@@ -9982,6 +9986,22 @@ type HushHistoryWhereInput struct {
 	DeletedByNotNil       *bool    `json:"deletedByNotNil,omitempty"`
 	DeletedByEqualFold    *string  `json:"deletedByEqualFold,omitempty"`
 	DeletedByContainsFold *string  `json:"deletedByContainsFold,omitempty"`
+	// owner_id field predicates
+	OwnerID             *string  `json:"ownerID,omitempty"`
+	OwnerIdneq          *string  `json:"ownerIDNEQ,omitempty"`
+	OwnerIDIn           []string `json:"ownerIDIn,omitempty"`
+	OwnerIDNotIn        []string `json:"ownerIDNotIn,omitempty"`
+	OwnerIdgt           *string  `json:"ownerIDGT,omitempty"`
+	OwnerIdgte          *string  `json:"ownerIDGTE,omitempty"`
+	OwnerIdlt           *string  `json:"ownerIDLT,omitempty"`
+	OwnerIdlte          *string  `json:"ownerIDLTE,omitempty"`
+	OwnerIDContains     *string  `json:"ownerIDContains,omitempty"`
+	OwnerIDHasPrefix    *string  `json:"ownerIDHasPrefix,omitempty"`
+	OwnerIDHasSuffix    *string  `json:"ownerIDHasSuffix,omitempty"`
+	OwnerIDIsNil        *bool    `json:"ownerIDIsNil,omitempty"`
+	OwnerIDNotNil       *bool    `json:"ownerIDNotNil,omitempty"`
+	OwnerIDEqualFold    *string  `json:"ownerIDEqualFold,omitempty"`
+	OwnerIDContainsFold *string  `json:"ownerIDContainsFold,omitempty"`
 	// name field predicates
 	Name             *string  `json:"name,omitempty"`
 	NameNeq          *string  `json:"nameNEQ,omitempty"`
@@ -10142,6 +10162,22 @@ type HushWhereInput struct {
 	DeletedByNotNil       *bool    `json:"deletedByNotNil,omitempty"`
 	DeletedByEqualFold    *string  `json:"deletedByEqualFold,omitempty"`
 	DeletedByContainsFold *string  `json:"deletedByContainsFold,omitempty"`
+	// owner_id field predicates
+	OwnerID             *string  `json:"ownerID,omitempty"`
+	OwnerIdneq          *string  `json:"ownerIDNEQ,omitempty"`
+	OwnerIDIn           []string `json:"ownerIDIn,omitempty"`
+	OwnerIDNotIn        []string `json:"ownerIDNotIn,omitempty"`
+	OwnerIdgt           *string  `json:"ownerIDGT,omitempty"`
+	OwnerIdgte          *string  `json:"ownerIDGTE,omitempty"`
+	OwnerIdlt           *string  `json:"ownerIDLT,omitempty"`
+	OwnerIdlte          *string  `json:"ownerIDLTE,omitempty"`
+	OwnerIDContains     *string  `json:"ownerIDContains,omitempty"`
+	OwnerIDHasPrefix    *string  `json:"ownerIDHasPrefix,omitempty"`
+	OwnerIDHasSuffix    *string  `json:"ownerIDHasSuffix,omitempty"`
+	OwnerIDIsNil        *bool    `json:"ownerIDIsNil,omitempty"`
+	OwnerIDNotNil       *bool    `json:"ownerIDNotNil,omitempty"`
+	OwnerIDEqualFold    *string  `json:"ownerIDEqualFold,omitempty"`
+	OwnerIDContainsFold *string  `json:"ownerIDContainsFold,omitempty"`
 	// name field predicates
 	Name             *string  `json:"name,omitempty"`
 	NameNeq          *string  `json:"nameNEQ,omitempty"`
@@ -10188,12 +10224,12 @@ type HushWhereInput struct {
 	SecretNameNotNil       *bool    `json:"secretNameNotNil,omitempty"`
 	SecretNameEqualFold    *string  `json:"secretNameEqualFold,omitempty"`
 	SecretNameContainsFold *string  `json:"secretNameContainsFold,omitempty"`
+	// owner edge predicates
+	HasOwner     *bool                     `json:"hasOwner,omitempty"`
+	HasOwnerWith []*OrganizationWhereInput `json:"hasOwnerWith,omitempty"`
 	// integrations edge predicates
 	HasIntegrations     *bool                    `json:"hasIntegrations,omitempty"`
 	HasIntegrationsWith []*IntegrationWhereInput `json:"hasIntegrationsWith,omitempty"`
-	// organization edge predicates
-	HasOrganization     *bool                     `json:"hasOrganization,omitempty"`
-	HasOrganizationWith []*OrganizationWhereInput `json:"hasOrganizationWith,omitempty"`
 	// events edge predicates
 	HasEvents     *bool              `json:"hasEvents,omitempty"`
 	HasEventsWith []*EventWhereInput `json:"hasEventsWith,omitempty"`
@@ -22493,17 +22529,16 @@ type UpdateHushInput struct {
 	Description      *string `json:"description,omitempty"`
 	ClearDescription *bool   `json:"clearDescription,omitempty"`
 	// the kind of secret, such as sshkey, certificate, api token, etc.
-	Kind                  *string  `json:"kind,omitempty"`
-	ClearKind             *bool    `json:"clearKind,omitempty"`
-	AddIntegrationIDs     []string `json:"addIntegrationIDs,omitempty"`
-	RemoveIntegrationIDs  []string `json:"removeIntegrationIDs,omitempty"`
-	ClearIntegrations     *bool    `json:"clearIntegrations,omitempty"`
-	AddOrganizationIDs    []string `json:"addOrganizationIDs,omitempty"`
-	RemoveOrganizationIDs []string `json:"removeOrganizationIDs,omitempty"`
-	ClearOrganization     *bool    `json:"clearOrganization,omitempty"`
-	AddEventIDs           []string `json:"addEventIDs,omitempty"`
-	RemoveEventIDs        []string `json:"removeEventIDs,omitempty"`
-	ClearEvents           *bool    `json:"clearEvents,omitempty"`
+	Kind                 *string  `json:"kind,omitempty"`
+	ClearKind            *bool    `json:"clearKind,omitempty"`
+	OwnerID              *string  `json:"ownerID,omitempty"`
+	ClearOwner           *bool    `json:"clearOwner,omitempty"`
+	AddIntegrationIDs    []string `json:"addIntegrationIDs,omitempty"`
+	RemoveIntegrationIDs []string `json:"removeIntegrationIDs,omitempty"`
+	ClearIntegrations    *bool    `json:"clearIntegrations,omitempty"`
+	AddEventIDs          []string `json:"addEventIDs,omitempty"`
+	RemoveEventIDs       []string `json:"removeEventIDs,omitempty"`
+	ClearEvents          *bool    `json:"clearEvents,omitempty"`
 }
 
 // UpdateIntegrationInput is used for update Integration object.


### PR DESCRIPTION
- removes cascade delete of control implementations when a control/subcontrol is deleted. These could be linked to more than just one and shouldnt be automatically deleted
- removes control cascade delete from standard, controls can be linked back to a standard but not "owned" by the standard
- adds cascade delete for api tokens + hush from organization deletion
- switch hush from "organization" -> "owner" to match other schemas