### PR TITLE
feat: paginate organization members

### DIFF
--- a/cmd/cli/cmd/organization/root.go
+++ b/cmd/cli/cmd/organization/root.go
@@ -96,7 +96,7 @@ func tableOutput(out []openlaneclient.Organization) {
 			childrenLen = len(i.Children.Edges)
 		}
 
-		writer.AddRow(i.ID, i.DisplayName, *i.Description, *i.PersonalOrg, childrenLen, len(i.Members))
+		writer.AddRow(i.ID, i.DisplayName, *i.Description, *i.PersonalOrg, childrenLen, i.Members.TotalCount)
 	}
 
 	writer.Render()

--- a/internal/ent/generated/gql_collection.go
+++ b/internal/ent/generated/gql_collection.go
@@ -16593,8 +16593,88 @@ func (o *OrganizationQuery) collectField(ctx context.Context, oneNode bool, opCt
 				path  = append(path, alias)
 				query = (&UserClient{config: o.config}).Query()
 			)
-			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, userImplementors)...); err != nil {
+			args := newUserPaginateArgs(fieldArgs(ctx, new(UserWhereInput), path...))
+			if err := validateFirstLast(args.first, args.last); err != nil {
+				return fmt.Errorf("validate first and last in path %q: %w", path, err)
+			}
+			pager, err := newUserPager(args.opts, args.last != nil)
+			if err != nil {
+				return fmt.Errorf("create new pager in path %q: %w", path, err)
+			}
+			if query, err = pager.applyFilter(query); err != nil {
 				return err
+			}
+			ignoredEdges := !hasCollectedField(ctx, append(path, edgesField)...)
+			if hasCollectedField(ctx, append(path, totalCountField)...) || hasCollectedField(ctx, append(path, pageInfoField)...) {
+				hasPagination := args.after != nil || args.first != nil || args.before != nil || args.last != nil
+				if hasPagination || ignoredEdges {
+					query := query.Clone()
+					o.loadTotal = append(o.loadTotal, func(ctx context.Context, nodes []*Organization) error {
+						ids := make([]driver.Value, len(nodes))
+						for i := range nodes {
+							ids[i] = nodes[i].ID
+						}
+						var v []struct {
+							NodeID string `sql:"organization_id"`
+							Count  int    `sql:"count"`
+						}
+						query.Where(func(s *sql.Selector) {
+							joinT := sql.Table(organization.UsersTable)
+							s.Join(joinT).On(s.C(user.FieldID), joinT.C(organization.UsersPrimaryKey[0]))
+							s.Where(sql.InValues(joinT.C(organization.UsersPrimaryKey[1]), ids...))
+							s.Select(joinT.C(organization.UsersPrimaryKey[1]), sql.Count("*"))
+							s.GroupBy(joinT.C(organization.UsersPrimaryKey[1]))
+						})
+						if err := query.Select().Scan(ctx, &v); err != nil {
+							return err
+						}
+						m := make(map[string]int, len(v))
+						for i := range v {
+							m[v[i].NodeID] = v[i].Count
+						}
+						for i := range nodes {
+							n := m[nodes[i].ID]
+							if nodes[i].Edges.totalCount[14] == nil {
+								nodes[i].Edges.totalCount[14] = make(map[string]int)
+							}
+							nodes[i].Edges.totalCount[14][alias] = n
+						}
+						return nil
+					})
+				} else {
+					o.loadTotal = append(o.loadTotal, func(_ context.Context, nodes []*Organization) error {
+						for i := range nodes {
+							n := len(nodes[i].Edges.Users)
+							if nodes[i].Edges.totalCount[14] == nil {
+								nodes[i].Edges.totalCount[14] = make(map[string]int)
+							}
+							nodes[i].Edges.totalCount[14][alias] = n
+						}
+						return nil
+					})
+				}
+			}
+			if ignoredEdges || (args.first != nil && *args.first == 0) || (args.last != nil && *args.last == 0) {
+				continue
+			}
+			if query, err = pager.applyCursors(query, args.after, args.before); err != nil {
+				return err
+			}
+			path = append(path, edgesField, nodeField)
+			if field := collectedField(ctx, path...); field != nil {
+				if err := query.collectField(ctx, false, opCtx, *field, path, mayAddCondition(satisfies, userImplementors)...); err != nil {
+					return err
+				}
+			}
+			if limit := paginateLimit(args.first, args.last); limit > 0 {
+				if oneNode {
+					pager.applyOrder(query.Limit(limit))
+				} else {
+					modify := entgql.LimitPerRow(organization.UsersPrimaryKey[1], limit, pager.orderExpr(query))
+					query.modifiers = append(query.modifiers, modify)
+				}
+			} else {
+				query = pager.applyOrder(query)
 			}
 			o.WithNamedUsers(alias, func(wq *UserQuery) {
 				*wq = *query
@@ -18956,8 +19036,84 @@ func (o *OrganizationQuery) collectField(ctx context.Context, oneNode bool, opCt
 				path  = append(path, alias)
 				query = (&OrgMembershipClient{config: o.config}).Query()
 			)
-			if err := query.collectField(ctx, false, opCtx, field, path, mayAddCondition(satisfies, orgmembershipImplementors)...); err != nil {
+			args := newOrgMembershipPaginateArgs(fieldArgs(ctx, new(OrgMembershipWhereInput), path...))
+			if err := validateFirstLast(args.first, args.last); err != nil {
+				return fmt.Errorf("validate first and last in path %q: %w", path, err)
+			}
+			pager, err := newOrgMembershipPager(args.opts, args.last != nil)
+			if err != nil {
+				return fmt.Errorf("create new pager in path %q: %w", path, err)
+			}
+			if query, err = pager.applyFilter(query); err != nil {
 				return err
+			}
+			ignoredEdges := !hasCollectedField(ctx, append(path, edgesField)...)
+			if hasCollectedField(ctx, append(path, totalCountField)...) || hasCollectedField(ctx, append(path, pageInfoField)...) {
+				hasPagination := args.after != nil || args.first != nil || args.before != nil || args.last != nil
+				if hasPagination || ignoredEdges {
+					query := query.Clone()
+					o.loadTotal = append(o.loadTotal, func(ctx context.Context, nodes []*Organization) error {
+						ids := make([]driver.Value, len(nodes))
+						for i := range nodes {
+							ids[i] = nodes[i].ID
+						}
+						var v []struct {
+							NodeID string `sql:"organization_id"`
+							Count  int    `sql:"count"`
+						}
+						query.Where(func(s *sql.Selector) {
+							s.Where(sql.InValues(s.C(organization.MembersColumn), ids...))
+						})
+						if err := query.GroupBy(organization.MembersColumn).Aggregate(Count()).Scan(ctx, &v); err != nil {
+							return err
+						}
+						m := make(map[string]int, len(v))
+						for i := range v {
+							m[v[i].NodeID] = v[i].Count
+						}
+						for i := range nodes {
+							n := m[nodes[i].ID]
+							if nodes[i].Edges.totalCount[43] == nil {
+								nodes[i].Edges.totalCount[43] = make(map[string]int)
+							}
+							nodes[i].Edges.totalCount[43][alias] = n
+						}
+						return nil
+					})
+				} else {
+					o.loadTotal = append(o.loadTotal, func(_ context.Context, nodes []*Organization) error {
+						for i := range nodes {
+							n := len(nodes[i].Edges.Members)
+							if nodes[i].Edges.totalCount[43] == nil {
+								nodes[i].Edges.totalCount[43] = make(map[string]int)
+							}
+							nodes[i].Edges.totalCount[43][alias] = n
+						}
+						return nil
+					})
+				}
+			}
+			if ignoredEdges || (args.first != nil && *args.first == 0) || (args.last != nil && *args.last == 0) {
+				continue
+			}
+			if query, err = pager.applyCursors(query, args.after, args.before); err != nil {
+				return err
+			}
+			path = append(path, edgesField, nodeField)
+			if field := collectedField(ctx, path...); field != nil {
+				if err := query.collectField(ctx, false, opCtx, *field, path, mayAddCondition(satisfies, orgmembershipImplementors)...); err != nil {
+					return err
+				}
+			}
+			if limit := paginateLimit(args.first, args.last); limit > 0 {
+				if oneNode {
+					pager.applyOrder(query.Limit(limit))
+				} else {
+					modify := entgql.LimitPerRow(organization.MembersColumn, limit, pager.orderExpr(query))
+					query.modifiers = append(query.modifiers, modify)
+				}
+			} else {
+				query = pager.applyOrder(query)
 			}
 			o.WithNamedMembers(alias, func(wq *OrgMembershipQuery) {
 				*wq = *query

--- a/internal/ent/generated/gql_edge.go
+++ b/internal/ent/generated/gql_edge.go
@@ -2638,16 +2638,25 @@ func (o *Organization) APITokens(
 	return o.QueryAPITokens().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (o *Organization) Users(ctx context.Context) (result []*User, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedUsers(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.UsersOrErr()
+func (o *Organization) Users(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*UserOrder, where *UserWhereInput,
+) (*UserConnection, error) {
+	opts := []UserPaginateOption{
+		WithUserOrder(orderBy),
+		WithUserFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QueryUsers().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[14][alias]
+	if nodes, err := o.NamedUsers(alias); err == nil || hasTotalCount {
+		pager, err := newUserPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &UserConnection{Edges: []*UserEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QueryUsers().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (o *Organization) Files(
@@ -3216,16 +3225,25 @@ func (o *Organization) ActionPlans(
 	return o.QueryActionPlans().Paginate(ctx, after, first, before, last, opts...)
 }
 
-func (o *Organization) Members(ctx context.Context) (result []*OrgMembership, err error) {
-	if fc := graphql.GetFieldContext(ctx); fc != nil && fc.Field.Alias != "" {
-		result, err = o.NamedMembers(graphql.GetFieldContext(ctx).Field.Alias)
-	} else {
-		result, err = o.Edges.MembersOrErr()
+func (o *Organization) Members(
+	ctx context.Context, after *Cursor, first *int, before *Cursor, last *int, orderBy []*OrgMembershipOrder, where *OrgMembershipWhereInput,
+) (*OrgMembershipConnection, error) {
+	opts := []OrgMembershipPaginateOption{
+		WithOrgMembershipOrder(orderBy),
+		WithOrgMembershipFilter(where.Filter),
 	}
-	if IsNotLoaded(err) {
-		result, err = o.QueryMembers().All(ctx)
+	alias := graphql.GetFieldContext(ctx).Field.Alias
+	totalCount, hasTotalCount := o.Edges.totalCount[43][alias]
+	if nodes, err := o.NamedMembers(alias); err == nil || hasTotalCount {
+		pager, err := newOrgMembershipPager(opts, last != nil)
+		if err != nil {
+			return nil, err
+		}
+		conn := &OrgMembershipConnection{Edges: []*OrgMembershipEdge{}, TotalCount: totalCount}
+		conn.build(nodes, pager, after, first, before, last)
+		return conn, nil
 	}
-	return result, err
+	return o.QueryMembers().Paginate(ctx, after, first, before, last, opts...)
 }
 
 func (os *OrganizationSetting) Organization(ctx context.Context) (*Organization, error) {

--- a/internal/ent/schema/organization.go
+++ b/internal/ent/schema/organization.go
@@ -158,7 +158,9 @@ func (o Organization) Edges() []ent.Edge {
 			Ref("organizations").
 			// Skip the mutation input for the users edge
 			// this should be done via the members edge
-			Annotations(entgql.Skip(entgql.SkipMutationCreateInput, entgql.SkipMutationUpdateInput)).
+			Annotations(
+				entgql.Skip(entgql.SkipMutationCreateInput, entgql.SkipMutationUpdateInput),
+				entgql.RelayConnection()).
 			Through("members", OrgMembership.Type),
 
 		// files can be owned by an organization, but don't have to be

--- a/internal/graphapi/clientschema/schema.graphql
+++ b/internal/graphapi/clientschema/schema.graphql
@@ -23457,7 +23457,37 @@ type Organization implements Node {
 		"""
 		where: APITokenWhereInput
 	): APITokenConnection!
-	users: [User!]
+	users(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for Users returned from the connection.
+		"""
+		orderBy: [UserOrder!]
+
+		"""
+		Filtering options for Users returned from the connection.
+		"""
+		where: UserWhereInput
+	): UserConnection!
 	files(
 		"""
 		Returns the elements in the list that come after the specified cursor.
@@ -24266,7 +24296,37 @@ type Organization implements Node {
 		"""
 		where: ActionPlanWhereInput
 	): ActionPlanConnection!
-	members: [OrgMembership!]
+	members(
+		"""
+		Returns the elements in the list that come after the specified cursor.
+		"""
+		after: Cursor
+
+		"""
+		Returns the first _n_ elements from the list.
+		"""
+		first: Int
+
+		"""
+		Returns the elements in the list that come before the specified cursor.
+		"""
+		before: Cursor
+
+		"""
+		Returns the last _n_ elements from the list.
+		"""
+		last: Int
+
+		"""
+		Ordering options for OrgMemberships returned from the connection.
+		"""
+		orderBy: [OrgMembershipOrder!]
+
+		"""
+		Filtering options for OrgMemberships returned from the connection.
+		"""
+		where: OrgMembershipWhereInput
+	): OrgMembershipConnection!
 }
 """
 Return response for createBulkOrganization mutation

--- a/internal/graphapi/generated/root_.generated.go
+++ b/internal/graphapi/generated/root_.generated.go
@@ -2298,7 +2298,7 @@ type ComplexityRoot struct {
 		InternalPolicies         func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.InternalPolicyOrder, where *generated.InternalPolicyWhereInput) int
 		InternalPolicyCreators   func(childComplexity int) int
 		Invites                  func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.InviteOrder, where *generated.InviteWhereInput) int
-		Members                  func(childComplexity int) int
+		Members                  func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.OrgMembershipOrder, where *generated.OrgMembershipWhereInput) int
 		Name                     func(childComplexity int) int
 		NarrativeCreators        func(childComplexity int) int
 		Narratives               func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.NarrativeOrder, where *generated.NarrativeWhereInput) int
@@ -2324,7 +2324,7 @@ type ComplexityRoot struct {
 		Templates                func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.TemplateOrder, where *generated.TemplateWhereInput) int
 		UpdatedAt                func(childComplexity int) int
 		UpdatedBy                func(childComplexity int) int
-		Users                    func(childComplexity int) int
+		Users                    func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.UserOrder, where *generated.UserWhereInput) int
 	}
 
 	OrganizationBulkCreatePayload struct {
@@ -15642,7 +15642,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Organization.Members(childComplexity), true
+		args, err := ec.field_Organization_members_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.Members(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.OrgMembershipOrder), args["where"].(*generated.OrgMembershipWhereInput)), true
 
 	case "Organization.name":
 		if e.complexity.Organization.Name == nil {
@@ -15884,7 +15889,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Organization.Users(childComplexity), true
+		args, err := ec.field_Organization_users_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Organization.Users(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.UserOrder), args["where"].(*generated.UserWhereInput)), true
 
 	case "OrganizationBulkCreatePayload.organizations":
 		if e.complexity.OrganizationBulkCreatePayload.Organizations == nil {
@@ -46316,7 +46326,37 @@ type Organization implements Node {
     """
     where: APITokenWhereInput
   ): APITokenConnection!
-  users: [User!]
+  users(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Users returned from the connection.
+    """
+    orderBy: [UserOrder!]
+
+    """
+    Filtering options for Users returned from the connection.
+    """
+    where: UserWhereInput
+  ): UserConnection!
   files(
     """
     Returns the elements in the list that come after the specified cursor.
@@ -47125,7 +47165,37 @@ type Organization implements Node {
     """
     where: ActionPlanWhereInput
   ): ActionPlanConnection!
-  members: [OrgMembership!]
+  members(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for OrgMemberships returned from the connection.
+    """
+    orderBy: [OrgMembershipOrder!]
+
+    """
+    Filtering options for OrgMemberships returned from the connection.
+    """
+    where: OrgMembershipWhereInput
+  ): OrgMembershipConnection!
 }
 """
 A connection to a list of items.

--- a/internal/graphapi/organization_test.go
+++ b/internal/graphapi/organization_test.go
@@ -80,13 +80,13 @@ func (suite *GraphTestSuite) TestQueryOrganization() {
 			require.NotNil(t, resp)
 			require.NotNil(t, resp.Organization)
 			require.NotNil(t, resp.Organization.Members)
-			assert.Len(t, resp.Organization.Members, tc.orgMembersExpected)
+			assert.Len(t, resp.Organization.Members.Edges, tc.orgMembersExpected)
 
 			if tc.orgMembersExpected > 1 {
 				orgMemberFound := false
 
-				for _, m := range resp.Organization.Members {
-					if m.User.ID == viewOnlyUser.ID {
+				for _, m := range resp.Organization.Members.Edges {
+					if m.Node.User.ID == viewOnlyUser.ID {
 						orgMemberFound = true
 					}
 				}
@@ -560,10 +560,14 @@ func (suite *GraphTestSuite) TestMutationUpdateOrganization() {
 				Name:        nameUpdate,
 				DisplayName: org.DisplayName,
 				Description: &org.Description,
-				Members: []*openlaneclient.UpdateOrganization_UpdateOrganization_Organization_Members{
-					{
-						Role:   enums.RoleAdmin,
-						UserID: user1.ID,
+				Members: openlaneclient.UpdateOrganization_UpdateOrganization_Organization_Members{
+					Edges: []*openlaneclient.UpdateOrganization_UpdateOrganization_Organization_Members_Edges{
+						{
+							Node: &openlaneclient.UpdateOrganization_UpdateOrganization_Organization_Members_Edges_Node{
+								Role:   enums.RoleAdmin,
+								UserID: user1.ID,
+							},
+						},
 					},
 				},
 			},
@@ -772,9 +776,9 @@ func (suite *GraphTestSuite) TestMutationUpdateOrganization() {
 				// Adding a member to an org will make it 3 users, there is an owner
 				// assigned to the org automatically and an another member added in the test and
 				// 3 created as part of the group member logic
-				assert.Len(t, updatedOrg.Members, 6)
-				assert.Equal(t, tc.expectedRes.Members[0].Role, updatedOrg.Members[5].Role)
-				assert.Equal(t, tc.expectedRes.Members[0].UserID, updatedOrg.Members[5].UserID)
+				assert.Len(t, updatedOrg.Members.Edges, 6)
+				assert.Equal(t, tc.expectedRes.Members.Edges[0].Node.Role, updatedOrg.Members.Edges[5].Node.Role)
+				assert.Equal(t, tc.expectedRes.Members.Edges[0].Node.UserID, updatedOrg.Members.Edges[5].Node.UserID)
 			}
 
 			if tc.updateInput.UpdateOrgSettings != nil {

--- a/internal/graphapi/orgmembers_test.go
+++ b/internal/graphapi/orgmembers_test.go
@@ -114,13 +114,6 @@ func (suite *GraphTestSuite) TestMutationCreateOrgMembers() {
 
 	org1 := (&OrganizationBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
-	// allow access to organization
-	checkCtx := privacy.DecisionContext(testUser1.UserCtx, privacy.Allow)
-
-	orgMember, err := org1.Members(checkCtx)
-	require.NoError(t, err)
-	require.Len(t, orgMember, 1)
-
 	userCtx := auth.NewTestContextWithOrgID(testUser1.ID, org1.ID)
 
 	user1 := (&UserBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)

--- a/internal/graphapi/query/organization.graphql
+++ b/internal/graphapi/query/organization.graphql
@@ -74,6 +74,7 @@ mutation CreateOrganizationWithMembers($organizationInput: CreateOrganizationInp
         tags
       }
       members {
+        totalCount
         edges {
           node {
             id
@@ -121,6 +122,7 @@ query GetAllOrganizations {
           }
         }
         members {
+          totalCount
           edges {
             node {
               id
@@ -237,6 +239,7 @@ query GetOrganizationByID($organizationId: ID!) {
       }
     }
     members {
+      totalCount
       edges {
         node {
           id
@@ -353,6 +356,7 @@ query GetOrganizations($where: OrganizationWhereInput) {
           }
         }
         members {
+          totalCount
           edges {
             node {
               id
@@ -463,6 +467,7 @@ mutation UpdateOrganization($updateOrganizationId: ID!, $input: UpdateOrganizati
       }
       tags
       members {
+        totalCount
         edges {
           node {
             id

--- a/internal/graphapi/query/organization.graphql
+++ b/internal/graphapi/query/organization.graphql
@@ -74,12 +74,16 @@ mutation CreateOrganizationWithMembers($organizationInput: CreateOrganizationInp
         tags
       }
       members {
-        id
-        role
-        user {
-          id
-          firstName
-          lastName
+        edges {
+          node {
+            id
+            role
+            user {
+              id
+              firstName
+              lastName
+            }
+          }
         }
       }
     }
@@ -117,12 +121,16 @@ query GetAllOrganizations {
           }
         }
         members {
-          id
-          role
-          user {
-            id
-            firstName
-            lastName
+          edges {
+            node {
+              id
+              role
+              user {
+                id
+                firstName
+                lastName
+              }
+            }
           }
         }
         setting {
@@ -229,12 +237,16 @@ query GetOrganizationByID($organizationId: ID!) {
       }
     }
     members {
-      id
-      role
-      user {
-        id
-        firstName
-        lastName
+      edges {
+        node {
+          id
+          role
+          user {
+            id
+            firstName
+            lastName
+          }
+        }
       }
     }
     setting {
@@ -341,12 +353,16 @@ query GetOrganizations($where: OrganizationWhereInput) {
           }
         }
         members {
-          id
-          role
-          user {
-            id
-            firstName
-            lastName
+          edges {
+            node {
+              id
+              role
+              user {
+                id
+                firstName
+                lastName
+              }
+            }
           }
         }
         setting {
@@ -447,9 +463,13 @@ mutation UpdateOrganization($updateOrganizationId: ID!, $input: UpdateOrganizati
       }
       tags
       members {
-        id
-        role
-        userID
+        edges {
+          node {
+            id
+            role
+            userID
+          }
+        }
       }
       setting {
         id

--- a/internal/graphapi/query/user.graphql
+++ b/internal/graphapi/query/user.graphql
@@ -176,8 +176,12 @@ query GetUserByID($userId: ID!) {
           name
           personalOrg
           members {
-            id
-            role
+            edges {
+              node {
+                id
+                role
+              }
+            }
           }
         }
       }
@@ -226,8 +230,6 @@ query GetUserByIDWithOrgs($userId: ID!) {
     orgMemberships {
       edges {
         node {
-          id
-          role
           id
           role
           user {

--- a/internal/graphapi/schema/ent.graphql
+++ b/internal/graphapi/schema/ent.graphql
@@ -20690,7 +20690,37 @@ type Organization implements Node {
     """
     where: APITokenWhereInput
   ): APITokenConnection!
-  users: [User!]
+  users(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for Users returned from the connection.
+    """
+    orderBy: [UserOrder!]
+
+    """
+    Filtering options for Users returned from the connection.
+    """
+    where: UserWhereInput
+  ): UserConnection!
   files(
     """
     Returns the elements in the list that come after the specified cursor.
@@ -21499,7 +21529,37 @@ type Organization implements Node {
     """
     where: ActionPlanWhereInput
   ): ActionPlanConnection!
-  members: [OrgMembership!]
+  members(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: Cursor
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: Cursor
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    Ordering options for OrgMemberships returned from the connection.
+    """
+    orderBy: [OrgMembershipOrder!]
+
+    """
+    Filtering options for OrgMemberships returned from the connection.
+    """
+    where: OrgMembershipWhereInput
+  ): OrgMembershipConnection!
 }
 """
 A connection to a list of items.

--- a/pkg/openlaneclient/graphclient.go
+++ b/pkg/openlaneclient/graphclient.go
@@ -34163,62 +34163,84 @@ func (t *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organizatio
 	return t.UpdatedBy
 }
 
-type CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_User struct {
+type CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_Edges_Node_User struct {
 	FirstName *string "json:\"firstName,omitempty\" graphql:\"firstName\""
 	ID        string  "json:\"id\" graphql:\"id\""
 	LastName  *string "json:\"lastName,omitempty\" graphql:\"lastName\""
 }
 
-func (t *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_User) GetFirstName() *string {
+func (t *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_Edges_Node_User) GetFirstName() *string {
 	if t == nil {
-		t = &CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_User{}
+		t = &CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_Edges_Node_User{}
 	}
 	return t.FirstName
 }
-func (t *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_User) GetID() string {
+func (t *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_Edges_Node_User) GetID() string {
 	if t == nil {
-		t = &CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_User{}
+		t = &CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_Edges_Node_User{}
 	}
 	return t.ID
 }
-func (t *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_User) GetLastName() *string {
+func (t *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_Edges_Node_User) GetLastName() *string {
 	if t == nil {
-		t = &CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_User{}
+		t = &CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_Edges_Node_User{}
 	}
 	return t.LastName
 }
 
-type CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members struct {
-	ID   string                                                                                "json:\"id\" graphql:\"id\""
-	Role enums.Role                                                                            "json:\"role\" graphql:\"role\""
-	User CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_User "json:\"user\" graphql:\"user\""
+type CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_Edges_Node struct {
+	ID   string                                                                                           "json:\"id\" graphql:\"id\""
+	Role enums.Role                                                                                       "json:\"role\" graphql:\"role\""
+	User CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_Edges_Node_User "json:\"user\" graphql:\"user\""
 }
 
-func (t *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members) GetID() string {
+func (t *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_Edges_Node) GetID() string {
 	if t == nil {
-		t = &CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members{}
+		t = &CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members) GetRole() *enums.Role {
+func (t *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_Edges_Node) GetRole() *enums.Role {
 	if t == nil {
-		t = &CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members{}
+		t = &CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_Edges_Node{}
 	}
 	return &t.Role
 }
-func (t *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members) GetUser() *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_User {
+func (t *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_Edges_Node) GetUser() *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_Edges_Node_User {
 	if t == nil {
-		t = &CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members{}
+		t = &CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_Edges_Node{}
 	}
 	return &t.User
 }
 
+type CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_Edges struct {
+	Node *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_Edges) GetNode() *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_Edges_Node {
+	if t == nil {
+		t = &CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_Edges{}
+	}
+	return t.Node
+}
+
+type CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members struct {
+	Edges []*CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members) GetEdges() []*CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_Edges {
+	if t == nil {
+		t = &CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members{}
+	}
+	return t.Edges
+}
+
 type CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization struct {
-	DisplayName string                                                                              "json:\"displayName\" graphql:\"displayName\""
-	ID          string                                                                              "json:\"id\" graphql:\"id\""
-	Members     []*CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members "json:\"members,omitempty\" graphql:\"members\""
-	Name        string                                                                              "json:\"name\" graphql:\"name\""
-	Setting     *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Setting   "json:\"setting,omitempty\" graphql:\"setting\""
+	DisplayName string                                                                            "json:\"displayName\" graphql:\"displayName\""
+	ID          string                                                                            "json:\"id\" graphql:\"id\""
+	Members     CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members  "json:\"members\" graphql:\"members\""
+	Name        string                                                                            "json:\"name\" graphql:\"name\""
+	Setting     *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Setting "json:\"setting,omitempty\" graphql:\"setting\""
 }
 
 func (t *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization) GetDisplayName() string {
@@ -34233,11 +34255,11 @@ func (t *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organizatio
 	}
 	return t.ID
 }
-func (t *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization) GetMembers() []*CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members {
+func (t *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization) GetMembers() *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members {
 	if t == nil {
 		t = &CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization{}
 	}
-	return t.Members
+	return &t.Members
 }
 func (t *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization) GetName() string {
 	if t == nil {
@@ -34346,54 +34368,76 @@ func (t *GetAllOrganizations_Organizations_Edges_Node_Children) GetEdges() []*Ge
 	return t.Edges
 }
 
-type GetAllOrganizations_Organizations_Edges_Node_Members_User struct {
+type GetAllOrganizations_Organizations_Edges_Node_Members_Edges_Node_User struct {
 	FirstName *string "json:\"firstName,omitempty\" graphql:\"firstName\""
 	ID        string  "json:\"id\" graphql:\"id\""
 	LastName  *string "json:\"lastName,omitempty\" graphql:\"lastName\""
 }
 
-func (t *GetAllOrganizations_Organizations_Edges_Node_Members_User) GetFirstName() *string {
+func (t *GetAllOrganizations_Organizations_Edges_Node_Members_Edges_Node_User) GetFirstName() *string {
 	if t == nil {
-		t = &GetAllOrganizations_Organizations_Edges_Node_Members_User{}
+		t = &GetAllOrganizations_Organizations_Edges_Node_Members_Edges_Node_User{}
 	}
 	return t.FirstName
 }
-func (t *GetAllOrganizations_Organizations_Edges_Node_Members_User) GetID() string {
+func (t *GetAllOrganizations_Organizations_Edges_Node_Members_Edges_Node_User) GetID() string {
 	if t == nil {
-		t = &GetAllOrganizations_Organizations_Edges_Node_Members_User{}
+		t = &GetAllOrganizations_Organizations_Edges_Node_Members_Edges_Node_User{}
 	}
 	return t.ID
 }
-func (t *GetAllOrganizations_Organizations_Edges_Node_Members_User) GetLastName() *string {
+func (t *GetAllOrganizations_Organizations_Edges_Node_Members_Edges_Node_User) GetLastName() *string {
 	if t == nil {
-		t = &GetAllOrganizations_Organizations_Edges_Node_Members_User{}
+		t = &GetAllOrganizations_Organizations_Edges_Node_Members_Edges_Node_User{}
 	}
 	return t.LastName
 }
 
-type GetAllOrganizations_Organizations_Edges_Node_Members struct {
-	ID   string                                                    "json:\"id\" graphql:\"id\""
-	Role enums.Role                                                "json:\"role\" graphql:\"role\""
-	User GetAllOrganizations_Organizations_Edges_Node_Members_User "json:\"user\" graphql:\"user\""
+type GetAllOrganizations_Organizations_Edges_Node_Members_Edges_Node struct {
+	ID   string                                                               "json:\"id\" graphql:\"id\""
+	Role enums.Role                                                           "json:\"role\" graphql:\"role\""
+	User GetAllOrganizations_Organizations_Edges_Node_Members_Edges_Node_User "json:\"user\" graphql:\"user\""
 }
 
-func (t *GetAllOrganizations_Organizations_Edges_Node_Members) GetID() string {
+func (t *GetAllOrganizations_Organizations_Edges_Node_Members_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetAllOrganizations_Organizations_Edges_Node_Members{}
+		t = &GetAllOrganizations_Organizations_Edges_Node_Members_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetAllOrganizations_Organizations_Edges_Node_Members) GetRole() *enums.Role {
+func (t *GetAllOrganizations_Organizations_Edges_Node_Members_Edges_Node) GetRole() *enums.Role {
 	if t == nil {
-		t = &GetAllOrganizations_Organizations_Edges_Node_Members{}
+		t = &GetAllOrganizations_Organizations_Edges_Node_Members_Edges_Node{}
 	}
 	return &t.Role
 }
-func (t *GetAllOrganizations_Organizations_Edges_Node_Members) GetUser() *GetAllOrganizations_Organizations_Edges_Node_Members_User {
+func (t *GetAllOrganizations_Organizations_Edges_Node_Members_Edges_Node) GetUser() *GetAllOrganizations_Organizations_Edges_Node_Members_Edges_Node_User {
+	if t == nil {
+		t = &GetAllOrganizations_Organizations_Edges_Node_Members_Edges_Node{}
+	}
+	return &t.User
+}
+
+type GetAllOrganizations_Organizations_Edges_Node_Members_Edges struct {
+	Node *GetAllOrganizations_Organizations_Edges_Node_Members_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetAllOrganizations_Organizations_Edges_Node_Members_Edges) GetNode() *GetAllOrganizations_Organizations_Edges_Node_Members_Edges_Node {
+	if t == nil {
+		t = &GetAllOrganizations_Organizations_Edges_Node_Members_Edges{}
+	}
+	return t.Node
+}
+
+type GetAllOrganizations_Organizations_Edges_Node_Members struct {
+	Edges []*GetAllOrganizations_Organizations_Edges_Node_Members_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetAllOrganizations_Organizations_Edges_Node_Members) GetEdges() []*GetAllOrganizations_Organizations_Edges_Node_Members_Edges {
 	if t == nil {
 		t = &GetAllOrganizations_Organizations_Edges_Node_Members{}
 	}
-	return &t.User
+	return t.Edges
 }
 
 type GetAllOrganizations_Organizations_Edges_Node_Setting struct {
@@ -34809,7 +34853,7 @@ type GetAllOrganizations_Organizations_Edges_Node struct {
 	DisplayName              string                                                                   "json:\"displayName\" graphql:\"displayName\""
 	ID                       string                                                                   "json:\"id\" graphql:\"id\""
 	InternalPolicyCreators   []*GetAllOrganizations_Organizations_Edges_Node_InternalPolicyCreators   "json:\"internalPolicyCreators,omitempty\" graphql:\"internalPolicyCreators\""
-	Members                  []*GetAllOrganizations_Organizations_Edges_Node_Members                  "json:\"members,omitempty\" graphql:\"members\""
+	Members                  GetAllOrganizations_Organizations_Edges_Node_Members                     "json:\"members\" graphql:\"members\""
 	Name                     string                                                                   "json:\"name\" graphql:\"name\""
 	NarrativeCreators        []*GetAllOrganizations_Organizations_Edges_Node_NarrativeCreators        "json:\"narrativeCreators,omitempty\" graphql:\"narrativeCreators\""
 	OrgSubscriptions         []*GetAllOrganizations_Organizations_Edges_Node_OrgSubscriptions         "json:\"orgSubscriptions,omitempty\" graphql:\"orgSubscriptions\""
@@ -34872,11 +34916,11 @@ func (t *GetAllOrganizations_Organizations_Edges_Node) GetInternalPolicyCreators
 	}
 	return t.InternalPolicyCreators
 }
-func (t *GetAllOrganizations_Organizations_Edges_Node) GetMembers() []*GetAllOrganizations_Organizations_Edges_Node_Members {
+func (t *GetAllOrganizations_Organizations_Edges_Node) GetMembers() *GetAllOrganizations_Organizations_Edges_Node_Members {
 	if t == nil {
 		t = &GetAllOrganizations_Organizations_Edges_Node{}
 	}
-	return t.Members
+	return &t.Members
 }
 func (t *GetAllOrganizations_Organizations_Edges_Node) GetName() string {
 	if t == nil {
@@ -35045,54 +35089,76 @@ func (t *GetOrganizationByID_Organization_Children) GetEdges() []*GetOrganizatio
 	return t.Edges
 }
 
-type GetOrganizationByID_Organization_Members_User struct {
+type GetOrganizationByID_Organization_Members_Edges_Node_User struct {
 	FirstName *string "json:\"firstName,omitempty\" graphql:\"firstName\""
 	ID        string  "json:\"id\" graphql:\"id\""
 	LastName  *string "json:\"lastName,omitempty\" graphql:\"lastName\""
 }
 
-func (t *GetOrganizationByID_Organization_Members_User) GetFirstName() *string {
+func (t *GetOrganizationByID_Organization_Members_Edges_Node_User) GetFirstName() *string {
 	if t == nil {
-		t = &GetOrganizationByID_Organization_Members_User{}
+		t = &GetOrganizationByID_Organization_Members_Edges_Node_User{}
 	}
 	return t.FirstName
 }
-func (t *GetOrganizationByID_Organization_Members_User) GetID() string {
+func (t *GetOrganizationByID_Organization_Members_Edges_Node_User) GetID() string {
 	if t == nil {
-		t = &GetOrganizationByID_Organization_Members_User{}
+		t = &GetOrganizationByID_Organization_Members_Edges_Node_User{}
 	}
 	return t.ID
 }
-func (t *GetOrganizationByID_Organization_Members_User) GetLastName() *string {
+func (t *GetOrganizationByID_Organization_Members_Edges_Node_User) GetLastName() *string {
 	if t == nil {
-		t = &GetOrganizationByID_Organization_Members_User{}
+		t = &GetOrganizationByID_Organization_Members_Edges_Node_User{}
 	}
 	return t.LastName
 }
 
-type GetOrganizationByID_Organization_Members struct {
-	ID   string                                        "json:\"id\" graphql:\"id\""
-	Role enums.Role                                    "json:\"role\" graphql:\"role\""
-	User GetOrganizationByID_Organization_Members_User "json:\"user\" graphql:\"user\""
+type GetOrganizationByID_Organization_Members_Edges_Node struct {
+	ID   string                                                   "json:\"id\" graphql:\"id\""
+	Role enums.Role                                               "json:\"role\" graphql:\"role\""
+	User GetOrganizationByID_Organization_Members_Edges_Node_User "json:\"user\" graphql:\"user\""
 }
 
-func (t *GetOrganizationByID_Organization_Members) GetID() string {
+func (t *GetOrganizationByID_Organization_Members_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetOrganizationByID_Organization_Members{}
+		t = &GetOrganizationByID_Organization_Members_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetOrganizationByID_Organization_Members) GetRole() *enums.Role {
+func (t *GetOrganizationByID_Organization_Members_Edges_Node) GetRole() *enums.Role {
 	if t == nil {
-		t = &GetOrganizationByID_Organization_Members{}
+		t = &GetOrganizationByID_Organization_Members_Edges_Node{}
 	}
 	return &t.Role
 }
-func (t *GetOrganizationByID_Organization_Members) GetUser() *GetOrganizationByID_Organization_Members_User {
+func (t *GetOrganizationByID_Organization_Members_Edges_Node) GetUser() *GetOrganizationByID_Organization_Members_Edges_Node_User {
+	if t == nil {
+		t = &GetOrganizationByID_Organization_Members_Edges_Node{}
+	}
+	return &t.User
+}
+
+type GetOrganizationByID_Organization_Members_Edges struct {
+	Node *GetOrganizationByID_Organization_Members_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetOrganizationByID_Organization_Members_Edges) GetNode() *GetOrganizationByID_Organization_Members_Edges_Node {
+	if t == nil {
+		t = &GetOrganizationByID_Organization_Members_Edges{}
+	}
+	return t.Node
+}
+
+type GetOrganizationByID_Organization_Members struct {
+	Edges []*GetOrganizationByID_Organization_Members_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetOrganizationByID_Organization_Members) GetEdges() []*GetOrganizationByID_Organization_Members_Edges {
 	if t == nil {
 		t = &GetOrganizationByID_Organization_Members{}
 	}
-	return &t.User
+	return t.Edges
 }
 
 type GetOrganizationByID_Organization_Setting struct {
@@ -35511,7 +35577,7 @@ type GetOrganizationByID_Organization struct {
 	DisplayName              string                                                       "json:\"displayName\" graphql:\"displayName\""
 	ID                       string                                                       "json:\"id\" graphql:\"id\""
 	InternalPolicyCreators   []*GetOrganizationByID_Organization_InternalPolicyCreators   "json:\"internalPolicyCreators,omitempty\" graphql:\"internalPolicyCreators\""
-	Members                  []*GetOrganizationByID_Organization_Members                  "json:\"members,omitempty\" graphql:\"members\""
+	Members                  GetOrganizationByID_Organization_Members                     "json:\"members\" graphql:\"members\""
 	Name                     string                                                       "json:\"name\" graphql:\"name\""
 	NarrativeCreators        []*GetOrganizationByID_Organization_NarrativeCreators        "json:\"narrativeCreators,omitempty\" graphql:\"narrativeCreators\""
 	OrgSubscriptions         []*GetOrganizationByID_Organization_OrgSubscriptions         "json:\"orgSubscriptions,omitempty\" graphql:\"orgSubscriptions\""
@@ -35593,11 +35659,11 @@ func (t *GetOrganizationByID_Organization) GetInternalPolicyCreators() []*GetOrg
 	}
 	return t.InternalPolicyCreators
 }
-func (t *GetOrganizationByID_Organization) GetMembers() []*GetOrganizationByID_Organization_Members {
+func (t *GetOrganizationByID_Organization) GetMembers() *GetOrganizationByID_Organization_Members {
 	if t == nil {
 		t = &GetOrganizationByID_Organization{}
 	}
-	return t.Members
+	return &t.Members
 }
 func (t *GetOrganizationByID_Organization) GetName() string {
 	if t == nil {
@@ -35750,54 +35816,76 @@ func (t *GetOrganizations_Organizations_Edges_Node_Children) GetEdges() []*GetOr
 	return t.Edges
 }
 
-type GetOrganizations_Organizations_Edges_Node_Members_User struct {
+type GetOrganizations_Organizations_Edges_Node_Members_Edges_Node_User struct {
 	FirstName *string "json:\"firstName,omitempty\" graphql:\"firstName\""
 	ID        string  "json:\"id\" graphql:\"id\""
 	LastName  *string "json:\"lastName,omitempty\" graphql:\"lastName\""
 }
 
-func (t *GetOrganizations_Organizations_Edges_Node_Members_User) GetFirstName() *string {
+func (t *GetOrganizations_Organizations_Edges_Node_Members_Edges_Node_User) GetFirstName() *string {
 	if t == nil {
-		t = &GetOrganizations_Organizations_Edges_Node_Members_User{}
+		t = &GetOrganizations_Organizations_Edges_Node_Members_Edges_Node_User{}
 	}
 	return t.FirstName
 }
-func (t *GetOrganizations_Organizations_Edges_Node_Members_User) GetID() string {
+func (t *GetOrganizations_Organizations_Edges_Node_Members_Edges_Node_User) GetID() string {
 	if t == nil {
-		t = &GetOrganizations_Organizations_Edges_Node_Members_User{}
+		t = &GetOrganizations_Organizations_Edges_Node_Members_Edges_Node_User{}
 	}
 	return t.ID
 }
-func (t *GetOrganizations_Organizations_Edges_Node_Members_User) GetLastName() *string {
+func (t *GetOrganizations_Organizations_Edges_Node_Members_Edges_Node_User) GetLastName() *string {
 	if t == nil {
-		t = &GetOrganizations_Organizations_Edges_Node_Members_User{}
+		t = &GetOrganizations_Organizations_Edges_Node_Members_Edges_Node_User{}
 	}
 	return t.LastName
 }
 
-type GetOrganizations_Organizations_Edges_Node_Members struct {
-	ID   string                                                 "json:\"id\" graphql:\"id\""
-	Role enums.Role                                             "json:\"role\" graphql:\"role\""
-	User GetOrganizations_Organizations_Edges_Node_Members_User "json:\"user\" graphql:\"user\""
+type GetOrganizations_Organizations_Edges_Node_Members_Edges_Node struct {
+	ID   string                                                            "json:\"id\" graphql:\"id\""
+	Role enums.Role                                                        "json:\"role\" graphql:\"role\""
+	User GetOrganizations_Organizations_Edges_Node_Members_Edges_Node_User "json:\"user\" graphql:\"user\""
 }
 
-func (t *GetOrganizations_Organizations_Edges_Node_Members) GetID() string {
+func (t *GetOrganizations_Organizations_Edges_Node_Members_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetOrganizations_Organizations_Edges_Node_Members{}
+		t = &GetOrganizations_Organizations_Edges_Node_Members_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetOrganizations_Organizations_Edges_Node_Members) GetRole() *enums.Role {
+func (t *GetOrganizations_Organizations_Edges_Node_Members_Edges_Node) GetRole() *enums.Role {
 	if t == nil {
-		t = &GetOrganizations_Organizations_Edges_Node_Members{}
+		t = &GetOrganizations_Organizations_Edges_Node_Members_Edges_Node{}
 	}
 	return &t.Role
 }
-func (t *GetOrganizations_Organizations_Edges_Node_Members) GetUser() *GetOrganizations_Organizations_Edges_Node_Members_User {
+func (t *GetOrganizations_Organizations_Edges_Node_Members_Edges_Node) GetUser() *GetOrganizations_Organizations_Edges_Node_Members_Edges_Node_User {
+	if t == nil {
+		t = &GetOrganizations_Organizations_Edges_Node_Members_Edges_Node{}
+	}
+	return &t.User
+}
+
+type GetOrganizations_Organizations_Edges_Node_Members_Edges struct {
+	Node *GetOrganizations_Organizations_Edges_Node_Members_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetOrganizations_Organizations_Edges_Node_Members_Edges) GetNode() *GetOrganizations_Organizations_Edges_Node_Members_Edges_Node {
+	if t == nil {
+		t = &GetOrganizations_Organizations_Edges_Node_Members_Edges{}
+	}
+	return t.Node
+}
+
+type GetOrganizations_Organizations_Edges_Node_Members struct {
+	Edges []*GetOrganizations_Organizations_Edges_Node_Members_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetOrganizations_Organizations_Edges_Node_Members) GetEdges() []*GetOrganizations_Organizations_Edges_Node_Members_Edges {
 	if t == nil {
 		t = &GetOrganizations_Organizations_Edges_Node_Members{}
 	}
-	return &t.User
+	return t.Edges
 }
 
 type GetOrganizations_Organizations_Edges_Node_Setting struct {
@@ -36213,7 +36301,7 @@ type GetOrganizations_Organizations_Edges_Node struct {
 	DisplayName              string                                                                "json:\"displayName\" graphql:\"displayName\""
 	ID                       string                                                                "json:\"id\" graphql:\"id\""
 	InternalPolicyCreators   []*GetOrganizations_Organizations_Edges_Node_InternalPolicyCreators   "json:\"internalPolicyCreators,omitempty\" graphql:\"internalPolicyCreators\""
-	Members                  []*GetOrganizations_Organizations_Edges_Node_Members                  "json:\"members,omitempty\" graphql:\"members\""
+	Members                  GetOrganizations_Organizations_Edges_Node_Members                     "json:\"members\" graphql:\"members\""
 	Name                     string                                                                "json:\"name\" graphql:\"name\""
 	NarrativeCreators        []*GetOrganizations_Organizations_Edges_Node_NarrativeCreators        "json:\"narrativeCreators,omitempty\" graphql:\"narrativeCreators\""
 	OrgSubscriptions         []*GetOrganizations_Organizations_Edges_Node_OrgSubscriptions         "json:\"orgSubscriptions,omitempty\" graphql:\"orgSubscriptions\""
@@ -36276,11 +36364,11 @@ func (t *GetOrganizations_Organizations_Edges_Node) GetInternalPolicyCreators() 
 	}
 	return t.InternalPolicyCreators
 }
-func (t *GetOrganizations_Organizations_Edges_Node) GetMembers() []*GetOrganizations_Organizations_Edges_Node_Members {
+func (t *GetOrganizations_Organizations_Edges_Node) GetMembers() *GetOrganizations_Organizations_Edges_Node_Members {
 	if t == nil {
 		t = &GetOrganizations_Organizations_Edges_Node{}
 	}
-	return t.Members
+	return &t.Members
 }
 func (t *GetOrganizations_Organizations_Edges_Node) GetName() string {
 	if t == nil {
@@ -36388,29 +36476,51 @@ func (t *UpdateOrganization_UpdateOrganization_Organization_AvatarFile) GetPresi
 	return t.PresignedURL
 }
 
-type UpdateOrganization_UpdateOrganization_Organization_Members struct {
+type UpdateOrganization_UpdateOrganization_Organization_Members_Edges_Node struct {
 	ID     string     "json:\"id\" graphql:\"id\""
 	Role   enums.Role "json:\"role\" graphql:\"role\""
 	UserID string     "json:\"userID\" graphql:\"userID\""
 }
 
-func (t *UpdateOrganization_UpdateOrganization_Organization_Members) GetID() string {
+func (t *UpdateOrganization_UpdateOrganization_Organization_Members_Edges_Node) GetID() string {
 	if t == nil {
-		t = &UpdateOrganization_UpdateOrganization_Organization_Members{}
+		t = &UpdateOrganization_UpdateOrganization_Organization_Members_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *UpdateOrganization_UpdateOrganization_Organization_Members) GetRole() *enums.Role {
+func (t *UpdateOrganization_UpdateOrganization_Organization_Members_Edges_Node) GetRole() *enums.Role {
 	if t == nil {
-		t = &UpdateOrganization_UpdateOrganization_Organization_Members{}
+		t = &UpdateOrganization_UpdateOrganization_Organization_Members_Edges_Node{}
 	}
 	return &t.Role
 }
-func (t *UpdateOrganization_UpdateOrganization_Organization_Members) GetUserID() string {
+func (t *UpdateOrganization_UpdateOrganization_Organization_Members_Edges_Node) GetUserID() string {
+	if t == nil {
+		t = &UpdateOrganization_UpdateOrganization_Organization_Members_Edges_Node{}
+	}
+	return t.UserID
+}
+
+type UpdateOrganization_UpdateOrganization_Organization_Members_Edges struct {
+	Node *UpdateOrganization_UpdateOrganization_Organization_Members_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *UpdateOrganization_UpdateOrganization_Organization_Members_Edges) GetNode() *UpdateOrganization_UpdateOrganization_Organization_Members_Edges_Node {
+	if t == nil {
+		t = &UpdateOrganization_UpdateOrganization_Organization_Members_Edges{}
+	}
+	return t.Node
+}
+
+type UpdateOrganization_UpdateOrganization_Organization_Members struct {
+	Edges []*UpdateOrganization_UpdateOrganization_Organization_Members_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *UpdateOrganization_UpdateOrganization_Organization_Members) GetEdges() []*UpdateOrganization_UpdateOrganization_Organization_Members_Edges {
 	if t == nil {
 		t = &UpdateOrganization_UpdateOrganization_Organization_Members{}
 	}
-	return t.UserID
+	return t.Edges
 }
 
 type UpdateOrganization_UpdateOrganization_Organization_Setting struct {
@@ -36827,7 +36937,7 @@ type UpdateOrganization_UpdateOrganization_Organization struct {
 	DisplayName              string                                                                         "json:\"displayName\" graphql:\"displayName\""
 	ID                       string                                                                         "json:\"id\" graphql:\"id\""
 	InternalPolicyCreators   []*UpdateOrganization_UpdateOrganization_Organization_InternalPolicyCreators   "json:\"internalPolicyCreators,omitempty\" graphql:\"internalPolicyCreators\""
-	Members                  []*UpdateOrganization_UpdateOrganization_Organization_Members                  "json:\"members,omitempty\" graphql:\"members\""
+	Members                  UpdateOrganization_UpdateOrganization_Organization_Members                     "json:\"members\" graphql:\"members\""
 	Name                     string                                                                         "json:\"name\" graphql:\"name\""
 	NarrativeCreators        []*UpdateOrganization_UpdateOrganization_Organization_NarrativeCreators        "json:\"narrativeCreators,omitempty\" graphql:\"narrativeCreators\""
 	OrgSubscriptions         []*UpdateOrganization_UpdateOrganization_Organization_OrgSubscriptions         "json:\"orgSubscriptions,omitempty\" graphql:\"orgSubscriptions\""
@@ -36894,11 +37004,11 @@ func (t *UpdateOrganization_UpdateOrganization_Organization) GetInternalPolicyCr
 	}
 	return t.InternalPolicyCreators
 }
-func (t *UpdateOrganization_UpdateOrganization_Organization) GetMembers() []*UpdateOrganization_UpdateOrganization_Organization_Members {
+func (t *UpdateOrganization_UpdateOrganization_Organization) GetMembers() *UpdateOrganization_UpdateOrganization_Organization_Members {
 	if t == nil {
 		t = &UpdateOrganization_UpdateOrganization_Organization{}
 	}
-	return t.Members
+	return &t.Members
 }
 func (t *UpdateOrganization_UpdateOrganization_Organization) GetName() string {
 	if t == nil {
@@ -59747,29 +59857,51 @@ func (t *GetUserByID_User_Setting) GetUpdatedBy() *string {
 	return t.UpdatedBy
 }
 
-type GetUserByID_User_Organizations_Edges_Node_Members struct {
+type GetUserByID_User_Organizations_Edges_Node_Members_Edges_Node struct {
 	ID   string     "json:\"id\" graphql:\"id\""
 	Role enums.Role "json:\"role\" graphql:\"role\""
 }
 
-func (t *GetUserByID_User_Organizations_Edges_Node_Members) GetID() string {
+func (t *GetUserByID_User_Organizations_Edges_Node_Members_Edges_Node) GetID() string {
 	if t == nil {
-		t = &GetUserByID_User_Organizations_Edges_Node_Members{}
+		t = &GetUserByID_User_Organizations_Edges_Node_Members_Edges_Node{}
 	}
 	return t.ID
 }
-func (t *GetUserByID_User_Organizations_Edges_Node_Members) GetRole() *enums.Role {
+func (t *GetUserByID_User_Organizations_Edges_Node_Members_Edges_Node) GetRole() *enums.Role {
 	if t == nil {
-		t = &GetUserByID_User_Organizations_Edges_Node_Members{}
+		t = &GetUserByID_User_Organizations_Edges_Node_Members_Edges_Node{}
 	}
 	return &t.Role
 }
 
+type GetUserByID_User_Organizations_Edges_Node_Members_Edges struct {
+	Node *GetUserByID_User_Organizations_Edges_Node_Members_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetUserByID_User_Organizations_Edges_Node_Members_Edges) GetNode() *GetUserByID_User_Organizations_Edges_Node_Members_Edges_Node {
+	if t == nil {
+		t = &GetUserByID_User_Organizations_Edges_Node_Members_Edges{}
+	}
+	return t.Node
+}
+
+type GetUserByID_User_Organizations_Edges_Node_Members struct {
+	Edges []*GetUserByID_User_Organizations_Edges_Node_Members_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetUserByID_User_Organizations_Edges_Node_Members) GetEdges() []*GetUserByID_User_Organizations_Edges_Node_Members_Edges {
+	if t == nil {
+		t = &GetUserByID_User_Organizations_Edges_Node_Members{}
+	}
+	return t.Edges
+}
+
 type GetUserByID_User_Organizations_Edges_Node struct {
-	ID          string                                               "json:\"id\" graphql:\"id\""
-	Members     []*GetUserByID_User_Organizations_Edges_Node_Members "json:\"members,omitempty\" graphql:\"members\""
-	Name        string                                               "json:\"name\" graphql:\"name\""
-	PersonalOrg *bool                                                "json:\"personalOrg,omitempty\" graphql:\"personalOrg\""
+	ID          string                                            "json:\"id\" graphql:\"id\""
+	Members     GetUserByID_User_Organizations_Edges_Node_Members "json:\"members\" graphql:\"members\""
+	Name        string                                            "json:\"name\" graphql:\"name\""
+	PersonalOrg *bool                                             "json:\"personalOrg,omitempty\" graphql:\"personalOrg\""
 }
 
 func (t *GetUserByID_User_Organizations_Edges_Node) GetID() string {
@@ -59778,11 +59910,11 @@ func (t *GetUserByID_User_Organizations_Edges_Node) GetID() string {
 	}
 	return t.ID
 }
-func (t *GetUserByID_User_Organizations_Edges_Node) GetMembers() []*GetUserByID_User_Organizations_Edges_Node_Members {
+func (t *GetUserByID_User_Organizations_Edges_Node) GetMembers() *GetUserByID_User_Organizations_Edges_Node_Members {
 	if t == nil {
 		t = &GetUserByID_User_Organizations_Edges_Node{}
 	}
-	return t.Members
+	return &t.Members
 }
 func (t *GetUserByID_User_Organizations_Edges_Node) GetName() string {
 	if t == nil {
@@ -75098,12 +75230,16 @@ const CreateOrganizationWithMembersDocument = `mutation CreateOrganizationWithMe
 				tags
 			}
 			members {
-				id
-				role
-				user {
-					id
-					firstName
-					lastName
+				edges {
+					node {
+						id
+						role
+						user {
+							id
+							firstName
+							lastName
+						}
+					}
 				}
 			}
 		}
@@ -75178,12 +75314,16 @@ const GetAllOrganizationsDocument = `query GetAllOrganizations {
 					}
 				}
 				members {
-					id
-					role
-					user {
-						id
-						firstName
-						lastName
+					edges {
+						node {
+							id
+							role
+							user {
+								id
+								firstName
+								lastName
+							}
+						}
 					}
 				}
 				setting {
@@ -75306,12 +75446,16 @@ const GetOrganizationByIDDocument = `query GetOrganizationByID ($organizationId:
 			}
 		}
 		members {
-			id
-			role
-			user {
-				id
-				firstName
-				lastName
+			edges {
+				node {
+					id
+					role
+					user {
+						id
+						firstName
+						lastName
+					}
+				}
 			}
 		}
 		setting {
@@ -75436,12 +75580,16 @@ const GetOrganizationsDocument = `query GetOrganizations ($where: OrganizationWh
 					}
 				}
 				members {
-					id
-					role
-					user {
-						id
-						firstName
-						lastName
+					edges {
+						node {
+							id
+							role
+							user {
+								id
+								firstName
+								lastName
+							}
+						}
 					}
 				}
 				setting {
@@ -75556,9 +75704,13 @@ const UpdateOrganizationDocument = `mutation UpdateOrganization ($updateOrganiza
 			}
 			tags
 			members {
-				id
-				role
-				userID
+				edges {
+					node {
+						id
+						role
+						userID
+					}
+				}
 			}
 			setting {
 				id
@@ -82038,8 +82190,12 @@ const GetUserByIDDocument = `query GetUserByID ($userId: ID!) {
 					name
 					personalOrg
 					members {
-						id
-						role
+						edges {
+							node {
+								id
+								role
+							}
+						}
 					}
 				}
 			}
@@ -82106,8 +82262,6 @@ const GetUserByIDWithOrgsDocument = `query GetUserByIDWithOrgs ($userId: ID!) {
 		orgMemberships {
 			edges {
 				node {
-					id
-					role
 					id
 					role
 					user {

--- a/pkg/openlaneclient/graphclient.go
+++ b/pkg/openlaneclient/graphclient.go
@@ -34225,7 +34225,8 @@ func (t *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organizatio
 }
 
 type CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members struct {
-	Edges []*CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+	Edges      []*CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+	TotalCount int64                                                                                     "json:\"totalCount\" graphql:\"totalCount\""
 }
 
 func (t *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members) GetEdges() []*CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members_Edges {
@@ -34233,6 +34234,12 @@ func (t *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organizatio
 		t = &CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members{}
 	}
 	return t.Edges
+}
+func (t *CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members) GetTotalCount() int64 {
+	if t == nil {
+		t = &CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization_Members{}
+	}
+	return t.TotalCount
 }
 
 type CreateOrganizationWithMembers_CreateOrganizationWithMembers_Organization struct {
@@ -34430,7 +34437,8 @@ func (t *GetAllOrganizations_Organizations_Edges_Node_Members_Edges) GetNode() *
 }
 
 type GetAllOrganizations_Organizations_Edges_Node_Members struct {
-	Edges []*GetAllOrganizations_Organizations_Edges_Node_Members_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+	Edges      []*GetAllOrganizations_Organizations_Edges_Node_Members_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+	TotalCount int64                                                         "json:\"totalCount\" graphql:\"totalCount\""
 }
 
 func (t *GetAllOrganizations_Organizations_Edges_Node_Members) GetEdges() []*GetAllOrganizations_Organizations_Edges_Node_Members_Edges {
@@ -34438,6 +34446,12 @@ func (t *GetAllOrganizations_Organizations_Edges_Node_Members) GetEdges() []*Get
 		t = &GetAllOrganizations_Organizations_Edges_Node_Members{}
 	}
 	return t.Edges
+}
+func (t *GetAllOrganizations_Organizations_Edges_Node_Members) GetTotalCount() int64 {
+	if t == nil {
+		t = &GetAllOrganizations_Organizations_Edges_Node_Members{}
+	}
+	return t.TotalCount
 }
 
 type GetAllOrganizations_Organizations_Edges_Node_Setting struct {
@@ -35151,7 +35165,8 @@ func (t *GetOrganizationByID_Organization_Members_Edges) GetNode() *GetOrganizat
 }
 
 type GetOrganizationByID_Organization_Members struct {
-	Edges []*GetOrganizationByID_Organization_Members_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+	Edges      []*GetOrganizationByID_Organization_Members_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+	TotalCount int64                                             "json:\"totalCount\" graphql:\"totalCount\""
 }
 
 func (t *GetOrganizationByID_Organization_Members) GetEdges() []*GetOrganizationByID_Organization_Members_Edges {
@@ -35159,6 +35174,12 @@ func (t *GetOrganizationByID_Organization_Members) GetEdges() []*GetOrganization
 		t = &GetOrganizationByID_Organization_Members{}
 	}
 	return t.Edges
+}
+func (t *GetOrganizationByID_Organization_Members) GetTotalCount() int64 {
+	if t == nil {
+		t = &GetOrganizationByID_Organization_Members{}
+	}
+	return t.TotalCount
 }
 
 type GetOrganizationByID_Organization_Setting struct {
@@ -35878,7 +35899,8 @@ func (t *GetOrganizations_Organizations_Edges_Node_Members_Edges) GetNode() *Get
 }
 
 type GetOrganizations_Organizations_Edges_Node_Members struct {
-	Edges []*GetOrganizations_Organizations_Edges_Node_Members_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+	Edges      []*GetOrganizations_Organizations_Edges_Node_Members_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+	TotalCount int64                                                      "json:\"totalCount\" graphql:\"totalCount\""
 }
 
 func (t *GetOrganizations_Organizations_Edges_Node_Members) GetEdges() []*GetOrganizations_Organizations_Edges_Node_Members_Edges {
@@ -35886,6 +35908,12 @@ func (t *GetOrganizations_Organizations_Edges_Node_Members) GetEdges() []*GetOrg
 		t = &GetOrganizations_Organizations_Edges_Node_Members{}
 	}
 	return t.Edges
+}
+func (t *GetOrganizations_Organizations_Edges_Node_Members) GetTotalCount() int64 {
+	if t == nil {
+		t = &GetOrganizations_Organizations_Edges_Node_Members{}
+	}
+	return t.TotalCount
 }
 
 type GetOrganizations_Organizations_Edges_Node_Setting struct {
@@ -36513,7 +36541,8 @@ func (t *UpdateOrganization_UpdateOrganization_Organization_Members_Edges) GetNo
 }
 
 type UpdateOrganization_UpdateOrganization_Organization_Members struct {
-	Edges []*UpdateOrganization_UpdateOrganization_Organization_Members_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+	Edges      []*UpdateOrganization_UpdateOrganization_Organization_Members_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+	TotalCount int64                                                               "json:\"totalCount\" graphql:\"totalCount\""
 }
 
 func (t *UpdateOrganization_UpdateOrganization_Organization_Members) GetEdges() []*UpdateOrganization_UpdateOrganization_Organization_Members_Edges {
@@ -36521,6 +36550,12 @@ func (t *UpdateOrganization_UpdateOrganization_Organization_Members) GetEdges() 
 		t = &UpdateOrganization_UpdateOrganization_Organization_Members{}
 	}
 	return t.Edges
+}
+func (t *UpdateOrganization_UpdateOrganization_Organization_Members) GetTotalCount() int64 {
+	if t == nil {
+		t = &UpdateOrganization_UpdateOrganization_Organization_Members{}
+	}
+	return t.TotalCount
 }
 
 type UpdateOrganization_UpdateOrganization_Organization_Setting struct {
@@ -75230,6 +75265,7 @@ const CreateOrganizationWithMembersDocument = `mutation CreateOrganizationWithMe
 				tags
 			}
 			members {
+				totalCount
 				edges {
 					node {
 						id
@@ -75314,6 +75350,7 @@ const GetAllOrganizationsDocument = `query GetAllOrganizations {
 					}
 				}
 				members {
+					totalCount
 					edges {
 						node {
 							id
@@ -75446,6 +75483,7 @@ const GetOrganizationByIDDocument = `query GetOrganizationByID ($organizationId:
 			}
 		}
 		members {
+			totalCount
 			edges {
 				node {
 					id
@@ -75580,6 +75618,7 @@ const GetOrganizationsDocument = `query GetOrganizations ($where: OrganizationWh
 					}
 				}
 				members {
+					totalCount
 					edges {
 						node {
 							id
@@ -75704,6 +75743,7 @@ const UpdateOrganizationDocument = `mutation UpdateOrganization ($updateOrganiza
 			}
 			tags
 			members {
+				totalCount
 				edges {
 					node {
 						id

--- a/pkg/openlaneclient/models.go
+++ b/pkg/openlaneclient/models.go
@@ -14304,7 +14304,7 @@ type Organization struct {
 	Setting                *OrganizationSetting             `json:"setting,omitempty"`
 	PersonalAccessTokens   *PersonalAccessTokenConnection   `json:"personalAccessTokens"`
 	APITokens              *APITokenConnection              `json:"apiTokens"`
-	Users                  []*User                          `json:"users,omitempty"`
+	Users                  *UserConnection                  `json:"users"`
 	Files                  *FileConnection                  `json:"files"`
 	Events                 *EventConnection                 `json:"events"`
 	Secrets                *HushConnection                  `json:"secrets"`
@@ -14333,7 +14333,7 @@ type Organization struct {
 	Evidence               *EvidenceConnection              `json:"evidence"`
 	Standards              *StandardConnection              `json:"standards"`
 	ActionPlans            *ActionPlanConnection            `json:"actionPlans"`
-	Members                []*OrgMembership                 `json:"members,omitempty"`
+	Members                *OrgMembershipConnection         `json:"members"`
 }
 
 func (Organization) IsNode() {}


### PR DESCRIPTION
Adds pagination to the `organization.members` edge, it will now require `edges.node` in the request:

```
query GetOrganizationByID($organizationId: ID!) {
  organization(id: $organizationId) {
    id
    name
    members {
      edges {
        node {
          id
          role
          user {
            id
            firstName
            lastName
          }
        }
      }
    }
   
  }
}
```