### PR TITLE
feat: add user filter to org memberships

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     rev: v5.0.0
     hooks:
       - id: trailing-whitespace
-        exclude: jsonschema/api-docs.md|internal/graphapi/generated/.+\.go
+        exclude: jsonschema/api-docs.md|internal/graphapi/generated/.+\.go|internal/graphapi/clientschema/.+\.graphql
       - id: detect-private-key
   - repo: https://github.com/google/yamlfmt
     rev: v0.15.0

--- a/internal/graphapi/clientschema/schema.graphql
+++ b/internal/graphapi/clientschema/schema.graphql
@@ -22334,6 +22334,7 @@ input OrgMembershipWhereInput {
 	roleNotIn: [OrgMembershipRole!]
 	organizationID: String
 	userID: String
+	hasUserWith: [UserWhereInput!]
 }
 type OrgSubscription implements Node {
 	id: ID!

--- a/internal/graphapi/generated/root_.generated.go
+++ b/internal/graphapi/generated/root_.generated.go
@@ -67154,6 +67154,10 @@ type OrgMembershipBulkCreatePayload {
     Created orgMemberships
     """
     orgMemberships: [OrgMembership!]
+}
+
+extend input OrgMembershipWhereInput {
+  hasUserWith: [UserWhereInput!]
 }`, BuiltIn: false},
 	{Name: "../schema/orgsubscription.graphql", Input: `extend type Query {
     """

--- a/internal/graphapi/schema/orgmembership.graphql
+++ b/internal/graphapi/schema/orgmembership.graphql
@@ -101,3 +101,7 @@ type OrgMembershipBulkCreatePayload {
     """
     orgMemberships: [OrgMembership!]
 }
+
+extend input OrgMembershipWhereInput {
+  hasUserWith: [UserWhereInput!]
+}

--- a/pkg/openlaneclient/models.go
+++ b/pkg/openlaneclient/models.go
@@ -13454,12 +13454,13 @@ type OrgMembershipWhereInput struct {
 	DeletedByEqualFold    *string  `json:"deletedByEqualFold,omitempty"`
 	DeletedByContainsFold *string  `json:"deletedByContainsFold,omitempty"`
 	// role field predicates
-	Role           *enums.Role  `json:"role,omitempty"`
-	RoleNeq        *enums.Role  `json:"roleNEQ,omitempty"`
-	RoleIn         []enums.Role `json:"roleIn,omitempty"`
-	RoleNotIn      []enums.Role `json:"roleNotIn,omitempty"`
-	OrganizationID *string      `json:"organizationID,omitempty"`
-	UserID         *string      `json:"userID,omitempty"`
+	Role           *enums.Role       `json:"role,omitempty"`
+	RoleNeq        *enums.Role       `json:"roleNEQ,omitempty"`
+	RoleIn         []enums.Role      `json:"roleIn,omitempty"`
+	RoleNotIn      []enums.Role      `json:"roleNotIn,omitempty"`
+	OrganizationID *string           `json:"organizationID,omitempty"`
+	UserID         *string           `json:"userID,omitempty"`
+	HasUserWith    []*UserWhereInput `json:"hasUserWith,omitempty"`
 }
 
 type OrgSubscription struct {


### PR DESCRIPTION
Allows members to be filtered on user details:

```
query OrgMemberships($where: OrgMembershipWhereInput) {
  orgMemberships(where: $where) {
    edges {
      node {
        id
        role
        user {
          firstName
          lastName
          displayName
        }
      }
    }
  }
}
```

```
{
  "where": {
    "hasUserWith": {
      "or": [
        { "displayNameContainsFold": "Matt" },
        { "firstNameContainsFold": "Matt" },
        { "lastNameContainsFold": "Matt" }
      ]
    }
  }
}
```

Result:

```
{
  "data": {
    "orgMemberships": {
      "edges": [
        {
          "node": {
            "id": "01JS7BNNSEAB8KE7AFMZHQRCWZ",
            "role": "OWNER",
            "user": {
              "firstName": "matt",
              "lastName": "anderson",
              "displayName": "matt anderson"
            }
          }
        }
      ]
    }
  },
  "extensions": {
    "auth": {
      "authentication_type": "api_token",
      "authorized_organization": [
        "01JS7BNNRHSXY1B4ZB016EH563"
      ]
    },
    "server_latency": "56.789291ms",
    "trace_id": "kFfqSplqTBRojBYRBQjKkYBKpvQNalVX"
  }
}
```

