### PR TITLE
feat: allow user to login with any credential type, last seen webauth

### DIFF
--- a/db/migrations-goose-postgres/20250422051415_user_last_login_provider.sql
+++ b/db/migrations-goose-postgres/20250422051415_user_last_login_provider.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- modify "user_history" table
+ALTER TABLE "user_history" ADD COLUMN "last_login_provider" character varying NULL;
+-- modify "users" table
+ALTER TABLE "users" ADD COLUMN "last_login_provider" character varying NULL;
+
+-- +goose Down
+-- reverse: modify "users" table
+ALTER TABLE "users" DROP COLUMN "last_login_provider";
+-- reverse: modify "user_history" table
+ALTER TABLE "user_history" DROP COLUMN "last_login_provider";

--- a/db/migrations-goose-postgres/atlas.sum
+++ b/db/migrations-goose-postgres/atlas.sum
@@ -1,5 +1,6 @@
-h1:b8Zm+ugUNSjiRgi6n02dncQ9vA4XU/WIJlseDaD1Wrc=
+h1:KG0yX7sfDP1mH3j8/EOsLq+T+bu2yNujwLIKy37NKV4=
 20250414203515_init.sql h1:BeTEtWy9s9mO1t9vLhKE/W3Z/NZS7kklzlmvffjgMys=
 20250418204251_control_objective.sql h1:2zhXUjbVshiTwzY0qh87de8Wh8j2tLDO6KRbn6oohx4=
 20250421141007_aauid_not_unique_per_machine.sql h1:bMzfq+NBG4IFyOf/YintEKVhmQ6ttnQymzRV8/RiuPo=
 20250421202320_policy_edges.sql h1:1PvGpS2VycW0MD70cpdR+/Mbp/YDESTagNPc4GulEo8=
+20250422051415_user_last_login_provider.sql h1:eTAETK3TOXgjMDDlnXrq1VQoxL1bII98Ld/+3HGy1wg=

--- a/db/migrations/20250422051412_user_last_login_provider.sql
+++ b/db/migrations/20250422051412_user_last_login_provider.sql
@@ -1,0 +1,4 @@
+-- Modify "user_history" table
+ALTER TABLE "user_history" ADD COLUMN "last_login_provider" character varying NULL;
+-- Modify "users" table
+ALTER TABLE "users" ADD COLUMN "last_login_provider" character varying NULL;

--- a/db/migrations/atlas.sum
+++ b/db/migrations/atlas.sum
@@ -1,5 +1,6 @@
-h1:d62LuDVVn3cp4YHKeJM8Wwt/Ttax0xS/WFcgfEfvQ8o=
+h1:GeXZf72aWyIzJFtok8hTDuiyDvhJuZMYQDPGaH3Etko=
 20250414203514_init.sql h1:NmCV8ML7NQDnzWVgI8QwOPofl3cp1WGzZWzPQhilEbY=
 20250418204249_control_objective.sql h1:NVX8qKq77/54YdYSQZMyI+HS5RXNahqyyDtNHf9oMnQ=
 20250421141003_aauid_not_unique_per_machine.sql h1:/ZFOjmdeEiPZl23+/MIjK1sxFWSi8PrMvV3kJ4iqbW4=
 20250421202316_policy_edges.sql h1:2iKPA/aa9IP/flY8ld71Cdo9Hz2+Da+t/1PABHHCIYE=
+20250422051412_user_last_login_provider.sql h1:HY7UvEagoFBCV+WnU2TRee2xMUdOE4r8wJMKGmf7h8w=

--- a/internal/ent/generated/auditing.go
+++ b/internal/ent/generated/auditing.go
@@ -2470,6 +2470,9 @@ func (uh *UserHistory) changes(new *UserHistory) []Change {
 	if !reflect.DeepEqual(uh.LastSeen, new.LastSeen) {
 		changes = append(changes, NewChange(userhistory.FieldLastSeen, uh.LastSeen, new.LastSeen))
 	}
+	if !reflect.DeepEqual(uh.LastLoginProvider, new.LastLoginProvider) {
+		changes = append(changes, NewChange(userhistory.FieldLastLoginProvider, uh.LastLoginProvider, new.LastLoginProvider))
+	}
 	if !reflect.DeepEqual(uh.Password, new.Password) {
 		changes = append(changes, NewChange(userhistory.FieldPassword, uh.Password, new.Password))
 	}

--- a/internal/ent/generated/entql.go
+++ b/internal/ent/generated/entql.go
@@ -2252,6 +2252,7 @@ var schemaGraph = func() *sqlgraph.Schema {
 			user.FieldAvatarLocalFileID: {Type: field.TypeString, Column: user.FieldAvatarLocalFileID},
 			user.FieldAvatarUpdatedAt:   {Type: field.TypeTime, Column: user.FieldAvatarUpdatedAt},
 			user.FieldLastSeen:          {Type: field.TypeTime, Column: user.FieldLastSeen},
+			user.FieldLastLoginProvider: {Type: field.TypeEnum, Column: user.FieldLastLoginProvider},
 			user.FieldPassword:          {Type: field.TypeString, Column: user.FieldPassword},
 			user.FieldSub:               {Type: field.TypeString, Column: user.FieldSub},
 			user.FieldAuthProvider:      {Type: field.TypeEnum, Column: user.FieldAuthProvider},
@@ -2288,6 +2289,7 @@ var schemaGraph = func() *sqlgraph.Schema {
 			userhistory.FieldAvatarLocalFileID: {Type: field.TypeString, Column: userhistory.FieldAvatarLocalFileID},
 			userhistory.FieldAvatarUpdatedAt:   {Type: field.TypeTime, Column: userhistory.FieldAvatarUpdatedAt},
 			userhistory.FieldLastSeen:          {Type: field.TypeTime, Column: userhistory.FieldLastSeen},
+			userhistory.FieldLastLoginProvider: {Type: field.TypeEnum, Column: userhistory.FieldLastLoginProvider},
 			userhistory.FieldPassword:          {Type: field.TypeString, Column: userhistory.FieldPassword},
 			userhistory.FieldSub:               {Type: field.TypeString, Column: userhistory.FieldSub},
 			userhistory.FieldAuthProvider:      {Type: field.TypeEnum, Column: userhistory.FieldAuthProvider},
@@ -19225,6 +19227,11 @@ func (f *UserFilter) WhereLastSeen(p entql.TimeP) {
 	f.Where(p.Field(user.FieldLastSeen))
 }
 
+// WhereLastLoginProvider applies the entql string predicate on the last_login_provider field.
+func (f *UserFilter) WhereLastLoginProvider(p entql.StringP) {
+	f.Where(p.Field(user.FieldLastLoginProvider))
+}
+
 // WherePassword applies the entql string predicate on the password field.
 func (f *UserFilter) WherePassword(p entql.StringP) {
 	f.Where(p.Field(user.FieldPassword))
@@ -19644,6 +19651,11 @@ func (f *UserHistoryFilter) WhereAvatarUpdatedAt(p entql.TimeP) {
 // WhereLastSeen applies the entql time.Time predicate on the last_seen field.
 func (f *UserHistoryFilter) WhereLastSeen(p entql.TimeP) {
 	f.Where(p.Field(userhistory.FieldLastSeen))
+}
+
+// WhereLastLoginProvider applies the entql string predicate on the last_login_provider field.
+func (f *UserHistoryFilter) WhereLastLoginProvider(p entql.StringP) {
+	f.Where(p.Field(userhistory.FieldLastLoginProvider))
 }
 
 // WherePassword applies the entql string predicate on the password field.

--- a/internal/ent/generated/gql_collection.go
+++ b/internal/ent/generated/gql_collection.go
@@ -30223,6 +30223,11 @@ func (u *UserQuery) collectField(ctx context.Context, oneNode bool, opCtx *graph
 				selectedFields = append(selectedFields, user.FieldLastSeen)
 				fieldSeen[user.FieldLastSeen] = struct{}{}
 			}
+		case "lastLoginProvider":
+			if _, ok := fieldSeen[user.FieldLastLoginProvider]; !ok {
+				selectedFields = append(selectedFields, user.FieldLastLoginProvider)
+				fieldSeen[user.FieldLastLoginProvider] = struct{}{}
+			}
 		case "sub":
 			if _, ok := fieldSeen[user.FieldSub]; !ok {
 				selectedFields = append(selectedFields, user.FieldSub)
@@ -30422,6 +30427,11 @@ func (uh *UserHistoryQuery) collectField(ctx context.Context, oneNode bool, opCt
 			if _, ok := fieldSeen[userhistory.FieldLastSeen]; !ok {
 				selectedFields = append(selectedFields, userhistory.FieldLastSeen)
 				fieldSeen[userhistory.FieldLastSeen] = struct{}{}
+			}
+		case "lastLoginProvider":
+			if _, ok := fieldSeen[userhistory.FieldLastLoginProvider]; !ok {
+				selectedFields = append(selectedFields, userhistory.FieldLastLoginProvider)
+				fieldSeen[userhistory.FieldLastLoginProvider] = struct{}{}
 			}
 		case "sub":
 			if _, ok := fieldSeen[userhistory.FieldSub]; !ok {

--- a/internal/ent/generated/gql_mutation_input.go
+++ b/internal/ent/generated/gql_mutation_input.go
@@ -8147,6 +8147,7 @@ type CreateUserInput struct {
 	AvatarRemoteURL           *string
 	AvatarUpdatedAt           *time.Time
 	LastSeen                  *time.Time
+	LastLoginProvider         *enums.AuthProvider
 	Password                  *string
 	Sub                       *string
 	AuthProvider              *enums.AuthProvider
@@ -8190,6 +8191,9 @@ func (i *CreateUserInput) Mutate(m *UserMutation) {
 	}
 	if v := i.LastSeen; v != nil {
 		m.SetLastSeen(*v)
+	}
+	if v := i.LastLoginProvider; v != nil {
+		m.SetLastLoginProvider(*v)
 	}
 	if v := i.Password; v != nil {
 		m.SetPassword(*v)
@@ -8274,6 +8278,8 @@ type UpdateUserInput struct {
 	AvatarUpdatedAt                 *time.Time
 	ClearLastSeen                   bool
 	LastSeen                        *time.Time
+	ClearLastLoginProvider          bool
+	LastLoginProvider               *enums.AuthProvider
 	ClearPassword                   bool
 	Password                        *string
 	ClearSub                        bool
@@ -8374,6 +8380,12 @@ func (i *UpdateUserInput) Mutate(m *UserMutation) {
 	}
 	if v := i.LastSeen; v != nil {
 		m.SetLastSeen(*v)
+	}
+	if i.ClearLastLoginProvider {
+		m.ClearLastLoginProvider()
+	}
+	if v := i.LastLoginProvider; v != nil {
+		m.SetLastLoginProvider(*v)
 	}
 	if i.ClearPassword {
 		m.ClearPassword()

--- a/internal/ent/generated/gql_where_input.go
+++ b/internal/ent/generated/gql_where_input.go
@@ -66860,6 +66860,14 @@ type UserWhereInput struct {
 	LastSeenIsNil  bool        `json:"lastSeenIsNil,omitempty"`
 	LastSeenNotNil bool        `json:"lastSeenNotNil,omitempty"`
 
+	// "last_login_provider" field predicates.
+	LastLoginProvider       *enums.AuthProvider  `json:"lastLoginProvider,omitempty"`
+	LastLoginProviderNEQ    *enums.AuthProvider  `json:"lastLoginProviderNEQ,omitempty"`
+	LastLoginProviderIn     []enums.AuthProvider `json:"lastLoginProviderIn,omitempty"`
+	LastLoginProviderNotIn  []enums.AuthProvider `json:"lastLoginProviderNotIn,omitempty"`
+	LastLoginProviderIsNil  bool                 `json:"lastLoginProviderIsNil,omitempty"`
+	LastLoginProviderNotNil bool                 `json:"lastLoginProviderNotNil,omitempty"`
+
 	// "password" field predicates.
 	Password             *string  `json:"password,omitempty"`
 	PasswordNEQ          *string  `json:"passwordNEQ,omitempty"`
@@ -67656,6 +67664,24 @@ func (i *UserWhereInput) P() (predicate.User, error) {
 	if i.LastSeenNotNil {
 		predicates = append(predicates, user.LastSeenNotNil())
 	}
+	if i.LastLoginProvider != nil {
+		predicates = append(predicates, user.LastLoginProviderEQ(*i.LastLoginProvider))
+	}
+	if i.LastLoginProviderNEQ != nil {
+		predicates = append(predicates, user.LastLoginProviderNEQ(*i.LastLoginProviderNEQ))
+	}
+	if len(i.LastLoginProviderIn) > 0 {
+		predicates = append(predicates, user.LastLoginProviderIn(i.LastLoginProviderIn...))
+	}
+	if len(i.LastLoginProviderNotIn) > 0 {
+		predicates = append(predicates, user.LastLoginProviderNotIn(i.LastLoginProviderNotIn...))
+	}
+	if i.LastLoginProviderIsNil {
+		predicates = append(predicates, user.LastLoginProviderIsNil())
+	}
+	if i.LastLoginProviderNotNil {
+		predicates = append(predicates, user.LastLoginProviderNotNil())
+	}
 	if i.Password != nil {
 		predicates = append(predicates, user.PasswordEQ(*i.Password))
 	}
@@ -68350,6 +68376,14 @@ type UserHistoryWhereInput struct {
 	LastSeenLTE    *time.Time  `json:"lastSeenLTE,omitempty"`
 	LastSeenIsNil  bool        `json:"lastSeenIsNil,omitempty"`
 	LastSeenNotNil bool        `json:"lastSeenNotNil,omitempty"`
+
+	// "last_login_provider" field predicates.
+	LastLoginProvider       *enums.AuthProvider  `json:"lastLoginProvider,omitempty"`
+	LastLoginProviderNEQ    *enums.AuthProvider  `json:"lastLoginProviderNEQ,omitempty"`
+	LastLoginProviderIn     []enums.AuthProvider `json:"lastLoginProviderIn,omitempty"`
+	LastLoginProviderNotIn  []enums.AuthProvider `json:"lastLoginProviderNotIn,omitempty"`
+	LastLoginProviderIsNil  bool                 `json:"lastLoginProviderIsNil,omitempty"`
+	LastLoginProviderNotNil bool                 `json:"lastLoginProviderNotNil,omitempty"`
 
 	// "password" field predicates.
 	Password             *string  `json:"password,omitempty"`
@@ -69163,6 +69197,24 @@ func (i *UserHistoryWhereInput) P() (predicate.UserHistory, error) {
 	}
 	if i.LastSeenNotNil {
 		predicates = append(predicates, userhistory.LastSeenNotNil())
+	}
+	if i.LastLoginProvider != nil {
+		predicates = append(predicates, userhistory.LastLoginProviderEQ(*i.LastLoginProvider))
+	}
+	if i.LastLoginProviderNEQ != nil {
+		predicates = append(predicates, userhistory.LastLoginProviderNEQ(*i.LastLoginProviderNEQ))
+	}
+	if len(i.LastLoginProviderIn) > 0 {
+		predicates = append(predicates, userhistory.LastLoginProviderIn(i.LastLoginProviderIn...))
+	}
+	if len(i.LastLoginProviderNotIn) > 0 {
+		predicates = append(predicates, userhistory.LastLoginProviderNotIn(i.LastLoginProviderNotIn...))
+	}
+	if i.LastLoginProviderIsNil {
+		predicates = append(predicates, userhistory.LastLoginProviderIsNil())
+	}
+	if i.LastLoginProviderNotNil {
+		predicates = append(predicates, userhistory.LastLoginProviderNotNil())
 	}
 	if i.Password != nil {
 		predicates = append(predicates, userhistory.PasswordEQ(*i.Password))

--- a/internal/ent/generated/history_from_mutation.go
+++ b/internal/ent/generated/history_from_mutation.go
@@ -8306,6 +8306,10 @@ func (m *UserMutation) CreateHistoryFromCreate(ctx context.Context) error {
 		create = create.SetNillableLastSeen(&lastSeen)
 	}
 
+	if lastLoginProvider, exists := m.LastLoginProvider(); exists {
+		create = create.SetLastLoginProvider(lastLoginProvider)
+	}
+
 	if password, exists := m.Password(); exists {
 		create = create.SetNillablePassword(&password)
 	}
@@ -8448,6 +8452,12 @@ func (m *UserMutation) CreateHistoryFromUpdate(ctx context.Context) error {
 			create = create.SetNillableLastSeen(user.LastSeen)
 		}
 
+		if lastLoginProvider, exists := m.LastLoginProvider(); exists {
+			create = create.SetLastLoginProvider(lastLoginProvider)
+		} else {
+			create = create.SetLastLoginProvider(user.LastLoginProvider)
+		}
+
 		if password, exists := m.Password(); exists {
 			create = create.SetNillablePassword(&password)
 		} else {
@@ -8520,6 +8530,7 @@ func (m *UserMutation) CreateHistoryFromDelete(ctx context.Context) error {
 			SetNillableAvatarLocalFileID(user.AvatarLocalFileID).
 			SetNillableAvatarUpdatedAt(user.AvatarUpdatedAt).
 			SetNillableLastSeen(user.LastSeen).
+			SetLastLoginProvider(user.LastLoginProvider).
 			SetNillablePassword(user.Password).
 			SetSub(user.Sub).
 			SetAuthProvider(user.AuthProvider).

--- a/internal/ent/generated/migrate/schema.go
+++ b/internal/ent/generated/migrate/schema.go
@@ -3237,6 +3237,7 @@ var (
 		{Name: "avatar_remote_url", Type: field.TypeString, Nullable: true, Size: 2048},
 		{Name: "avatar_updated_at", Type: field.TypeTime, Nullable: true},
 		{Name: "last_seen", Type: field.TypeTime, Nullable: true},
+		{Name: "last_login_provider", Type: field.TypeEnum, Nullable: true, Enums: []string{"CREDENTIALS", "GOOGLE", "GITHUB", "WEBAUTHN"}},
 		{Name: "password", Type: field.TypeString, Nullable: true},
 		{Name: "sub", Type: field.TypeString, Unique: true, Nullable: true},
 		{Name: "auth_provider", Type: field.TypeEnum, Enums: []string{"CREDENTIALS", "GOOGLE", "GITHUB", "WEBAUTHN"}, Default: "CREDENTIALS"},
@@ -3251,7 +3252,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "users_files_avatar_file",
-				Columns:    []*schema.Column{UsersColumns[20]},
+				Columns:    []*schema.Column{UsersColumns[21]},
 				RefColumns: []*schema.Column{FilesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -3294,6 +3295,7 @@ var (
 		{Name: "avatar_local_file_id", Type: field.TypeString, Nullable: true},
 		{Name: "avatar_updated_at", Type: field.TypeTime, Nullable: true},
 		{Name: "last_seen", Type: field.TypeTime, Nullable: true},
+		{Name: "last_login_provider", Type: field.TypeEnum, Nullable: true, Enums: []string{"CREDENTIALS", "GOOGLE", "GITHUB", "WEBAUTHN"}},
 		{Name: "password", Type: field.TypeString, Nullable: true},
 		{Name: "sub", Type: field.TypeString, Nullable: true},
 		{Name: "auth_provider", Type: field.TypeEnum, Enums: []string{"CREDENTIALS", "GOOGLE", "GITHUB", "WEBAUTHN"}, Default: "CREDENTIALS"},

--- a/internal/ent/generated/user/user.go
+++ b/internal/ent/generated/user/user.go
@@ -50,6 +50,8 @@ const (
 	FieldAvatarUpdatedAt = "avatar_updated_at"
 	// FieldLastSeen holds the string denoting the last_seen field in the database.
 	FieldLastSeen = "last_seen"
+	// FieldLastLoginProvider holds the string denoting the last_login_provider field in the database.
+	FieldLastLoginProvider = "last_login_provider"
 	// FieldPassword holds the string denoting the password field in the database.
 	FieldPassword = "password"
 	// FieldSub holds the string denoting the sub field in the database.
@@ -240,6 +242,7 @@ var Columns = []string{
 	FieldAvatarLocalFileID,
 	FieldAvatarUpdatedAt,
 	FieldLastSeen,
+	FieldLastLoginProvider,
 	FieldPassword,
 	FieldSub,
 	FieldAuthProvider,
@@ -315,6 +318,16 @@ var (
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() string
 )
+
+// LastLoginProviderValidator is a validator for the "last_login_provider" field enum values. It is called by the builders before save.
+func LastLoginProviderValidator(llp enums.AuthProvider) error {
+	switch llp.String() {
+	case "CREDENTIALS", "GOOGLE", "GITHUB", "WEBAUTHN":
+		return nil
+	default:
+		return fmt.Errorf("user: invalid enum value for last_login_provider field: %q", llp)
+	}
+}
 
 const DefaultAuthProvider enums.AuthProvider = "CREDENTIALS"
 
@@ -421,6 +434,11 @@ func ByAvatarUpdatedAt(opts ...sql.OrderTermOption) OrderOption {
 // ByLastSeen orders the results by the last_seen field.
 func ByLastSeen(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldLastSeen, opts...).ToFunc()
+}
+
+// ByLastLoginProvider orders the results by the last_login_provider field.
+func ByLastLoginProvider(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldLastLoginProvider, opts...).ToFunc()
 }
 
 // ByPassword orders the results by the password field.
@@ -827,6 +845,13 @@ func newProgramMembershipsStep() *sqlgraph.Step {
 		sqlgraph.Edge(sqlgraph.O2M, true, ProgramMembershipsTable, ProgramMembershipsColumn),
 	)
 }
+
+var (
+	// enums.AuthProvider must implement graphql.Marshaler.
+	_ graphql.Marshaler = (*enums.AuthProvider)(nil)
+	// enums.AuthProvider must implement graphql.Unmarshaler.
+	_ graphql.Unmarshaler = (*enums.AuthProvider)(nil)
+)
 
 var (
 	// enums.AuthProvider must implement graphql.Marshaler.

--- a/internal/ent/generated/user/where.go
+++ b/internal/ent/generated/user/where.go
@@ -1133,6 +1133,46 @@ func LastSeenNotNil() predicate.User {
 	return predicate.User(sql.FieldNotNull(FieldLastSeen))
 }
 
+// LastLoginProviderEQ applies the EQ predicate on the "last_login_provider" field.
+func LastLoginProviderEQ(v enums.AuthProvider) predicate.User {
+	vc := v
+	return predicate.User(sql.FieldEQ(FieldLastLoginProvider, vc))
+}
+
+// LastLoginProviderNEQ applies the NEQ predicate on the "last_login_provider" field.
+func LastLoginProviderNEQ(v enums.AuthProvider) predicate.User {
+	vc := v
+	return predicate.User(sql.FieldNEQ(FieldLastLoginProvider, vc))
+}
+
+// LastLoginProviderIn applies the In predicate on the "last_login_provider" field.
+func LastLoginProviderIn(vs ...enums.AuthProvider) predicate.User {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.User(sql.FieldIn(FieldLastLoginProvider, v...))
+}
+
+// LastLoginProviderNotIn applies the NotIn predicate on the "last_login_provider" field.
+func LastLoginProviderNotIn(vs ...enums.AuthProvider) predicate.User {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.User(sql.FieldNotIn(FieldLastLoginProvider, v...))
+}
+
+// LastLoginProviderIsNil applies the IsNil predicate on the "last_login_provider" field.
+func LastLoginProviderIsNil() predicate.User {
+	return predicate.User(sql.FieldIsNull(FieldLastLoginProvider))
+}
+
+// LastLoginProviderNotNil applies the NotNil predicate on the "last_login_provider" field.
+func LastLoginProviderNotNil() predicate.User {
+	return predicate.User(sql.FieldNotNull(FieldLastLoginProvider))
+}
+
 // PasswordEQ applies the EQ predicate on the "password" field.
 func PasswordEQ(v string) predicate.User {
 	return predicate.User(sql.FieldEQ(FieldPassword, v))

--- a/internal/ent/generated/user_create.go
+++ b/internal/ent/generated/user_create.go
@@ -230,6 +230,20 @@ func (uc *UserCreate) SetNillableLastSeen(t *time.Time) *UserCreate {
 	return uc
 }
 
+// SetLastLoginProvider sets the "last_login_provider" field.
+func (uc *UserCreate) SetLastLoginProvider(ep enums.AuthProvider) *UserCreate {
+	uc.mutation.SetLastLoginProvider(ep)
+	return uc
+}
+
+// SetNillableLastLoginProvider sets the "last_login_provider" field if the given value is not nil.
+func (uc *UserCreate) SetNillableLastLoginProvider(ep *enums.AuthProvider) *UserCreate {
+	if ep != nil {
+		uc.SetLastLoginProvider(*ep)
+	}
+	return uc
+}
+
 // SetPassword sets the "password" field.
 func (uc *UserCreate) SetPassword(s string) *UserCreate {
 	uc.mutation.SetPassword(s)
@@ -706,6 +720,11 @@ func (uc *UserCreate) check() error {
 			return &ValidationError{Name: "avatar_remote_url", err: fmt.Errorf(`generated: validator failed for field "User.avatar_remote_url": %w`, err)}
 		}
 	}
+	if v, ok := uc.mutation.LastLoginProvider(); ok {
+		if err := user.LastLoginProviderValidator(v); err != nil {
+			return &ValidationError{Name: "last_login_provider", err: fmt.Errorf(`generated: validator failed for field "User.last_login_provider": %w`, err)}
+		}
+	}
 	if _, ok := uc.mutation.AuthProvider(); !ok {
 		return &ValidationError{Name: "auth_provider", err: errors.New(`generated: missing required field "User.auth_provider"`)}
 	}
@@ -817,6 +836,10 @@ func (uc *UserCreate) createSpec() (*User, *sqlgraph.CreateSpec) {
 	if value, ok := uc.mutation.LastSeen(); ok {
 		_spec.SetField(user.FieldLastSeen, field.TypeTime, value)
 		_node.LastSeen = &value
+	}
+	if value, ok := uc.mutation.LastLoginProvider(); ok {
+		_spec.SetField(user.FieldLastLoginProvider, field.TypeEnum, value)
+		_node.LastLoginProvider = value
 	}
 	if value, ok := uc.mutation.Password(); ok {
 		_spec.SetField(user.FieldPassword, field.TypeString, value)

--- a/internal/ent/generated/user_update.go
+++ b/internal/ent/generated/user_update.go
@@ -272,6 +272,26 @@ func (uu *UserUpdate) ClearLastSeen() *UserUpdate {
 	return uu
 }
 
+// SetLastLoginProvider sets the "last_login_provider" field.
+func (uu *UserUpdate) SetLastLoginProvider(ep enums.AuthProvider) *UserUpdate {
+	uu.mutation.SetLastLoginProvider(ep)
+	return uu
+}
+
+// SetNillableLastLoginProvider sets the "last_login_provider" field if the given value is not nil.
+func (uu *UserUpdate) SetNillableLastLoginProvider(ep *enums.AuthProvider) *UserUpdate {
+	if ep != nil {
+		uu.SetLastLoginProvider(*ep)
+	}
+	return uu
+}
+
+// ClearLastLoginProvider clears the value of the "last_login_provider" field.
+func (uu *UserUpdate) ClearLastLoginProvider() *UserUpdate {
+	uu.mutation.ClearLastLoginProvider()
+	return uu
+}
+
 // SetPassword sets the "password" field.
 func (uu *UserUpdate) SetPassword(s string) *UserUpdate {
 	uu.mutation.SetPassword(s)
@@ -1088,6 +1108,11 @@ func (uu *UserUpdate) check() error {
 			return &ValidationError{Name: "avatar_remote_url", err: fmt.Errorf(`generated: validator failed for field "User.avatar_remote_url": %w`, err)}
 		}
 	}
+	if v, ok := uu.mutation.LastLoginProvider(); ok {
+		if err := user.LastLoginProviderValidator(v); err != nil {
+			return &ValidationError{Name: "last_login_provider", err: fmt.Errorf(`generated: validator failed for field "User.last_login_provider": %w`, err)}
+		}
+	}
 	if v, ok := uu.mutation.AuthProvider(); ok {
 		if err := user.AuthProviderValidator(v); err != nil {
 			return &ValidationError{Name: "auth_provider", err: fmt.Errorf(`generated: validator failed for field "User.auth_provider": %w`, err)}
@@ -1198,6 +1223,12 @@ func (uu *UserUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if uu.mutation.LastSeenCleared() {
 		_spec.ClearField(user.FieldLastSeen, field.TypeTime)
+	}
+	if value, ok := uu.mutation.LastLoginProvider(); ok {
+		_spec.SetField(user.FieldLastLoginProvider, field.TypeEnum, value)
+	}
+	if uu.mutation.LastLoginProviderCleared() {
+		_spec.ClearField(user.FieldLastLoginProvider, field.TypeEnum)
 	}
 	if value, ok := uu.mutation.Password(); ok {
 		_spec.SetField(user.FieldPassword, field.TypeString, value)
@@ -2407,6 +2438,26 @@ func (uuo *UserUpdateOne) ClearLastSeen() *UserUpdateOne {
 	return uuo
 }
 
+// SetLastLoginProvider sets the "last_login_provider" field.
+func (uuo *UserUpdateOne) SetLastLoginProvider(ep enums.AuthProvider) *UserUpdateOne {
+	uuo.mutation.SetLastLoginProvider(ep)
+	return uuo
+}
+
+// SetNillableLastLoginProvider sets the "last_login_provider" field if the given value is not nil.
+func (uuo *UserUpdateOne) SetNillableLastLoginProvider(ep *enums.AuthProvider) *UserUpdateOne {
+	if ep != nil {
+		uuo.SetLastLoginProvider(*ep)
+	}
+	return uuo
+}
+
+// ClearLastLoginProvider clears the value of the "last_login_provider" field.
+func (uuo *UserUpdateOne) ClearLastLoginProvider() *UserUpdateOne {
+	uuo.mutation.ClearLastLoginProvider()
+	return uuo
+}
+
 // SetPassword sets the "password" field.
 func (uuo *UserUpdateOne) SetPassword(s string) *UserUpdateOne {
 	uuo.mutation.SetPassword(s)
@@ -3236,6 +3287,11 @@ func (uuo *UserUpdateOne) check() error {
 			return &ValidationError{Name: "avatar_remote_url", err: fmt.Errorf(`generated: validator failed for field "User.avatar_remote_url": %w`, err)}
 		}
 	}
+	if v, ok := uuo.mutation.LastLoginProvider(); ok {
+		if err := user.LastLoginProviderValidator(v); err != nil {
+			return &ValidationError{Name: "last_login_provider", err: fmt.Errorf(`generated: validator failed for field "User.last_login_provider": %w`, err)}
+		}
+	}
 	if v, ok := uuo.mutation.AuthProvider(); ok {
 		if err := user.AuthProviderValidator(v); err != nil {
 			return &ValidationError{Name: "auth_provider", err: fmt.Errorf(`generated: validator failed for field "User.auth_provider": %w`, err)}
@@ -3363,6 +3419,12 @@ func (uuo *UserUpdateOne) sqlSave(ctx context.Context) (_node *User, err error) 
 	}
 	if uuo.mutation.LastSeenCleared() {
 		_spec.ClearField(user.FieldLastSeen, field.TypeTime)
+	}
+	if value, ok := uuo.mutation.LastLoginProvider(); ok {
+		_spec.SetField(user.FieldLastLoginProvider, field.TypeEnum, value)
+	}
+	if uuo.mutation.LastLoginProviderCleared() {
+		_spec.ClearField(user.FieldLastLoginProvider, field.TypeEnum)
 	}
 	if value, ok := uuo.mutation.Password(); ok {
 		_spec.SetField(user.FieldPassword, field.TypeString, value)

--- a/internal/ent/generated/userhistory.go
+++ b/internal/ent/generated/userhistory.go
@@ -58,6 +58,8 @@ type UserHistory struct {
 	AvatarUpdatedAt *time.Time `json:"avatar_updated_at,omitempty"`
 	// the time the user was last seen
 	LastSeen *time.Time `json:"last_seen,omitempty"`
+	// the last auth provider used to login
+	LastLoginProvider enums.AuthProvider `json:"last_login_provider,omitempty"`
 	// user password hash
 	Password *string `json:"-"`
 	// the Subject of the user JWT
@@ -78,7 +80,7 @@ func (*UserHistory) scanValues(columns []string) ([]any, error) {
 			values[i] = new([]byte)
 		case userhistory.FieldOperation:
 			values[i] = new(history.OpType)
-		case userhistory.FieldID, userhistory.FieldRef, userhistory.FieldCreatedBy, userhistory.FieldUpdatedBy, userhistory.FieldDeletedBy, userhistory.FieldDisplayID, userhistory.FieldEmail, userhistory.FieldFirstName, userhistory.FieldLastName, userhistory.FieldDisplayName, userhistory.FieldAvatarRemoteURL, userhistory.FieldAvatarLocalFileID, userhistory.FieldPassword, userhistory.FieldSub, userhistory.FieldAuthProvider, userhistory.FieldRole:
+		case userhistory.FieldID, userhistory.FieldRef, userhistory.FieldCreatedBy, userhistory.FieldUpdatedBy, userhistory.FieldDeletedBy, userhistory.FieldDisplayID, userhistory.FieldEmail, userhistory.FieldFirstName, userhistory.FieldLastName, userhistory.FieldDisplayName, userhistory.FieldAvatarRemoteURL, userhistory.FieldAvatarLocalFileID, userhistory.FieldLastLoginProvider, userhistory.FieldPassword, userhistory.FieldSub, userhistory.FieldAuthProvider, userhistory.FieldRole:
 			values[i] = new(sql.NullString)
 		case userhistory.FieldHistoryTime, userhistory.FieldCreatedAt, userhistory.FieldUpdatedAt, userhistory.FieldDeletedAt, userhistory.FieldAvatarUpdatedAt, userhistory.FieldLastSeen:
 			values[i] = new(sql.NullTime)
@@ -223,6 +225,12 @@ func (uh *UserHistory) assignValues(columns []string, values []any) error {
 				uh.LastSeen = new(time.Time)
 				*uh.LastSeen = value.Time
 			}
+		case userhistory.FieldLastLoginProvider:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field last_login_provider", values[i])
+			} else if value.Valid {
+				uh.LastLoginProvider = enums.AuthProvider(value.String)
+			}
 		case userhistory.FieldPassword:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field password", values[i])
@@ -348,6 +356,9 @@ func (uh *UserHistory) String() string {
 		builder.WriteString("last_seen=")
 		builder.WriteString(v.Format(time.ANSIC))
 	}
+	builder.WriteString(", ")
+	builder.WriteString("last_login_provider=")
+	builder.WriteString(fmt.Sprintf("%v", uh.LastLoginProvider))
 	builder.WriteString(", ")
 	builder.WriteString("password=<sensitive>")
 	builder.WriteString(", ")

--- a/internal/ent/generated/userhistory/userhistory.go
+++ b/internal/ent/generated/userhistory/userhistory.go
@@ -56,6 +56,8 @@ const (
 	FieldAvatarUpdatedAt = "avatar_updated_at"
 	// FieldLastSeen holds the string denoting the last_seen field in the database.
 	FieldLastSeen = "last_seen"
+	// FieldLastLoginProvider holds the string denoting the last_login_provider field in the database.
+	FieldLastLoginProvider = "last_login_provider"
 	// FieldPassword holds the string denoting the password field in the database.
 	FieldPassword = "password"
 	// FieldSub holds the string denoting the sub field in the database.
@@ -90,6 +92,7 @@ var Columns = []string{
 	FieldAvatarLocalFileID,
 	FieldAvatarUpdatedAt,
 	FieldLastSeen,
+	FieldLastLoginProvider,
 	FieldPassword,
 	FieldSub,
 	FieldAuthProvider,
@@ -140,6 +143,16 @@ func OperationValidator(o history.OpType) error {
 		return nil
 	default:
 		return fmt.Errorf("userhistory: invalid enum value for operation field: %q", o)
+	}
+}
+
+// LastLoginProviderValidator is a validator for the "last_login_provider" field enum values. It is called by the builders before save.
+func LastLoginProviderValidator(llp enums.AuthProvider) error {
+	switch llp.String() {
+	case "CREDENTIALS", "GOOGLE", "GITHUB", "WEBAUTHN":
+		return nil
+	default:
+		return fmt.Errorf("userhistory: invalid enum value for last_login_provider field: %q", llp)
 	}
 }
 
@@ -265,6 +278,11 @@ func ByLastSeen(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldLastSeen, opts...).ToFunc()
 }
 
+// ByLastLoginProvider orders the results by the last_login_provider field.
+func ByLastLoginProvider(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldLastLoginProvider, opts...).ToFunc()
+}
+
 // ByPassword orders the results by the password field.
 func ByPassword(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldPassword, opts...).ToFunc()
@@ -290,6 +308,13 @@ var (
 	_ graphql.Marshaler = (*history.OpType)(nil)
 	// history.OpType must implement graphql.Unmarshaler.
 	_ graphql.Unmarshaler = (*history.OpType)(nil)
+)
+
+var (
+	// enums.AuthProvider must implement graphql.Marshaler.
+	_ graphql.Marshaler = (*enums.AuthProvider)(nil)
+	// enums.AuthProvider must implement graphql.Unmarshaler.
+	_ graphql.Unmarshaler = (*enums.AuthProvider)(nil)
 )
 
 var (

--- a/internal/ent/generated/userhistory/where.go
+++ b/internal/ent/generated/userhistory/where.go
@@ -1276,6 +1276,46 @@ func LastSeenNotNil() predicate.UserHistory {
 	return predicate.UserHistory(sql.FieldNotNull(FieldLastSeen))
 }
 
+// LastLoginProviderEQ applies the EQ predicate on the "last_login_provider" field.
+func LastLoginProviderEQ(v enums.AuthProvider) predicate.UserHistory {
+	vc := v
+	return predicate.UserHistory(sql.FieldEQ(FieldLastLoginProvider, vc))
+}
+
+// LastLoginProviderNEQ applies the NEQ predicate on the "last_login_provider" field.
+func LastLoginProviderNEQ(v enums.AuthProvider) predicate.UserHistory {
+	vc := v
+	return predicate.UserHistory(sql.FieldNEQ(FieldLastLoginProvider, vc))
+}
+
+// LastLoginProviderIn applies the In predicate on the "last_login_provider" field.
+func LastLoginProviderIn(vs ...enums.AuthProvider) predicate.UserHistory {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.UserHistory(sql.FieldIn(FieldLastLoginProvider, v...))
+}
+
+// LastLoginProviderNotIn applies the NotIn predicate on the "last_login_provider" field.
+func LastLoginProviderNotIn(vs ...enums.AuthProvider) predicate.UserHistory {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.UserHistory(sql.FieldNotIn(FieldLastLoginProvider, v...))
+}
+
+// LastLoginProviderIsNil applies the IsNil predicate on the "last_login_provider" field.
+func LastLoginProviderIsNil() predicate.UserHistory {
+	return predicate.UserHistory(sql.FieldIsNull(FieldLastLoginProvider))
+}
+
+// LastLoginProviderNotNil applies the NotNil predicate on the "last_login_provider" field.
+func LastLoginProviderNotNil() predicate.UserHistory {
+	return predicate.UserHistory(sql.FieldNotNull(FieldLastLoginProvider))
+}
+
 // PasswordEQ applies the EQ predicate on the "password" field.
 func PasswordEQ(v string) predicate.UserHistory {
 	return predicate.UserHistory(sql.FieldEQ(FieldPassword, v))

--- a/internal/ent/generated/userhistory_create.go
+++ b/internal/ent/generated/userhistory_create.go
@@ -248,6 +248,20 @@ func (uhc *UserHistoryCreate) SetNillableLastSeen(t *time.Time) *UserHistoryCrea
 	return uhc
 }
 
+// SetLastLoginProvider sets the "last_login_provider" field.
+func (uhc *UserHistoryCreate) SetLastLoginProvider(ep enums.AuthProvider) *UserHistoryCreate {
+	uhc.mutation.SetLastLoginProvider(ep)
+	return uhc
+}
+
+// SetNillableLastLoginProvider sets the "last_login_provider" field if the given value is not nil.
+func (uhc *UserHistoryCreate) SetNillableLastLoginProvider(ep *enums.AuthProvider) *UserHistoryCreate {
+	if ep != nil {
+		uhc.SetLastLoginProvider(*ep)
+	}
+	return uhc
+}
+
 // SetPassword sets the "password" field.
 func (uhc *UserHistoryCreate) SetPassword(s string) *UserHistoryCreate {
 	uhc.mutation.SetPassword(s)
@@ -409,6 +423,11 @@ func (uhc *UserHistoryCreate) check() error {
 	if _, ok := uhc.mutation.DisplayName(); !ok {
 		return &ValidationError{Name: "display_name", err: errors.New(`generated: missing required field "UserHistory.display_name"`)}
 	}
+	if v, ok := uhc.mutation.LastLoginProvider(); ok {
+		if err := userhistory.LastLoginProviderValidator(v); err != nil {
+			return &ValidationError{Name: "last_login_provider", err: fmt.Errorf(`generated: validator failed for field "UserHistory.last_login_provider": %w`, err)}
+		}
+	}
 	if _, ok := uhc.mutation.AuthProvider(); !ok {
 		return &ValidationError{Name: "auth_provider", err: errors.New(`generated: missing required field "UserHistory.auth_provider"`)}
 	}
@@ -533,6 +552,10 @@ func (uhc *UserHistoryCreate) createSpec() (*UserHistory, *sqlgraph.CreateSpec) 
 	if value, ok := uhc.mutation.LastSeen(); ok {
 		_spec.SetField(userhistory.FieldLastSeen, field.TypeTime, value)
 		_node.LastSeen = &value
+	}
+	if value, ok := uhc.mutation.LastLoginProvider(); ok {
+		_spec.SetField(userhistory.FieldLastLoginProvider, field.TypeEnum, value)
+		_node.LastLoginProvider = value
 	}
 	if value, ok := uhc.mutation.Password(); ok {
 		_spec.SetField(userhistory.FieldPassword, field.TypeString, value)

--- a/internal/ent/generated/userhistory_update.go
+++ b/internal/ent/generated/userhistory_update.go
@@ -255,6 +255,26 @@ func (uhu *UserHistoryUpdate) ClearLastSeen() *UserHistoryUpdate {
 	return uhu
 }
 
+// SetLastLoginProvider sets the "last_login_provider" field.
+func (uhu *UserHistoryUpdate) SetLastLoginProvider(ep enums.AuthProvider) *UserHistoryUpdate {
+	uhu.mutation.SetLastLoginProvider(ep)
+	return uhu
+}
+
+// SetNillableLastLoginProvider sets the "last_login_provider" field if the given value is not nil.
+func (uhu *UserHistoryUpdate) SetNillableLastLoginProvider(ep *enums.AuthProvider) *UserHistoryUpdate {
+	if ep != nil {
+		uhu.SetLastLoginProvider(*ep)
+	}
+	return uhu
+}
+
+// ClearLastLoginProvider clears the value of the "last_login_provider" field.
+func (uhu *UserHistoryUpdate) ClearLastLoginProvider() *UserHistoryUpdate {
+	uhu.mutation.ClearLastLoginProvider()
+	return uhu
+}
+
 // SetPassword sets the "password" field.
 func (uhu *UserHistoryUpdate) SetPassword(s string) *UserHistoryUpdate {
 	uhu.mutation.SetPassword(s)
@@ -380,6 +400,11 @@ func (uhu *UserHistoryUpdate) defaults() {
 
 // check runs all checks and user-defined validators on the builder.
 func (uhu *UserHistoryUpdate) check() error {
+	if v, ok := uhu.mutation.LastLoginProvider(); ok {
+		if err := userhistory.LastLoginProviderValidator(v); err != nil {
+			return &ValidationError{Name: "last_login_provider", err: fmt.Errorf(`generated: validator failed for field "UserHistory.last_login_provider": %w`, err)}
+		}
+	}
 	if v, ok := uhu.mutation.AuthProvider(); ok {
 		if err := userhistory.AuthProviderValidator(v); err != nil {
 			return &ValidationError{Name: "auth_provider", err: fmt.Errorf(`generated: validator failed for field "UserHistory.auth_provider": %w`, err)}
@@ -496,6 +521,12 @@ func (uhu *UserHistoryUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if uhu.mutation.LastSeenCleared() {
 		_spec.ClearField(userhistory.FieldLastSeen, field.TypeTime)
+	}
+	if value, ok := uhu.mutation.LastLoginProvider(); ok {
+		_spec.SetField(userhistory.FieldLastLoginProvider, field.TypeEnum, value)
+	}
+	if uhu.mutation.LastLoginProviderCleared() {
+		_spec.ClearField(userhistory.FieldLastLoginProvider, field.TypeEnum)
 	}
 	if value, ok := uhu.mutation.Password(); ok {
 		_spec.SetField(userhistory.FieldPassword, field.TypeString, value)
@@ -764,6 +795,26 @@ func (uhuo *UserHistoryUpdateOne) ClearLastSeen() *UserHistoryUpdateOne {
 	return uhuo
 }
 
+// SetLastLoginProvider sets the "last_login_provider" field.
+func (uhuo *UserHistoryUpdateOne) SetLastLoginProvider(ep enums.AuthProvider) *UserHistoryUpdateOne {
+	uhuo.mutation.SetLastLoginProvider(ep)
+	return uhuo
+}
+
+// SetNillableLastLoginProvider sets the "last_login_provider" field if the given value is not nil.
+func (uhuo *UserHistoryUpdateOne) SetNillableLastLoginProvider(ep *enums.AuthProvider) *UserHistoryUpdateOne {
+	if ep != nil {
+		uhuo.SetLastLoginProvider(*ep)
+	}
+	return uhuo
+}
+
+// ClearLastLoginProvider clears the value of the "last_login_provider" field.
+func (uhuo *UserHistoryUpdateOne) ClearLastLoginProvider() *UserHistoryUpdateOne {
+	uhuo.mutation.ClearLastLoginProvider()
+	return uhuo
+}
+
 // SetPassword sets the "password" field.
 func (uhuo *UserHistoryUpdateOne) SetPassword(s string) *UserHistoryUpdateOne {
 	uhuo.mutation.SetPassword(s)
@@ -902,6 +953,11 @@ func (uhuo *UserHistoryUpdateOne) defaults() {
 
 // check runs all checks and user-defined validators on the builder.
 func (uhuo *UserHistoryUpdateOne) check() error {
+	if v, ok := uhuo.mutation.LastLoginProvider(); ok {
+		if err := userhistory.LastLoginProviderValidator(v); err != nil {
+			return &ValidationError{Name: "last_login_provider", err: fmt.Errorf(`generated: validator failed for field "UserHistory.last_login_provider": %w`, err)}
+		}
+	}
 	if v, ok := uhuo.mutation.AuthProvider(); ok {
 		if err := userhistory.AuthProviderValidator(v); err != nil {
 			return &ValidationError{Name: "auth_provider", err: fmt.Errorf(`generated: validator failed for field "UserHistory.auth_provider": %w`, err)}
@@ -1035,6 +1091,12 @@ func (uhuo *UserHistoryUpdateOne) sqlSave(ctx context.Context) (_node *UserHisto
 	}
 	if uhuo.mutation.LastSeenCleared() {
 		_spec.ClearField(userhistory.FieldLastSeen, field.TypeTime)
+	}
+	if value, ok := uhuo.mutation.LastLoginProvider(); ok {
+		_spec.SetField(userhistory.FieldLastLoginProvider, field.TypeEnum, value)
+	}
+	if uhuo.mutation.LastLoginProviderCleared() {
+		_spec.ClearField(userhistory.FieldLastLoginProvider, field.TypeEnum)
 	}
 	if value, ok := uhuo.mutation.Password(); ok {
 		_spec.SetField(userhistory.FieldPassword, field.TypeString, value)

--- a/internal/ent/schema/user.go
+++ b/internal/ent/schema/user.go
@@ -120,6 +120,10 @@ func (User) Fields() []ent.Field {
 			UpdateDefault(time.Now).
 			Optional().
 			Nillable(),
+		field.Enum("last_login_provider").
+			Comment("the last auth provider used to login").
+			Optional().
+			GoType(enums.AuthProvider("")),
 		field.String("password").
 			Comment("user password hash").
 			Nillable().

--- a/internal/ent/schema/usersetting.go
+++ b/internal/ent/schema/usersetting.go
@@ -130,6 +130,7 @@ func (UserSetting) Policy() ent.Policy {
 		policy.WithOnMutationRules(
 			ent.OpUpdateOne|ent.OpUpdate,
 			rule.AllowIfContextHasPrivacyTokenOfType[*token.VerifyToken](),
+			rule.AllowIfContextHasPrivacyTokenOfType[*token.OauthTooToken](),
 			rule.AllowIfSelf(),
 		),
 		policy.WithOnMutationRules(

--- a/internal/graphapi/clientschema/schema.graphql
+++ b/internal/graphapi/clientschema/schema.graphql
@@ -7683,6 +7683,10 @@ input CreateUserInput {
 	"""
 	lastSeen: Time
 	"""
+	the last auth provider used to login
+	"""
+	lastLoginProvider: UserAuthProvider
+	"""
 	user password hash
 	"""
 	password: String
@@ -42906,6 +42910,11 @@ input UpdateUserInput {
 	lastSeen: Time
 	clearLastSeen: Boolean
 	"""
+	the last auth provider used to login
+	"""
+	lastLoginProvider: UserAuthProvider
+	clearLastLoginProvider: Boolean
+	"""
 	user password hash
 	"""
 	password: String
@@ -43065,6 +43074,10 @@ type User implements Node {
 	the time the user was last seen
 	"""
 	lastSeen: Time
+	"""
+	the last auth provider used to login
+	"""
+	lastLoginProvider: UserAuthProvider
 	"""
 	the Subject of the user JWT
 	"""
@@ -43455,7 +43468,7 @@ type User implements Node {
 	programMemberships: [ProgramMembership!]
 }
 """
-UserAuthProvider is enum for the field auth_provider
+UserAuthProvider is enum for the field last_login_provider
 """
 enum UserAuthProvider @goModel(model: "github.com/theopenlane/core/pkg/enums.AuthProvider") {
 	CREDENTIALS
@@ -43563,6 +43576,10 @@ type UserHistory implements Node {
 	"""
 	lastSeen: Time
 	"""
+	the last auth provider used to login
+	"""
+	lastLoginProvider: UserHistoryAuthProvider
+	"""
 	the Subject of the user JWT
 	"""
 	sub: String
@@ -43576,7 +43593,7 @@ type UserHistory implements Node {
 	role: UserHistoryRole
 }
 """
-UserHistoryAuthProvider is enum for the field auth_provider
+UserHistoryAuthProvider is enum for the field last_login_provider
 """
 enum UserHistoryAuthProvider @goModel(model: "github.com/theopenlane/core/pkg/enums.AuthProvider") {
 	CREDENTIALS
@@ -43949,6 +43966,15 @@ input UserHistoryWhereInput {
 	lastSeenLTE: Time
 	lastSeenIsNil: Boolean
 	lastSeenNotNil: Boolean
+	"""
+	last_login_provider field predicates
+	"""
+	lastLoginProvider: UserHistoryAuthProvider
+	lastLoginProviderNEQ: UserHistoryAuthProvider
+	lastLoginProviderIn: [UserHistoryAuthProvider!]
+	lastLoginProviderNotIn: [UserHistoryAuthProvider!]
+	lastLoginProviderIsNil: Boolean
+	lastLoginProviderNotNil: Boolean
 	"""
 	sub field predicates
 	"""
@@ -44993,6 +45019,15 @@ input UserWhereInput {
 	lastSeenLTE: Time
 	lastSeenIsNil: Boolean
 	lastSeenNotNil: Boolean
+	"""
+	last_login_provider field predicates
+	"""
+	lastLoginProvider: UserAuthProvider
+	lastLoginProviderNEQ: UserAuthProvider
+	lastLoginProviderIn: [UserAuthProvider!]
+	lastLoginProviderNotIn: [UserAuthProvider!]
+	lastLoginProviderIsNil: Boolean
+	lastLoginProviderNotNil: Boolean
 	"""
 	sub field predicates
 	"""

--- a/internal/graphapi/generated/root_.generated.go
+++ b/internal/graphapi/generated/root_.generated.go
@@ -3556,6 +3556,7 @@ type ComplexityRoot struct {
 		GroupMemberships     func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.GroupMembershipOrder, where *generated.GroupMembershipWhereInput) int
 		Groups               func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.GroupOrder, where *generated.GroupWhereInput) int
 		ID                   func(childComplexity int) int
+		LastLoginProvider    func(childComplexity int) int
 		LastName             func(childComplexity int) int
 		LastSeen             func(childComplexity int) int
 		OrgMemberships       func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.OrgMembershipOrder, where *generated.OrgMembershipWhereInput) int
@@ -3611,6 +3612,7 @@ type ComplexityRoot struct {
 		FirstName         func(childComplexity int) int
 		HistoryTime       func(childComplexity int) int
 		ID                func(childComplexity int) int
+		LastLoginProvider func(childComplexity int) int
 		LastName          func(childComplexity int) int
 		LastSeen          func(childComplexity int) int
 		Operation         func(childComplexity int) int
@@ -23470,6 +23472,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.User.ID(childComplexity), true
 
+	case "User.lastLoginProvider":
+		if e.complexity.User.LastLoginProvider == nil {
+			break
+		}
+
+		return e.complexity.User.LastLoginProvider(childComplexity), true
+
 	case "User.lastName":
 		if e.complexity.User.LastName == nil {
 			break
@@ -23753,6 +23762,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.UserHistory.ID(childComplexity), true
+
+	case "UserHistory.lastLoginProvider":
+		if e.complexity.UserHistory.LastLoginProvider == nil {
+			break
+		}
+
+		return e.complexity.UserHistory.LastLoginProvider(childComplexity), true
 
 	case "UserHistory.lastName":
 		if e.complexity.UserHistory.LastName == nil {
@@ -33554,6 +33570,10 @@ input CreateUserInput {
   the time the user was last seen
   """
   lastSeen: Time
+  """
+  the last auth provider used to login
+  """
+  lastLoginProvider: UserAuthProvider
   """
   user password hash
   """
@@ -63528,6 +63548,11 @@ input UpdateUserInput {
   lastSeen: Time
   clearLastSeen: Boolean
   """
+  the last auth provider used to login
+  """
+  lastLoginProvider: UserAuthProvider
+  clearLastLoginProvider: Boolean
+  """
   user password hash
   """
   password: String
@@ -63682,6 +63707,10 @@ type User implements Node {
   the time the user was last seen
   """
   lastSeen: Time
+  """
+  the last auth provider used to login
+  """
+  lastLoginProvider: UserAuthProvider
   """
   the Subject of the user JWT
   """
@@ -64072,7 +64101,7 @@ type User implements Node {
   programMemberships: [ProgramMembership!]
 }
 """
-UserAuthProvider is enum for the field auth_provider
+UserAuthProvider is enum for the field last_login_provider
 """
 enum UserAuthProvider @goModel(model: "github.com/theopenlane/core/pkg/enums.AuthProvider") {
   CREDENTIALS
@@ -64153,6 +64182,10 @@ type UserHistory implements Node {
   """
   lastSeen: Time
   """
+  the last auth provider used to login
+  """
+  lastLoginProvider: UserHistoryAuthProvider
+  """
   the Subject of the user JWT
   """
   sub: String
@@ -64166,7 +64199,7 @@ type UserHistory implements Node {
   role: UserHistoryRole
 }
 """
-UserHistoryAuthProvider is enum for the field auth_provider
+UserHistoryAuthProvider is enum for the field last_login_provider
 """
 enum UserHistoryAuthProvider @goModel(model: "github.com/theopenlane/core/pkg/enums.AuthProvider") {
   CREDENTIALS
@@ -64539,6 +64572,15 @@ input UserHistoryWhereInput {
   lastSeenLTE: Time
   lastSeenIsNil: Boolean
   lastSeenNotNil: Boolean
+  """
+  last_login_provider field predicates
+  """
+  lastLoginProvider: UserHistoryAuthProvider
+  lastLoginProviderNEQ: UserHistoryAuthProvider
+  lastLoginProviderIn: [UserHistoryAuthProvider!]
+  lastLoginProviderNotIn: [UserHistoryAuthProvider!]
+  lastLoginProviderIsNil: Boolean
+  lastLoginProviderNotNil: Boolean
   """
   sub field predicates
   """
@@ -65547,6 +65589,15 @@ input UserWhereInput {
   lastSeenLTE: Time
   lastSeenIsNil: Boolean
   lastSeenNotNil: Boolean
+  """
+  last_login_provider field predicates
+  """
+  lastLoginProvider: UserAuthProvider
+  lastLoginProviderNEQ: UserAuthProvider
+  lastLoginProviderIn: [UserAuthProvider!]
+  lastLoginProviderNotIn: [UserAuthProvider!]
+  lastLoginProviderIsNil: Boolean
+  lastLoginProviderNotNil: Boolean
   """
   sub field predicates
   """

--- a/internal/graphapi/generated/user.generated.go
+++ b/internal/graphapi/generated/user.generated.go
@@ -99,6 +99,8 @@ func (ec *executionContext) fieldContext_UserBulkCreatePayload_users(_ context.C
 				return ec.fieldContext_User_avatarUpdatedAt(ctx, field)
 			case "lastSeen":
 				return ec.fieldContext_User_lastSeen(ctx, field)
+			case "lastLoginProvider":
+				return ec.fieldContext_User_lastLoginProvider(ctx, field)
 			case "sub":
 				return ec.fieldContext_User_sub(ctx, field)
 			case "authProvider":
@@ -217,6 +219,8 @@ func (ec *executionContext) fieldContext_UserCreatePayload_user(_ context.Contex
 				return ec.fieldContext_User_avatarUpdatedAt(ctx, field)
 			case "lastSeen":
 				return ec.fieldContext_User_lastSeen(ctx, field)
+			case "lastLoginProvider":
+				return ec.fieldContext_User_lastLoginProvider(ctx, field)
 			case "sub":
 				return ec.fieldContext_User_sub(ctx, field)
 			case "authProvider":
@@ -379,6 +383,8 @@ func (ec *executionContext) fieldContext_UserUpdatePayload_user(_ context.Contex
 				return ec.fieldContext_User_avatarUpdatedAt(ctx, field)
 			case "lastSeen":
 				return ec.fieldContext_User_lastSeen(ctx, field)
+			case "lastLoginProvider":
+				return ec.fieldContext_User_lastLoginProvider(ctx, field)
 			case "sub":
 				return ec.fieldContext_User_sub(ctx, field)
 			case "authProvider":

--- a/internal/graphapi/models_test.go
+++ b/internal/graphapi/models_test.go
@@ -413,6 +413,8 @@ func (u *UserBuilder) MustNew(ctx context.Context, t *testing.T) *ent.User {
 		SetLastName(u.LastName).
 		SetEmail(u.Email).
 		SetPassword(u.Password).
+		SetLastLoginProvider(enums.AuthProviderCredentials).
+		SetLastSeen(time.Now()).
 		SetSetting(userSetting).
 		Save(ctx)
 	require.NoError(t, err)

--- a/internal/graphapi/schema/ent.graphql
+++ b/internal/graphapi/schema/ent.graphql
@@ -7374,6 +7374,10 @@ input CreateUserInput {
   """
   lastSeen: Time
   """
+  the last auth provider used to login
+  """
+  lastLoginProvider: UserAuthProvider
+  """
   user password hash
   """
   password: String
@@ -37347,6 +37351,11 @@ input UpdateUserInput {
   lastSeen: Time
   clearLastSeen: Boolean
   """
+  the last auth provider used to login
+  """
+  lastLoginProvider: UserAuthProvider
+  clearLastLoginProvider: Boolean
+  """
   user password hash
   """
   password: String
@@ -37501,6 +37510,10 @@ type User implements Node {
   the time the user was last seen
   """
   lastSeen: Time
+  """
+  the last auth provider used to login
+  """
+  lastLoginProvider: UserAuthProvider
   """
   the Subject of the user JWT
   """
@@ -37891,7 +37904,7 @@ type User implements Node {
   programMemberships: [ProgramMembership!]
 }
 """
-UserAuthProvider is enum for the field auth_provider
+UserAuthProvider is enum for the field last_login_provider
 """
 enum UserAuthProvider @goModel(model: "github.com/theopenlane/core/pkg/enums.AuthProvider") {
   CREDENTIALS
@@ -37972,6 +37985,10 @@ type UserHistory implements Node {
   """
   lastSeen: Time
   """
+  the last auth provider used to login
+  """
+  lastLoginProvider: UserHistoryAuthProvider
+  """
   the Subject of the user JWT
   """
   sub: String
@@ -37985,7 +38002,7 @@ type UserHistory implements Node {
   role: UserHistoryRole
 }
 """
-UserHistoryAuthProvider is enum for the field auth_provider
+UserHistoryAuthProvider is enum for the field last_login_provider
 """
 enum UserHistoryAuthProvider @goModel(model: "github.com/theopenlane/core/pkg/enums.AuthProvider") {
   CREDENTIALS
@@ -38358,6 +38375,15 @@ input UserHistoryWhereInput {
   lastSeenLTE: Time
   lastSeenIsNil: Boolean
   lastSeenNotNil: Boolean
+  """
+  last_login_provider field predicates
+  """
+  lastLoginProvider: UserHistoryAuthProvider
+  lastLoginProviderNEQ: UserHistoryAuthProvider
+  lastLoginProviderIn: [UserHistoryAuthProvider!]
+  lastLoginProviderNotIn: [UserHistoryAuthProvider!]
+  lastLoginProviderIsNil: Boolean
+  lastLoginProviderNotNil: Boolean
   """
   sub field predicates
   """
@@ -39366,6 +39392,15 @@ input UserWhereInput {
   lastSeenLTE: Time
   lastSeenIsNil: Boolean
   lastSeenNotNil: Boolean
+  """
+  last_login_provider field predicates
+  """
+  lastLoginProvider: UserAuthProvider
+  lastLoginProviderNEQ: UserAuthProvider
+  lastLoginProviderIn: [UserAuthProvider!]
+  lastLoginProviderNotIn: [UserAuthProvider!]
+  lastLoginProviderIsNil: Boolean
+  lastLoginProviderNotNil: Boolean
   """
   sub field predicates
   """

--- a/internal/httpserve/handlers/forgotpassword.go
+++ b/internal/httpserve/handlers/forgotpassword.go
@@ -11,7 +11,6 @@ import (
 	"github.com/theopenlane/utils/rout"
 
 	ent "github.com/theopenlane/core/internal/ent/generated"
-	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/models"
 )
 
@@ -35,7 +34,7 @@ func (h *Handler) ForgotPassword(ctx echo.Context) error {
 
 	reqCtx := ctx.Request().Context()
 
-	entUser, err := h.getUserByEmail(reqCtx, in.Email, enums.AuthProviderCredentials)
+	entUser, err := h.getUserByEmail(reqCtx, in.Email)
 	if err != nil {
 		if ent.IsNotFound(err) {
 			// return a 200 response even if user is not found to avoid

--- a/internal/httpserve/handlers/forgotpassword_test.go
+++ b/internal/httpserve/handlers/forgotpassword_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/brianvoe/gofakeit/v7"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
@@ -19,6 +20,7 @@ import (
 	"github.com/theopenlane/riverboat/pkg/jobs"
 
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
+	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/models"
 )
 
@@ -43,6 +45,8 @@ func (suite *HandlerTestSuite) TestForgotPasswordHandler() {
 		SetEmail("asandler@theopenlane.io").
 		SetPassword(validPassword).
 		SetSetting(userSetting).
+		SetLastLoginProvider(enums.AuthProviderCredentials).
+		SetLastSeen(time.Now()).
 		SaveX(ctx)
 
 	var mitb = "mitb@theopenlane.io"

--- a/internal/httpserve/handlers/invite_test.go
+++ b/internal/httpserve/handlers/invite_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivertest"
@@ -39,6 +40,8 @@ func (suite *HandlerTestSuite) TestOrgInviteAcceptHandler() {
 		SetFirstName("Groot").
 		SetLastName("JustGroot").
 		SetAuthProvider(enums.AuthProviderGoogle).
+		SetLastLoginProvider(enums.AuthProviderCredentials).
+		SetLastSeen(time.Now()).
 		SaveX(ctx)
 
 	userSetting, err := recipient.Setting(ctx)

--- a/internal/httpserve/handlers/login.go
+++ b/internal/httpserve/handlers/login.go
@@ -32,7 +32,7 @@ func (h *Handler) LoginHandler(ctx echo.Context) error {
 	reqCtx := ctx.Request().Context()
 
 	// check user in the database, username == email and ensure only one record is returned
-	user, err := h.getUserByEmail(reqCtx, in.Username, enums.AuthProviderCredentials)
+	user, err := h.getUserByEmail(reqCtx, in.Username)
 	if err != nil {
 		return h.BadRequest(ctx, auth.ErrNoAuthUser)
 	}
@@ -62,7 +62,7 @@ func (h *Handler) LoginHandler(ctx echo.Context) error {
 		return h.InternalServerError(ctx, err)
 	}
 
-	if err := h.updateUserLastSeen(userCtx, user.ID); err != nil {
+	if err := h.updateUserLastSeen(userCtx, user.ID, enums.AuthProviderCredentials); err != nil {
 		log.Error().Err(err).Msg("unable to update last seen")
 
 		return h.InternalServerError(ctx, err)

--- a/internal/httpserve/handlers/oauth_login_handlers_test.go
+++ b/internal/httpserve/handlers/oauth_login_handlers_test.go
@@ -51,17 +51,17 @@ func (suite *HandlerTestSuite) TestHandlerCheckAndCreateUser() {
 				image:    "https://example.com/images/photo.jpg",
 			},
 			want: &ent.User{
-				FirstName:       "Wanda",
-				LastName:        "Maximoff",
-				Email:           "wmaximoff@marvel.com",
-				AuthProvider:    enums.AuthProviderGitHub,
-				AvatarRemoteURL: lo.ToPtr("https://example.com/images/photo.jpg"),
+				FirstName:         "Wanda",
+				LastName:          "Maximoff",
+				Email:             "wmaximoff@marvel.com",
+				AuthProvider:      enums.AuthProviderGitHub,
+				LastLoginProvider: enums.AuthProviderGitHub,
+				AvatarRemoteURL:   lo.ToPtr("https://example.com/images/photo.jpg"),
 			},
 			writes: true,
 		},
 		{
-			// TODO (sfunk): allow this to pass by associating the user with an oauth login instead
-			name: "happy path, same email, different provider, this will fail today",
+			name: "happy path, same email, different provider, should not fail",
 			args: args{
 				name:     "Wanda Maximoff",
 				email:    "wmaximoff@marvel.com",
@@ -69,14 +69,15 @@ func (suite *HandlerTestSuite) TestHandlerCheckAndCreateUser() {
 				image:    "https://example.com/images/photo.jpg",
 			},
 			want: &ent.User{
-				FirstName:       "Wanda",
-				LastName:        "Maximoff",
-				Email:           "wmaximoff@marvel.com",
-				AuthProvider:    enums.AuthProviderGoogle,
-				AvatarRemoteURL: lo.ToPtr("https://example.com/images/photo.jpg"),
+				FirstName:         "Wanda",
+				LastName:          "Maximoff",
+				Email:             "wmaximoff@marvel.com",
+				AuthProvider:      enums.AuthProviderGitHub,
+				LastLoginProvider: enums.AuthProviderGoogle,
+				AvatarRemoteURL:   lo.ToPtr("https://example.com/images/photo.jpg"),
 			},
-			writes:  false,
-			wantErr: true,
+			writes:  true,
+			wantErr: false,
 		},
 		{
 			name: "user already exists, should not fail, just update last seen",
@@ -87,11 +88,12 @@ func (suite *HandlerTestSuite) TestHandlerCheckAndCreateUser() {
 				image:    "https://example.com/images/photo.jpg",
 			},
 			want: &ent.User{
-				FirstName:       "Wanda",
-				LastName:        "Maximoff",
-				Email:           "wmaximoff@marvel.com",
-				AuthProvider:    enums.AuthProviderGitHub,
-				AvatarRemoteURL: lo.ToPtr("https://example.com/images/photo.jpg"),
+				FirstName:         "Wanda",
+				LastName:          "Maximoff",
+				Email:             "wmaximoff@marvel.com",
+				AuthProvider:      enums.AuthProviderGitHub,
+				LastLoginProvider: enums.AuthProviderGitHub,
+				AvatarRemoteURL:   lo.ToPtr("https://example.com/images/photo.jpg"),
 			},
 			writes: false,
 		},
@@ -104,10 +106,11 @@ func (suite *HandlerTestSuite) TestHandlerCheckAndCreateUser() {
 				image:    "",
 			},
 			want: &ent.User{
-				FirstName:    "Wand",
-				LastName:     "Maxim",
-				Email:        "wmaximoff1@marvel.com",
-				AuthProvider: enums.AuthProviderGitHub,
+				FirstName:         "Wand",
+				LastName:          "Maxim",
+				Email:             "wmaximoff1@marvel.com",
+				AuthProvider:      enums.AuthProviderGitHub,
+				LastLoginProvider: enums.AuthProviderGitHub,
 			},
 			writes: true,
 		},
@@ -120,10 +123,11 @@ func (suite *HandlerTestSuite) TestHandlerCheckAndCreateUser() {
 				image:    "",
 			},
 			want: &ent.User{
-				FirstName:    "Wand",
-				LastName:     "Maxim",
-				Email:        "wmaximoff1@marvel.com",
-				AuthProvider: enums.AuthProviderGitHub,
+				FirstName:         "Wand",
+				LastName:          "Maxim",
+				Email:             "wmaximoff1@marvel.com",
+				AuthProvider:      enums.AuthProviderGitHub,
+				LastLoginProvider: enums.AuthProviderGitHub,
 			},
 			writes: false,
 		},
@@ -159,6 +163,7 @@ func (suite *HandlerTestSuite) TestHandlerCheckAndCreateUser() {
 			assert.Equal(t, tt.want.LastName, got.LastName)
 			assert.Equal(t, tt.want.Email, got.Email)
 			assert.Equal(t, tt.want.AuthProvider, got.AuthProvider)
+			assert.Equal(t, tt.want.LastLoginProvider, got.LastLoginProvider)
 			assert.WithinDuration(t, now, *got.LastSeen, time.Second*5)
 
 			if tt.args.image == "" {

--- a/internal/httpserve/handlers/oauth_register.go
+++ b/internal/httpserve/handlers/oauth_register.go
@@ -43,6 +43,13 @@ func (h *Handler) OauthRegister(ctx echo.Context) error {
 		return h.InternalServerError(ctx, err)
 	}
 
+	// set user to verified
+	if err := h.setEmailConfirmed(ctxWithToken, user); err != nil {
+		log.Error().Err(err).Msg("unable to set email as verified")
+
+		return h.InternalServerError(ctx, err)
+	}
+
 	// create claims for verified user
 	auth, err := h.AuthManager.GenerateOauthAuthSession(ctx.Request().Context(), ctx.Response().Writer, user, in)
 	if err != nil {

--- a/internal/httpserve/handlers/refresh_test.go
+++ b/internal/httpserve/handlers/refresh_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/theopenlane/echox/middleware/echocontext"
 
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
+	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/models"
 	"github.com/theopenlane/core/pkg/testutils"
 )
@@ -62,6 +63,8 @@ func (suite *HandlerTestSuite) TestRefreshHandler() {
 		SetPassword(validPassword).
 		SetSetting(userSetting).
 		SetID(userID).
+		SetLastLoginProvider(enums.AuthProviderCredentials).
+		SetLastSeen(time.Now()).
 		SetSub(userID). // this is required to parse the refresh token
 		SaveX(ec)
 

--- a/internal/httpserve/handlers/register.go
+++ b/internal/httpserve/handlers/register.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/privacy/token"
+	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/models"
 )
 
@@ -34,10 +35,11 @@ func (h *Handler) RegisterHandler(ctx echo.Context) error {
 
 	// create user
 	input := generated.CreateUserInput{
-		FirstName: &in.FirstName,
-		LastName:  &in.LastName,
-		Email:     in.Email,
-		Password:  &in.Password,
+		FirstName:         &in.FirstName,
+		LastName:          &in.LastName,
+		Email:             in.Email,
+		Password:          &in.Password,
+		LastLoginProvider: &enums.AuthProviderCredentials,
 	}
 
 	// set viewer context

--- a/internal/httpserve/handlers/resend_test.go
+++ b/internal/httpserve/handlers/resend_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/brianvoe/gofakeit/v7"
 	"github.com/stretchr/testify/assert"
@@ -16,6 +17,7 @@ import (
 	"github.com/theopenlane/echox/middleware/echocontext"
 
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
+	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/models"
 )
 
@@ -40,6 +42,8 @@ func (suite *HandlerTestSuite) TestResendHandler() {
 		SetEmail("bsanderson@theopenlane.io").
 		SetPassword(validPassword).
 		SetSetting(userSetting).
+		SetLastLoginProvider(enums.AuthProviderCredentials).
+		SetLastSeen(time.Now()).
 		SaveX(ctx)
 
 	// create user in the database
@@ -53,6 +57,8 @@ func (suite *HandlerTestSuite) TestResendHandler() {
 		SetEmail("dabraham@theopenlane.io").
 		SetPassword(validPassword).
 		SetSetting(userSetting2).
+		SetLastLoginProvider(enums.AuthProviderCredentials).
+		SetLastSeen(time.Now()).
 		SaveX(ctx)
 
 	testCases := []struct {

--- a/internal/httpserve/handlers/resendemail.go
+++ b/internal/httpserve/handlers/resendemail.go
@@ -12,7 +12,6 @@ import (
 
 	ent "github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/privacy/token"
-	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/models"
 )
 
@@ -36,7 +35,7 @@ func (h *Handler) ResendEmail(ctx echo.Context) error {
 	}
 
 	// email verifications only come to users that were created with username/password logins
-	entUser, err := h.getUserByEmail(ctxWithToken, in.Email, enums.AuthProviderCredentials)
+	entUser, err := h.getUserByEmail(ctxWithToken, in.Email)
 	if err != nil {
 		if ent.IsNotFound(err) {
 			// return a 200 response even if user is not found to avoid

--- a/internal/httpserve/handlers/resetpassword.go
+++ b/internal/httpserve/handlers/resetpassword.go
@@ -95,9 +95,13 @@ func (h *Handler) ResetPassword(ctx echo.Context) error {
 	}
 
 	// make sure its not the same password as current
-	valid, err := passwd.VerifyDerivedKey(*entUser.Password, in.Password)
-	if err != nil || valid {
-		return h.BadRequest(ctx, ErrNonUniquePassword)
+	// a user that previously authenticated with oauth and resets their password
+	// won't have a password originally so this will be nil
+	if entUser.Password != nil {
+		valid, err := passwd.VerifyDerivedKey(*entUser.Password, in.Password)
+		if err != nil || valid {
+			return h.BadRequest(ctx, ErrNonUniquePassword)
+		}
 	}
 
 	// set context for remaining request based on logged in user

--- a/internal/httpserve/handlers/resetpassword_test.go
+++ b/internal/httpserve/handlers/resetpassword_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
 
 	"github.com/theopenlane/core/internal/httpserve/handlers"
+	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/models"
 )
 
@@ -181,6 +182,8 @@ func (suite *HandlerTestSuite) createUserWithResetToken(t *testing.T, ec context
 		SetEmail(email).
 		SetPassword(validPassword).
 		SetSetting(userSetting).
+		SetLastLoginProvider(enums.AuthProviderCredentials).
+		SetLastSeen(time.Now()).
 		SaveX(ctx)
 
 	user := handlers.User{

--- a/internal/httpserve/handlers/seed_test.go
+++ b/internal/httpserve/handlers/seed_test.go
@@ -2,11 +2,13 @@ package handlers_test
 
 import (
 	"context"
+	"time"
 
 	"github.com/brianvoe/gofakeit/v7"
 	"github.com/stretchr/testify/require"
 	ent "github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
+	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/iam/auth"
 )
 
@@ -68,7 +70,9 @@ func (suite *HandlerTestSuite) userBuilderWithInput(ctx context.Context, input *
 	builder := suite.db.User.Create().
 		SetEmail(email).
 		SetFirstName(gofakeit.FirstName()).
-		SetLastName(gofakeit.LastName())
+		SetLastName(gofakeit.LastName()).
+		SetLastLoginProvider(enums.AuthProviderCredentials).
+		SetLastSeen(time.Now())
 
 	if input != nil && input.password != "" {
 		builder.SetPassword(input.password)

--- a/internal/httpserve/handlers/verify_test.go
+++ b/internal/httpserve/handlers/verify_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
 	"github.com/theopenlane/core/internal/httpserve/handlers"
+	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/models"
 )
 
@@ -90,6 +91,8 @@ func (suite *HandlerTestSuite) TestVerifyHandler() {
 				SetEmail(tc.email).
 				SetPassword(validPassword).
 				SetSetting(userSetting).
+				SetLastLoginProvider(enums.AuthProviderCredentials).
+				SetLastSeen(time.Now()).
 				SaveX(ctx)
 
 			user := handlers.User{

--- a/pkg/openlaneclient/models.go
+++ b/pkg/openlaneclient/models.go
@@ -4865,6 +4865,8 @@ type CreateUserInput struct {
 	AvatarUpdatedAt *time.Time `json:"avatarUpdatedAt,omitempty"`
 	// the time the user was last seen
 	LastSeen *time.Time `json:"lastSeen,omitempty"`
+	// the last auth provider used to login
+	LastLoginProvider *enums.AuthProvider `json:"lastLoginProvider,omitempty"`
 	// user password hash
 	Password *string `json:"password,omitempty"`
 	// the Subject of the user JWT
@@ -23346,6 +23348,9 @@ type UpdateUserInput struct {
 	// the time the user was last seen
 	LastSeen      *time.Time `json:"lastSeen,omitempty"`
 	ClearLastSeen *bool      `json:"clearLastSeen,omitempty"`
+	// the last auth provider used to login
+	LastLoginProvider      *enums.AuthProvider `json:"lastLoginProvider,omitempty"`
+	ClearLastLoginProvider *bool               `json:"clearLastLoginProvider,omitempty"`
 	// user password hash
 	Password      *string `json:"password,omitempty"`
 	ClearPassword *bool   `json:"clearPassword,omitempty"`
@@ -23463,6 +23468,8 @@ type User struct {
 	AvatarUpdatedAt *time.Time `json:"avatarUpdatedAt,omitempty,omitzero"`
 	// the time the user was last seen
 	LastSeen *time.Time `json:"lastSeen,omitempty,omitzero"`
+	// the last auth provider used to login
+	LastLoginProvider *enums.AuthProvider `json:"lastLoginProvider,omitempty,omitzero"`
 	// the Subject of the user JWT
 	Sub *string `json:"sub,omitempty,omitzero"`
 	// auth provider used to register the account
@@ -23553,6 +23560,8 @@ type UserHistory struct {
 	AvatarUpdatedAt *time.Time `json:"avatarUpdatedAt,omitempty,omitzero"`
 	// the time the user was last seen
 	LastSeen *time.Time `json:"lastSeen,omitempty,omitzero"`
+	// the last auth provider used to login
+	LastLoginProvider *enums.AuthProvider `json:"lastLoginProvider,omitempty,omitzero"`
 	// the Subject of the user JWT
 	Sub *string `json:"sub,omitempty,omitzero"`
 	// auth provider used to register the account
@@ -23845,6 +23854,13 @@ type UserHistoryWhereInput struct {
 	LastSeenLte    *time.Time   `json:"lastSeenLTE,omitempty"`
 	LastSeenIsNil  *bool        `json:"lastSeenIsNil,omitempty"`
 	LastSeenNotNil *bool        `json:"lastSeenNotNil,omitempty"`
+	// last_login_provider field predicates
+	LastLoginProvider       *enums.AuthProvider  `json:"lastLoginProvider,omitempty"`
+	LastLoginProviderNeq    *enums.AuthProvider  `json:"lastLoginProviderNEQ,omitempty"`
+	LastLoginProviderIn     []enums.AuthProvider `json:"lastLoginProviderIn,omitempty"`
+	LastLoginProviderNotIn  []enums.AuthProvider `json:"lastLoginProviderNotIn,omitempty"`
+	LastLoginProviderIsNil  *bool                `json:"lastLoginProviderIsNil,omitempty"`
+	LastLoginProviderNotNil *bool                `json:"lastLoginProviderNotNil,omitempty"`
 	// sub field predicates
 	Sub             *string  `json:"sub,omitempty"`
 	SubNeq          *string  `json:"subNEQ,omitempty"`
@@ -24607,6 +24623,13 @@ type UserWhereInput struct {
 	LastSeenLte    *time.Time   `json:"lastSeenLTE,omitempty"`
 	LastSeenIsNil  *bool        `json:"lastSeenIsNil,omitempty"`
 	LastSeenNotNil *bool        `json:"lastSeenNotNil,omitempty"`
+	// last_login_provider field predicates
+	LastLoginProvider       *enums.AuthProvider  `json:"lastLoginProvider,omitempty"`
+	LastLoginProviderNeq    *enums.AuthProvider  `json:"lastLoginProviderNEQ,omitempty"`
+	LastLoginProviderIn     []enums.AuthProvider `json:"lastLoginProviderIn,omitempty"`
+	LastLoginProviderNotIn  []enums.AuthProvider `json:"lastLoginProviderNotIn,omitempty"`
+	LastLoginProviderIsNil  *bool                `json:"lastLoginProviderIsNil,omitempty"`
+	LastLoginProviderNotNil *bool                `json:"lastLoginProviderNotNil,omitempty"`
 	// sub field predicates
 	Sub             *string  `json:"sub,omitempty"`
 	SubNeq          *string  `json:"subNEQ,omitempty"`


### PR DESCRIPTION
- Adds new `LastLoginProvider` so we can keep an audit log of user logins
- `AuthProvider` will remain the auth provider used at registration
- Fixes `lastSeen` not being set when using passkeys
- Auto sets email verified for oauth users, so if they switch to credentials they don't have to re-confirm the email
- Allows password + passkeys to be set for previously registered oauth user
