### PR TITLE
bug: do not evaluate STORE_ID by default

### DIFF
--- a/fga/Taskfile.yaml
+++ b/fga/Taskfile.yaml
@@ -5,8 +5,6 @@ vars:
   FGA_API_TOKEN: '{{ .FGA_API_TOKEN | default "QKwHEmWX99RnFh28eSRJ3GWlfb2FQkL7toh1GJpzch1mMkVeMg" }}'
   SYSTEM_OBJECT: "system:openlane_core"
   SYSTEM_ADMIN_RELATION: "system_admin"
-  STORE_ID:
-    sh: fga store list --api-token={{ .FGA_API_TOKEN }} |jq -r '.stores.[].id'
 
 tasks:
   create:
@@ -22,6 +20,8 @@ tasks:
   add:admin:
     desc: Add a user to the system:openlane admin group, if no USER_ID is provided, the logged in user will be used
     vars:
+      STORE_ID:
+        sh: fga store list --api-token={{ .FGA_API_TOKEN }} |jq -r '.stores.[].id'
       LOGGED_IN_USER:
         sh: openlane user get -z json | jq -r '.self.id'
       USER_ID: "{{ .USER_ID | default .LOGGED_IN_USER }}"


### PR DESCRIPTION
Causes an infinite hang until the dev env is brought up, this shouldn't be the case as simple tasks like linting now require a full development env