### PR TITLE
feat: bk pipeline cache + linter config cleanup

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -5,4 +5,3 @@ set -euo pipefail
 mkdir -p $HOME/.cache/go-build
 mkdir -p $HOME/.cache/golangci-lint
 mkdir -p $HOME/.cache/go/pkg/mod
-mkdir -p $HOME/.cache/sonar

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+
+mkdir -p $HOME/.cache/go-build
+mkdir -p $HOME/.cache/golangci-lint
+mkdir -p $HOME/.cache/go/pkg/mod
+mkdir -p $HOME/.cache/sonar

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -4,13 +4,16 @@ env:
   GCR_REPO: us-west1-docker.pkg.dev/neural-vista-433523-c1/openlane/openlane
   IMAGE_TAG: ${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT:0:8}
   SONAR_HOST: https://sonarcloud.io
-  GOFLAGS: -buildvcs=false
   LARGE_RUNNER_QUEUE: self-hosted-garage-vms
   SMALL_RUNNER_QUEUE: self-hosted-garage-vms
   RUNNER_LARGE: "large"
   RUNNER_SMALL: "small"
   GRAPHQL_SCHEMA_LOCATION: "internal/graphapi/clientschema/schema.graphql"
   GRAPHQL_SCHEMA_NAME: "Openlane-2fwyqq@current"
+  GOFLAGS: -buildvcs=false
+  GOCACHE: $HOME/.cache/go-build
+  GOMODCACHE: $HOME/.cache/go/pkg/mod
+  GOLANGCI_LINT_CACHE: $HOME/.cache/golangci-lint
 
 steps:
   - group: ":knife: Pre-check"
@@ -21,12 +24,18 @@ steps:
         agents:
           queue: $LARGE_RUNNER_QUEUE
           size: $RUNNER_LARGE
+          location: "NYC"
         cancel_on_build_failing: true
         plugins:
           - docker#v5.12.0:
               image: "ghcr.io/theopenlane/build-image:latest"
               always_pull: true
               command: ["task", "ci"]
+              propagate-environment: true
+              volumes:
+                - $GOCACHE:$GOCACHE
+                - $GOMODCACHE:$GOMODCACHE
+                - $GOLANGCI_LINT_CACHE:$GOLANGCI_LINT_CACHE
               environment:
                 - "GOTOOLCHAIN=auto"
       - label: ":yaml: generate config"
@@ -37,6 +46,11 @@ steps:
               image: "ghcr.io/theopenlane/build-image:latest"
               always_pull: true
               command: ["task", "config:ci"]
+              propagate-environment: true
+              volumes:
+                - $GOCACHE:$GOCACHE
+                - $GOMODCACHE:$GOMODCACHE
+                - $GOLANGCI_LINT_CACHE:$GOLANGCI_LINT_CACHE
               environment:
                 - "GOTOOLCHAIN=auto"
   - group: ":test_tube: Tests"
@@ -47,7 +61,7 @@ steps:
         agents:
           queue: $LARGE_RUNNER_QUEUE
           size: $RUNNER_LARGE
-          location: "SAT"
+          location: "NYC"
         cancel_on_build_failing: true
         timeout_in_minutes: 20
         key: "lint"
@@ -56,6 +70,11 @@ steps:
               image: "ghcr.io/theopenlane/build-image:latest"
               command: ["task", "go:lint:ci"]
               always_pull: true
+              propagate-environment: true
+              volumes:
+                - $GOCACHE:$GOCACHE
+                - $GOMODCACHE:$GOMODCACHE
+                - $GOLANGCI_LINT_CACHE:$GOLANGCI_LINT_CACHE
               environment:
                 - "GOTOOLCHAIN=auto"
         artifact_paths: ["coverage.out"]
@@ -63,7 +82,7 @@ steps:
         agents:
           queue: $LARGE_RUNNER_QUEUE
           size: $RUNNER_LARGE
-          location: "SAT"
+          location: "NYC"
         key: "go_test"
         cancel_on_build_failing: true
         env:
@@ -77,13 +96,17 @@ steps:
               image: ghcr.io/theopenlane/build-image:latest
               always_pull: true
               command: ["task", "go:test:cover"]
+              propagate-environment: true
+              volumes:
+                - $GOCACHE:$GOCACHE
+                - $GOMODCACHE:$GOMODCACHE
+                - $GOLANGCI_LINT_CACHE:$GOLANGCI_LINT_CACHE
+                - "/var/run/docker.sock:/var/run/docker.sock"
               environment:
+                - "GOMAXPROCS=8"
                 - "TEST_DB_URL"
                 - "TEST_DB_CONTAINER_EXPIRY=20" # container expiry in minutes
                 - "TEST_DB_HOST=172.17.0.1" # docker host ip on linux
-                - "TESTCONTAINERS_RYUK_DISABLED=true"
-              volumes:
-                - "/var/run/docker.sock:/var/run/docker.sock"
         artifact_paths: ["coverage.out"]
       - label: ":auth0: fga model test"
         if: build.branch !~ /^renovate\//
@@ -94,6 +117,7 @@ steps:
         plugins:
           - docker#v5.12.0:
               image: openfga/cli:v0.5.1
+              propagate-environment: true
               command: ["model", "test", "--tests", "fga/tests/tests.yaml"]
   - group: ":closed_lock_with_key: Security Checks"
     key: "security"
@@ -113,6 +137,11 @@ steps:
               step: "go_test"
           - docker#v5.12.0:
               image: "sonarsource/sonar-scanner-cli:11.2"
+              propagate-environment: true
+              volumes:
+                - $GOCACHE:$GOCACHE
+                - $GOMODCACHE:$GOMODCACHE
+                - $GOLANGCI_LINT_CACHE:$GOLANGCI_LINT_CACHE
               environment:
                 - "SONAR_TOKEN"
                 - "SONAR_HOST_URL=$SONAR_HOST"
@@ -131,6 +160,11 @@ steps:
               step: "go_test"
           - docker#v5.12.0:
               image: "sonarsource/sonar-scanner-cli:11.2"
+              propagate-environment: true
+              volumes:
+                - $GOCACHE:$GOCACHE
+                - $GOMODCACHE:$GOMODCACHE
+                - $GOLANGCI_LINT_CACHE:$GOLANGCI_LINT_CACHE
               environment:
                 - "SONAR_TOKEN"
                 - "SONAR_HOST_URL=$SONAR_HOST"
@@ -149,6 +183,11 @@ steps:
           - docker#v5.12.0:
               image: "ghcr.io/theopenlane/build-image:latest"
               always_pull: true
+              propagate-environment: true
+              volumes:
+                - $GOCACHE:$GOCACHE
+                - $GOMODCACHE:$GOMODCACHE
+                - $GOLANGCI_LINT_CACHE:$GOLANGCI_LINT_CACHE
               environment:
                 - CGO_ENABLED=0
                 - GOOS=linux
@@ -164,6 +203,11 @@ steps:
           - docker#v5.12.0:
               image: "ghcr.io/theopenlane/build-image:latest"
               always_pull: true
+              propagate-environment: true
+              volumes:
+                - $GOCACHE:$GOCACHE
+                - $GOMODCACHE:$GOMODCACHE
+                - $GOLANGCI_LINT_CACHE:$GOLANGCI_LINT_CACHE
               environment:
                 - GOOS=darwin
                 - GOARCH=arm64

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -103,7 +103,7 @@ steps:
                 - $GOLANGCI_LINT_CACHE:$GOLANGCI_LINT_CACHE
                 - "/var/run/docker.sock:/var/run/docker.sock"
               environment:
-                - "GOMAXPROCS=8"
+                - "GOMAXPROCS=16"
                 - "TEST_DB_URL"
                 - "TEST_DB_CONTAINER_EXPIRY=20" # container expiry in minutes
                 - "TEST_DB_HOST=172.17.0.1" # docker host ip on linux

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -103,7 +103,7 @@ steps:
                 - $GOLANGCI_LINT_CACHE:$GOLANGCI_LINT_CACHE
                 - "/var/run/docker.sock:/var/run/docker.sock"
               environment:
-                - "GOMAXPROCS=16"
+                - "GOMAXPROCS=8"
                 - "TEST_DB_URL"
                 - "TEST_DB_CONTAINER_EXPIRY=20" # container expiry in minutes
                 - "TEST_DB_HOST=172.17.0.1" # docker host ip on linux

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,8 +3,7 @@ run:
   modules-download-mode: readonly
   tests: false
   allow-parallel-runners: true
-  build-tags:
-    - codeanalysis
+  show-stats: true
 linters:
   enable:
     - bodyclose
@@ -21,39 +20,26 @@ linters:
     - wsl
   exclusions:
     generated: lax
+    warn-unused: true
     presets:
-      - comments
+      - comments # undisable this after fixing all comments
       - common-false-positives
       - legacy
       - std-error-handling
     paths:
       - internal/graphapi/model/gen_models.go
       - pkg/openlaneclient/graphclient.go
-      - schema.graphql
       - pkg/testutils/*
-      - .buildkite/*
-      - .github/*
-      - docker/*
       - internal/ent/generated/*
       - internal/ent/templates/*
       - jsonschema/templates/*
       - pkg/objects/mocks/*
-      - schema/*
-      - query/*
-      - fga/model/*
-      - fga/tests/*
-      - docs/*
       - internal/graphapi/generate/*
       - internal/graphapi/generated/*
-      - db/migrations/*
-      - db/migrations-goose-postgres/*
       - pkg/entitlements/test/*
       - cmd/cli/cmd/*
       - pkg/sleuth/static/*
       - pkg/entitlements/mocks/*
-      - third_party$
-      - builtin$
-      - examples$
       - pkg/events/soiree/examples/*
       - pkg/middleware/ratelimiter/examples/*
 formatters:
@@ -68,31 +54,24 @@ formatters:
         - github.com/theopenlane/core
   exclusions:
     generated: lax
+    warn-unused: true
     paths:
       - internal/graphapi/model/gen_models.go
       - pkg/openlaneclient/graphclient.go
-      - schema.graphql
       - pkg/testutils/*
-      - .buildkite/*
-      - .github/*
-      - docker/*
       - internal/ent/generated/*
+      - internal/ent/generate/generate/*
       - internal/ent/templates/*
       - jsonschema/templates/*
       - pkg/objects/mocks/*
-      - schema/*
-      - query/*
-      - fga/model/*
-      - fga/tests/*
-      - docs/*
       - internal/graphapi/generate/*
       - internal/graphapi/generated/*
-      - db/migrations/*
-      - db/migrations-goose-postgres/*
       - pkg/entitlements/test/*
       - cmd/cli/cmd/*
       - pkg/sleuth/static/*
       - pkg/entitlements/mocks/*
-      - third_party$
-      - builtin$
-      - examples$
+      - pkg/events/soiree/examples/*
+      - pkg/middleware/ratelimiter/examples/*
+      - pkg/sleuth/dnsx/* # this should be fixed in the future
+      - jsonschema/*
+      - pkg/gencmd/*

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -116,7 +116,7 @@ tasks:
     desc: runs golangci-lint, the most annoying opinionated linter ever, for CI
     ## do not use --fix in CI
     cmds:
-      - golangci-lint run --config=.golangci.yaml --verbose
+      - golangci-lint run --config=.golangci.yaml --verbose --concurrency 8 --print-resources-usage
 
   go:test:
     desc: runs and outputs results of created go tests
@@ -130,7 +130,7 @@ tasks:
     desc: runs and outputs results of created go tests with coverage
     aliases: [cover]
     cmds:
-      - go test ./... -coverprofile=coverage.out -timeout 20m
+      - go test -v ./... -coverprofile=coverage.out -timeout 20m
 
   go:test:coverout:
     desc: runs and outputs results of created go tests with coverage

--- a/config/config.go
+++ b/config/config.go
@@ -145,7 +145,7 @@ type PondPool struct {
 }
 
 var (
-	DefaultConfigFilePath = "./config/.config.yaml"
+	defaultConfigFilePath = "./config/.config.yaml"
 )
 
 // Load is responsible for loading the configuration from a YAML file and environment variables.
@@ -156,7 +156,7 @@ func Load(cfgFile *string) (*Config, error) {
 	k := koanf.New(".")
 
 	if cfgFile == nil || *cfgFile == "" {
-		*cfgFile = DefaultConfigFilePath
+		*cfgFile = defaultConfigFilePath
 	}
 
 	if _, err := os.Stat(*cfgFile); err != nil {

--- a/internal/ent/base/entinit.tmpl
+++ b/internal/ent/base/entinit.tmpl
@@ -29,14 +29,17 @@ type {{ $name }} struct {
 // Schema{{ $name }}is the name of the schema in snake case
 const Schema{{ $name }} = "{{ $name | snake }}"
 
+// Name is the name of the schema in snake case
 func ({{ $name }}) Name() string {
 	return Schema{{ . | singular }}
 }
 
+// GetType returns the type of the schema
 func ({{ $name }}) GetType() any {
 	return {{ $name }}.Type
 }
 
+// PluralName returns the plural name of the schema
 func ({{ $name }}) PluralName() string {
 	return pluralize.NewClient().Plural(Schema{{ $name }})
 }

--- a/internal/ent/interceptors/query.go
+++ b/internal/ent/interceptors/query.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"entgo.io/ent"
-
 	"github.com/rs/zerolog"
+
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/intercept"
 )

--- a/internal/ent/mixin/user_owned_policy_mixin.go
+++ b/internal/ent/mixin/user_owned_policy_mixin.go
@@ -10,17 +10,19 @@ import (
 )
 
 type (
+	// UserOwnedMutationPolicyMixin is a mixin for user owned mutation policy
 	UserOwnedMutationPolicyMixin struct {
 		mixin.Schema
 		AllowAdminMutation bool
 	}
 
+	// UserOwnedQueryPolicyMixin is a mixin for user owned query policy
 	UserOwnedQueryPolicyMixin struct {
 		mixin.Schema
 	}
 )
 
-// Policy sets the policy for updating owned fields by the user
+// UserOwnedMutationPolicyMixin sets the policy for updating owned fields by the user
 func (mixin UserOwnedMutationPolicyMixin) Policy() ent.Policy {
 	return privacy.Policy{
 		Mutation: privacy.MutationPolicy{

--- a/internal/ent/privacy/policy/base.go
+++ b/internal/ent/privacy/policy/base.go
@@ -52,7 +52,7 @@ func WithMutationRules(rules ...privacy.MutationRule) Option {
 	}
 }
 
-// WithOnQueryRules adds query rules to policy for specific operations.
+// WithOnMutationRules adds mutation rules to policy for specific operations.
 func WithOnMutationRules(op ent.Op, rules ...privacy.MutationRule) Option {
 	opRules := []privacy.MutationRule{}
 

--- a/internal/ent/privacy/rule/allow_if_system_admin.go
+++ b/internal/ent/privacy/rule/allow_if_system_admin.go
@@ -12,9 +12,9 @@ import (
 )
 
 const (
-	// system object type for FGA authorization
+	// SystemObject type for FGA authorization
 	SystemObject = "system"
-	// system object id for FGA authorization
+	// SystemObjectID for FGA authorization
 	SystemObjectID = "openlane_core"
 )
 
@@ -35,7 +35,7 @@ func AllowMutationIfSystemAdmin() privacy.MutationRuleFunc {
 	})
 }
 
-// AllowMutationIfSystemAdmin determines whether a query operation should be allowed based on whether the user is a system admin
+// AllowQueryIfSystemAdmin determines whether a query operation should be allowed based on whether the user is a system admin
 func AllowQueryIfSystemAdmin() privacy.QueryRule {
 	return privacy.QueryRuleFunc(func(ctx context.Context, _ ent.Query) error {
 		allow, err := CheckIsSystemAdminWithContext(ctx)

--- a/internal/ent/privacy/rule/allow_if_token_valid.go
+++ b/internal/ent/privacy/rule/allow_if_token_valid.go
@@ -38,6 +38,7 @@ func ContextHasPrivacyTokenOfType[T token.PrivacyToken](ctx context.Context) boo
 	return ok
 }
 
+// PrivacyToken is an interface that defines a method to get the token string
 type PrivacyToken interface {
 	GetToken() string
 }

--- a/internal/ent/privacy/rule/allow_mutation_valid_signup_token.go
+++ b/internal/ent/privacy/rule/allow_mutation_valid_signup_token.go
@@ -8,12 +8,12 @@ import (
 	"github.com/theopenlane/core/internal/ent/privacy/token"
 )
 
-type MutationEmailGetter func(generated.Mutation) (string, error)
+type mutationEmailGetter func(generated.Mutation) (string, error)
 
 // AllowMutationIfContextHasValidEmailSignUpToken is used to determine whether a
 // mutation should be allowed or skipped based on the presence and validity of an
 // email signup token in the context
-func AllowMutationIfContextHasValidEmailSignUpToken(getEmail MutationEmailGetter) privacy.MutationRule {
+func AllowMutationIfContextHasValidEmailSignUpToken(getEmail mutationEmailGetter) privacy.MutationRule {
 	return privacy.MutationRuleFunc(
 		func(ctx context.Context, mutation generated.Mutation) error {
 			emailSignupToken := token.EmailSignUpTokenFromContext(ctx)

--- a/internal/ent/privacy/rule/internal.go
+++ b/internal/ent/privacy/rule/internal.go
@@ -10,6 +10,7 @@ import (
 
 type internalAllowContextKey struct{}
 
+// WithInternalContext adds an internal request key to the context
 func WithInternalContext(ctx context.Context) context.Context {
 	return contextx.With(ctx, internalAllowContextKey{})
 }

--- a/internal/ent/privacy/rule/standard.go
+++ b/internal/ent/privacy/rule/standard.go
@@ -13,6 +13,7 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated/standard"
 )
 
+// ErrAdminOnlyField is returned when a user attempts to set a field that is only allowed to be set by an admin
 var ErrAdminOnlyField = errors.New("attempted to set admin only field")
 
 // SystemOwnedStandards is a privacy rule that checks if the standard is system owned

--- a/internal/ent/schema/actionplan.go
+++ b/internal/ent/schema/actionplan.go
@@ -21,16 +21,20 @@ type ActionPlan struct {
 	ent.Schema
 }
 
+// SchemaActionPlan is the name of the actionplan schema.
 const SchemaActionPlan = "action_plan"
 
+// Name returns the name of the actionplan schema.
 func (ActionPlan) Name() string {
 	return SchemaActionPlan
 }
 
+// GetType returns the type of the actionplan schema.
 func (ActionPlan) GetType() any {
 	return ActionPlan.Type
 }
 
+// PluralName returns the plural name of the actionplan schema.
 func (ActionPlan) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaActionPlan)
 }

--- a/internal/ent/schema/apitoken.go
+++ b/internal/ent/schema/apitoken.go
@@ -26,16 +26,20 @@ type APIToken struct {
 	ent.Schema
 }
 
+// SchemaAPIToken is the name of the APIToken schema.
 const SchemaAPIToken = "api_token"
 
+// Name returns the name of the APIToken schema.
 func (APIToken) Name() string {
 	return SchemaAPIToken
 }
 
+// GetType returns the type of the APIToken schema.
 func (APIToken) GetType() any {
 	return APIToken.Type
 }
 
+// PluralName returns the plural name of the APIToken schema.
 func (APIToken) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaAPIToken)
 }

--- a/internal/ent/schema/contact.go
+++ b/internal/ent/schema/contact.go
@@ -25,16 +25,20 @@ type Contact struct {
 	ent.Schema
 }
 
+// SchemaContact is the name of the Contact schema.
 const SchemaContact = "contact"
 
+// Name returns the name of the Contact schema.
 func (Contact) Name() string {
 	return SchemaContact
 }
 
+// GetType returns the type of the Contact schema.
 func (Contact) GetType() any {
 	return Contact.Type
 }
 
+// PluralName returns the plural name of the Contact schema.
 func (Contact) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaContact)
 }

--- a/internal/ent/schema/control.go
+++ b/internal/ent/schema/control.go
@@ -23,16 +23,20 @@ type Control struct {
 	ent.Schema
 }
 
+// SchemaControl is the name of the control schema.
 const SchemaControl = "control"
 
+// Name returns the name of the control schema.
 func (Control) Name() string {
 	return SchemaControl
 }
 
+// GetType returns the type of the control schema.
 func (Control) GetType() any {
 	return Control.Type
 }
 
+// PluralName returns the plural name of the control schema.
 func (Control) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaControl)
 }

--- a/internal/ent/schema/controlimplementation.go
+++ b/internal/ent/schema/controlimplementation.go
@@ -5,15 +5,16 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/schema"
 	"entgo.io/ent/schema/field"
-
 	"github.com/gertd/go-pluralize"
+
+	"github.com/theopenlane/iam/entfga"
+
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
 	"github.com/theopenlane/core/internal/ent/hooks"
 	"github.com/theopenlane/core/internal/ent/privacy/policy"
 	"github.com/theopenlane/core/internal/ent/privacy/rule"
 	"github.com/theopenlane/core/pkg/enums"
-	"github.com/theopenlane/iam/entfga"
 )
 
 // ControlImplementation holds the schema definition for the ControlImplementation entity
@@ -23,16 +24,20 @@ type ControlImplementation struct {
 	ent.Schema
 }
 
+// SchemaImplementation is the name of the ControlImplementation schema.
 const SchemaImplementation = "control_implementation"
 
+// Name returns the name of the ControlImplementation schema.
 func (ControlImplementation) Name() string {
 	return SchemaImplementation
 }
 
+// GetType returns the type of the ControlImplementation schema.
 func (ControlImplementation) GetType() any {
 	return ControlImplementation.Type
 }
 
+// PluralName returns the plural name of the ControlImplementation schema.
 func (ControlImplementation) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaImplementation)
 }

--- a/internal/ent/schema/controlobjective.go
+++ b/internal/ent/schema/controlobjective.go
@@ -23,16 +23,20 @@ type ControlObjective struct {
 	ent.Schema
 }
 
+// SchemaControlObjective is the name of the controlobjective schema.
 const SchemaControlObjective = "control_objective"
 
+// Name returns the name of the controlobjective schema.
 func (ControlObjective) Name() string {
 	return SchemaControlObjective
 }
 
+// GetType returns the type of the controlobjective schema.
 func (ControlObjective) GetType() any {
 	return ControlObjective.Type
 }
 
+// PluralName returns the plural name of the controlobjective schema.
 func (ControlObjective) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaControlObjective)
 }

--- a/internal/ent/schema/customdomain.go
+++ b/internal/ent/schema/customdomain.go
@@ -23,19 +23,23 @@ type CustomDomain struct {
 }
 
 const (
+	// SchemaCustomDomain is the name of the CustomDomain schema.
 	SchemaCustomDomain = "custom_domain"
 	maxDomainNameLen   = 255
 	maxTXTValueLen     = 64
 )
 
+// Name returns the name of the CustomDomain schema.
 func (CustomDomain) Name() string {
 	return SchemaCustomDomain
 }
 
+// GetType returns the type of the CustomDomain schema.
 func (CustomDomain) GetType() any {
 	return CustomDomain.Type
 }
 
+// PluralName returns the plural name of the CustomDomain schema.
 func (CustomDomain) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaCustomDomain)
 }
@@ -64,7 +68,7 @@ func (CustomDomain) Fields() []ent.Field {
 			Default("_olverify").
 			NotEmpty().
 			Immutable().
-			MaxLen(16),
+			MaxLen(16), //nolint:mnd
 		field.String("txt_record_value").
 			Comment("Hashed expected value of the TXT record. This is a random string that is generated on creation and is used to verify ownership of the domain.").
 			Annotations(

--- a/internal/ent/schema/defaults.go
+++ b/internal/ent/schema/defaults.go
@@ -6,16 +6,21 @@ import (
 	"entgo.io/ent/schema"
 	"entgo.io/ent/schema/edge"
 	"github.com/rs/zerolog/log"
-	"github.com/stoewer/go-strcase"
-	"github.com/theopenlane/core/internal/ent/mixin"
+
 	"github.com/theopenlane/entx"
 	emixin "github.com/theopenlane/entx/mixin"
+
+	"github.com/theopenlane/core/internal/ent/mixin"
+)
+
+const (
+	minNameLength = 3
 )
 
 // SchemaFuncs defines the methods that a custom schema must implement
 // in order to use the helper functions provided by this file
 // including Name(), PluralName(), and GetType()
-type SchemaFuncs interface {
+type SchemaFuncs interface { //nolint:revive
 	Name() string
 	PluralName() string
 	GetType() any
@@ -146,11 +151,6 @@ func getType(schema any) any {
 	sch := toSchemaFuncs(schema)
 
 	return sch.GetType()
-}
-
-// graphqlName returns the graphql name of the schema using LowerCamelCase of the name provided
-func graphqlName(name string) string {
-	return strcase.LowerCamelCase(name)
 }
 
 // edgeToWithPagination uses the provided edge definition to create an edge with pagination

--- a/internal/ent/schema/documentdata.go
+++ b/internal/ent/schema/documentdata.go
@@ -20,16 +20,20 @@ type DocumentData struct {
 	ent.Schema
 }
 
+// SchemaDocumentData is the name of the DocumentData schema.
 const SchemaDocumentData = "document"
 
+// Name returns the name of the DocumentData schema.
 func (DocumentData) Name() string {
 	return SchemaDocumentData
 }
 
+// GetType returns the type of the DocumentData schema.
 func (DocumentData) GetType() any {
 	return DocumentData.Type
 }
 
+// PluralName returns the plural name of the DocumentData schema.
 func (DocumentData) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaDocumentData)
 }

--- a/internal/ent/schema/emailverificationtoken.go
+++ b/internal/ent/schema/emailverificationtoken.go
@@ -31,16 +31,20 @@ type EmailVerificationToken struct {
 	ent.Schema
 }
 
-const SchemaEmailVerificationToken = "email_verification_token"
+// SchemaEmailVerificationToken is the name of the EmailVerificationToken schema.
+const SchemaEmailVerificationToken = "email_verification_token" // nolint:gosec
 
+// Name returns the name of the EmailVerificationToken schema.
 func (EmailVerificationToken) Name() string {
 	return SchemaEmailVerificationToken
 }
 
+// GetType returns the type of the EmailVerificationToken schema.
 func (EmailVerificationToken) GetType() any {
 	return EmailVerificationToken.Type
 }
 
+// PluralName returns the plural name of the EmailVerificationToken schema.
 func (EmailVerificationToken) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaEmailVerificationToken)
 }

--- a/internal/ent/schema/entity.go
+++ b/internal/ent/schema/entity.go
@@ -24,16 +24,20 @@ type Entity struct {
 	ent.Schema
 }
 
+// SchemaEntity is the name of the Entity schema.
 const SchemaEntity = "entity"
 
+// Name returns the name of the Entity schema.
 func (Entity) Name() string {
 	return SchemaEntity
 }
 
+// GetType returns the type of the Entity schema.
 func (Entity) GetType() any {
 	return Entity.Type
 }
 
+// PluralName returns the plural name of the Entity schema.
 func (Entity) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaEntity)
 }
@@ -47,7 +51,7 @@ func (Entity) Fields() []ent.Field {
 			SchemaType(map[string]string{
 				dialect.Postgres: "citext",
 			}).
-			MinLen(3).
+			MinLen(minNameLength).
 			Validate(validator.SpecialCharValidator).
 			Annotations(
 				entx.FieldSearchable(),

--- a/internal/ent/schema/entitytype.go
+++ b/internal/ent/schema/entitytype.go
@@ -26,16 +26,20 @@ type EntityType struct {
 	ent.Schema
 }
 
+// SchemaEntityType is the name of the EntityType schema.
 const SchemaEntityType = "entity_type"
 
+// Name returns the name of the EntityType schema.
 func (EntityType) Name() string {
 	return SchemaEntityType
 }
 
+// GetType returns the type of the EntityType schema.
 func (EntityType) GetType() any {
 	return EntityType.Type
 }
 
+// PluralName returns the plural name of the EntityType schema.
 func (EntityType) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaEntityType)
 }

--- a/internal/ent/schema/event.go
+++ b/internal/ent/schema/event.go
@@ -5,8 +5,9 @@ import (
 	"entgo.io/ent/schema"
 	"entgo.io/ent/schema/field"
 	"github.com/gertd/go-pluralize"
-	"github.com/theopenlane/core/internal/ent/mixin"
 	emixin "github.com/theopenlane/entx/mixin"
+
+	"github.com/theopenlane/core/internal/ent/mixin"
 )
 
 // Event holds the schema definition for the Event entity
@@ -16,16 +17,20 @@ type Event struct {
 	ent.Schema
 }
 
+// SchemaEvent is the name of the Event schema.
 const SchemaEvent = "event"
 
+// Name returns the name of the Event schema.
 func (Event) Name() string {
 	return SchemaEvent
 }
 
+// GetType returns the type of the Event schema.
 func (Event) GetType() any {
 	return Event.Type
 }
 
+// PluralName returns the plural name of the Event schema.
 func (Event) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaEvent)
 }

--- a/internal/ent/schema/evidence.go
+++ b/internal/ent/schema/evidence.go
@@ -26,16 +26,20 @@ type Evidence struct {
 	ent.Schema
 }
 
+// SchemaEvidence is the name of the Evidence schema.
 const SchemaEvidence = "evidence"
 
+// Name returns the name of the Evidence schema.
 func (Evidence) Name() string {
 	return SchemaEvidence
 }
 
+// GetType returns the type of the Evidence schema.
 func (Evidence) GetType() any {
 	return Evidence.Type
 }
 
+// PluralName returns the plural name of the Evidence schema.
 func (Evidence) PluralName() string {
 	return SchemaEvidence // special case because evidences is a weird plural
 }

--- a/internal/ent/schema/group.go
+++ b/internal/ent/schema/group.go
@@ -29,16 +29,20 @@ type Group struct {
 	ent.Schema
 }
 
+// SchemaGroup is the name of the Group schema.
 const SchemaGroup = "group"
 
+// Name returns the name of the Group schema.
 func (Group) Name() string {
 	return SchemaGroup
 }
 
+// GetType returns the type of the Group schema.
 func (Group) GetType() any {
 	return Group.Type
 }
 
+// PluralName returns the plural name of the Group schema.
 func (Group) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaGroup)
 }
@@ -51,7 +55,7 @@ func (Group) Fields() []ent.Field {
 			SchemaType(map[string]string{
 				dialect.Postgres: "citext",
 			}).
-			MinLen(3).
+			MinLen(minNameLength).
 			Validate(validator.SpecialCharValidator).
 			Annotations(
 				entx.FieldSearchable(),

--- a/internal/ent/schema/groupmembership.go
+++ b/internal/ent/schema/groupmembership.go
@@ -26,16 +26,20 @@ type GroupMembership struct {
 	ent.Schema
 }
 
+// SchemaGroupMembership is the name of the GroupMembership schema.
 const SchemaGroupMembership = "groupmembership"
 
+// Name returns the name of the GroupMembership schema.
 func (GroupMembership) Name() string {
 	return SchemaGroupMembership
 }
 
+// GetType returns the type of the GroupMembership schema.
 func (GroupMembership) GetType() any {
 	return GroupMembership.Type
 }
 
+// PluralName returns the plural name of the GroupMembership schema.
 func (GroupMembership) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaGroupMembership)
 }

--- a/internal/ent/schema/hush.go
+++ b/internal/ent/schema/hush.go
@@ -19,16 +19,20 @@ type Hush struct {
 	ent.Schema
 }
 
+// SchemaHush is the name of the Hush schema.
 const SchemaHush = "secret"
 
+// Name returns the name of the Hush schema.
 func (Hush) Name() string {
 	return SchemaHush
 }
 
+// GetType returns the type of the Hush schema.
 func (Hush) GetType() any {
 	return Hush.Type
 }
 
+// PluralName returns the plural name of the Hush schema.
 func (Hush) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaHush)
 }

--- a/internal/ent/schema/integration.go
+++ b/internal/ent/schema/integration.go
@@ -18,16 +18,20 @@ type Integration struct {
 	ent.Schema
 }
 
+// SchemaIntegration is the name of the Integration schema.
 const SchemaIntegration = "integration"
 
+// Name returns the name of the Integration schema.
 func (Integration) Name() string {
 	return SchemaIntegration
 }
 
+// GetType returns the type of the Integration schema.
 func (Integration) GetType() any {
 	return Integration.Type
 }
 
+// PluralName returns the plural name of the Integration schema.
 func (Integration) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaIntegration)
 }

--- a/internal/ent/schema/internalpolicy.go
+++ b/internal/ent/schema/internalpolicy.go
@@ -22,16 +22,20 @@ type InternalPolicy struct {
 	ent.Schema
 }
 
+// SchemaInternalPolicy is the name of the internal policy schema.
 const SchemaInternalPolicy = "internal_policy"
 
+// Name returns the name of the internal policy schema.
 func (InternalPolicy) Name() string {
 	return SchemaInternalPolicy
 }
 
+// GetType returns the type of the internal policy schema.
 func (InternalPolicy) GetType() any {
 	return InternalPolicy.Type
 }
 
+// PluralName returns the plural name of the internal policy schema.
 func (InternalPolicy) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaInternalPolicy)
 }

--- a/internal/ent/schema/mappable_domain.go
+++ b/internal/ent/schema/mappable_domain.go
@@ -23,6 +23,7 @@ type MappableDomain struct {
 }
 
 const (
+	// SchemaMappableDomain is the name of the MappableDomain schema.
 	SchemaMappableDomain = "mappable_domain"
 )
 

--- a/internal/ent/schema/mappedcontrol.go
+++ b/internal/ent/schema/mappedcontrol.go
@@ -5,8 +5,8 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/schema"
 	"entgo.io/ent/schema/field"
-
 	"github.com/gertd/go-pluralize"
+
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
 	"github.com/theopenlane/core/internal/ent/privacy/policy"
 )
@@ -66,7 +66,6 @@ func (m MappedControl) Edges() []ent.Edge {
 // Mixin of the MappedControl
 func (MappedControl) Mixin() []ent.Mixin {
 	return getDefaultMixins()
-
 }
 
 // Annotations of the MappedControl

--- a/internal/ent/schema/mixin_controls.go
+++ b/internal/ent/schema/mixin_controls.go
@@ -6,12 +6,14 @@ import (
 	"entgo.io/ent/schema"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/mixin"
+
+	"github.com/theopenlane/entx"
+	"github.com/theopenlane/iam/entfga"
+
 	"github.com/theopenlane/core/internal/ent/generated/hook"
 	"github.com/theopenlane/core/internal/ent/hooks"
 	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/models"
-	"github.com/theopenlane/entx"
-	"github.com/theopenlane/iam/entfga"
 )
 
 // ControlMixin implements the control pattern fields for different schemas.

--- a/internal/ent/schema/mixin_createacess.go
+++ b/internal/ent/schema/mixin_createacess.go
@@ -7,9 +7,10 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/mixin"
+	"github.com/theopenlane/iam/fgax"
+
 	"github.com/theopenlane/core/internal/ent/generated/hook"
 	"github.com/theopenlane/core/internal/ent/hooks"
-	"github.com/theopenlane/iam/fgax"
 )
 
 // createObjectTypes is a list of object types that access can be granted specifically for creation

--- a/internal/ent/schema/mixin_document.go
+++ b/internal/ent/schema/mixin_document.go
@@ -10,10 +10,11 @@ import (
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/mixin"
 
+	"github.com/theopenlane/entx"
+
 	"github.com/theopenlane/core/internal/ent/generated/hook"
 	"github.com/theopenlane/core/internal/ent/hooks"
 	"github.com/theopenlane/core/pkg/enums"
-	"github.com/theopenlane/entx"
 )
 
 // DocumentMixin implements the document pattern with approver for schemas.

--- a/internal/ent/schema/mixin_grouppermissions.go
+++ b/internal/ent/schema/mixin_grouppermissions.go
@@ -6,9 +6,11 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/mixin"
+
+	"github.com/theopenlane/iam/fgax"
+
 	"github.com/theopenlane/core/internal/ent/generated/hook"
 	"github.com/theopenlane/core/internal/ent/hooks"
-	"github.com/theopenlane/iam/fgax"
 )
 
 // GroupPermissionsMixin is a mixin for group permissions on an entity
@@ -134,10 +136,6 @@ func (g GroupPermissionsMixin) Hooks() (hooks []ent.Hook) {
 	return
 }
 
-// groupReadWriteHooks are the hooks that are used to add the editor, blocked, and viewer tuples
-// based on a group
-var groupReadWriteHooks = append(groupWriteOnlyHooks, groupReadOnlyHooks...)
-
 // groupReadOnlyHooks are the hooks that are used to add the viewer tuples
 // based on a group
 var groupReadOnlyHooks = []ent.Hook{
@@ -172,6 +170,7 @@ func (g GroupPermissionsEdgesMixin) Edges() []ent.Edge {
 
 	for _, schema := range g.EdgeInfo {
 		sch := toSchemaFuncs(schema.Schema)
+
 		var defaultReverseEdges = []ent.Edge{
 			edge.From(fmt.Sprintf("%s_editors", sch.Name()), sch.GetType()).
 				Ref("editors"),

--- a/internal/ent/schema/mixin_orgowned.go
+++ b/internal/ent/schema/mixin_orgowned.go
@@ -255,7 +255,6 @@ func (o ObjectOwnedMixin) orgInterceptorSkipper(ctx context.Context, q intercept
 		if _, allow := privacy.DecisionFromContext(ctx); allow {
 			return true
 		}
-
 	}
 
 	// skip the interceptor if the context has the organization creation context key

--- a/internal/ent/schema/onboarding.go
+++ b/internal/ent/schema/onboarding.go
@@ -5,15 +5,16 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/schema"
 	"entgo.io/ent/schema/field"
-
 	"github.com/gertd/go-pluralize"
+
+	"github.com/theopenlane/entx/history"
+	emixin "github.com/theopenlane/entx/mixin"
+
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
 	"github.com/theopenlane/core/internal/ent/hooks"
 	"github.com/theopenlane/core/internal/ent/mixin"
 	"github.com/theopenlane/core/internal/ent/privacy/policy"
 	"github.com/theopenlane/core/internal/ent/privacy/rule"
-	"github.com/theopenlane/entx/history"
-	emixin "github.com/theopenlane/entx/mixin"
 )
 
 // Onboarding holds the schema definition for the Onboarding entity
@@ -23,16 +24,20 @@ type Onboarding struct {
 	ent.Schema
 }
 
+// SchemaOnboarding is the name of the Onboarding schema.
 const SchemaOnboarding = "onboarding"
 
+// Name returns the name of the Onboarding schema.
 func (Onboarding) Name() string {
 	return SchemaOnboarding
 }
 
+// GetType returns the type of the Onboarding schema.
 func (Onboarding) GetType() any {
 	return Onboarding.Type
 }
 
+// PluralName returns the plural name of the Onboarding schema.
 func (Onboarding) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaOnboarding)
 }

--- a/internal/ent/schema/organization.go
+++ b/internal/ent/schema/organization.go
@@ -59,7 +59,7 @@ func (Organization) Fields() []ent.Field {
 				dialect.Postgres: "citext",
 			}).
 			MaxLen(orgNameMaxLen).
-			MinLen(3).
+			MinLen(minNameLength).
 			Validate(validator.SpecialCharValidator).
 			Annotations(
 				entx.FieldSearchable(),

--- a/internal/ent/schema/organizationsetting.go
+++ b/internal/ent/schema/organizationsetting.go
@@ -27,16 +27,20 @@ type OrganizationSetting struct {
 	ent.Schema
 }
 
+// SchemaOrganizationSetting is the name of the OrganizationSetting schema.
 const SchemaOrganizationSetting = "organization_setting"
 
+// Name returns the name of the OrganizationSetting schema.
 func (OrganizationSetting) Name() string {
 	return SchemaOrganizationSetting
 }
 
+// GetType returns the type of the OrganizationSetting schema.
 func (OrganizationSetting) GetType() any {
 	return OrganizationSetting.Type
 }
 
+// PluralName returns the plural name of the OrganizationSetting schema.
 func (OrganizationSetting) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaOrganizationSetting)
 }

--- a/internal/ent/schema/orgsubscription.go
+++ b/internal/ent/schema/orgsubscription.go
@@ -20,16 +20,20 @@ type OrgSubscription struct {
 	ent.Schema
 }
 
+// SchemaOrgSubscription is the name of the OrgSubscription schema.
 const SchemaOrgSubscription = "org_subscription"
 
+// Name returns the name of the OrgSubscription schema.
 func (OrgSubscription) Name() string {
 	return SchemaOrgSubscription
 }
 
+// GetType returns the type of the OrgSubscription schema.
 func (OrgSubscription) GetType() any {
 	return OrgSubscription.Type
 }
 
+// PluralName returns the plural name of the OrgSubscription schema.
 func (OrgSubscription) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaOrgSubscription)
 }

--- a/internal/ent/schema/passwordresettoken.go
+++ b/internal/ent/schema/passwordresettoken.go
@@ -31,16 +31,20 @@ type PasswordResetToken struct {
 	ent.Schema
 }
 
+// SchemaPasswordResetToken is the name of the PasswordResetToken schema.
 const SchemaPasswordResetToken = "password_reset_token"
 
+// Name returns the name of the PasswordResetToken schema.
 func (PasswordResetToken) Name() string {
 	return SchemaPasswordResetToken
 }
 
+// GetType returns the type of the PasswordResetToken schema.
 func (PasswordResetToken) GetType() any {
 	return PasswordResetToken.Type
 }
 
+// PluralName returns the plural name of the PasswordResetToken schema.
 func (PasswordResetToken) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaPasswordResetToken)
 }

--- a/internal/ent/schema/personalaccesstoken.go
+++ b/internal/ent/schema/personalaccesstoken.go
@@ -25,16 +25,20 @@ type PersonalAccessToken struct {
 	ent.Schema
 }
 
+// SchemaPersonalAccessToken is the name of the PersonalAccessToken schema.
 const SchemaPersonalAccessToken = "personal_access_token"
 
+// Name returns the name of the PersonalAccessToken schema.
 func (PersonalAccessToken) Name() string {
 	return SchemaPersonalAccessToken
 }
 
+// GetType returns the type of the PersonalAccessToken schema.
 func (PersonalAccessToken) GetType() any {
 	return PersonalAccessToken.Type
 }
 
+// PluralName returns the plural name of the PersonalAccessToken schema.
 func (PersonalAccessToken) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaPersonalAccessToken)
 }

--- a/internal/ent/schema/procedure.go
+++ b/internal/ent/schema/procedure.go
@@ -22,16 +22,20 @@ type Procedure struct {
 	ent.Schema
 }
 
+// SchemaProcedure is the name of the procedure schema.
 const SchemaProcedure = "procedure"
 
+// Name returns the name of the procedure schema.
 func (Procedure) Name() string {
 	return SchemaProcedure
 }
 
+// GetType returns the type of the procedure schema.
 func (Procedure) GetType() any {
 	return Procedure.Type
 }
 
+// PluralName returns the plural name of the procedure schema.
 func (Procedure) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaProcedure)
 }

--- a/internal/ent/schema/program.go
+++ b/internal/ent/schema/program.go
@@ -10,14 +10,16 @@ import (
 	"entgo.io/ent/schema/field"
 
 	"github.com/gertd/go-pluralize"
+
+	"github.com/theopenlane/entx"
+	"github.com/theopenlane/iam/entfga"
+
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
 	"github.com/theopenlane/core/internal/ent/hooks"
 	"github.com/theopenlane/core/internal/ent/interceptors"
 	"github.com/theopenlane/core/internal/ent/privacy/policy"
 	"github.com/theopenlane/core/pkg/enums"
-	"github.com/theopenlane/entx"
-	"github.com/theopenlane/iam/entfga"
 )
 
 // Program holds the schema definition for the Program entity
@@ -27,16 +29,20 @@ type Program struct {
 	ent.Schema
 }
 
+// SchemaProgram is the name of the Program schema.
 const SchemaProgram = "program"
 
+// Name returns the name of the Program schema.
 func (Program) Name() string {
 	return SchemaProgram
 }
 
+// GetType returns the type of the Program schema.
 func (Program) GetType() any {
 	return Program.Type
 }
 
+// PluralName returns the plural name of the Program schema.
 func (Program) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaProgram)
 }

--- a/internal/ent/schema/programmembership.go
+++ b/internal/ent/schema/programmembership.go
@@ -26,16 +26,20 @@ type ProgramMembership struct {
 	ent.Schema
 }
 
+// SchemaProgramMembership is the name of the ProgramMembership schema.
 const SchemaProgramMembership = "programmembership"
 
+// Name returns the name of the ProgramMembership schema.
 func (ProgramMembership) Name() string {
 	return SchemaProgramMembership
 }
 
+// GetType returns the type of the ProgramMembership schema.
 func (ProgramMembership) GetType() any {
 	return ProgramMembership.Type
 }
 
+// PluralName returns the plural name of the ProgramMembership schema.
 func (ProgramMembership) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaProgramMembership)
 }

--- a/internal/ent/schema/risk.go
+++ b/internal/ent/schema/risk.go
@@ -25,16 +25,20 @@ type Risk struct {
 	ent.Schema
 }
 
+// SchemaRisk is the name of the risk schema.
 const SchemaRisk = "risk"
 
+// Name returns the name of the risk schema.
 func (Risk) Name() string {
 	return SchemaRisk
 }
 
+// GetType returns the type of the risk schema.
 func (Risk) GetType() any {
 	return Risk.Type
 }
 
+// PluralName returns the plural name of the risk schema.
 func (Risk) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaRisk)
 }

--- a/internal/ent/schema/standard.go
+++ b/internal/ent/schema/standard.go
@@ -25,16 +25,20 @@ type Standard struct {
 	ent.Schema
 }
 
+// SchemaStandard is the name of the standard schema.
 const SchemaStandard = "standard"
 
+// Name returns the name of the standard schema.
 func (Standard) Name() string {
 	return SchemaStandard
 }
 
+// GetType returns the type of the standard schema.
 func (Standard) GetType() any {
 	return Standard.Type
 }
 
+// PluralName returns the plural name of the standard schema.
 func (Standard) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaStandard)
 }

--- a/internal/ent/schema/subcontrol.go
+++ b/internal/ent/schema/subcontrol.go
@@ -24,16 +24,20 @@ type Subcontrol struct {
 	ent.Schema
 }
 
+// SchemaSubcontrol is the name of the Subcontrol schema.
 const SchemaSubcontrol = "subcontrol"
 
+// Name returns the name of the Subcontrol schema.
 func (Subcontrol) Name() string {
 	return SchemaSubcontrol
 }
 
+// GetType returns the type of the Subcontrol schema.
 func (Subcontrol) GetType() any {
 	return Subcontrol.Type
 }
 
+// PluralName returns the plural name of the Subcontrol schema.
 func (Subcontrol) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaSubcontrol)
 }

--- a/internal/ent/schema/subscriber.go
+++ b/internal/ent/schema/subscriber.go
@@ -29,16 +29,20 @@ type Subscriber struct {
 	ent.Schema
 }
 
+// SchemaSubscriber is the name of the Subscriber schema.
 const SchemaSubscriber = "subscriber"
 
+// Name returns the name of the Subscriber schema.
 func (Subscriber) Name() string {
 	return SchemaSubscriber
 }
 
+// GetType returns the type of the Subscriber schema.
 func (Subscriber) GetType() any {
 	return Subscriber.Type
 }
 
+// PluralName returns the plural name of the Subscriber schema.
 func (Subscriber) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaSubscriber)
 }

--- a/internal/ent/schema/task.go
+++ b/internal/ent/schema/task.go
@@ -7,14 +7,16 @@ import (
 	"entgo.io/ent/schema/field"
 
 	"github.com/gertd/go-pluralize"
+
+	"github.com/theopenlane/entx"
+	"github.com/theopenlane/iam/entfga"
+
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
 	"github.com/theopenlane/core/internal/ent/hooks"
 	"github.com/theopenlane/core/internal/ent/privacy/policy"
 	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/models"
-	"github.com/theopenlane/entx"
-	"github.com/theopenlane/iam/entfga"
 )
 
 // Task holds the schema definition for the Task entity
@@ -24,16 +26,20 @@ type Task struct {
 	ent.Schema
 }
 
+// SchemaTask is the name of the Task schema.
 const SchemaTask = "task"
 
+// Name returns the name of the Task schema.
 func (Task) Name() string {
 	return SchemaTask
 }
 
+// GetType returns the type of the Task schema.
 func (Task) GetType() any {
 	return Task.Type
 }
 
+// PluralName returns the plural name of the Task schema.
 func (Task) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaTask)
 }

--- a/internal/ent/schema/template.go
+++ b/internal/ent/schema/template.go
@@ -21,16 +21,20 @@ type Template struct {
 	ent.Schema
 }
 
+// SchemaTemplate is the name of the Template schema.
 const SchemaTemplate = "template"
 
+// SchemaTemplate is the name of the Template schema.
 func (Template) Name() string {
 	return SchemaTemplate
 }
 
+// GetType returns the type of the Template schema.
 func (Template) GetType() any {
 	return Template.Type
 }
 
+// PluralName returns the plural name of the Template schema.
 func (Template) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaTemplate)
 }

--- a/internal/ent/schema/tfasetting.go
+++ b/internal/ent/schema/tfasetting.go
@@ -21,16 +21,20 @@ type TFASetting struct {
 	ent.Schema
 }
 
+// SchemaTFASetting is the name of the TFASetting schema.
 const SchemaTFASetting = "tfa_setting"
 
+// Name returns the name of the TFASetting schema.
 func (TFASetting) Name() string {
 	return SchemaTFASetting
 }
 
+// GetType returns the type of the TFASetting schema.
 func (TFASetting) GetType() any {
 	return TFASetting.Type
 }
 
+// PluralName returns the plural name of the TFASetting schema.
 func (TFASetting) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaTFASetting)
 }

--- a/internal/ent/schema/user.go
+++ b/internal/ent/schema/user.go
@@ -39,16 +39,20 @@ type User struct {
 	ent.Schema
 }
 
+// SchemaUser is the name of the User schema.
 const SchemaUser = "user"
 
+// Name returns the name of the User schema.
 func (User) Name() string {
 	return SchemaUser
 }
 
+// GetType returns the type of the User schema.
 func (User) GetType() any {
 	return User.Type
 }
 
+// PluralName returns the plural name of the User schema.
 func (User) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaUser)
 }
@@ -276,7 +280,7 @@ func (User) Hooks() []ent.Hook {
 }
 
 // Interceptors of the User.
-func (d User) Interceptors() []ent.Interceptor {
+func (User) Interceptors() []ent.Interceptor {
 	return []ent.Interceptor{
 		interceptors.TraverseUser(),
 	}

--- a/internal/ent/schema/usersetting.go
+++ b/internal/ent/schema/usersetting.go
@@ -24,16 +24,20 @@ type UserSetting struct {
 	ent.Schema
 }
 
+// SchemaUserSetting is the name of the UserSetting schema.
 const SchemaUserSetting = "user_setting"
 
+// Name returns the name of the UserSetting schema.
 func (UserSetting) Name() string {
 	return SchemaUserSetting
 }
 
+// GetType returns the type of the UserSetting schema.
 func (UserSetting) GetType() any {
 	return UserSetting.Type
 }
 
+// PluralName returns the plural name of the UserSetting schema.
 func (UserSetting) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaUserSetting)
 }
@@ -118,7 +122,7 @@ func (UserSetting) Hooks() []ent.Hook {
 }
 
 // Interceptors of the UserSetting.
-func (d UserSetting) Interceptors() []ent.Interceptor {
+func (UserSetting) Interceptors() []ent.Interceptor {
 	return []ent.Interceptor{
 		interceptors.InterceptorUserSetting(),
 	}

--- a/internal/ent/schema/webauthn.go
+++ b/internal/ent/schema/webauthn.go
@@ -8,10 +8,12 @@ import (
 	"entgo.io/ent/schema/field"
 
 	"github.com/gertd/go-pluralize"
-	"github.com/theopenlane/core/internal/ent/hooks"
-	"github.com/theopenlane/core/pkg/models"
+
 	"github.com/theopenlane/entx/history"
 	emixin "github.com/theopenlane/entx/mixin"
+
+	"github.com/theopenlane/core/internal/ent/hooks"
+	"github.com/theopenlane/core/pkg/models"
 )
 
 // Webauthn holds the schema definition for the Webauthn entity
@@ -21,16 +23,20 @@ type Webauthn struct {
 	ent.Schema
 }
 
+// SchemaWebauthn is the name of the Webauthn schema.
 const SchemaWebauthn = "webauthn"
 
+// Name returns the name of the Webauthn schema.
 func (Webauthn) Name() string {
 	return SchemaWebauthn
 }
 
+// GetType returns the type of the Webauthn schema.
 func (Webauthn) GetType() any {
 	return Webauthn.Type
 }
 
+// PluralName returns the plural name of the Webauthn schema.
 func (Webauthn) PluralName() string {
 	return pluralize.NewClient().Plural(SchemaWebauthn)
 }

--- a/internal/httpserve/route/2fa.go
+++ b/internal/httpserve/route/2fa.go
@@ -25,7 +25,7 @@ func register2faHandler(router *Router) (err error) {
 
 	tfaOperation := router.Handler.BindTFAHandler()
 
-	if err := router.Addv1Route(path, method, tfaOperation, route); err != nil {
+	if err := router.AddV1Route(path, method, tfaOperation, route); err != nil {
 		return err
 	}
 

--- a/internal/httpserve/route/accountaccess.go
+++ b/internal/httpserve/route/accountaccess.go
@@ -24,7 +24,7 @@ func registerAccountAccessHandler(router *Router) (err error) {
 
 	accountAccessOperation := router.Handler.BindAccountAccess()
 
-	if err := router.Addv1Route(path, method, accountAccessOperation, route); err != nil {
+	if err := router.AddV1Route(path, method, accountAccessOperation, route); err != nil {
 		return err
 	}
 

--- a/internal/httpserve/route/accountfeatures.go
+++ b/internal/httpserve/route/accountfeatures.go
@@ -25,7 +25,7 @@ func registerAccountFeaturesHandler(router *Router) (err error) {
 
 	featuresOrganizationOperation := router.Handler.BindAccountFeatures()
 
-	if err := router.Addv1Route(route.Path, route.Method, featuresOrganizationOperation, route); err != nil {
+	if err := router.AddV1Route(route.Path, route.Method, featuresOrganizationOperation, route); err != nil {
 		return err
 	}
 
@@ -35,7 +35,7 @@ func registerAccountFeaturesHandler(router *Router) (err error) {
 
 	rolesOrganizationOperationByID := router.Handler.BindAccountFeaturesByID()
 
-	if err := router.Addv1Route(route.Path, route.Method, rolesOrganizationOperationByID, route); err != nil {
+	if err := router.AddV1Route(route.Path, route.Method, rolesOrganizationOperationByID, route); err != nil {
 		return err
 	}
 

--- a/internal/httpserve/route/accountroles.go
+++ b/internal/httpserve/route/accountroles.go
@@ -24,7 +24,7 @@ func registerAccountRolesHandler(router *Router) (err error) {
 
 	rolesOperation := router.Handler.BindAccountRoles()
 
-	if err := router.Addv1Route(path, method, rolesOperation, route); err != nil {
+	if err := router.AddV1Route(path, method, rolesOperation, route); err != nil {
 		return err
 	}
 

--- a/internal/httpserve/route/accountrolesorganization.go
+++ b/internal/httpserve/route/accountrolesorganization.go
@@ -25,7 +25,7 @@ func registerAccountRolesOrganizationHandler(router *Router) (err error) {
 
 	rolesOrganizationOperation := router.Handler.BindAccountRolesOrganization()
 
-	if err := router.Addv1Route(route.Path, route.Method, rolesOrganizationOperation, route); err != nil {
+	if err := router.AddV1Route(route.Path, route.Method, rolesOrganizationOperation, route); err != nil {
 		return err
 	}
 
@@ -35,7 +35,7 @@ func registerAccountRolesOrganizationHandler(router *Router) (err error) {
 
 	rolesOrganizationOperationByID := router.Handler.BindAccountRolesOrganizationByID()
 
-	if err := router.Addv1Route(route.Path, route.Method, rolesOrganizationOperationByID, route); err != nil {
+	if err := router.AddV1Route(route.Path, route.Method, rolesOrganizationOperationByID, route); err != nil {
 		return err
 	}
 

--- a/internal/httpserve/route/forgotpass.go
+++ b/internal/httpserve/route/forgotpass.go
@@ -24,7 +24,7 @@ func registerForgotPasswordHandler(router *Router) (err error) {
 
 	forgotPasswordOperation := router.Handler.BindForgotPassword()
 
-	if err := router.Addv1Route(path, method, forgotPasswordOperation, route); err != nil {
+	if err := router.AddV1Route(path, method, forgotPasswordOperation, route); err != nil {
 		return err
 	}
 

--- a/internal/httpserve/route/invite.go
+++ b/internal/httpserve/route/invite.go
@@ -24,7 +24,7 @@ func registerInviteHandler(router *Router) (err error) {
 
 	inviteOperation := router.Handler.BindOrganizationInviteAccept()
 
-	if err := router.Addv1Route(path, method, inviteOperation, route); err != nil {
+	if err := router.AddV1Route(path, method, inviteOperation, route); err != nil {
 		return err
 	}
 

--- a/internal/httpserve/route/login.go
+++ b/internal/httpserve/route/login.go
@@ -25,7 +25,7 @@ func registerLoginHandler(router *Router) (err error) {
 
 	loginOperation := router.Handler.BindLoginHandler()
 
-	if err := router.Addv1Route(path, method, loginOperation, route); err != nil {
+	if err := router.AddV1Route(path, method, loginOperation, route); err != nil {
 		return err
 	}
 

--- a/internal/httpserve/route/oauth.go
+++ b/internal/httpserve/route/oauth.go
@@ -71,7 +71,7 @@ func registerGithubLoginHandler(router *Router) (err error) {
 		Handler:     githubLogin(router),
 	}
 
-	if err := router.Addv1Route(path, method, nil, route); err != nil {
+	if err := router.AddV1Route(path, method, nil, route); err != nil {
 		return err
 	}
 
@@ -92,7 +92,7 @@ func registerGithubCallbackHandler(router *Router) (err error) {
 		Handler:     githubCallback(router),
 	}
 
-	if err := router.Addv1Route(path, method, nil, route); err != nil {
+	if err := router.AddV1Route(path, method, nil, route); err != nil {
 		return err
 	}
 
@@ -113,7 +113,7 @@ func registerGoogleLoginHandler(router *Router) (err error) {
 		Handler:     googleLogin(router),
 	}
 
-	if err := router.Addv1Route(path, method, nil, route); err != nil {
+	if err := router.AddV1Route(path, method, nil, route); err != nil {
 		return err
 	}
 
@@ -134,7 +134,7 @@ func registerGoogleCallbackHandler(router *Router) (err error) {
 		Handler:     googleCallback(router),
 	}
 
-	if err := router.Addv1Route(path, method, nil, route); err != nil {
+	if err := router.AddV1Route(path, method, nil, route); err != nil {
 		return err
 	}
 

--- a/internal/httpserve/route/refresh.go
+++ b/internal/httpserve/route/refresh.go
@@ -24,7 +24,7 @@ func registerRefreshHandler(router *Router) (err error) {
 
 	refreshOperation := router.Handler.BindRefreshHandler()
 
-	if err := router.Addv1Route(path, method, refreshOperation, route); err != nil {
+	if err := router.AddV1Route(path, method, refreshOperation, route); err != nil {
 		return err
 	}
 

--- a/internal/httpserve/route/register.go
+++ b/internal/httpserve/route/register.go
@@ -24,7 +24,7 @@ func registerRegisterHandler(router *Router) (err error) {
 
 	registerOperation := router.Handler.BindRegisterHandler()
 
-	if err := router.Addv1Route(path, method, registerOperation, route); err != nil {
+	if err := router.AddV1Route(path, method, registerOperation, route); err != nil {
 		return err
 	}
 

--- a/internal/httpserve/route/resend.go
+++ b/internal/httpserve/route/resend.go
@@ -24,7 +24,7 @@ func registerResendEmailHandler(router *Router) (err error) {
 
 	resendOperation := router.Handler.BindResendEmailHandler()
 
-	if err := router.Addv1Route(path, method, resendOperation, route); err != nil {
+	if err := router.AddV1Route(path, method, resendOperation, route); err != nil {
 		return err
 	}
 

--- a/internal/httpserve/route/resetpass.go
+++ b/internal/httpserve/route/resetpass.go
@@ -24,7 +24,7 @@ func registerResetPasswordHandler(router *Router) (err error) {
 
 	resetOperation := router.Handler.BindResetPasswordHandler()
 
-	if err := router.Addv1Route(path, method, resetOperation, route); err != nil {
+	if err := router.AddV1Route(path, method, resetOperation, route); err != nil {
 		return err
 	}
 

--- a/internal/httpserve/route/router.go
+++ b/internal/httpserve/route/router.go
@@ -30,6 +30,7 @@ type Router struct {
 	Logger        *echo.Logger
 }
 
+// RouterOption is an option function that can be used to configure the router
 type RouterOption func(*Router)
 
 // WithLogger is a RouterOption that allows the logger to be set on the router
@@ -97,8 +98,8 @@ func (r *Router) AddRoute(pattern, method string, op *openapi3.Operation, route 
 	return nil
 }
 
-// AddRoute is used to add a route to the echo router and OpenAPI schema at the same time ensuring consistency between the spec and the server
-func (r *Router) Addv1Route(pattern, method string, op *openapi3.Operation, route echo.Routable) error {
+// AddV1Route is used to add a route to the echo router and OpenAPI schema at the same time ensuring consistency between the spec and the server for version 1 routes of the api
+func (r *Router) AddV1Route(pattern, method string, op *openapi3.Operation, route echo.Routable) error {
 	grp := r.VersionOne()
 
 	_, err := grp.AddRoute(route)
@@ -111,7 +112,7 @@ func (r *Router) Addv1Route(pattern, method string, op *openapi3.Operation, rout
 	return nil
 }
 
-// AddRoute is used to add a route to the echo router and OpenAPI schema at the same time ensuring consistency between the spec and the server
+// AddUnversionedRoute is used to add a versioned route to the echo router and OpenAPI schema at the same time ensuring consistency between the spec and the server
 func (r *Router) AddUnversionedRoute(pattern, method string, op *openapi3.Operation, route echo.Routable) error {
 	grp := r.Base()
 

--- a/internal/httpserve/route/subscribe.go
+++ b/internal/httpserve/route/subscribe.go
@@ -24,7 +24,7 @@ func registerVerifySubscribeHandler(router *Router) (err error) {
 
 	subscribeOperation := router.Handler.BindVerifySubscriberHandler()
 
-	if err := router.Addv1Route(path, method, subscribeOperation, route); err != nil {
+	if err := router.AddV1Route(path, method, subscribeOperation, route); err != nil {
 		return err
 	}
 

--- a/internal/httpserve/route/switch.go
+++ b/internal/httpserve/route/switch.go
@@ -24,7 +24,7 @@ func registerSwitchRoute(router *Router) (err error) {
 
 	switchOperation := router.Handler.BindSwitchHandler()
 
-	if err := router.Addv1Route(path, method, switchOperation, route); err != nil {
+	if err := router.AddV1Route(path, method, switchOperation, route); err != nil {
 		return err
 	}
 

--- a/internal/httpserve/route/verify.go
+++ b/internal/httpserve/route/verify.go
@@ -24,7 +24,7 @@ func registerVerifyHandler(router *Router) (err error) {
 
 	verifyOperation := router.Handler.BindVerifyEmailHandler()
 
-	if err := router.Addv1Route(path, method, verifyOperation, route); err != nil {
+	if err := router.AddV1Route(path, method, verifyOperation, route); err != nil {
 		return err
 	}
 

--- a/internal/httpserve/server/server.go
+++ b/internal/httpserve/server/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/theopenlane/core/pkg/objects/storage"
 )
 
+// Server is a struct that holds the configuration for the server
 type Server struct {
 	// config contains the base server settings
 	config config.Config
@@ -27,6 +28,7 @@ type Server struct {
 	Router *route.Router
 }
 
+// ConfigureEcho sets up the echo server with the default middleware and logging
 func ConfigureEcho() *echo.Echo {
 	e := echo.New()
 	e.HTTPErrorHandler = CustomHTTPErrorHandler

--- a/internal/middleware/objects/doc.go
+++ b/internal/middleware/objects/doc.go
@@ -1,2 +1,2 @@
-// package objects provides the customizations for the object upload middleware
+// Package objects provides the customizations for the object upload middleware
 package objects

--- a/internal/middleware/objects/permissions.go
+++ b/internal/middleware/objects/permissions.go
@@ -12,8 +12,10 @@ import (
 	"github.com/theopenlane/core/pkg/objects"
 )
 
+// ErrMissingParent is returned when the parent id or type is missing for file uploads
 var ErrMissingParent = fmt.Errorf("parent id or type is missing")
 
+// AddFilePermissions adds file permissions to the object store
 func AddFilePermissions(ctx context.Context) error {
 	filesUpload, err := objects.FilesFromContext(ctx)
 	if err != nil {

--- a/jsonschema/api-docs.md
+++ b/jsonschema/api-docs.md
@@ -20,7 +20,7 @@ Config contains the configuration for the core server
 |[**sessions**](#sessions)|`object`|||
 |[**totp**](#totp)|`object`|||
 |[**ratelimit**](#ratelimit)|`object`|Config defines the configuration settings for the default rate limiter<br/>||
-|[**objectStorage**](#objectstorage)|`object`|||
+|[**objectStorage**](#objectstorage)|`object`|Config is the configuration for the object store<br/>||
 |[**subscription**](#subscription)|`object`|||
 
 **Additional Properties:** not allowed  
@@ -822,6 +822,9 @@ Config defines the configuration settings for the default rate limiter
 **Additional Properties:** not allowed  
 <a name="objectstorage"></a>
 ## objectStorage: object
+
+Config is the configuration for the object store
+
 
 **Properties**
 

--- a/jsonschema/core.config.json
+++ b/jsonschema/core.config.json
@@ -921,7 +921,8 @@
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "description": "Config is the configuration for the object store"
     },
     "otelx.Config": {
       "properties": {

--- a/pkg/enums/control_objective.go
+++ b/pkg/enums/control_objective.go
@@ -24,7 +24,8 @@ func (ObjectiveStatus) Values() (kinds []string) {
 	for _, s := range []ObjectiveStatus{
 		ObjectiveActiveStatus,
 		ObjectiveArchivedStatus,
-		ObjectiveDraftStatus} {
+		ObjectiveDraftStatus,
+	} {
 		kinds = append(kinds, string(s))
 	}
 

--- a/pkg/enums/controlstatus.go
+++ b/pkg/enums/controlstatus.go
@@ -29,8 +29,14 @@ var (
 // Possible default values are "PREPARING", "NEEDS APPROVAL", "CHANGES REQUESTED",
 // "APPROVED" and "ARCHIVED".
 func (ControlStatus) Values() (kinds []string) {
-	for _, s := range []ControlStatus{ControlStatusPreparing, ControlStatusNeedsApproval, ControlStatusChangesRequested,
-		ControlStatusApproved, ControlStatusArchived, ControlStatusNull} {
+	for _, s := range []ControlStatus{
+		ControlStatusPreparing,
+		ControlStatusNeedsApproval,
+		ControlStatusChangesRequested,
+		ControlStatusApproved,
+		ControlStatusArchived,
+		ControlStatusNull,
+	} {
 		kinds = append(kinds, string(s))
 	}
 

--- a/pkg/logx/doc.go
+++ b/pkg/logx/doc.go
@@ -1,2 +1,2 @@
-// package logx is a package for logging with echo and
+// Package logx is a package for logging with echo and
 package logx

--- a/pkg/logx/logger.go
+++ b/pkg/logx/logger.go
@@ -185,6 +185,7 @@ func (l *Logger) Prefix() string {
 	return l.prefix
 }
 
+// SetHeader implements echo.Logger interface
 func (l *Logger) SetHeader(_ string) {
 	// not implemented
 }

--- a/pkg/logx/middleware.go
+++ b/pkg/logx/middleware.go
@@ -51,6 +51,7 @@ func NewContext(ctx echo.Context, logger *Logger) *Context {
 	return &Context{ctx, logger}
 }
 
+// Logger returns the logger from the context
 func (c *Context) Logger() echo.Logger {
 	return c.logger
 }

--- a/pkg/middleware/auth/authoptions.go
+++ b/pkg/middleware/auth/authoptions.go
@@ -53,6 +53,7 @@ type Reauthenticator interface {
 	Refresh(context.Context, *api.RefreshRequest) (*api.LoginReply, error)
 }
 
+// DefaultAuthOptions is the default auth options used by the middleware.
 var DefaultAuthOptions = Options{
 	KeysURL:            "http://localhost:17608/.well-known/jwks.json",
 	Audience:           "http://localhost:17608",

--- a/pkg/models/aaguid.go
+++ b/pkg/models/aaguid.go
@@ -9,9 +9,7 @@ import (
 	"github.com/google/uuid"
 )
 
-var (
-	ErrUnsupportedDataType = errors.New("unsupported aaguid format")
-)
+var ErrUnsupportedDataType = errors.New("unsupported aaguid format")
 
 // AAGUID is a custom type representing an authenticator attestation uuid.
 type AAGUID []byte

--- a/pkg/objects/config.go
+++ b/pkg/objects/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/theopenlane/utils/ulids"
 )
 
+// Config is the configuration for the object store
 type Config struct {
 	// Enabled indicates if the store is enabled
 	Enabled bool `json:"enabled" koanf:"enabled" default:"true"`
@@ -115,6 +116,7 @@ var (
 	}
 )
 
+// OrganizationNameFunc is a function that generates the organization name
 var OrganizationNameFunc NameGeneratorFunc = func(s string) string {
 	return s
 }

--- a/pkg/objects/errors.go
+++ b/pkg/objects/errors.go
@@ -33,5 +33,6 @@ type errorMsg string
 func (e errorMsg) Error() string { return string(e) }
 
 const (
+	// ErrNoFilesUploaded is returned when no files were uploaded in the request
 	ErrNoFilesUploaded = errorMsg("objects: no uploadable files found in request")
 )

--- a/pkg/objects/objects.go
+++ b/pkg/objects/objects.go
@@ -160,7 +160,7 @@ type ParentObject struct {
 	Type string `json:"type"`
 }
 
-// SKipperFunc is a function that defines whether to skip the middleware
+// SkipperFunc is a function that defines whether to skip the middleware
 type SkipperFunc func(r *http.Request) bool
 
 // UploaderFunc is a function that handles the file upload process and returns the files uploaded

--- a/pkg/objects/options.go
+++ b/pkg/objects/options.go
@@ -97,6 +97,7 @@ func WithDownloadFileOptions(opts *DownloadFileOptions) Option {
 	}
 }
 
+// WithMetadata allows you to provide metadata for the upload
 func WithMetadata(mp map[string]interface{}) Option {
 	return func(o *Objects) {
 		if o.UploadFileOptions.Metadata == nil {

--- a/pkg/objects/storage/disk.go
+++ b/pkg/objects/storage/disk.go
@@ -28,6 +28,7 @@ var _ objects.Storage = &Disk{}
 // ProviderDisk is the provider for the disk storage
 var ProviderDisk = "disk"
 
+// NewDiskStorage creates a new Disk storage backend
 func NewDiskStorage(opts *DiskOptions) (*Disk, error) {
 	if isStringEmpty(opts.Bucket) {
 		return nil, ErrInvalidFolderPath
@@ -50,8 +51,10 @@ func NewDiskStorage(opts *DiskOptions) (*Disk, error) {
 	return disk, nil
 }
 
+// Close satisfies the Storage interface
 func (d *Disk) Close() error { return nil }
 
+// Upload satisfies the Storage interface
 func (d *Disk) Upload(_ context.Context, r io.Reader, opts *objects.UploadFileOptions) (*objects.UploadedFileMetadata, error) {
 	f, err := os.Create(filepath.Join(d.Opts.Bucket, opts.FileName))
 	if err != nil {

--- a/pkg/objects/storage/diskoptions.go
+++ b/pkg/objects/storage/diskoptions.go
@@ -1,7 +1,9 @@
 package storage
 
+// DiskOption is an options function for the DiskOptions
 type DiskOption func(*DiskOptions)
 
+// DiskOptions are options for the disk storage
 type DiskOptions struct {
 	Bucket string
 	Key    string
@@ -24,6 +26,7 @@ func WithLocalKey(key string) DiskOption {
 	}
 }
 
+// WithLocalURL specifies the URL to use for the "presigned" URL for the file
 func WithLocalURL(url string) DiskOption {
 	return func(d *DiskOptions) {
 		d.LocalURL = url


### PR DESCRIPTION
- Mounts the go cache for all docker plugins that want the cache (e.g. generate, lint, test) (h/t @matoszz for finding this solution)
- removes all the excludes in the linter for non-go directories, these isn't needed
- fixes a bunch of linter issues from `internal/ent/schema` because this was previously excluded
- I tried to turn on a linter (e..g comments) but more issues than I had time to fix
- Reruns of a cached lint now take 15 seconds, reruns of the generate check now take 2 minutes instead of 8-10, all should now be working on nyc server too
- we may have ensure our cache doesnt get too large + is cleaned up occasionally on the runners