### PR TITLE
stripe webhook updates; additional ent and webhook metrics

### DIFF
--- a/internal/ent/hooks/metrics.go
+++ b/internal/ent/hooks/metrics.go
@@ -49,11 +49,23 @@ func initOpsDuration() *prometheus.HistogramVec {
 	)
 }
 
+// initOpsTotalDuration creates a collector for total duration counter
+func initOpsTotalDuration() *prometheus.CounterVec {
+	return promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ent_operation_total_duration_seconds",
+			Help: "Total time in seconds per operation type and mutation",
+		},
+		entLabels,
+	)
+}
+
 // initialize the collectors, prometheus will register them automatically
 var (
 	opsProcessedTotal = initOpsProcessedTotal()
 	opsProcessedError = initOpsProcessedError()
 	opsDuration       = initOpsDuration()
+	opsTotalDuration  = initOpsTotalDuration()
 )
 
 // MetricsHook inits the collectors with count total at beginning, error on mutation error and a duration after the mutation
@@ -75,6 +87,7 @@ func MetricsHook() ent.Hook {
 
 			duration := time.Since(start)
 			opsDuration.With(labels).Observe(duration.Seconds())
+			opsTotalDuration.With(labels).Add(duration.Seconds())
 
 			return v, err
 		})

--- a/internal/ent/interceptors/orgsubscription.go
+++ b/internal/ent/interceptors/orgsubscription.go
@@ -12,6 +12,7 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated/intercept"
 )
 
+// InterceptorSubscriptionURL is an ent interceptor to fetch data from an external source (in this case stripe) and populate the URLs in the graph return response
 func InterceptorSubscriptionURL() ent.Interceptor {
 	return ent.InterceptFunc(func(next ent.Querier) ent.Querier {
 		return intercept.OrgSubscriptionFunc(func(ctx context.Context, q *generated.OrgSubscriptionQuery) (generated.Value, error) {
@@ -75,21 +76,21 @@ func setSubscriptionURL(ctx context.Context, orgSub *generated.OrgSubscription, 
 	// create a billing portal session
 	updateSubscription, err := q.EntitlementManager.CreateBillingPortalUpdateSession(orgSub.StripeSubscriptionID, orgSub.StripeCustomerID)
 	if err != nil {
-		zerolog.Ctx(ctx).Err(err).Msg("failed to create billing portal session")
+		zerolog.Ctx(ctx).Err(err).Msg("failed to create update subscription billing portal session type")
 
 		return err
 	}
 
 	cancelSubscription, err := q.EntitlementManager.CancellationBillingPortalSession(orgSub.StripeSubscriptionID, orgSub.StripeCustomerID)
 	if err != nil {
-		zerolog.Ctx(ctx).Err(err).Msg("failed to create billing portal session")
+		zerolog.Ctx(ctx).Err(err).Msg("failed to create cancel subscription billing portal session type")
 
 		return err
 	}
 
-	updatePaymentMethod, err := q.EntitlementManager.CreateBillingPortalPaymentMethods(orgSub.StripeSubscriptionID)
+	updatePaymentMethod, err := q.EntitlementManager.CreateBillingPortalPaymentMethods(orgSub.StripeCustomerID)
 	if err != nil {
-		zerolog.Ctx(ctx).Err(err).Msg("failed to create billing portal session")
+		zerolog.Ctx(ctx).Err(err).Msg("failed to create update payment method billing portal session type")
 
 		return err
 	}

--- a/internal/httpserve/authmanager/authmanager.go
+++ b/internal/httpserve/authmanager/authmanager.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
 	"github.com/theopenlane/iam/auth"
@@ -101,11 +102,22 @@ func (a *Client) GenerateOauthAuthSession(ctx context.Context, w http.ResponseWr
 	return auth, nil
 }
 
-// checkActiveSubscription checks if the user has an active subscription for the organization
+var (
+	// ErrOrganizationIDRequired is the error message when the organization ID is required
+	ErrOrganizationIDRequired = errors.New("organization ID is required")
+)
+
+// checkActiveSubscription checks if the organization has an active subscription
 func (a *Client) checkActiveSubscription(ctx context.Context, orgID string) (active bool, err error) {
 	// if the entitlement manager is disabled, we can skip the check
 	if a.db.EntitlementManager == nil {
 		return true, nil
+	}
+
+	if orgID == "" {
+		log.Debug().Msg("organization ID is required to check for active subscription")
+
+		return false, ErrOrganizationIDRequired
 	}
 
 	if _, ok := contextx.From[auth.OrganizationCreationContextKey](ctx); ok {
@@ -116,8 +128,10 @@ func (a *Client) checkActiveSubscription(ctx context.Context, orgID string) (act
 	allowCtx := privacy.DecisionContext(ctx, privacy.Allow)
 	allowCtx = contextx.With(allowCtx, auth.OrgSubscriptionContextKey{})
 
-	subscription, err := a.db.OrgSubscription.Query().Select("active").Where(orgsubscription.OwnerID(orgID)).Only(allowCtx)
+	subscription, err := a.db.OrgSubscription.Query().Where(orgsubscription.OwnerID(orgID)).Only(allowCtx)
 	if err != nil {
+		zerolog.Ctx(ctx).Error().Err(err).Str("organization_id", orgID).Msg("failed to find org subscription for organization")
+
 		return false, err
 	}
 
@@ -211,13 +225,6 @@ func (a *Client) generateOauthUserSession(ctx context.Context, w http.ResponseWr
 
 	return session, nil
 }
-
-var (
-	// ErrSubscriptionNotFound is the error message when the subscription is not found
-	ErrSubscriptionNotFound = errors.New("subscription not found")
-	// ErrSubscriptionNotActive is the error message when the subscription is not active
-	ErrSubscriptionNotActive = errors.New("subscription not active")
-)
 
 // authCheck checks if the user has access to the target organization before issuing a new session and claims
 // if the user does not have access to the target organization, the user's default org is used (or falls back)

--- a/internal/httpserve/authmanager/authmanager.go
+++ b/internal/httpserve/authmanager/authmanager.go
@@ -2,7 +2,6 @@ package authmanager
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -102,11 +101,6 @@ func (a *Client) GenerateOauthAuthSession(ctx context.Context, w http.ResponseWr
 	return auth, nil
 }
 
-var (
-	// ErrOrganizationIDRequired is the error message when the organization ID is required
-	ErrOrganizationIDRequired = errors.New("organization ID is required")
-)
-
 // checkActiveSubscription checks if the organization has an active subscription
 func (a *Client) checkActiveSubscription(ctx context.Context, orgID string) (active bool, err error) {
 	// if the entitlement manager is disabled, we can skip the check
@@ -117,7 +111,7 @@ func (a *Client) checkActiveSubscription(ctx context.Context, orgID string) (act
 	if orgID == "" {
 		log.Debug().Msg("organization ID is required to check for active subscription")
 
-		return false, ErrOrganizationIDRequired
+		return false, nil
 	}
 
 	if _, ok := contextx.From[auth.OrganizationCreationContextKey](ctx); ok {

--- a/internal/httpserve/authmanager/authmanager.go
+++ b/internal/httpserve/authmanager/authmanager.go
@@ -122,7 +122,7 @@ func (a *Client) checkActiveSubscription(ctx context.Context, orgID string) (act
 	allowCtx := privacy.DecisionContext(ctx, privacy.Allow)
 	allowCtx = contextx.With(allowCtx, auth.OrgSubscriptionContextKey{})
 
-	subscription, err := a.db.OrgSubscription.Query().Where(orgsubscription.OwnerID(orgID)).Only(allowCtx)
+	subscription, err := a.db.OrgSubscription.Query().Select("active").Where(orgsubscription.OwnerID(orgID)).Only(allowCtx)
 	if err != nil {
 		zerolog.Ctx(ctx).Error().Err(err).Str("organization_id", orgID).Msg("failed to find org subscription for organization")
 

--- a/internal/httpserve/handlers/tools_test.go
+++ b/internal/httpserve/handlers/tools_test.go
@@ -207,6 +207,7 @@ func handlerSetup(db *ent.Client) *handlers.Handler {
 		RedisClient:   db.SessionConfig.RedisClient,
 		SessionConfig: db.SessionConfig,
 		AuthManager:   as,
+		Entitlements:  db.EntitlementManager,
 	}
 
 	return h

--- a/internal/httpserve/handlers/webhook.go
+++ b/internal/httpserve/handlers/webhook.go
@@ -376,7 +376,7 @@ func syncOrgSubscriptionWithStripe(ctx context.Context, subscription *stripe.Sub
 
 		changed = true
 
-		log.Debug().Str("subscription_id", orgSubscription.ID).Str("trial_expires_at", stripeOrgSubscription.ExpiresAt.String()).Msg("subscription trial expiration changed")
+		log.Debug().Str("subscription_id", orgSubscription.ID).Str("trial_expires_at", stripeOrgSubscription.TrialExpiresAt.String()).Msg("subscription trial expiration changed")
 	}
 
 	if !slices.Equal(orgSubscription.FeatureLookupKeys, stripeOrgSubscription.FeatureLookupKeys) {

--- a/internal/httpserve/handlers/webhook.go
+++ b/internal/httpserve/handlers/webhook.go
@@ -371,12 +371,12 @@ func syncOrgSubscriptionWithStripe(ctx context.Context, subscription *stripe.Sub
 		log.Debug().Str("subscription_id", orgSubscription.ID).Str("price", orgSubscription.ProductPrice.String()).Msgf("product price changed")
 	}
 
-	if stripeOrgSubscription.ExpiresAt != nil && orgSubscription.TrialExpiresAt != stripeOrgSubscription.TrialExpiresAt {
-		mutation.SetTrialExpiresAt(*stripeOrgSubscription.ExpiresAt)
+	if stripeOrgSubscription.TrialExpiresAt != nil && orgSubscription.TrialExpiresAt != stripeOrgSubscription.TrialExpiresAt {
+		mutation.SetTrialExpiresAt(*stripeOrgSubscription.TrialExpiresAt)
 
 		changed = true
 
-		log.Debug().Str("subscription_id", orgSubscription.ID).Str("expires_at", stripeOrgSubscription.ExpiresAt.String()).Msg("subscription expiration changed")
+		log.Debug().Str("subscription_id", orgSubscription.ID).Str("trial_expires_at", stripeOrgSubscription.ExpiresAt.String()).Msg("subscription trial expiration changed")
 	}
 
 	if !slices.Equal(orgSubscription.FeatureLookupKeys, stripeOrgSubscription.FeatureLookupKeys) {

--- a/internal/httpserve/handlers/webhook.go
+++ b/internal/httpserve/handlers/webhook.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog/log"
 	"github.com/stripe/stripe-go/v81"
 	"github.com/stripe/stripe-go/v81/webhook"
@@ -46,13 +47,49 @@ var supportedEventTypes = map[stripe.EventType]bool{
 	stripe.EventTypeCustomerUpdated: false,
 }
 
+var (
+	webhookReceivedCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "webhook_received_total",
+			Help: "Total number of webhooks received",
+		},
+		[]string{"event_type"},
+	)
+
+	webhookProcessingLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "webhook_processing_latency_seconds",
+			Help:    "Latency of webhook processing in seconds",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"event_type"},
+	)
+
+	webhookResponseCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "webhook_response_total",
+			Help: "Total number of webhook responses grouped by event type and status code",
+		},
+		[]string{"event_type", "status_code"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(webhookReceivedCounter)
+	prometheus.MustRegister(webhookProcessingLatency)
+	prometheus.MustRegister(webhookResponseCounter)
+}
+
 // WebhookReceiverHandler handles incoming stripe webhook events for the supported event types
 func (h *Handler) WebhookReceiverHandler(ctx echo.Context) error {
+	startTime := time.Now()
+
 	req := ctx.Request()
 	res := ctx.Response()
 
 	payload, err := io.ReadAll(http.MaxBytesReader(res.Writer, req.Body, maxBodyBytes))
 	if err != nil {
+		webhookResponseCounter.WithLabelValues("payload_exceeded", "500").Inc()
 		log.Error().Err(err).Msg("failed to read request body")
 
 		return h.InternalServerError(ctx, err)
@@ -60,15 +97,19 @@ func (h *Handler) WebhookReceiverHandler(ctx echo.Context) error {
 
 	event, err := webhook.ConstructEvent(payload, req.Header.Get(stripeSignatureHeaderKey), h.Entitlements.Config.StripeWebhookSecret)
 	if err != nil {
+		webhookResponseCounter.WithLabelValues("event_signature_failure", "400").Inc()
 		log.Error().Err(err).Msg("failed to construct event")
 
-		return ctx.String(http.StatusConflict, fmt.Errorf("error verifying webhook signature. Error: %w", err).Error())
+		return h.BadRequest(ctx, err)
 	}
 
+	webhookReceivedCounter.WithLabelValues(string(event.Type)).Inc()
+
 	if !supportedEventTypes[event.Type] {
+		webhookResponseCounter.WithLabelValues(string(event.Type)+"_discarded", "200").Inc()
 		log.Debug().Str("event_type", string(event.Type)).Msg("unsupported event type")
 
-		return h.BadRequest(ctx, ErrUnsupportedEventType)
+		return h.Success(ctx, "unsupported event type")
 	}
 
 	newCtx := privacy.DecisionContext(req.Context(), privacy.Allow)
@@ -76,6 +117,7 @@ func (h *Handler) WebhookReceiverHandler(ctx echo.Context) error {
 
 	exists, err := h.checkForEventID(newCtx, event.ID)
 	if err != nil {
+		webhookResponseCounter.WithLabelValues(string(event.Type), "500").Inc()
 		log.Error().Err(err).Msg("failed to check for event ID")
 
 		return h.InternalServerError(ctx, err)
@@ -84,6 +126,7 @@ func (h *Handler) WebhookReceiverHandler(ctx echo.Context) error {
 	if !exists {
 		meowevent, err := h.createEvent(newCtx, ent.CreateEventInput{EventID: &event.ID})
 		if err != nil {
+			webhookResponseCounter.WithLabelValues(string(event.Type), "500").Inc()
 			log.Error().Err(err).Msg("failed to create event")
 
 			return h.InternalServerError(ctx, err)
@@ -92,11 +135,16 @@ func (h *Handler) WebhookReceiverHandler(ctx echo.Context) error {
 		log.Debug().Msgf("internal event: %v", meowevent)
 
 		if err = h.HandleEvent(newCtx, &event); err != nil {
+			webhookResponseCounter.WithLabelValues(string(event.Type), "500").Inc()
 			log.Error().Err(err).Msg("failed to handle event")
 
 			return h.InternalServerError(ctx, err)
 		}
 	}
+
+	duration := time.Since(startTime).Seconds()
+	webhookProcessingLatency.WithLabelValues(string(event.Type)).Observe(duration)
+	webhookResponseCounter.WithLabelValues(string(event.Type)+"_processed", "200").Inc()
 
 	return h.Success(ctx, nil)
 }
@@ -144,14 +192,6 @@ func (h *Handler) HandleEvent(c context.Context, e *stripe.Event) error {
 		}
 
 		return h.handleSubscriptionPaused(c, subscription)
-	// TODO: add support for these events so details like billing address can be updated
-	// case stripe.EventTypeCustomerUpdated:
-	// customer, err := unmarshalEventData[stripe.Customer](e)
-	// if err != nil {
-	// 	return err
-	// }
-
-	// return h.handleCustomerUpdated(c, customer)
 	default:
 		log.Warn().Str("event_type", string(e.Type)).Msg("unsupported event type")
 
@@ -301,7 +341,7 @@ func syncOrgSubscriptionWithStripe(ctx context.Context, subscription *stripe.Sub
 		log.Debug().Str("subscription_id", orgSubscription.ID).Str("status", orgSubscription.StripeSubscriptionStatus).Msg("stripe subscription status changed")
 	}
 
-	if slices.Equal(orgSubscription.Features, stripeOrgSubscription.Features) {
+	if !slices.Equal(orgSubscription.Features, stripeOrgSubscription.Features) {
 		mutation.SetFeatures(stripeOrgSubscription.Features)
 
 		changed = true
@@ -318,7 +358,11 @@ func syncOrgSubscriptionWithStripe(ctx context.Context, subscription *stripe.Sub
 	}
 
 	if orgSubscription.ProductPrice != stripeOrgSubscription.ProductPrice {
-		stripeOrgSubscription.ProductPrice.Amount /= 100 // nolint:mnd // convert to dollars from cents
+		productPriceCopy := stripeOrgSubscription.ProductPrice
+
+		productPriceCopy.Amount /= 100 // convert to dollars from cents
+
+		mutation.SetProductPrice(productPriceCopy)
 
 		mutation.SetProductPrice(stripeOrgSubscription.ProductPrice)
 
@@ -327,15 +371,15 @@ func syncOrgSubscriptionWithStripe(ctx context.Context, subscription *stripe.Sub
 		log.Debug().Str("subscription_id", orgSubscription.ID).Str("price", orgSubscription.ProductPrice.String()).Msgf("product price changed")
 	}
 
-	if stripeOrgSubscription.ExpiresAt != nil && orgSubscription.ExpiresAt != stripeOrgSubscription.ExpiresAt {
-		mutation.SetExpiresAt(*stripeOrgSubscription.ExpiresAt)
+	if stripeOrgSubscription.ExpiresAt != nil && orgSubscription.TrialExpiresAt != stripeOrgSubscription.TrialExpiresAt {
+		mutation.SetTrialExpiresAt(*stripeOrgSubscription.ExpiresAt)
 
 		changed = true
 
 		log.Debug().Str("subscription_id", orgSubscription.ID).Str("expires_at", stripeOrgSubscription.ExpiresAt.String()).Msg("subscription expiration changed")
 	}
 
-	if slices.Equal(orgSubscription.FeatureLookupKeys, stripeOrgSubscription.FeatureLookupKeys) {
+	if !slices.Equal(orgSubscription.FeatureLookupKeys, stripeOrgSubscription.FeatureLookupKeys) {
 		mutation.SetFeatureLookupKeys(stripeOrgSubscription.FeatureLookupKeys)
 
 		changed = true
@@ -364,7 +408,11 @@ func syncOrgSubscriptionWithStripe(ctx context.Context, subscription *stripe.Sub
 
 		changed = true
 
-		log.Debug().Str("subscription_id", orgSubscription.ID).Bool("payment_method_added", *orgSubscription.PaymentMethodAdded).Msg("payment method added changed")
+		if orgSubscription.PaymentMethodAdded != nil {
+			log.Debug().Str("subscription_id", orgSubscription.ID).Bool("payment_method_added", *orgSubscription.PaymentMethodAdded).Msg("payment method added changed")
+		} else {
+			log.Debug().Str("subscription_id", orgSubscription.ID).Msg("payment method added changed but was previously nil")
+		}
 	}
 
 	if orgSubscription.Active != stripeOrgSubscription.Active {
@@ -376,13 +424,15 @@ func syncOrgSubscriptionWithStripe(ctx context.Context, subscription *stripe.Sub
 	}
 
 	if changed {
-		// Save the updated OrgSubscription
+		// Collect all changes and execute the mutation once
 		err = mutation.Exec(ctx)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to update OrgSubscription")
 
 			return nil, err
 		}
+
+		log.Debug().Str("subscription_id", orgSubscription.ID).Msg("OrgSubscription updated successfully")
 	}
 
 	return &orgSubscription.OwnerID, nil

--- a/internal/httpserve/handlers/webhook_test.go
+++ b/internal/httpserve/handlers/webhook_test.go
@@ -103,7 +103,7 @@ func (suite *HandlerTestSuite) TestWebhookReceiverHandler() {
 					Raw: json.RawMessage(jsonDataUpdate),
 				},
 			},
-			expectedStatus: http.StatusConflict,
+			expectedStatus: http.StatusBadRequest,
 		},
 		{
 			name: "valid payload - subscription updated",
@@ -148,7 +148,7 @@ func (suite *HandlerTestSuite) TestWebhookReceiverHandler() {
 				Type:       stripe.EventTypeCustomerUpdated,
 				APIVersion: stripe.APIVersion,
 			},
-			expectedStatus: http.StatusBadRequest,
+			expectedStatus: http.StatusOK,
 		},
 	}
 


### PR DESCRIPTION
- changes the current webhook handler behavior from returning a code in the error range (4xx 5xx) when an event type we dont support is received to a success response code - we are discarding the event regardless, but when you return 4xx/5xx to stripe they attempt to resend every event up to 5+ times which is a lot of extra overhead on us (and results in getting emails from them, etc.)
- updates / corrects several of the field evaluations in the `syncOrgSubscriptionWithStripe` function to perform updates if the fields are _not_ alike rather than if they are (`if !slices.Equal` vs. `if slices.Equal` 🤦 )
- fixes a bug in `InterceptorSubscriptionURL` causing none of the URL's to be populated and populates different log error text to make it more obvious which individual URL may have been the culprit