### PR TITLE
bug: fixes issue where default org was not updated when subscription expired

### DIFF
--- a/internal/httpserve/authmanager/authmanager.go
+++ b/internal/httpserve/authmanager/authmanager.go
@@ -126,7 +126,7 @@ func (a *Client) checkActiveSubscription(ctx context.Context, orgID string) (act
 	}
 
 	if subscription == nil || !subscription.Active {
-		return false, ErrOrgSubscriptionNotActive
+		return false, nil
 	}
 
 	return true, nil

--- a/internal/httpserve/authmanager/authmanager.go
+++ b/internal/httpserve/authmanager/authmanager.go
@@ -101,11 +101,7 @@ func (a *Client) GenerateOauthAuthSession(ctx context.Context, w http.ResponseWr
 	return auth, nil
 }
 
-var (
-	// ErrOrgSubscriptionNotActive is the error message when the organization subscription is not active
-	ErrOrgSubscriptionNotActive = errors.New("organization subscription is not active")
-)
-
+// checkActiveSubscription checks if the user has an active subscription for the organization
 func (a *Client) checkActiveSubscription(ctx context.Context, orgID string) (active bool, err error) {
 	// if the entitlement manager is disabled, we can skip the check
 	if a.db.EntitlementManager == nil {
@@ -125,11 +121,7 @@ func (a *Client) checkActiveSubscription(ctx context.Context, orgID string) (act
 		return false, err
 	}
 
-	if subscription == nil || !subscription.Active {
-		return false, nil
-	}
-
-	return true, nil
+	return subscription != nil && subscription.Active, nil
 }
 
 // createClaims creates the claims for the JWT token using the id for the user and organization

--- a/internal/httpserve/handlers/login_test.go
+++ b/internal/httpserve/handlers/login_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/theopenlane/core/internal/ent/generated"
 	ent "github.com/theopenlane/core/internal/ent/generated"
+	"github.com/theopenlane/core/internal/ent/generated/orgsubscription"
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
 	"github.com/theopenlane/core/pkg/models"
 )
@@ -61,6 +62,11 @@ func (suite *HandlerTestSuite) TestLoginHandler() {
 		confirmedUser: false,
 	})
 
+	userWithInactiveDefaultOrg := suite.userBuilderWithInput(ctx, &userInput{
+		password:      validPassword,
+		confirmedUser: true,
+	})
+
 	orgSetting := suite.db.OrganizationSetting.Create().SetInput(
 		generated.CreateOrganizationSettingInput{
 			AllowedEmailDomains: []string{"examples.com"}, // intentionally misspelled to ensure owner (validConfirmedUserRestrictedOrg) can still login
@@ -80,10 +86,24 @@ func (suite *HandlerTestSuite) TestLoginHandler() {
 
 	// update the user settings to have the default org set that is the domain restricted org
 	suite.db.UserSetting.UpdateOneID(validConfirmedUserRestrictedOrg.UserInfo.Edges.Setting.ID).
-		SetDefaultOrgID(org.ID).SaveX(allowCtx)
+		SetDefaultOrgID(org.ID).ExecX(allowCtx)
 
 	suite.db.UserSetting.UpdateOneID(invalidConfirmedUserRestrictedOrg.UserInfo.Edges.Setting.ID).
-		SetDefaultOrgID(org.ID).SaveX(allowCtx)
+		SetDefaultOrgID(org.ID).ExecX(allowCtx)
+
+	// update the user settings to have the default org set to an inactive subscription
+	suite.db.OrgSubscription.Update().Where(orgsubscription.OwnerID(userWithInactiveDefaultOrg.OrganizationID)).
+		SetActive(false).ExecX(allowCtx)
+
+	suite.db.UserSetting.UpdateOneID(userWithInactiveDefaultOrg.UserInfo.Edges.Setting.ID).
+		SetDefaultOrgID(userWithInactiveDefaultOrg.OrganizationID).ExecX(allowCtx)
+
+	// setup mock entitlements client
+	entitlements, err := suite.mockStripeClient()
+	require.NoError(t, err)
+
+	suite.h.DBClient.EntitlementManager = entitlements
+	suite.h.Entitlements = entitlements
 
 	testCases := []struct {
 		name           string
@@ -93,6 +113,13 @@ func (suite *HandlerTestSuite) TestLoginHandler() {
 		expectedErr    error
 		expectedStatus int
 	}{
+		{
+			name:           "happy path, valid credentials",
+			username:       userWithInactiveDefaultOrg.UserInfo.Email,
+			password:       validPassword,
+			expectedStatus: http.StatusOK,
+			expectedOrgID:  userWithInactiveDefaultOrg.PersonalOrgID,
+		},
 		{
 			name:           "happy path, valid credentials",
 			username:       validConfirmedUser.UserInfo.Email,

--- a/internal/httpserve/handlers/login_test.go
+++ b/internal/httpserve/handlers/login_test.go
@@ -115,13 +115,6 @@ func (suite *HandlerTestSuite) TestLoginHandler() {
 	}{
 		{
 			name:           "happy path, valid credentials",
-			username:       userWithInactiveDefaultOrg.UserInfo.Email,
-			password:       validPassword,
-			expectedStatus: http.StatusOK,
-			expectedOrgID:  userWithInactiveDefaultOrg.PersonalOrgID,
-		},
-		{
-			name:           "happy path, valid credentials",
 			username:       validConfirmedUser.UserInfo.Email,
 			password:       validPassword,
 			expectedStatus: http.StatusOK,
@@ -140,6 +133,13 @@ func (suite *HandlerTestSuite) TestLoginHandler() {
 			password:       validPassword,
 			expectedStatus: http.StatusOK,
 			expectedOrgID:  invalidConfirmedUserRestrictedOrg.PersonalOrgID,
+		},
+		{
+			name:           "inactive org, switch to personal org",
+			username:       userWithInactiveDefaultOrg.UserInfo.Email,
+			password:       validPassword,
+			expectedStatus: http.StatusOK,
+			expectedOrgID:  userWithInactiveDefaultOrg.PersonalOrgID,
 		},
 		{
 			name:           "email unverified",


### PR DESCRIPTION
- Returns the active status and allows the function to continue to update the org instead of returning an error
- Adds a test to the login handler to ensure this path is covered