### PR TITLE
feat: updates for account roles endpoints, adds account features

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/labstack/echo-contrib v0.17.3
 	github.com/labstack/echo/v4 v4.13.3
 	github.com/lestrrat-go/httprc/v3 v3.0.0-beta2
+	github.com/lestrrat-go/jwx/v3 v3.0.1
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mcuadros/go-defaults v1.2.0
 	github.com/miekg/dns v1.1.65
@@ -75,7 +76,7 @@ require (
 	github.com/theopenlane/entx v0.7.2
 	github.com/theopenlane/gqlgen-plugins v0.6.0
 	github.com/theopenlane/httpsling v0.2.2
-	github.com/theopenlane/iam v0.12.3
+	github.com/theopenlane/iam v0.12.4
 	github.com/theopenlane/newman v0.1.4
 	github.com/theopenlane/riverboat v0.0.10
 	github.com/theopenlane/utils v0.4.5
@@ -85,7 +86,7 @@ require (
 	github.com/wundergraph/graphql-go-tools v1.67.4
 	gocloud.dev v0.41.0
 	golang.org/x/crypto v0.37.0
-	golang.org/x/oauth2 v0.29.0
+	golang.org/x/oauth2 v0.30.0
 	golang.org/x/term v0.31.0
 	golang.org/x/text v0.24.0
 	golang.org/x/tools v0.32.0
@@ -502,7 +503,6 @@ require (
 	github.com/labstack/gommon v0.4.2
 	github.com/lestrrat-go/blackmagic v1.0.3 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect
-	github.com/lestrrat-go/jwx/v3 v3.0.1
 	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/lib/pq v1.10.9
 	github.com/magiconair/properties v1.8.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1227,8 +1227,8 @@ github.com/theopenlane/gqlgen-plugins v0.6.0 h1:6rvNWwy+6PXqCtKr4Bj/p+8C0sJpkSHD
 github.com/theopenlane/gqlgen-plugins v0.6.0/go.mod h1:s7SQkJORo+mUidtz/HvpRIcBSysVzaDsplRomJ+RtwE=
 github.com/theopenlane/httpsling v0.2.2 h1:QqJo/VsjeiM6/RnWZpRQX3I7T62j5u9WdXo52zUWyi0=
 github.com/theopenlane/httpsling v0.2.2/go.mod h1:mrSaIZs4lhcBsOJCv/n67N7eDZ/skD6vA8l8y9MDrKk=
-github.com/theopenlane/iam v0.12.3 h1:aug0KcrpzbaZyuHoW3PBHFrWWFBj/BVhd0Tb+edXJWw=
-github.com/theopenlane/iam v0.12.3/go.mod h1:nyUXplYWcvTJj/cgINqxJJF2ZvNlKALRSAlpdTHi37g=
+github.com/theopenlane/iam v0.12.4 h1:QdKeYnEJFDJTo9CpkKNFmYgqIbm10TJon/Xn7c2/Ry8=
+github.com/theopenlane/iam v0.12.4/go.mod h1:5b51FdGYaH5yZp2iFfv7r6ZLjmb6JsTOR53RNHwYaag=
 github.com/theopenlane/newman v0.1.4 h1:LO1BuARRhMti904AWT0JvG7daGE9opzS7ivmjt5YC84=
 github.com/theopenlane/newman v0.1.4/go.mod h1:teuFLhRs7E1mgdAmt84t5D2wA4eHBWlg/Dlbb2xGkew=
 github.com/theopenlane/riverboat v0.0.10 h1:PTAuBVl2uiO+tEhGPo2ksBahbLHkf/dQwJTtHYUmO/g=
@@ -1558,8 +1558,8 @@ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-golang.org/x/oauth2 v0.29.0 h1:WdYw2tdTK1S8olAzWHdgeqfy+Mtm9XNhv/xJsY65d98=
-golang.org/x/oauth2 v0.29.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
+golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=
+golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/internal/httpserve/handlers/accountaccess_test.go
+++ b/internal/httpserve/handlers/accountaccess_test.go
@@ -51,7 +51,7 @@ func (suite *HandlerTestSuite) TestAccountAccessHandler() {
 				ObjectType: "organization",
 				Relation:   "can_delete",
 			},
-			errMsg: "objectId is required",
+			errMsg: "object_id is required",
 		},
 		{
 			name: "missing object type",
@@ -59,7 +59,7 @@ func (suite *HandlerTestSuite) TestAccountAccessHandler() {
 				ObjectID: "org-id",
 				Relation: "can_delete",
 			},
-			errMsg: "objectType is required",
+			errMsg: "object_type is required",
 		},
 		{
 			name: "missing relation",

--- a/internal/httpserve/handlers/accountfeatures.go
+++ b/internal/httpserve/handlers/accountfeatures.go
@@ -24,10 +24,6 @@ func (h *Handler) AccountFeaturesHandler(ctx echo.Context) error {
 		return h.InvalidInput(ctx, err)
 	}
 
-	if err := in.Validate(); err != nil {
-		return h.BadRequest(ctx, err)
-	}
-
 	reqCtx := ctx.Request().Context()
 
 	au, err := auth.GetAuthenticatedUserFromContext(reqCtx)

--- a/internal/httpserve/handlers/accountfeatures.go
+++ b/internal/httpserve/handlers/accountfeatures.go
@@ -24,6 +24,10 @@ func (h *Handler) AccountFeaturesHandler(ctx echo.Context) error {
 		return h.InvalidInput(ctx, err)
 	}
 
+	if err := in.Validate(); err != nil {
+		return h.BadRequest(ctx, err)
+	}
+
 	reqCtx := ctx.Request().Context()
 
 	au, err := auth.GetAuthenticatedUserFromContext(reqCtx)

--- a/internal/httpserve/handlers/accountfeatures.go
+++ b/internal/httpserve/handlers/accountfeatures.go
@@ -1,0 +1,124 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/rs/zerolog"
+	echo "github.com/theopenlane/echox"
+
+	"github.com/theopenlane/utils/rout"
+
+	"github.com/theopenlane/iam/auth"
+
+	"github.com/theopenlane/core/internal/ent/generated/organization"
+	"github.com/theopenlane/core/pkg/models"
+
+	sliceutil "github.com/theopenlane/utils/slice"
+)
+
+// AccountFeaturesHandler lists all features the authenticated user has access to in relation to an organization
+func (h *Handler) AccountFeaturesHandler(ctx echo.Context) error {
+	var in models.AccountFeaturesRequest
+	if err := ctx.Bind(&in); err != nil {
+		return h.InvalidInput(ctx, err)
+	}
+
+	reqCtx := ctx.Request().Context()
+
+	au, err := auth.GetAuthenticatedUserFromContext(reqCtx)
+	if err != nil {
+		zerolog.Ctx(reqCtx).Error().Err(err).Msg("error getting authenticated user")
+
+		return h.InternalServerError(ctx, err)
+	}
+
+	in.ID, err = h.getOrganizationID(in.ID, au)
+	if err != nil {
+		return h.BadRequest(ctx, err)
+	}
+
+	// validate the input
+	if err := in.Validate(); err != nil {
+		return h.BadRequest(ctx, err)
+	}
+
+	// TODO: get this from FGA instead of org subscriptions once that work is done
+	// so the backend and frontend are in sync
+	org, err := h.DBClient.Organization.Query().WithOrgSubscriptions().Where(organization.ID(in.ID)).Only(reqCtx)
+	if err != nil {
+		zerolog.Ctx(reqCtx).Error().Err(err).Msg("error getting organization")
+
+		return h.BadRequest(ctx, err)
+	}
+
+	if len(org.Edges.OrgSubscriptions) != 1 {
+		zerolog.Ctx(reqCtx).Error().Err(err).Msg("error getting organization subscription")
+
+		return h.BadRequest(ctx, ErrInvalidInput)
+	}
+
+	// get the features from the subscription
+	features := org.Edges.OrgSubscriptions[0].FeatureLookupKeys
+
+	return h.Success(ctx, models.AccountFeaturesReply{
+		Reply:          rout.Reply{Success: true},
+		Features:       features,
+		OrganizationID: in.ID,
+	})
+}
+
+// getOrganizationID returns the organization ID to use for the request based on the input and authenticated user
+func (h *Handler) getOrganizationID(id string, au *auth.AuthenticatedUser) (string, error) {
+	// if an ID is provided, check if the authenticated user has access to it
+	if id != "" {
+		if !sliceutil.Contains(au.OrganizationIDs, id) {
+			return "", ErrInvalidInput
+		}
+
+		return id, nil
+	}
+
+	// if no ID is provided, default to the authenticated organization
+	if au.OrganizationID != "" {
+		return au.OrganizationID, nil
+	}
+
+	// if it is still empty, and the personal access token only has one organization use that
+	if len(au.OrganizationIDs) == 1 {
+		return au.OrganizationIDs[0], nil
+	}
+
+	return "", nil
+}
+
+// BindAccountFeatures returns the OpenAPI3 operation for accepting an account features organization request
+func (h *Handler) BindAccountFeatures() *openapi3.Operation {
+	orgFeatures := openapi3.NewOperation()
+	orgFeatures.Description = "List features a subject has in relation to the authenticated organization"
+	orgFeatures.Tags = []string{"account"}
+	orgFeatures.OperationID = "AccountFeatures"
+	orgFeatures.Security = AllSecurityRequirements()
+
+	orgFeatures.AddResponse(http.StatusInternalServerError, internalServerError())
+	orgFeatures.AddResponse(http.StatusBadRequest, badRequest())
+	orgFeatures.AddResponse(http.StatusBadRequest, invalidInput())
+
+	return orgFeatures
+}
+
+// BindAccountFeatures returns the OpenAPI3 operation for accepting an account features organization request
+func (h *Handler) BindAccountFeaturesByID() *openapi3.Operation {
+	orgFeatures := openapi3.NewOperation()
+	orgFeatures.Description = "List the features a subject has in relation to the organization ID provided"
+	orgFeatures.Tags = []string{"account"}
+	orgFeatures.OperationID = "AccountFeaturesByID"
+	orgFeatures.Security = AllSecurityRequirements()
+
+	h.AddResponse("AccountFeaturesReply", "success", models.ExampleAccountFeaturesReply, orgFeatures, http.StatusOK)
+	orgFeatures.AddResponse(http.StatusInternalServerError, internalServerError())
+	orgFeatures.AddResponse(http.StatusBadRequest, badRequest())
+	orgFeatures.AddResponse(http.StatusUnauthorized, unauthorized())
+
+	return orgFeatures
+}

--- a/internal/httpserve/handlers/accountfeatures_test.go
+++ b/internal/httpserve/handlers/accountfeatures_test.go
@@ -28,11 +28,16 @@ func (suite *HandlerTestSuite) TestAccountFeaturesHandler() {
 		errMsg           string
 	}{
 		{
-			name: "happy path, default roles access",
+			name: "happy path, feature access",
 			request: models.AccountFeaturesRequest{
 				ID: testUser1.OrganizationID,
 			},
 			expectedFeatures: dummyFeatures,
+		},
+		{
+			name:    "no id provided",
+			request: models.AccountFeaturesRequest{},
+			errMsg:  "organization id is required",
 		},
 	}
 

--- a/internal/httpserve/handlers/accountfeatures_test.go
+++ b/internal/httpserve/handlers/accountfeatures_test.go
@@ -15,53 +15,30 @@ import (
 	"github.com/theopenlane/core/pkg/models"
 )
 
-func (suite *HandlerTestSuite) TestAccountRolesHandler() {
+func (suite *HandlerTestSuite) TestAccountFeaturesHandler() {
 	t := suite.T()
 
 	// add handler
-	suite.e.POST("account/roles", suite.h.AccountRolesHandler)
+	suite.e.POST("account/features", suite.h.AccountFeaturesHandler)
 
 	testCases := []struct {
-		name          string
-		request       models.AccountRolesRequest
-		expectedRoles []string
-		errMsg        string
+		name             string
+		request          models.AccountFeaturesRequest
+		expectedFeatures []string
+		errMsg           string
 	}{
 		{
 			name: "happy path, default roles access",
-			request: models.AccountRolesRequest{
-				ObjectID:   testUser1.OrganizationID,
-				ObjectType: "organization",
+			request: models.AccountFeaturesRequest{
+				ID: testUser1.OrganizationID,
 			},
-		},
-		{
-			name: "happy path, provide roles",
-			request: models.AccountRolesRequest{
-				ObjectID:   testUser1.OrganizationID,
-				ObjectType: "organization",
-				Relations:  []string{"owner"},
-			},
-			expectedRoles: []string{"owner"},
-		},
-		{
-			name: "missing object id",
-			request: models.AccountRolesRequest{
-				ObjectType: "organization",
-			},
-			errMsg: "objectId is required",
-		},
-		{
-			name: "missing object type",
-			request: models.AccountRolesRequest{
-				ObjectID: "org-id",
-			},
-			errMsg: "objectType is required",
+			expectedFeatures: dummyFeatures,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			target := "/account/roles"
+			target := "/account/features"
 
 			body, err := json.Marshal(tc.request)
 			if err != nil {
@@ -80,7 +57,7 @@ func (suite *HandlerTestSuite) TestAccountRolesHandler() {
 			res := recorder.Result()
 			defer res.Body.Close()
 
-			var out *models.AccountRolesReply
+			var out *models.AccountFeaturesReply
 
 			// parse request body
 			if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
@@ -97,14 +74,7 @@ func (suite *HandlerTestSuite) TestAccountRolesHandler() {
 
 			assert.Equal(t, http.StatusOK, recorder.Code)
 			assert.True(t, out.Success)
-
-			// if no roles are provided we expect all the roles, adding a number to assume its higher
-			// than our current model has
-			if len(tc.expectedRoles) == 0 {
-				assert.Greater(t, len(out.Roles), 5)
-			} else {
-				assert.ElementsMatch(t, tc.expectedRoles, out.Roles)
-			}
+			assert.ElementsMatch(t, tc.expectedFeatures, out.Features)
 		})
 	}
 }

--- a/internal/httpserve/handlers/accountfeatures_test.go
+++ b/internal/httpserve/handlers/accountfeatures_test.go
@@ -35,9 +35,9 @@ func (suite *HandlerTestSuite) TestAccountFeaturesHandler() {
 			expectedFeatures: dummyFeatures,
 		},
 		{
-			name:    "no id provided",
-			request: models.AccountFeaturesRequest{},
-			errMsg:  "organization id is required",
+			name:             "no id provided, get from context",
+			request:          models.AccountFeaturesRequest{},
+			expectedFeatures: dummyFeatures,
 		},
 	}
 

--- a/internal/httpserve/handlers/accountroles_test.go
+++ b/internal/httpserve/handlers/accountroles_test.go
@@ -48,14 +48,14 @@ func (suite *HandlerTestSuite) TestAccountRolesHandler() {
 			request: models.AccountRolesRequest{
 				ObjectType: "organization",
 			},
-			errMsg: "objectId is required",
+			errMsg: "object_id is required",
 		},
 		{
 			name: "missing object type",
 			request: models.AccountRolesRequest{
 				ObjectID: "org-id",
 			},
-			errMsg: "objectType is required",
+			errMsg: "object_type is required",
 		},
 	}
 

--- a/internal/httpserve/handlers/accountrolesorganization_test.go
+++ b/internal/httpserve/handlers/accountrolesorganization_test.go
@@ -69,7 +69,12 @@ func (suite *HandlerTestSuite) TestAccountRolesOrganizationHandler() {
 
 			assert.Equal(t, http.StatusOK, recorder.Code)
 			assert.True(t, out.Success)
-			assert.ElementsMatch(t, []string{"can_view", "can_edit", "can_delete", "audit_log_viewer", "can_invite_admins", "can_invite_members"}, out.Roles)
+
+			// ensure it contains some of the expected roles
+			for _, r := range []string{"can_view", "can_edit", "can_delete", "audit_log_viewer", "can_invite_admins", "can_invite_members"} {
+				assert.Contains(t, out.Roles, r)
+			}
+
 			assert.Equal(t, testUser1.OrganizationID, out.OrganizationID)
 		})
 	}

--- a/internal/httpserve/handlers/seed_test.go
+++ b/internal/httpserve/handlers/seed_test.go
@@ -7,13 +7,15 @@ import (
 	"github.com/brianvoe/gofakeit/v7"
 	"github.com/stretchr/testify/require"
 	ent "github.com/theopenlane/core/internal/ent/generated"
+	"github.com/theopenlane/core/internal/ent/generated/orgsubscription"
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
 	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/iam/auth"
 )
 
 var (
-	testUser1 testUserDetails
+	testUser1     testUserDetails
+	dummyFeatures = []string{"feature1", "feature2"}
 )
 
 // testUserDetails is a struct that holds the details of a test user
@@ -114,6 +116,12 @@ func (suite *HandlerTestSuite) userBuilderWithInput(ctx context.Context, input *
 		SaveX(userCtx)
 
 	testUser.OrganizationID = testOrg.ID
+
+	// add dummy subscription to the organization
+	err = suite.db.OrgSubscription.Update().Where(orgsubscription.OwnerID(testOrg.ID)).
+		SetFeatureLookupKeys(dummyFeatures).
+		Exec(userCtx)
+	require.NoError(t, err)
 
 	// setup user context with the org (and not the personal org)
 	testUser.UserCtx = auth.NewTestContextWithOrgID(testUser.ID, testUser.OrganizationID)

--- a/internal/httpserve/route/accountfeatures.go
+++ b/internal/httpserve/route/accountfeatures.go
@@ -1,0 +1,43 @@
+package route
+
+import (
+	"net/http"
+
+	echo "github.com/theopenlane/echox"
+)
+
+// registerAccountFeaturesHandler registers the /account/features handler
+func registerAccountFeaturesHandler(router *Router) (err error) {
+	// add route without the path param
+	path := "/account/features"
+	method := http.MethodGet
+	name := "AccountFeatures"
+
+	route := echo.Route{
+		Name:        name,
+		Method:      method,
+		Path:        path,
+		Middlewares: authMW,
+		Handler: func(c echo.Context) error {
+			return router.Handler.AccountFeaturesHandler(c)
+		},
+	}
+
+	featuresOrganizationOperation := router.Handler.BindAccountFeatures()
+
+	if err := router.Addv1Route(route.Path, route.Method, featuresOrganizationOperation, route); err != nil {
+		return err
+	}
+
+	// add an additional route with the path param
+	route.Path = "/account/features/:{id}"
+	route.Name = name + "ByID"
+
+	rolesOrganizationOperationByID := router.Handler.BindAccountFeaturesByID()
+
+	if err := router.Addv1Route(route.Path, route.Method, rolesOrganizationOperationByID, route); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/httpserve/route/router.go
+++ b/internal/httpserve/route/router.go
@@ -201,6 +201,7 @@ func RegisterRoutes(router *Router) error {
 		registerAccountAccessHandler,
 		registerAccountRolesHandler,
 		registerAccountRolesOrganizationHandler,
+		registerAccountFeaturesHandler,
 		registerAppleMerchantHandler,
 		registerWebhookHandler,
 		register2faHandler,

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -762,11 +762,11 @@ type AccountFeaturesRequest struct {
 	ID string `param:"id" description:"The ID of the organization to check roles for" example:"01J4HMNDSZCCQBTY93BF9CBF5D"`
 }
 
-// AccountRolesOrganizationReply holds the fields that are sent on a response to the `/account/roles/organization` endpoint
+// AccountFeaturesReply holds the fields that are sent on a response to the `/account/features` endpoint
 type AccountFeaturesReply struct {
 	rout.Reply
-	Features       []string `json:"features" description:"The roles the user has in the organization, e.g. policy-and-procedure-module, compliance-module" example:"policy-and-procedure-module, centralized-audit-documentation, risk-management, compliance-module"`
-	OrganizationID string   `json:"organization_id" description:"The ID of the organization the user has roles in" example:"01J4HMNDSZCCQBTY93BF9CBF5D"`
+	Features       []string `json:"features" description:"The features the user has access to in the organization, e.g. policy-and-procedure-module, compliance-module" example:"policy-and-procedure-module, centralized-audit-documentation, risk-management, compliance-module"`
+	OrganizationID string   `json:"organization_id" description:"The ID of the organization the user has features in" example:"01J4HMNDSZCCQBTY93BF9CBF5D"`
 }
 
 // Validate ensures the required fields are set on the AccountFeaturesRequest

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -732,7 +732,7 @@ type AccountRolesOrganizationReply struct {
 	OrganizationID string   `json:"organization_id" description:"The ID of the organization the user has roles in" example:"01J4HMNDSZCCQBTY93BF9CBF5D"`
 }
 
-// Validate ensures the required fields are set on the AccountAccessRequest
+// Validate ensures the required fields are set on the AccountRolesOrganizationRequest
 func (r *AccountRolesOrganizationRequest) Validate() error {
 	if r.ID == "" {
 		return rout.NewMissingRequiredFieldError("organization id")
@@ -750,6 +750,43 @@ var ExampleAccountRolesOrganizationRequest = AccountRolesOrganizationRequest{
 var ExampleAccountRolesOrganizationReply = AccountRolesOrganizationReply{
 	Reply:          rout.Reply{Success: true},
 	Roles:          []string{"can_view", "can_edit", "audit_log_viewer"},
+	OrganizationID: "01J4HMNDSZCCQBTY93BF9CBF5D",
+}
+
+// =========
+// ACCOUNT/FEATURES
+// =========
+
+// AccountFeaturesRequest holds the fields that should be included on a request to the `/account/features` endpoint
+type AccountFeaturesRequest struct {
+	ID string `param:"id" description:"The ID of the organization to check roles for" example:"01J4HMNDSZCCQBTY93BF9CBF5D"`
+}
+
+// AccountRolesOrganizationReply holds the fields that are sent on a response to the `/account/roles/organization` endpoint
+type AccountFeaturesReply struct {
+	rout.Reply
+	Features       []string `json:"features" description:"The roles the user has in the organization, e.g. policy-and-procedure-module, compliance-module" example:"policy-and-procedure-module, centralized-audit-documentation, risk-management, compliance-module"`
+	OrganizationID string   `json:"organization_id" description:"The ID of the organization the user has roles in" example:"01J4HMNDSZCCQBTY93BF9CBF5D"`
+}
+
+// Validate ensures the required fields are set on the AccountFeaturesRequest
+func (r *AccountFeaturesRequest) Validate() error {
+	if r.ID == "" {
+		return rout.NewMissingRequiredFieldError("organization id")
+	}
+
+	return nil
+}
+
+// ExampleAccountFeaturesRequest is an example of a successful `/account/features` request for OpenAPI documentation
+var ExampleAccountFeaturesRequest = AccountFeaturesRequest{
+	ID: "01J4HMNDSZCCQBTY93BF9CBF5D",
+}
+
+// ExampleAccountFeaturesReply is an example of a successful `/account/features` response for OpenAPI documentation
+var ExampleAccountFeaturesReply = AccountFeaturesReply{
+	Reply:          rout.Reply{Success: true},
+	Features:       []string{},
 	OrganizationID: "01J4HMNDSZCCQBTY93BF9CBF5D",
 }
 

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -621,10 +621,10 @@ type OauthTokenRequest struct {
 
 // AccountAccessRequest holds the fields that should be included on a request to the `/account/access` endpoint
 type AccountAccessRequest struct {
-	ObjectID    string `json:"objectId" description:"The ID of the object to check access for" example:"01J4EXD5MM60CX4YNYN0DEE3Y1"`
-	ObjectType  string `json:"objectType" description:"The type of object to check access for, e.g. organization, program, procedure, etc" example:"organization"`
+	ObjectID    string `json:"object_id" description:"The ID of the object to check access for" example:"01J4EXD5MM60CX4YNYN0DEE3Y1"`
+	ObjectType  string `json:"object_type" description:"The type of object to check access for, e.g. organization, program, procedure, etc" example:"organization"`
 	Relation    string `json:"relation" description:"The relation to check access for, e.g. can_view, can_edit" example:"can_view"`
-	SubjectType string `json:"subjectType,omitempty" description:"The type of subject to check access for, e.g. service, user" example:"user"`
+	SubjectType string `json:"subject_type,omitempty" description:"The type of subject to check access for, e.g. service, user" example:"user"`
 }
 
 // AccountAccessReply holds the fields that are sent on a response to the `/account/access` endpoint
@@ -636,11 +636,11 @@ type AccountAccessReply struct {
 // Validate ensures the required fields are set on the AccountAccessRequest
 func (r *AccountAccessRequest) Validate() error {
 	if r.ObjectID == "" {
-		return rout.NewMissingRequiredFieldError("objectId")
+		return rout.NewMissingRequiredFieldError("object_id")
 	}
 
 	if r.ObjectType == "" {
-		return rout.NewMissingRequiredFieldError("objectType")
+		return rout.NewMissingRequiredFieldError("object_type")
 	}
 
 	if r.Relation == "" {
@@ -674,9 +674,9 @@ var ExampleAccountAccessReply = AccountAccessReply{
 
 // AccountRolesRequest holds the fields that should be included on a request to the `/account/roles` endpoint
 type AccountRolesRequest struct {
-	ObjectID    string   `json:"objectId" description:"The ID of the object to check roles for" example:"01J4EXD5MM60CX4YNYN0DEE3Y1"`
-	ObjectType  string   `json:"objectType" description:"The type of object to check roles for, e.g. organization, program, procedure, etc" example:"organization"`
-	SubjectType string   `json:"subjectType,omitempty" description:"The type of subject to check roles for, e.g. service, user" example:"user"`
+	ObjectID    string   `json:"object_id" description:"The ID of the object to check roles for" example:"01J4EXD5MM60CX4YNYN0DEE3Y1"`
+	ObjectType  string   `json:"object_type" description:"The type of object to check roles for, e.g. organization, program, procedure, etc" example:"organization"`
+	SubjectType string   `json:"subject_type,omitempty" description:"The type of subject to check roles for, e.g. service, user" example:"user"`
 	Relations   []string `json:"relations,omitempty" description:"The relations to check roles for, e.g. can_view, can_edit" example:"can_view"`
 }
 
@@ -689,11 +689,11 @@ type AccountRolesReply struct {
 // Validate ensures the required fields are set on the AccountAccessRequest
 func (r *AccountRolesRequest) Validate() error {
 	if r.ObjectID == "" {
-		return rout.NewMissingRequiredFieldError("objectId")
+		return rout.NewMissingRequiredFieldError("object_id")
 	}
 
 	if r.ObjectType == "" {
-		return rout.NewMissingRequiredFieldError("objectType")
+		return rout.NewMissingRequiredFieldError("object_type")
 	}
 
 	// Default to user if not set, only when using an API token should this be overwritten and set to service


### PR DESCRIPTION
- **BREAKING**: fixes the request json to be `object_type`, `object_id`, etc. instead of `objectType`, `objectId` on the account roles REST endpoints
- Removes `DefaultAllRelations` and instead passes now relations, and allows the iam library to grab all relations for the current model under the specific object type
- Adds a `account/features` handler that will pull the account features from orgsubscriptions; this will eventually be updated to use fga instead

Example:

```
curl -s -H "Authorization: Bearer tolp_REDACTED" http://localhost:17608/v1/account/roles/organization  -H "Content-Type: application/json" |jq
{
  "success": true,
  "roles": [
    "member",
    "can_create_procedure",
    "access",
    "can_create_control_implementation",
    "can_create_risk",
    "can_invite_members",
    "can_invite_admins",
    "can_create_evidence",
    "can_create_template",
    "can_create_control_objective",
    "can_create_internal_policy",
    "can_create_control",
    "can_create_standard",
    "can_create_narrative",
    "can_delete",
    "owner",
    "audit_log_viewer",
    "can_create_group",
    "can_create_subcontrol",
    "can_view",
    "can_edit",
    "can_create_program"
  ],
  "organization_id": "01JTGQ5RCRGTHWS1W9YP5AYTXM"
}
```

```
curl -s -H "Authorization: Bearer tolp_REDACTED" http://localhost:17608/v1/account/features  -H "Content-Type: application/json" |jq
{
  "success": true,
  "features": [
    "policy-and-procedure-module",
    "centralized-audit-documentation",
    "risk-management",
    "compliance-module"
  ],
  "organization_id": "01JTGQ5RCRGTHWS1W9YP5AYTXM"
}
```