### PR TITLE
add /.well-known/webauthn route

### DIFF
--- a/internal/httpserve/route/router.go
+++ b/internal/httpserve/route/router.go
@@ -205,6 +205,7 @@ func RegisterRoutes(router *Router) error {
 		registerWebhookHandler,
 		register2faHandler,
 		registerExampleCSVHandler,
+		registerWebAuthnWellKnownHandler,
 	}
 
 	if router.LocalFilePath != "" {

--- a/internal/httpserve/route/static.go
+++ b/internal/httpserve/route/static.go
@@ -8,29 +8,6 @@ import (
 	"github.com/theopenlane/httpsling"
 )
 
-// registerJwksWellKnownHandler supplies the JWKS endpoint
-func registerJwksWellKnownHandler(router *Router) (err error) {
-	path := "/.well-known/jwks.json"
-	method := http.MethodGet
-	name := "JWKS"
-
-	route := echo.Route{
-		Name:        name,
-		Method:      method,
-		Path:        path,
-		Middlewares: mw,
-		Handler: func(c echo.Context) error {
-			return c.JSON(http.StatusOK, router.Handler.JWTKeys)
-		},
-	}
-
-	if err := router.AddUnversionedRoute(path, method, nil, route); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // registerOpenAPISpecHandler embeds our generated open api specs and serves it behind /api-docs
 func registerOpenAPIHandler(router *Router) (err error) {
 	path := "/api-docs"
@@ -45,30 +22,6 @@ func registerOpenAPIHandler(router *Router) (err error) {
 		Handler: echo.HandlerFunc(func(c echo.Context) error {
 			return c.JSON(http.StatusOK, router.OAS)
 		}),
-	}
-
-	if err := router.AddEchoOnlyRoute(route); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-//go:embed security.txt
-var securityTxt embed.FS
-
-// registerSecurityTxtHandler serves up the text output of the security.txt
-func registerSecurityTxtHandler(router *Router) (err error) {
-	path := "/.well-known/security.txt"
-	method := http.MethodGet
-	name := "SecurityTxt"
-
-	route := echo.Route{
-		Name:        name,
-		Method:      method,
-		Path:        path,
-		Middlewares: mw,
-		Handler:     echo.StaticFileHandler("security.txt", securityTxt),
 	}
 
 	if err := router.AddEchoOnlyRoute(route); err != nil {
@@ -117,30 +70,6 @@ func registerFaviconHandler(router *Router) (err error) {
 		Path:        path,
 		Middlewares: mw,
 		Handler:     echo.StaticFileHandler("assets/favicon.ico", assets),
-	}
-
-	if err := router.AddEchoOnlyRoute(route); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-//go:embed applemerchant
-var applemerchant embed.FS
-
-// registerAppleMerchantHandler serves up the text output of the applemerchant file
-func registerAppleMerchantHandler(router *Router) (err error) {
-	path := "/.well-known/apple-developer-merchantid-domain-association"
-	method := http.MethodGet
-	name := "Applemerchant"
-
-	route := echo.Route{
-		Name:        name,
-		Method:      method,
-		Path:        path,
-		Middlewares: mw,
-		Handler:     echo.StaticFileHandler("applemerchant", applemerchant),
 	}
 
 	if err := router.AddEchoOnlyRoute(route); err != nil {

--- a/internal/httpserve/route/webauthn
+++ b/internal/httpserve/route/webauthn
@@ -1,0 +1,8 @@
+{
+    "origins": [
+        "https://www.theopenlane.io",
+        "https://theopenlane.io",
+        "https://console.theopenlane.io",
+        "https://api.theopenlane.io"
+    ]
+}

--- a/internal/httpserve/route/wellknown.go
+++ b/internal/httpserve/route/wellknown.go
@@ -1,0 +1,103 @@
+package route
+
+import (
+	"embed"
+	"net/http"
+
+	echo "github.com/theopenlane/echox"
+)
+
+//go:embed webauthn
+var webauthn embed.FS
+
+// registerSecurityTxtHandler serves up the text output of the security.txt
+func registerWebAuthnWellKnownHandler(router *Router) (err error) {
+	path := "/.well-known/webauthn"
+	method := http.MethodGet
+	name := "WebAuthn"
+
+	route := echo.Route{
+		Name:        name,
+		Method:      method,
+		Path:        path,
+		Middlewares: mw,
+		Handler:     echo.StaticFileHandler("webauthn", webauthn),
+	}
+
+	if err := router.AddEchoOnlyRoute(route); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// registerJwksWellKnownHandler supplies the JWKS endpoint
+func registerJwksWellKnownHandler(router *Router) (err error) {
+	path := "/.well-known/jwks.json"
+	method := http.MethodGet
+	name := "JWKS"
+
+	route := echo.Route{
+		Name:        name,
+		Method:      method,
+		Path:        path,
+		Middlewares: mw,
+		Handler: func(c echo.Context) error {
+			return c.JSON(http.StatusOK, router.Handler.JWTKeys)
+		},
+	}
+
+	if err := router.AddUnversionedRoute(path, method, nil, route); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+//go:embed security.txt
+var securityTxt embed.FS
+
+// registerSecurityTxtHandler serves up the text output of the security.txt
+func registerSecurityTxtHandler(router *Router) (err error) {
+	path := "/.well-known/security.txt"
+	method := http.MethodGet
+	name := "SecurityTxt"
+
+	route := echo.Route{
+		Name:        name,
+		Method:      method,
+		Path:        path,
+		Middlewares: mw,
+		Handler:     echo.StaticFileHandler("security.txt", securityTxt),
+	}
+
+	if err := router.AddEchoOnlyRoute(route); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+//go:embed applemerchant
+var applemerchant embed.FS
+
+// registerAppleMerchantHandler serves up the text output of the applemerchant file
+func registerAppleMerchantHandler(router *Router) (err error) {
+	path := "/.well-known/apple-developer-merchantid-domain-association"
+	method := http.MethodGet
+	name := "Applemerchant"
+
+	route := echo.Route{
+		Name:        name,
+		Method:      method,
+		Path:        path,
+		Middlewares: mw,
+		Handler:     echo.StaticFileHandler("applemerchant", applemerchant),
+	}
+
+	if err := router.AddEchoOnlyRoute(route); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
adds /.well-known/webauthn route so that we can realize our passkey destiny!

```
➜  ~ curl http://localhost:17608/.well-known/webauthn   
{
    "origins": [
        "https://www.theopenlane.io",
        "https://theopenlane.io",
        "https://console.theopenlane.io",
        "https://api.theopenlane.io"
    ]
}
```