### PR TITLE
Bug: allow for same passkey to be used for multiple accounts

### DIFF
--- a/db/migrations-goose-postgres/20250421141007_aauid_not_unique_per_machine.sql
+++ b/db/migrations-goose-postgres/20250421141007_aauid_not_unique_per_machine.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+-- drop index "webauthns_aaguid_key" from table: "webauthns"
+DROP INDEX "webauthns_aaguid_key";
+
+-- +goose Down
+-- reverse: drop index "webauthns_aaguid_key" from table: "webauthns"
+CREATE UNIQUE INDEX "webauthns_aaguid_key" ON "webauthns" ("aaguid");

--- a/db/migrations-goose-postgres/atlas.sum
+++ b/db/migrations-goose-postgres/atlas.sum
@@ -1,3 +1,4 @@
-h1:tIozdRmh6O/zRwSnkFF76AA9e86oDYCT/Z3VTcT7IL8=
+h1:5USyfln55uCySfawv+JpK6mIZbk08fpvewJu3epxn30=
 20250414203515_init.sql h1:BeTEtWy9s9mO1t9vLhKE/W3Z/NZS7kklzlmvffjgMys=
 20250418204251_control_objective.sql h1:2zhXUjbVshiTwzY0qh87de8Wh8j2tLDO6KRbn6oohx4=
+20250421141007_aauid_not_unique_per_machine.sql h1:bMzfq+NBG4IFyOf/YintEKVhmQ6ttnQymzRV8/RiuPo=

--- a/db/migrations/20250421141003_aauid_not_unique_per_machine.sql
+++ b/db/migrations/20250421141003_aauid_not_unique_per_machine.sql
@@ -1,0 +1,2 @@
+-- Drop index "webauthns_aaguid_key" from table: "webauthns"
+DROP INDEX "webauthns_aaguid_key";

--- a/db/migrations/atlas.sum
+++ b/db/migrations/atlas.sum
@@ -1,3 +1,4 @@
-h1:O+EZdbRDb4xc2WpTP3Sgg+ITIA3VLZNjDcq+Y9F9fqM=
+h1:FSjBsWGX0kXETr8s2iTEmUYE4Xi4jbZGpkrEr024LfY=
 20250414203514_init.sql h1:NmCV8ML7NQDnzWVgI8QwOPofl3cp1WGzZWzPQhilEbY=
 20250418204249_control_objective.sql h1:NVX8qKq77/54YdYSQZMyI+HS5RXNahqyyDtNHf9oMnQ=
+20250421141003_aauid_not_unique_per_machine.sql h1:/ZFOjmdeEiPZl23+/MIjK1sxFWSi8PrMvV3kJ4iqbW4=

--- a/internal/ent/generated/migrate/schema.go
+++ b/internal/ent/generated/migrate/schema.go
@@ -3456,7 +3456,7 @@ var (
 		{Name: "credential_id", Type: field.TypeBytes, Unique: true, Nullable: true},
 		{Name: "public_key", Type: field.TypeBytes, Nullable: true},
 		{Name: "attestation_type", Type: field.TypeString, Nullable: true},
-		{Name: "aaguid", Type: field.TypeBytes, Unique: true},
+		{Name: "aaguid", Type: field.TypeBytes},
 		{Name: "sign_count", Type: field.TypeInt32},
 		{Name: "transports", Type: field.TypeJSON},
 		{Name: "backup_eligible", Type: field.TypeBool, Default: false},

--- a/internal/ent/schema/webauthn.go
+++ b/internal/ent/schema/webauthn.go
@@ -47,7 +47,6 @@ func (Webauthn) Fields() []ent.Field {
 			Optional(),
 		field.Bytes("aaguid").
 			Comment("The AAGUID of the authenticator; AAGUID is defined as an array containing the globally unique identifier of the authenticator model being sought").
-			Unique().
 			Immutable(),
 		field.Int32("sign_count").
 			Comment("SignCount -Upon a new login operation, the Relying Party compares the stored signature counter value with the new signCount value returned in the assertions authenticator data. If this new signCount value is less than or equal to the stored value, a cloned authenticator may exist, or the authenticator may be malfunctioning"),


### PR DESCRIPTION
I have made the `AAGUID` not unique as this value will always be the same across all passkey devices. 

E.g All Yubi key 5C can only have one AAGUID, Yubi Key 5NFC have a different one. 

So this issue will still occur if user a from another machine tried to use 1password and another user b from another machine
used 1password already .

TLDR: `credential_id` will always change on new passkey so it is meant to be unique still but AAGUID is default across all ___passkey generating device___ for a specific manufacturer 

> I haven't added tests here as it is been notoriously hard to set up without a frontend. Mocking it can lead to scope increment of this PR but I can always do that in another PR

References

https://support.yubico.com/hc/en-us/articles/360016648959-YubiKey-hardware-FIDO2-AAGUIDs

Also see here , the AAGUID are the same so we can even show on the frontend what key/device was used to make the passkey https://passkeydeveloper.github.io/passkey-authenticator-aaguids/explorer/

![image](https://github.com/user-attachments/assets/1b26f511-c15b-4f65-bd86-2abf9dd2b64f)

You can also see here my local 1password passkeys matches the community sourced list here

https://github.com/passkeydeveloper/passkey-authenticator-aaguids

https://www.corbado.com/glossary/aaguid