### PR TITLE
chore: speed up graphapi tests, use gotestsum

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -163,6 +163,9 @@ steps:
           - artifacts#v1.9.4:
               download: "coverage.out"
               step: "go_test"
+          - artifacts#v1.9.4:
+              download: "junit.xml"
+              step: "go_test"
           - docker#v5.12.0:
               image: "sonarsource/sonar-scanner-cli:11.2"
               propagate-environment: true
@@ -185,6 +188,9 @@ steps:
                 SONAR_TOKEN: SONAR_TOKEN
           - artifacts#v1.9.4:
               download: coverage.out
+              step: "go_test"
+          - artifacts#v1.9.4:
+              download: "junit.xml"
               step: "go_test"
           - docker#v5.12.0:
               image: "sonarsource/sonar-scanner-cli:11.2"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -92,9 +92,6 @@ steps:
             version:
               - 17-alpine
         plugins:
-          - cluster-secrets#v1.0.0:
-              variables:
-                ANALYTICS_KEY: ANALYTICS_KEY
           - docker#v5.12.0:
               image: ghcr.io/theopenlane/build-image:latest
               always_pull: true
@@ -111,7 +108,7 @@ steps:
                 - "TEST_DB_URL"
                 - "TEST_DB_CONTAINER_EXPIRY=20" # container expiry in minutes
                 - "TEST_DB_HOST=172.17.0.1" # docker host ip on linux
-        artifact_paths: ["coverage.out"]
+        artifact_paths: ["coverage.out", "junit.xml"]
       - label: ":auth0: fga model test"
         if: build.branch !~ /^renovate\//
         agents:
@@ -127,6 +124,35 @@ steps:
     key: "security"
     if: build.branch !~ /^renovate\//
     steps:
+      - label: ":buildkite: upload test analytics report"
+        key: "scan-upload-pr"
+        cancel_on_build_failing: true
+        if: build.pull_request.id != null
+        depends_on: ["go_test"]
+        commands: |
+          #!/bin/bash
+          curl \
+            -X POST \
+            --fail-with-body \
+            -H "Authorization: Token token=\"$$ANALYTICS_TOKEN\"" \
+            -F "data=@junit.xml" \
+            -F "format=junit" \
+            -F "run_env[CI]=buildkite" \
+            -F "run_env[key]=$BUILDKITE_BUILD_ID" \
+            -F "run_env[number]=$BUILDKITE_BUILD_NUMBER" \
+            -F "run_env[job_id]=$BUILDKITE_JOB_ID" \
+            -F "run_env[branch]=$BUILDKITE_BRANCH" \
+            -F "run_env[commit_sha]=$BUILDKITE_COMMIT" \
+            -F "run_env[message]=$BUILDKITE_MESSAGE" \
+            -F "run_env[url]=$BUILDKITE_BUILD_URL" \
+            https://analytics-api.buildkite.com/v1/uploads
+        plugins:
+          - cluster-secrets#v1.0.0:
+              variables:
+                ANALYTICS_KEY: ANALYTICS_KEY
+          - artifacts#v1.9.4:
+              download: "junit.xml"
+              step: "go_test"
       - label: ":github: upload PR reports"
         key: "scan-upload-pr"
         cancel_on_build_failing: true

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -107,9 +107,7 @@ steps:
                 - "TEST_DB_URL"
                 - "TEST_DB_CONTAINER_EXPIRY=20" # container expiry in minutes
                 - "TEST_DB_HOST=172.17.0.1" # docker host ip on linux
-        artifact_paths:
-          - coverage.out
-          - junit.xml
+        artifact_paths: ["coverage.out", "junit.xml"]
       - label: ":auth0: fga model test"
         if: build.branch !~ /^renovate\//
         agents:

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -133,7 +133,7 @@ steps:
           curl \
             -X POST \
             --fail-with-body \
-            -H "Authorization: Token token=\"$$ANALYTICS_TOKEN\"" \
+            -H "Authorization: Token token=\"$$ANALYTICS_KEY\"" \
             -F "data=@junit.xml" \
             -F "format=junit" \
             -F "run_env[CI]=buildkite" \

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -77,7 +77,6 @@ steps:
                 - $GOLANGCI_LINT_CACHE:$GOLANGCI_LINT_CACHE
               environment:
                 - "GOTOOLCHAIN=auto"
-        artifact_paths: ["coverage.out"]
       - label: ":golang: go test - {{matrix.version}}"
         agents:
           queue: $LARGE_RUNNER_QUEUE
@@ -108,7 +107,9 @@ steps:
                 - "TEST_DB_URL"
                 - "TEST_DB_CONTAINER_EXPIRY=20" # container expiry in minutes
                 - "TEST_DB_HOST=172.17.0.1" # docker host ip on linux
-        artifact_paths: ["coverage.out", "junit.xml"]
+        artifact_paths:
+          - coverage.out
+          - junit.xml
       - label: ":auth0: fga model test"
         if: build.branch !~ /^renovate\//
         agents:

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -92,6 +92,9 @@ steps:
             version:
               - 17-alpine
         plugins:
+          - cluster-secrets#v1.0.0:
+              variables:
+                ANALYTICS_KEY: ANALYTICS_KEY
           - docker#v5.12.0:
               image: ghcr.io/theopenlane/build-image:latest
               always_pull: true

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -95,7 +95,7 @@ steps:
           - docker#v5.12.0:
               image: ghcr.io/theopenlane/build-image:latest
               always_pull: true
-              command: ["task", "go:test:cover"]
+              command: ["task", "go:testsum:ci"]
               propagate-environment: true
               volumes:
                 - $GOCACHE:$GOCACHE
@@ -103,7 +103,7 @@ steps:
                 - $GOLANGCI_LINT_CACHE:$GOLANGCI_LINT_CACHE
                 - "/var/run/docker.sock:/var/run/docker.sock"
               environment:
-                - "GOMAXPROCS=8"
+                - "GOMAXPROCS=16"
                 - "TEST_DB_URL"
                 - "TEST_DB_CONTAINER_EXPIRY=20" # container expiry in minutes
                 - "TEST_DB_HOST=172.17.0.1" # docker host ip on linux

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -106,6 +106,7 @@ steps:
                 - $GOLANGCI_LINT_CACHE:$GOLANGCI_LINT_CACHE
                 - "/var/run/docker.sock:/var/run/docker.sock"
               environment:
+                - "ANALYTICS_KEY"
                 - "GOMAXPROCS=16"
                 - "TEST_DB_URL"
                 - "TEST_DB_CONTAINER_EXPIRY=20" # container expiry in minutes

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -125,9 +125,8 @@ steps:
     if: build.branch !~ /^renovate\//
     steps:
       - label: ":buildkite: upload test analytics report"
-        key: "scan-upload-pr"
-        cancel_on_build_failing: true
-        if: build.pull_request.id != null
+        key: "test-analytics"
+        cancel_on_build_failing: false
         depends_on: ["go_test"]
         commands: |
           #!/bin/bash

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ results.txt
 *.config.yaml
 .task
 .hermit
+
+junit.xml

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -17,7 +17,6 @@ linters:
     - mnd
     - noctx
     - revive
-    - staticcheck
     - whitespace
     - wsl
   exclusions:
@@ -29,7 +28,6 @@ linters:
       - legacy
       - std-error-handling
     rules:
-      # Completely exclude specified files and directories from all linters
       - path: ".*\\.generated\\.go"
         linters: ["*"]
       - path: "pkg/openlaneclient/graphclient.go"
@@ -69,13 +67,6 @@ linters:
 formatters:
   enable:
     - gofmt
-    - goimports
-  settings:
-    gofumpt:
-      extra-rules: true
-    goimports:
-      local-prefixes:
-        - github.com/theopenlane/core
   exclusions:
     generated: lax
     warn-unused: true
@@ -83,19 +74,7 @@ formatters:
       - internal/graphapi/model/gen_models.go
       - pkg/openlaneclient/graphclient.go
       - pkg/testutils/*
-      - internal/ent/generated/*
-      - internal/ent/generate/generate/*
-      - internal/ent/templates/*
-      - jsonschema/templates/*
-      - pkg/objects/mocks/*
-      - internal/graphapi/generate/*
-      - internal/graphapi/generated/*
       - pkg/entitlements/test/*
       - cmd/cli/cmd/*
-      - pkg/sleuth/static/*
-      - pkg/entitlements/mocks/*
       - pkg/events/soiree/examples/*
-      - pkg/middleware/ratelimiter/examples/*
       - pkg/sleuth/dnsx/* # this should be fixed in the future
-      - jsonschema/*
-      - pkg/gencmd/*

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,9 +3,6 @@ run:
   modules-download-mode: readonly
   tests: false
   allow-parallel-runners: true
-issues:
-  new: true
-  new-from-rev: HEAD~
 linters:
   enable:
     - bodyclose
@@ -23,47 +20,26 @@ linters:
     generated: lax
     warn-unused: true
     presets:
-      - comments # uncomment this after fixing all comments
+      - comments # undisable this after fixing all comments
       - common-false-positives
       - legacy
       - std-error-handling
-    rules:
-      - path: ".*\\.generated\\.go"
-        linters: ["*"]
-      - path: "pkg/openlaneclient/graphclient.go"
-        linters: ["*"]
-      - path: "pkg/openlaneclient/models.go"
-        linters: ["*"]
-      - path: "pkg/testutils/.*"
-        linters: ["*"]
-      - path: "internal/ent/generated/.*"
-        linters: ["*"]
-      - path: "internal/ent/templates/.*"
-        linters: ["*"]
-      - path: "jsonschema/templates/.*"
-        linters: ["*"]
-      - path: "pkg/objects/mocks/.*"
-        linters: ["*"]
-      - path: "internal/graphapi/generate/.*"
-        linters: ["*"]
-      - path: "internal/graphapi/generated/.*"
-        linters: ["*"]
-      - path: "internal/graphapi/directives/.*"
-        linters: ["*"]
-      - path: "internal/graphapi/model/.*"
-        linters: ["*"]
-      - path: "pkg/entitlements/test/.*"
-        linters: ["*"]
-      - path: "cmd/cli/cmd/.*"
-        linters: ["*"]
-      - path: "pkg/sleuth/static/.*"
-        linters: ["*"]
-      - path: "pkg/entitlements/mocks/.*"
-        linters: ["*"]
-      - path: "pkg/events/soiree/examples/.*"
-        linters: ["*"]
-      - path: "pkg/middleware/ratelimiter/examples/.*"
-        linters: ["*"]
+    paths:
+      - internal/graphapi/model/gen_models.go
+      - pkg/openlaneclient/graphclient.go
+      - pkg/testutils/*
+      - internal/ent/generated/*
+      - internal/ent/templates/*
+      - jsonschema/templates/*
+      - pkg/objects/mocks/*
+      - internal/graphapi/generate/*
+      - internal/graphapi/generated/*
+      - pkg/entitlements/test/*
+      - cmd/cli/cmd/*
+      - pkg/sleuth/static/*
+      - pkg/entitlements/mocks/*
+      - pkg/events/soiree/examples/*
+      - pkg/middleware/ratelimiter/examples/*
 formatters:
   enable:
     - gofmt

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,6 +3,9 @@ run:
   modules-download-mode: readonly
   tests: false
   allow-parallel-runners: true
+issues:
+  new: true
+  new-from-rev: HEAD~
 linters:
   enable:
     - bodyclose
@@ -21,26 +24,48 @@ linters:
     generated: lax
     warn-unused: true
     presets:
-      - comments # undisable this after fixing all comments
+      - comments # uncomment this after fixing all comments
       - common-false-positives
       - legacy
       - std-error-handling
-    paths:
-      - internal/graphapi/model/gen_models.go
-      - pkg/openlaneclient/graphclient.go
-      - pkg/testutils/*
-      - internal/ent/generated/*
-      - internal/ent/templates/*
-      - jsonschema/templates/*
-      - pkg/objects/mocks/*
-      - internal/graphapi/generate/*
-      - internal/graphapi/generated/*
-      - pkg/entitlements/test/*
-      - cmd/cli/cmd/*
-      - pkg/sleuth/static/*
-      - pkg/entitlements/mocks/*
-      - pkg/events/soiree/examples/*
-      - pkg/middleware/ratelimiter/examples/*
+    rules:
+      # Completely exclude specified files and directories from all linters
+      - path: ".*\\.generated\\.go"
+        linters: ["*"]
+      - path: "pkg/openlaneclient/graphclient.go"
+        linters: ["*"]
+      - path: "pkg/openlaneclient/models.go"
+        linters: ["*"]
+      - path: "pkg/testutils/.*"
+        linters: ["*"]
+      - path: "internal/ent/generated/.*"
+        linters: ["*"]
+      - path: "internal/ent/templates/.*"
+        linters: ["*"]
+      - path: "jsonschema/templates/.*"
+        linters: ["*"]
+      - path: "pkg/objects/mocks/.*"
+        linters: ["*"]
+      - path: "internal/graphapi/generate/.*"
+        linters: ["*"]
+      - path: "internal/graphapi/generated/.*"
+        linters: ["*"]
+      - path: "internal/graphapi/directives/.*"
+        linters: ["*"]
+      - path: "internal/graphapi/model/.*"
+        linters: ["*"]
+      - path: "pkg/entitlements/test/.*"
+        linters: ["*"]
+      - path: "cmd/cli/cmd/.*"
+        linters: ["*"]
+      - path: "pkg/sleuth/static/.*"
+        linters: ["*"]
+      - path: "pkg/entitlements/mocks/.*"
+        linters: ["*"]
+      - path: "pkg/events/soiree/examples/.*"
+        linters: ["*"]
+      - path: "pkg/middleware/ratelimiter/examples/.*"
+        linters: ["*"]
 formatters:
   enable:
     - gofmt

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -140,12 +140,14 @@ tasks:
       - go tool cover -html=coverage.out
 
   go:testsum:local:
+    silent: true
     desc: runs tests using gotestsum
     aliases: [testsum]
     cmds:
-      - gotestsum --format-hide-empty-pkg
+      - gotestsum --format-hide-empty-pkg --packages "./..." --format-hide-empty-pkg --rerun-fails --hide-summary output -- -p 20
 
   go:testsum:slow:
+    silent: true
     desc: finds slow tests using gotestsum
     aliases: ['testsum:slow']
     cmds:
@@ -163,7 +165,7 @@ tasks:
     silent: true
     aliases: ['testsum:graph']
     cmds:
-      - go run gotest.tools/gotestsum@latest --junitfile coverage.out --packages "github.com/theopenlane/core/internal/graphapi" --format-hide-empty-pkg --rerun-fails --format-icons hivis --hide-summary output -- -p 20 --race
+      - gotestsum --packages "github.com/theopenlane/core/internal/graphapi" --format-hide-empty-pkg --rerun-fails --format-icons hivis --hide-summary output -- -p 20
 
   go:fmt:
     desc: format all go code

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -164,7 +164,7 @@ tasks:
         curl \
         -X POST \
         --fail-with-body \
-        -H "Authorization: Token token=\"$ANALYTICS_TOKEN\"" \
+        -H "Authorization: Token token=\"$$ANALYTICS_TOKEN\"" \
         -F "data=@junit.xml" \
         -F "format=junit" \
         -F "run_env[CI]=buildkite" \

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -159,7 +159,7 @@ tasks:
     silent: true
     aliases: ['testsum:ci']
     cmds:
-      - go run gotest.tools/gotestsum@latest --junitfile coverage.out --junitfile junit.xml --rerun-fails --packages "./..." --format-hide-empty-pkg --rerun-fails --format-icons hivis --hide-summary output -- -p 20
+      - go run gotest.tools/gotestsum@latest --junitfile junit.xml --rerun-fails --packages "./..." --format-hide-empty-pkg --rerun-fails --format-icons hivis --hide-summary output -- -p 20 -coverprofile=coverage.out
 
   go:testsum:ci:cover:
     desc: pushes test results to buildkite using gotestsum

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -117,7 +117,7 @@ tasks:
     parallel: true
     ## do not use --fix in CI, run each in parallel
     cmds:
-      - golangci-lint run --config=.golangci.yaml --verbose --concurrency 16 --print-resources-usage
+      - golangci-lint run --config=.golangci.yaml --verbose --concurrency 8 --print-resources-usage
 
   go:test:
     desc: runs and outputs results of created go tests

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -114,8 +114,7 @@ tasks:
 
   go:lint:ci:
     desc: runs golangci-lint, the most annoying opinionated linter ever, for CI
-    parallel: true
-    ## do not use --fix in CI, run each in parallel
+    ## do not use --fix in CI
     cmds:
       - golangci-lint run --config=.golangci.yaml --verbose --concurrency 8 --print-resources-usage
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -139,6 +139,32 @@ tasks:
       - task: go:test:cover
       - go tool cover -html=coverage.out
 
+  go:testsum:local:
+    desc: runs tests using gotestsum
+    aliases: [testsum]
+    cmds:
+      - gotestsum --format-hide-empty-pkg
+
+  go:testsum:slow:
+    desc: finds slow tests using gotestsum
+    aliases: ['testsum:slow']
+    cmds:
+      - gotestsum tool slowest
+
+  go:testsum:ci:
+    desc: runs tests using gotestsum for CI
+    silent: true
+    aliases: ['testsum:ci']
+    cmds:
+      - go run gotest.tools/gotestsum@latest --junitfile coverage.out --packages "./..." --format-hide-empty-pkg --rerun-fails --format-icons hivis --hide-summary output -- -p 20
+
+  go:testsum:graph:
+    desc: runs only the graph tests using gotestsum
+    silent: true
+    aliases: ['testsum:graph']
+    cmds:
+      - go run gotest.tools/gotestsum@latest --junitfile coverage.out --packages "github.com/theopenlane/core/internal/graphapi" --format-hide-empty-pkg --rerun-fails --format-icons hivis --hide-summary output -- -p 20 --race
+
   go:fmt:
     desc: format all go code
     cmds:
@@ -295,6 +321,7 @@ tasks:
     vars:
       DEPS: >-
         age helm kubernetes-cli yq jq gomplate golangci-lint openfga/tap/fga pre-commit ariga/tap/atlas rover #magic___^_^___line
+
   brew-installed:
     silent: true
     desc: check if Homebrew is installed

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -160,11 +160,17 @@ tasks:
     aliases: ['testsum:ci']
     cmds:
       - go run gotest.tools/gotestsum@latest --junitfile coverage.out --junitfile junit.xml --rerun-fails --packages "./..." --format-hide-empty-pkg --rerun-fails --format-icons hivis --hide-summary output -- -p 20
+
+  go:testsum:ci:cover:
+    desc: pushes test results to buildkite using gotestsum
+    silent: true
+    aliases: ['testsum:ci:cover']
+    cmds:
       - |
         curl \
         -X POST \
         --fail-with-body \
-        -H "Authorization: Token token=\"$$ANALYTICS_TOKEN\"" \
+        -H "Authorization: Token token=\"$ANALYTICS_TOKEN\"" \
         -F "data=@junit.xml" \
         -F "format=junit" \
         -F "run_env[CI]=buildkite" \

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -114,9 +114,10 @@ tasks:
 
   go:lint:ci:
     desc: runs golangci-lint, the most annoying opinionated linter ever, for CI
-    ## do not use --fix in CI
+    parallel: true
+    ## do not use --fix in CI, run each in parallel
     cmds:
-      - golangci-lint run --config=.golangci.yaml --verbose --concurrency 8 --print-resources-usage
+      - golangci-lint run --config=.golangci.yaml --verbose --concurrency 16 --print-resources-usage
 
   go:test:
     desc: runs and outputs results of created go tests
@@ -158,7 +159,23 @@ tasks:
     silent: true
     aliases: ['testsum:ci']
     cmds:
-      - go run gotest.tools/gotestsum@latest --junitfile coverage.out --packages "./..." --format-hide-empty-pkg --rerun-fails --format-icons hivis --hide-summary output -- -p 20
+      - go run gotest.tools/gotestsum@latest --junitfile coverage.out --junitfile junit.xml --packages "./..." --format-hide-empty-pkg --rerun-fails --format-icons hivis --hide-summary output -- -p 20
+      - |
+        curl \
+        -X POST \
+        --fail-with-body \
+        -H "Authorization: Token token=\"$_ANALYTICS_TOKEN\"" \
+        -F "data=@junit.xml" \
+        -F "format=junit" \
+        -F "run_env[CI]=buildkite" \
+        -F "run_env[key]=$BUILDKITE_BUILD_ID" \
+        -F "run_env[number]=$BUILDKITE_BUILD_NUMBER" \
+        -F "run_env[job_id]=$BUILDKITE_JOB_ID" \
+        -F "run_env[branch]=$BUILDKITE_BRANCH" \
+        -F "run_env[commit_sha]=$BUILDKITE_COMMIT" \
+        -F "run_env[message]=$BUILDKITE_MESSAGE" \
+        -F "run_env[url]=$BUILDKITE_BUILD_URL" \
+        https://analytics-api.buildkite.com/v1/uploads
 
   go:testsum:graph:
     desc: runs only the graph tests using gotestsum

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -159,7 +159,7 @@ tasks:
     silent: true
     aliases: ['testsum:ci']
     cmds:
-      - go run gotest.tools/gotestsum@latest --junitfile coverage.out --junitfile junit.xml --packages "./..." --format-hide-empty-pkg --rerun-fails --format-icons hivis --hide-summary output -- -p 20
+      - go run gotest.tools/gotestsum@latest --junitfile coverage.out --junitfile junit.xml --rerun-fails 3 --packages "./..." --format-hide-empty-pkg --rerun-fails --format-icons hivis --hide-summary output -- -p 20
       - |
         curl \
         -X POST \

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -164,7 +164,7 @@ tasks:
         curl \
         -X POST \
         --fail-with-body \
-        -H "Authorization: Token token=\"$$ANALYTICS_TOKEN\"" \
+        -H "Authorization: Token token=\"$ANALYTICS_TOKEN\"" \
         -F "data=@junit.xml" \
         -F "format=junit" \
         -F "run_env[CI]=buildkite" \

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -164,7 +164,7 @@ tasks:
         curl \
         -X POST \
         --fail-with-body \
-        -H "Authorization: Token token=\"$_ANALYTICS_TOKEN\"" \
+        -H "Authorization: Token token=\"$ANALYTICS_TOKEN\"" \
         -F "data=@junit.xml" \
         -F "format=junit" \
         -F "run_env[CI]=buildkite" \

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -159,7 +159,7 @@ tasks:
     silent: true
     aliases: ['testsum:ci']
     cmds:
-      - go run gotest.tools/gotestsum@latest --junitfile coverage.out --junitfile junit.xml --rerun-fails 3 --packages "./..." --format-hide-empty-pkg --rerun-fails --format-icons hivis --hide-summary output -- -p 20
+      - go run gotest.tools/gotestsum@latest --junitfile coverage.out --junitfile junit.xml --rerun-fails --packages "./..." --format-hide-empty-pkg --rerun-fails --format-icons hivis --hide-summary output -- -p 20
       - |
         curl \
         -X POST \

--- a/go.mod
+++ b/go.mod
@@ -91,6 +91,8 @@ require (
 	golang.org/x/term v0.32.0
 	golang.org/x/text v0.25.0
 	golang.org/x/tools v0.33.0
+	gotest.tools/gotestsum v1.12.0
+	gotest.tools/v3 v3.5.2
 )
 
 require (
@@ -421,7 +423,6 @@ require (
 	gopkg.in/mattn/go-isatty.v0 v0.0.4 // indirect
 	gopkg.in/mattn/go-runewidth.v0 v0.0.4 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gotest.tools/gotestsum v1.12.0 // indirect
 	honnef.co/go/tools v0.6.1 // indirect
 	k8s.io/api v0.32.2 // indirect
 	k8s.io/apiextensions-apiserver v0.32.2 // indirect

--- a/internal/graphapi/_example_test.go
+++ b/internal/graphapi/_example_test.go
@@ -53,8 +53,7 @@ import (
 // 	return OBJECT
 // }
 
-func (suite *GraphTestSuite) TestQueryOBJECT() {
-	t := suite.T()
+func TestQueryOBJECT(t *testing.T) {
 
 	// create an OBJECT to be queried using testUser1
 	OBJECT := (&OBJECTBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
@@ -63,7 +62,7 @@ func (suite *GraphTestSuite) TestQueryOBJECT() {
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   *openlaneclient.OpenlaneClient
+		client   openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{
@@ -126,8 +125,7 @@ func (suite *GraphTestSuite) TestQueryOBJECT() {
 	}
 }
 
-func (suite *GraphTestSuite) TestQueryOBJECTs() {
-	t := suite.T()
+func TestQueryOBJECTs(t *testing.T) {
 
 	// create multiple objects to be queried using testUser1
 	(&OBJECTBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
@@ -135,7 +133,7 @@ func (suite *GraphTestSuite) TestQueryOBJECTs() {
 
 	testCases := []struct {
 		name            string
-		client          *openlaneclient.OpenlaneClient
+		client          openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int
 	}{
@@ -182,13 +180,12 @@ func (suite *GraphTestSuite) TestQueryOBJECTs() {
 	}
 }
 
-func (suite *GraphTestSuite) TestMutationCreateOBJECT() {
-	t := suite.T()
+func TestMutationCreateOBJECT(t *testing.T) {
 
 	testCases := []struct {
 		name        string
 		request     openlaneclient.CreateOBJECTInput
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -266,15 +263,14 @@ func (suite *GraphTestSuite) TestMutationCreateOBJECT() {
 	}
 }
 
-func (suite *GraphTestSuite) TestMutationUpdateOBJECT() {
-	t := suite.T()
+func TestMutationUpdateOBJECT(t *testing.T) {
 
 	OBJECT := (&OBJECTBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	testCases := []struct {
 		name        string
 		request     openlaneclient.UpdateOBJECTInput
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -334,8 +330,7 @@ func (suite *GraphTestSuite) TestMutationUpdateOBJECT() {
 	}
 }
 
-func (suite *GraphTestSuite) TestMutationDeleteOBJECT() {
-	t := suite.T()
+func TestMutationDeleteOBJECT(t *testing.T) {
 
 	// create objects to be deleted
 	OBJECT1 := (&OBJECTBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
@@ -344,7 +339,7 @@ func (suite *GraphTestSuite) TestMutationDeleteOBJECT() {
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{

--- a/internal/graphapi/_example_test.go
+++ b/internal/graphapi/_example_test.go
@@ -62,7 +62,7 @@ func TestQueryOBJECT(t *testing.T) {
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   openlaneclient.OpenlaneClient
+		client   *openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{
@@ -133,7 +133,7 @@ func TestQueryOBJECTs(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		client          openlaneclient.OpenlaneClient
+		client          *openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int
 	}{
@@ -185,7 +185,7 @@ func TestMutationCreateOBJECT(t *testing.T) {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.CreateOBJECTInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -270,7 +270,7 @@ func TestMutationUpdateOBJECT(t *testing.T) {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.UpdateOBJECTInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -339,7 +339,7 @@ func TestMutationDeleteOBJECT(t *testing.T) {
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{

--- a/internal/graphapi/apitoken_test.go
+++ b/internal/graphapi/apitoken_test.go
@@ -327,7 +327,7 @@ func TestMutationDeleteAPIToken(t *testing.T) {
 
 			assert.NilError(t, err)
 			assert.Assert(t, resp != nil)
-			assert.Equal(t, tc.tokenID, resp.DeleteAPIToken.DeletedID)
+			assert.Check(t, is.Equal(tc.tokenID, resp.DeleteAPIToken.DeletedID))
 		})
 	}
 }

--- a/internal/graphapi/apitoken_test.go
+++ b/internal/graphapi/apitoken_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func TestQueryApiToken(t *testing.T) {
-
 	apiToken := (&APITokenBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	testCases := []struct {
@@ -49,7 +48,6 @@ func TestQueryApiToken(t *testing.T) {
 			resp, err := suite.client.api.GetAPITokenByID(tc.ctx, tc.queryID)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 
@@ -67,7 +65,6 @@ func TestQueryApiToken(t *testing.T) {
 }
 
 func TestQueryAPITokens(t *testing.T) {
-
 	token1 := (&APITokenBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	token2 := (&APITokenBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
@@ -85,7 +82,6 @@ func TestQueryAPITokens(t *testing.T) {
 			resp, err := suite.client.api.GetAllAPITokens(testUser1.UserCtx)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 
@@ -106,7 +102,6 @@ func TestQueryAPITokens(t *testing.T) {
 }
 
 func TestMutationCreateAPIToken(t *testing.T) {
-
 	tokenDescription := gofakeit.Sentence(5)
 	expiration30Days := time.Now().Add(time.Hour * 24 * 30)
 
@@ -159,7 +154,6 @@ func TestMutationCreateAPIToken(t *testing.T) {
 			resp, err := suite.client.api.CreateAPIToken(testUser1.UserCtx, tc.input)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 
@@ -195,7 +189,6 @@ func TestMutationCreateAPIToken(t *testing.T) {
 }
 
 func TestMutationUpdateAPIToken(t *testing.T) {
-
 	token := (&APITokenBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	tokenDescription := gofakeit.Sentence(5)
@@ -257,7 +250,6 @@ func TestMutationUpdateAPIToken(t *testing.T) {
 			resp, err := suite.client.api.UpdateAPIToken(tc.ctx, tc.tokenID, tc.input)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 
@@ -291,7 +283,6 @@ func TestMutationUpdateAPIToken(t *testing.T) {
 }
 
 func TestMutationDeleteAPIToken(t *testing.T) {
-
 	// create user to make tokens
 	user := (&UserBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	user2 := (&UserBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
@@ -328,7 +319,6 @@ func TestMutationDeleteAPIToken(t *testing.T) {
 			resp, err := suite.client.api.DeleteAPIToken(reqCtx, tc.tokenID)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 
@@ -343,7 +333,6 @@ func TestMutationDeleteAPIToken(t *testing.T) {
 }
 
 func TestLastUsedAPIToken(t *testing.T) {
-
 	// create new API token
 	token := (&APITokenBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 

--- a/internal/graphapi/auditlog_test.go
+++ b/internal/graphapi/auditlog_test.go
@@ -4,18 +4,17 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/theopenlane/core/pkg/openlaneclient"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
-func (suite *GraphTestSuite) TestAuditLogList() {
-	t := suite.T()
+func TestAuditLogList(t *testing.T) {
 
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   *openlaneclient.OpenlaneClient
+		client   openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{
@@ -31,15 +30,15 @@ func (suite *GraphTestSuite) TestAuditLogList() {
 			resp, err := tc.client.AuditLogs(testUser1.UserCtx)
 
 			if tc.errorMsg != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 		})
 	}
 }

--- a/internal/graphapi/auditlog_test.go
+++ b/internal/graphapi/auditlog_test.go
@@ -13,7 +13,7 @@ func TestAuditLogList(t *testing.T) {
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   openlaneclient.OpenlaneClient
+		client   *openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{

--- a/internal/graphapi/auditlog_test.go
+++ b/internal/graphapi/auditlog_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestAuditLogList(t *testing.T) {
-
 	testCases := []struct {
 		name     string
 		queryID  string
@@ -30,7 +29,6 @@ func TestAuditLogList(t *testing.T) {
 			resp, err := tc.client.AuditLogs(testUser1.UserCtx)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 

--- a/internal/graphapi/contact_test.go
+++ b/internal/graphapi/contact_test.go
@@ -24,7 +24,7 @@ func TestQueryContact(t *testing.T) {
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   openlaneclient.OpenlaneClient
+		client   *openlaneclient.OpenlaneClient
 		ctx      context.Context
 		expected *ent.Contact
 		errorMsg string
@@ -87,7 +87,7 @@ func TestQueryContacts(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		client          openlaneclient.OpenlaneClient
+		client          *openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int
 	}{
@@ -141,7 +141,7 @@ func TestMutationCreateContact(t *testing.T) {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.CreateContactInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -266,7 +266,7 @@ func TestMutationUpdateContact(t *testing.T) {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.UpdateContactInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -406,7 +406,7 @@ func TestMutationDeleteContact(t *testing.T) {
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{

--- a/internal/graphapi/contact_test.go
+++ b/internal/graphapi/contact_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 func TestQueryContact(t *testing.T) {
-
 	contact := (&ContactBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	testCases := []struct {
@@ -68,7 +67,6 @@ func TestQueryContact(t *testing.T) {
 			resp, err := tc.client.GetContactByID(tc.ctx, tc.queryID)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 
@@ -84,7 +82,6 @@ func TestQueryContact(t *testing.T) {
 }
 
 func TestQueryContacts(t *testing.T) {
-
 	contact1 := (&ContactBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	contact2 := (&ContactBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
@@ -141,7 +138,6 @@ func TestQueryContacts(t *testing.T) {
 }
 
 func TestMutationCreateContact(t *testing.T) {
-
 	testCases := []struct {
 		name        string
 		request     openlaneclient.CreateContactInput
@@ -211,7 +207,6 @@ func TestMutationCreateContact(t *testing.T) {
 		t.Run("Create "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.CreateContact(tc.ctx, tc.request)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 
@@ -266,7 +261,6 @@ func TestMutationCreateContact(t *testing.T) {
 }
 
 func TestMutationUpdateContact(t *testing.T) {
-
 	contact := (&ContactBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	testCases := []struct {
@@ -366,7 +360,6 @@ func TestMutationUpdateContact(t *testing.T) {
 		t.Run("Update "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.UpdateContact(tc.ctx, contact.ID, tc.request)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 
@@ -406,7 +399,6 @@ func TestMutationUpdateContact(t *testing.T) {
 }
 
 func TestMutationDeleteContact(t *testing.T) {
-
 	contact1 := (&ContactBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	contact2 := (&ContactBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	contact3 := (&ContactBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
@@ -470,7 +462,6 @@ func TestMutationDeleteContact(t *testing.T) {
 		t.Run("Delete "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.DeleteContact(tc.ctx, tc.idToDelete)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 

--- a/internal/graphapi/control_test.go
+++ b/internal/graphapi/control_test.go
@@ -90,7 +90,6 @@ func TestQueryControl(t *testing.T) {
 			resp, err := tc.client.GetControlByID(tc.ctx, tc.queryID)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 
@@ -422,7 +421,6 @@ func TestMutationCreateControl(t *testing.T) {
 		t.Run("Create "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.CreateControl(tc.ctx, tc.request)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 
@@ -755,7 +753,6 @@ func TestMutationCreateControlsByClone(t *testing.T) {
 		t.Run("Create "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.CreateControlsByClone(tc.ctx, tc.request)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 
@@ -834,7 +831,6 @@ func TestMutationCreateControlsByClone(t *testing.T) {
 				// ensure view only user can see the control created by the admin user
 				res, err := suite.client.api.GetControlByID(viewOnlyUser.UserCtx, control.ID)
 				if tc.expectNoAccessViewer {
-
 					assert.ErrorContains(t, err, notFoundErrorMsg)
 					assert.Check(t, is.Nil(res))
 				} else {

--- a/internal/graphapi/control_test.go
+++ b/internal/graphapi/control_test.go
@@ -30,7 +30,7 @@ func TestQueryControl(t *testing.T) {
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   openlaneclient.OpenlaneClient
+		client   *openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{
@@ -133,7 +133,7 @@ func TestQueryControls(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		client          openlaneclient.OpenlaneClient
+		client          *openlaneclient.OpenlaneClient
 		first           *int64
 		last            *int64
 		ctx             context.Context
@@ -262,7 +262,7 @@ func TestMutationCreateControl(t *testing.T) {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.CreateControlInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -635,7 +635,7 @@ func TestMutationCreateControlsByClone(t *testing.T) {
 		name                 string
 		request              openlaneclient.CloneControlInput
 		expectedControls     []*generated.Control
-		client               openlaneclient.OpenlaneClient
+		client               *openlaneclient.OpenlaneClient
 		ctx                  context.Context
 		expectNoAccessViewer bool
 		expectedErr          string
@@ -891,7 +891,7 @@ func TestMutationUpdateControl(t *testing.T) {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.UpdateControlInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -1143,7 +1143,7 @@ func TestMutationDeleteControl(t *testing.T) {
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{

--- a/internal/graphapi/control_test.go
+++ b/internal/graphapi/control_test.go
@@ -4,23 +4,20 @@ import (
 	"context"
 	"testing"
 
-	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 
+	"github.com/samber/lo"
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/graphapi/gqlerrors"
 	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/models"
 	"github.com/theopenlane/core/pkg/openlaneclient"
 	"github.com/theopenlane/core/pkg/testutils"
-	"github.com/theopenlane/iam/auth"
 	"github.com/theopenlane/utils/ulids"
 )
 
-func (suite *GraphTestSuite) TestQueryControl() {
-	t := suite.T()
-
+func TestQueryControl(t *testing.T) {
 	program := (&ProgramBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	// add adminUser to the program so that they can create a control
@@ -28,11 +25,12 @@ func (suite *GraphTestSuite) TestQueryControl() {
 		UserID: adminUser.ID, Role: enums.RoleAdmin.String()}).
 		MustNew(testUser1.UserCtx, t)
 
+	controlIDs := []string{}
 	// add test cases for querying the control
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   *openlaneclient.OpenlaneClient
+		client   openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{
@@ -82,43 +80,44 @@ func (suite *GraphTestSuite) TestQueryControl() {
 						ProgramIDs: []string{program.ID},
 					})
 
-				require.NoError(t, err)
-				require.NotNil(t, resp)
+				assert.NilError(t, err)
+				assert.Assert(t, resp != nil)
 
 				tc.queryID = resp.CreateControl.Control.ID
+				controlIDs = append(controlIDs, tc.queryID)
 			}
 
 			resp, err := tc.client.GetControlByID(tc.ctx, tc.queryID)
 
 			if tc.errorMsg != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-
-			require.NotEmpty(t, resp.Control)
+			assert.NilError(t, err)
+			assert.Check(t, resp != nil)
 
 			assert.Equal(t, tc.queryID, resp.Control.ID)
-			assert.NotEmpty(t, resp.Control.RefCode)
+			assert.Check(t, len(resp.Control.RefCode) != 0)
 
-			require.Len(t, resp.Control.Programs.Edges, 1)
-			assert.NotEmpty(t, resp.Control.Programs.Edges[0].Node.ID)
+			assert.Check(t, is.Len(resp.Control.Programs.Edges, 1))
+			assert.Check(t, len(resp.Control.Programs.Edges[0].Node.ID) != 0)
 
-			(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, ID: resp.Control.ID}).MustDelete(testUser1.UserCtx, suite)
+			// delete the created evidence, update for the token user cases
+			if tc.ctx == context.Background() {
+				tc.ctx = testUser1.UserCtx
+			}
 		})
 	}
 
-	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, ID: program.ID}).MustDelete(testUser1.UserCtx, suite)
+	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: controlIDs}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, ID: program.ID}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestQueryControls() {
-	t := suite.T()
-
+func TestQueryControls(t *testing.T) {
 	// create multiple objects to be queried using testUser1
 	controlsToCreate := int64(11)
 	controlIDs := []string{}
@@ -127,16 +126,15 @@ func (suite *GraphTestSuite) TestQueryControls() {
 		controlIDs = append(controlIDs, control.ID)
 	}
 
-	org := (&OrganizationBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
-	userCtxAnotherOrg := auth.NewTestContextWithOrgID(testUser1.ID, org.ID)
+	userAnotherOrg := suite.userBuilder(context.Background(), t)
 
 	// add a control for the user to another org; this should not be returned for JWT auth, since it's
 	// restricted to a single org. PAT auth would return it if both orgs are authorized on the token
-	controlAnotherOrg := (&ControlBuilder{client: suite.client}).MustNew(userCtxAnotherOrg, t)
+	controlAnotherOrg := (&ControlBuilder{client: suite.client}).MustNew(userAnotherOrg.UserCtx, t)
 
 	testCases := []struct {
 		name            string
-		client          *openlaneclient.OpenlaneClient
+		client          openlaneclient.OpenlaneClient
 		first           *int64
 		last            *int64
 		ctx             context.Context
@@ -165,14 +163,14 @@ func (suite *GraphTestSuite) TestQueryControls() {
 		{
 			name:            "first set over max (10 in test)",
 			client:          suite.client.api,
-			first:           lo.ToPtr(int64(11)),
+			first:           &controlsToCreate,
 			ctx:             testUser1.UserCtx,
 			expectedResults: testutils.MaxResultLimit,
 		},
 		{
 			name:            "last set over max (10 in test)",
 			client:          suite.client.api,
-			last:            lo.ToPtr(int64(11)),
+			last:            &controlsToCreate,
 			ctx:             testUser1.UserCtx,
 			expectedResults: testutils.MaxResultLimit,
 		},
@@ -206,45 +204,43 @@ func (suite *GraphTestSuite) TestQueryControls() {
 		t.Run("List "+tc.name, func(t *testing.T) {
 			if tc.first != nil || tc.last != nil {
 				resp, err := tc.client.GetControls(tc.ctx, tc.first, tc.last, nil)
-				require.NoError(t, err)
-				require.NotNil(t, resp)
+				assert.NilError(t, err)
+				assert.Check(t, resp != nil)
 
-				assert.Len(t, resp.Controls.Edges, tc.expectedResults)
-				assert.Equal(t, int64(11), resp.Controls.TotalCount)
+				assert.Check(t, is.Len(resp.Controls.Edges, tc.expectedResults))
+				assert.Check(t, is.Equal(controlsToCreate, resp.Controls.TotalCount))
 
 				// if we are pulling the last, there won't be a next page, but there will be a previous page
 				if tc.last != nil {
-					assert.True(t, resp.Controls.PageInfo.HasPreviousPage)
+					assert.Check(t, resp.Controls.PageInfo.HasPreviousPage)
 				} else {
-					assert.True(t, resp.Controls.PageInfo.HasNextPage)
+					assert.Check(t, resp.Controls.PageInfo.HasNextPage)
 				}
 
 				return
 			}
 
 			resp, err := tc.client.GetAllControls(tc.ctx)
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Check(t, resp != nil)
 
-			assert.Len(t, resp.Controls.Edges, tc.expectedResults)
+			assert.Check(t, is.Len(resp.Controls.Edges, tc.expectedResults))
 
 			if tc.expectedResults > 0 {
-				assert.Equal(t, int64(controlsToCreate), resp.Controls.TotalCount)
-				assert.True(t, resp.Controls.PageInfo.HasNextPage)
+				assert.Check(t, is.Equal(int64(controlsToCreate), resp.Controls.TotalCount))
+				assert.Check(t, resp.Controls.PageInfo.HasNextPage)
 			} else {
-				assert.Equal(t, 0, len(resp.Controls.Edges))
+				assert.Check(t, is.Len(resp.Controls.Edges, 0))
 				assert.Equal(t, int64(0), resp.Controls.TotalCount)
-				assert.False(t, resp.Controls.PageInfo.HasNextPage)
+				assert.Check(t, !resp.Controls.PageInfo.HasNextPage)
 			}
 		})
 	}
-	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: controlIDs}).MustDelete(testUser1.UserCtx, suite)
-	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, ID: controlAnotherOrg.ID}).MustDelete(userCtxAnotherOrg, suite)
+	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: controlIDs}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, ID: controlAnotherOrg.ID}).MustDelete(userAnotherOrg.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationCreateControl() {
-	t := suite.T()
-
+func TestMutationCreateControl(t *testing.T) {
 	program1 := (&ProgramBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	program2 := (&ProgramBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	programAnotherUser := (&ProgramBuilder{client: suite.client}).MustNew(testUser2.UserCtx, t)
@@ -267,7 +263,7 @@ func (suite *GraphTestSuite) TestMutationCreateControl() {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.CreateControlInput
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -426,42 +422,41 @@ func (suite *GraphTestSuite) TestMutationCreateControl() {
 		t.Run("Create "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.CreateControl(tc.ctx, tc.request)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Check(t, resp != nil)
 
 			// check required fields
-			require.NotEmpty(t, resp.CreateControl.Control.ID)
+			assert.Check(t, len(resp.CreateControl.Control.ID) != 0)
 			assert.Equal(t, tc.request.RefCode, resp.CreateControl.Control.RefCode)
 
-			assert.NotEmpty(t, resp.CreateControl.Control.DisplayID)
-			assert.Contains(t, resp.CreateControl.Control.DisplayID, "CTL-")
+			assert.Check(t, len(resp.CreateControl.Control.DisplayID) != 0)
+			assert.Check(t, is.Contains(resp.CreateControl.Control.DisplayID, "CTL-"))
 
-			assert.NotEmpty(t, resp.CreateControl.Control.RefCode)
+			assert.Check(t, len(resp.CreateControl.Control.RefCode) != 0)
 			assert.Equal(t, tc.request.RefCode, resp.CreateControl.Control.RefCode)
 
 			// ensure the program is set
 			if len(tc.request.ProgramIDs) > 0 {
-				require.NotEmpty(t, resp.CreateControl.Control.Programs)
-				require.Len(t, resp.CreateControl.Control.Programs.Edges, len(tc.request.ProgramIDs))
+				assert.Check(t, is.Len(resp.CreateControl.Control.Programs.Edges, len(tc.request.ProgramIDs)))
 
 				for i, p := range resp.CreateControl.Control.Programs.Edges {
 					assert.Equal(t, tc.request.ProgramIDs[i], p.Node.ID)
 				}
 			} else {
-				assert.Empty(t, resp.CreateControl.Control.Programs.Edges)
+				assert.Check(t, is.Len(resp.CreateControl.Control.Programs.Edges, 0))
 			}
 
 			if tc.request.Description != nil {
 				assert.Equal(t, *tc.request.Description, *resp.CreateControl.Control.Description)
 			} else {
-				assert.Empty(t, resp.CreateControl.Control.Description)
+				assert.Equal(t, *resp.CreateControl.Control.Description, "")
 			}
 
 			if tc.request.Status != nil {
@@ -485,132 +480,134 @@ func (suite *GraphTestSuite) TestMutationCreateControl() {
 			if tc.request.Category != nil {
 				assert.Equal(t, *tc.request.Category, *resp.CreateControl.Control.Category)
 			} else {
-				assert.Empty(t, resp.CreateControl.Control.Category)
+				assert.Equal(t, *resp.CreateControl.Control.Category, "")
 			}
 
 			if tc.request.CategoryID != nil {
 				assert.Equal(t, *tc.request.CategoryID, *resp.CreateControl.Control.CategoryID)
 			} else {
-				assert.Empty(t, resp.CreateControl.Control.CategoryID)
+				assert.Equal(t, *resp.CreateControl.Control.CategoryID, "")
 			}
 
 			if tc.request.Subcategory != nil {
 				assert.Equal(t, *tc.request.Subcategory, *resp.CreateControl.Control.Subcategory)
 			} else {
-				assert.Empty(t, resp.CreateControl.Control.Subcategory)
+				assert.Equal(t, *resp.CreateControl.Control.Subcategory, "")
 			}
 
 			if tc.request.MappedCategories != nil {
-				assert.ElementsMatch(t, tc.request.MappedCategories, resp.CreateControl.Control.MappedCategories)
+				assert.DeepEqual(t, tc.request.MappedCategories, resp.CreateControl.Control.MappedCategories)
 			} else {
-				assert.Empty(t, resp.CreateControl.Control.MappedCategories)
+				assert.Check(t, is.Len(resp.CreateControl.Control.MappedCategories, 0))
 			}
 
 			if tc.request.ControlQuestions != nil {
-				assert.ElementsMatch(t, tc.request.ControlQuestions, resp.CreateControl.Control.ControlQuestions)
+				assert.DeepEqual(t, tc.request.ControlQuestions, resp.CreateControl.Control.ControlQuestions)
 			} else {
-				assert.Empty(t, resp.CreateControl.Control.ControlQuestions)
+				assert.Check(t, is.Len(resp.CreateControl.Control.ControlQuestions, 0))
 			}
 
 			if tc.request.AssessmentObjectives != nil {
-				require.Len(t, resp.CreateControl.Control.AssessmentObjectives, len(tc.request.AssessmentObjectives))
-				assert.ElementsMatch(t, tc.request.AssessmentObjectives, resp.CreateControl.Control.AssessmentObjectives)
+				assert.Check(t, is.Len(resp.CreateControl.Control.AssessmentObjectives, len(tc.request.AssessmentObjectives)))
+				assert.DeepEqual(t, tc.request.AssessmentObjectives, resp.CreateControl.Control.AssessmentObjectives)
 			} else {
-				assert.Empty(t, resp.CreateControl.Control.AssessmentObjectives)
+				assert.Check(t, is.Len(resp.CreateControl.Control.AssessmentObjectives, 0))
 			}
 
 			if tc.request.AssessmentMethods != nil {
-				require.Len(t, resp.CreateControl.Control.AssessmentMethods, len(tc.request.AssessmentMethods))
-				assert.ElementsMatch(t, tc.request.AssessmentMethods, resp.CreateControl.Control.AssessmentMethods)
+				assert.Check(t, is.Len(resp.CreateControl.Control.AssessmentMethods, len(tc.request.AssessmentMethods)))
+				assert.DeepEqual(t, tc.request.AssessmentMethods, resp.CreateControl.Control.AssessmentMethods)
 			} else {
-				assert.Empty(t, resp.CreateControl.Control.AssessmentMethods)
+				assert.Check(t, is.Len(resp.CreateControl.Control.AssessmentMethods, 0))
 			}
 
 			if tc.request.ImplementationGuidance != nil {
-				require.Len(t, resp.CreateControl.Control.ImplementationGuidance, len(tc.request.ImplementationGuidance))
-				assert.ElementsMatch(t, tc.request.ImplementationGuidance, resp.CreateControl.Control.ImplementationGuidance)
+				assert.Check(t, is.Len(resp.CreateControl.Control.ImplementationGuidance, len(tc.request.ImplementationGuidance)))
+				assert.DeepEqual(t, tc.request.ImplementationGuidance, resp.CreateControl.Control.ImplementationGuidance)
 			} else {
-				assert.Empty(t, resp.CreateControl.Control.ImplementationGuidance)
+				assert.Check(t, is.Len(resp.CreateControl.Control.ImplementationGuidance, 0))
 			}
 
 			if tc.request.ExampleEvidence != nil {
-				require.Len(t, resp.CreateControl.Control.ExampleEvidence, len(tc.request.ExampleEvidence))
-				assert.ElementsMatch(t, tc.request.ExampleEvidence, resp.CreateControl.Control.ExampleEvidence)
+				assert.Check(t, is.Len(resp.CreateControl.Control.ExampleEvidence, len(tc.request.ExampleEvidence)))
+				assert.DeepEqual(t, tc.request.ExampleEvidence, resp.CreateControl.Control.ExampleEvidence)
 			} else {
-				assert.Empty(t, resp.CreateControl.Control.ExampleEvidence)
+				assert.Check(t, is.Len(resp.CreateControl.Control.ExampleEvidence, 0))
 			}
 
 			if tc.request.References != nil {
-				require.Len(t, resp.CreateControl.Control.References, len(tc.request.References))
-				assert.ElementsMatch(t, tc.request.References, resp.CreateControl.Control.References)
+				assert.Check(t, is.Len(resp.CreateControl.Control.References, len(tc.request.References)))
+				assert.DeepEqual(t, tc.request.References, resp.CreateControl.Control.References)
 			} else {
-				assert.Empty(t, resp.CreateControl.Control.References)
+				assert.Check(t, is.Len(resp.CreateControl.Control.References, 0))
 			}
 
 			if tc.request.ControlOwnerID != nil {
-				require.NotEmpty(t, resp.CreateControl.Control.ControlOwner)
 				assert.Equal(t, *tc.request.ControlOwnerID, resp.CreateControl.Control.ControlOwner.ID)
 			} else {
-				assert.Empty(t, resp.CreateControl.Control.ControlOwner)
+				assert.Check(t, resp.CreateControl.Control.ControlOwner == nil)
 			}
 
 			if tc.request.DelegateID != nil {
-				require.NotEmpty(t, resp.CreateControl.Control.Delegate)
 				assert.Equal(t, *tc.request.DelegateID, resp.CreateControl.Control.Delegate.ID)
 			} else {
-				assert.Empty(t, resp.CreateControl.Control.Delegate)
+				assert.Check(t, resp.CreateControl.Control.Delegate == nil)
 			}
 
 			if len(tc.request.EditorIDs) > 0 {
-				require.Len(t, resp.CreateControl.Control.Editors, 1)
+				assert.Check(t, is.Len(resp.CreateControl.Control.Editors, 1))
 				for _, edge := range resp.CreateControl.Control.Editors {
 					assert.Equal(t, testUser1.GroupID, edge.ID)
 				}
 			}
 
 			if len(tc.request.BlockedGroupIDs) > 0 {
-				require.Len(t, resp.CreateControl.Control.BlockedGroups, 1)
+				assert.Check(t, is.Len(resp.CreateControl.Control.BlockedGroups, 1))
 				for _, edge := range resp.CreateControl.Control.BlockedGroups {
 					assert.Equal(t, blockedGroup.ID, edge.ID)
 				}
 			}
 
 			if len(tc.request.ViewerIDs) > 0 {
-				require.Len(t, resp.CreateControl.Control.Viewers, 1)
+				assert.Check(t, is.Len(resp.CreateControl.Control.Viewers, 1))
 				for _, edge := range resp.CreateControl.Control.Viewers {
 					assert.Equal(t, viewerGroup.ID, edge.ID)
 				}
 			}
 
 			if tc.request.ControlImplementationIDs != nil {
-				require.Len(t, resp.CreateControl.Control.ControlImplementations.Edges, len(tc.request.ControlImplementationIDs))
+				assert.Assert(t, is.Len(resp.CreateControl.Control.ControlImplementations.Edges, len(tc.request.ControlImplementationIDs)))
 			}
 
 			// ensure the org owner has access to the control that was created by an api token
 			if tc.client == suite.client.apiWithToken {
 				res, err := suite.client.api.GetControlByID(testUser1.UserCtx, resp.CreateControl.Control.ID)
-				require.NoError(t, err)
-				require.NotEmpty(t, res)
+				assert.NilError(t, err)
 				assert.Equal(t, resp.CreateControl.Control.ID, res.Control.ID)
 
 				if tc.request.ControlImplementationIDs != nil {
-					require.Len(t, res.Control.ControlImplementations.Edges, len(tc.request.ControlImplementationIDs))
+					assert.Check(t, is.Len(res.Control.ControlImplementations.Edges, len(tc.request.ControlImplementationIDs)))
 				}
 			}
 
-			(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, ID: resp.CreateControl.Control.ID}).MustDelete(testUser1.UserCtx, suite)
+			// delete the created evidence, update for the token user cases
+			if tc.ctx == context.Background() {
+				tc.ctx = testUser1.UserCtx
+			}
+
+			(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, ID: resp.CreateControl.Control.ID}).MustDelete(tc.ctx, t)
 		})
 	}
 
-	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, ID: program1.ID}).MustDelete(testUser1.UserCtx, suite)
-	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, ID: program2.ID}).MustDelete(testUser1.UserCtx, suite)
-	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, ID: programAnotherUser.ID}).MustDelete(testUser2.UserCtx, suite)
+	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, IDs: []string{program1.ID, program2.ID}}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, ID: programAnotherUser.ID}).MustDelete(testUser2.UserCtx, t)
+	(&Cleanup[*generated.ControlImplementationDeleteOne]{client: suite.client.db.ControlImplementation, ID: controlImplementation.ID}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.GroupDeleteOne]{client: suite.client.db.Group, IDs: []string{ownerGroup.ID, delegateGroup.ID, blockedGroup.ID, viewerGroup.ID}}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationCreateControlsByClone() {
-	t := suite.T()
-
+func TestMutationCreateControlsByClone(t *testing.T) {
 	program := (&ProgramBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+
 	(&ProgramMemberBuilder{client: suite.client, ProgramID: program.ID, UserID: viewOnlyUser.ID}).MustNew(testUser1.UserCtx, t)
 
 	programAnotherOrg := (&ProgramBuilder{client: suite.client}).MustNew(testUser2.UserCtx, t)
@@ -629,8 +626,8 @@ func (suite *GraphTestSuite) TestMutationCreateControlsByClone() {
 
 	// ensure the standard exists and has the correct number of controls for the non-system admin user
 	standard, err := suite.client.api.GetStandardByID(testUser2.UserCtx, publicStandard.ID)
-	require.NoError(t, err)
-	require.NotNil(t, standard)
+	assert.NilError(t, err)
+	assert.Assert(t, standard != nil)
 	assert.Equal(t, standard.Standard.Controls.TotalCount, numControls)
 
 	// create org owned control
@@ -640,7 +637,7 @@ func (suite *GraphTestSuite) TestMutationCreateControlsByClone() {
 		name                 string
 		request              openlaneclient.CloneControlInput
 		expectedControls     []*generated.Control
-		client               *openlaneclient.OpenlaneClient
+		client               openlaneclient.OpenlaneClient
 		ctx                  context.Context
 		expectNoAccessViewer bool
 		expectedErr          string
@@ -758,9 +755,9 @@ func (suite *GraphTestSuite) TestMutationCreateControlsByClone() {
 		t.Run("Create "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.CreateControlsByClone(tc.ctx, tc.request)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				errors := parseClientError(t, err)
 				for _, e := range errors {
@@ -772,99 +769,104 @@ func (suite *GraphTestSuite) TestMutationCreateControlsByClone() {
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Check(t, resp != nil)
 
 			for i, control := range resp.CreateControlsByClone.Controls {
 				// check required fields
-				require.NotEmpty(t, control.ID)
-				require.NotEmpty(t, control.DisplayID)
-				require.NotEmpty(t, control.RefCode)
+				assert.Check(t, len(control.ID) != 0)
+				assert.Check(t, len(control.DisplayID) != 0)
+				assert.Check(t, len(control.RefCode) != 0)
 
 				// all cloned controls should have an owner
-				assert.NotEmpty(t, control.OwnerID)
+				assert.Check(t, control.OwnerID != nil)
 
 				if tc.request.ProgramID != nil {
-					require.NotEmpty(t, control.Programs)
-					require.Len(t, control.Programs.Edges, 1)
+					assert.Check(t, is.Len(control.Programs.Edges, 1))
 					assert.Equal(t, *tc.request.ProgramID, control.Programs.Edges[0].Node.ID)
 				} else {
-					assert.Empty(t, control.Programs.Edges)
+					assert.Check(t, is.Len(control.Programs.Edges, 0))
 				}
 
 				// check the cloned control fields are set and match the original control
-				assert.Equal(t, tc.expectedControls[i].RefCode, control.RefCode)
-				assert.Equal(t, tc.expectedControls[i].ControlType, *control.ControlType)
-				assert.Equal(t, tc.expectedControls[i].Category, *control.Category)
-				assert.Equal(t, tc.expectedControls[i].CategoryID, *control.CategoryID)
-				assert.Equal(t, tc.expectedControls[i].Subcategory, *control.Subcategory)
-				assert.Equal(t, tc.expectedControls[i].MappedCategories, control.MappedCategories)
-				assert.Equal(t, tc.expectedControls[i].ControlQuestions, control.ControlQuestions)
-				assert.Equal(t, tc.expectedControls[i].Tags, control.Tags)
+				assert.Check(t, is.Equal(tc.expectedControls[i].RefCode, control.RefCode))
+				assert.Check(t, is.Equal(tc.expectedControls[i].ControlType, *control.ControlType))
+				assert.Check(t, is.Equal(tc.expectedControls[i].Category, *control.Category))
+				assert.Check(t, is.Equal(tc.expectedControls[i].CategoryID, *control.CategoryID))
+				assert.Check(t, is.Equal(tc.expectedControls[i].Subcategory, *control.Subcategory))
+				assert.Check(t, is.DeepEqual(tc.expectedControls[i].MappedCategories, control.MappedCategories))
+				assert.Check(t, is.DeepEqual(tc.expectedControls[i].ControlQuestions, control.ControlQuestions))
+				assert.Check(t, is.DeepEqual(tc.expectedControls[i].Tags, control.Tags))
 				// expected control status ignored as we always set to preparing
-				assert.Equal(t, enums.ControlStatusPreparing, *control.Status)
-				assert.Equal(t, tc.expectedControls[i].ControlType, *control.ControlType)
-				assert.Equal(t, tc.expectedControls[i].Source, *control.Source)
-				assert.Equal(t, tc.expectedControls[i].StandardID, *control.StandardID)
+				assert.Check(t, is.Equal(enums.ControlStatusPreparing, *control.Status))
+				assert.Check(t, is.Equal(tc.expectedControls[i].ControlType, *control.ControlType))
+				assert.Check(t, is.Equal(tc.expectedControls[i].Source, *control.Source))
+				assert.Check(t, is.Equal(tc.expectedControls[i].StandardID, *control.StandardID))
 
 				for j, ao := range control.AssessmentObjectives {
-					assert.Equal(t, tc.expectedControls[i].AssessmentObjectives[j], *ao)
+					assert.Check(t, is.DeepEqual(tc.expectedControls[i].AssessmentObjectives[j], *ao))
 				}
 
 				for j, am := range control.AssessmentMethods {
-					assert.Equal(t, tc.expectedControls[i].AssessmentMethods[j], *am)
+					assert.Check(t, is.DeepEqual(tc.expectedControls[i].AssessmentMethods[j], *am))
 				}
 
 				for j, ig := range control.ImplementationGuidance {
-					assert.Equal(t, tc.expectedControls[i].ImplementationGuidance[j], *ig)
+					assert.Check(t, is.DeepEqual(tc.expectedControls[i].ImplementationGuidance[j], *ig))
 				}
 
 				for j, ref := range control.References {
-					assert.Equal(t, tc.expectedControls[i].References[j], *ref)
+					assert.Check(t, is.DeepEqual(tc.expectedControls[i].References[j], *ref))
 				}
 
 				for j, ee := range control.ExampleEvidence {
-					assert.Equal(t, tc.expectedControls[i].ExampleEvidence[j], *ee)
+					assert.Check(t, is.DeepEqual(tc.expectedControls[i].ExampleEvidence[j], *ee))
 				}
 
 				// ensure the org owner has access to the control that was created by an api token
 				if tc.client == suite.client.apiWithToken {
 					res, err := suite.client.api.GetControlByID(testUser1.UserCtx, control.ID)
-					require.NoError(t, err)
-					require.NotEmpty(t, res)
-					assert.Equal(t, control.ID, res.Control.ID)
+					assert.NilError(t, err)
+					assert.Check(t, res != nil)
+					assert.Check(t, is.Equal(control.ID, res.Control.ID))
 				}
 
 				// ensure view only user can see the control created by the admin user
 				res, err := suite.client.api.GetControlByID(viewOnlyUser.UserCtx, control.ID)
 				if tc.expectNoAccessViewer {
-					require.Error(t, err)
+
 					assert.ErrorContains(t, err, notFoundErrorMsg)
-					assert.Nil(t, res)
+					assert.Check(t, is.Nil(res))
 				} else {
-					require.NoError(t, err)
-					require.NotEmpty(t, res)
-					assert.Equal(t, control.ID, res.Control.ID)
+					assert.NilError(t, err)
+					assert.Check(t, res != nil)
+					assert.Check(t, is.Equal(control.ID, res.Control.ID))
 				}
 
 				// ensure a user outside my organization cannot get the control
 				res, err = suite.client.api.GetControlByID(testUser2.UserCtx, control.ID)
-				require.Nil(t, res)
-				require.Error(t, err)
+				assert.Check(t, is.Nil(res))
+
 				assert.ErrorContains(t, err, notFoundErrorMsg)
+
+				// delete the created evidence, update for the token user cases
+				if tc.ctx == context.Background() {
+					tc.ctx = testUser1.UserCtx
+				}
+
+				(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, ID: control.ID}).MustDelete(tc.ctx, t)
 			}
 		})
 	}
 
 	// cleanup created controls and standards
-	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: publicStandard.ID}).MustDelete(testUser1.UserCtx, suite)
-	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, ID: orgOwnedControl.ID}).MustDelete(testUser1.UserCtx, suite)
-	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: controlIDs}).MustDelete(testUser1.UserCtx, suite)
+	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: publicStandard.ID}).MustDelete(systemAdminUser.UserCtx, t)
+	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, ID: orgOwnedControl.ID}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: controlIDs}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, ID: program.ID}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationUpdateControl() {
-	t := suite.T()
-
+func TestMutationUpdateControl(t *testing.T) {
 	program1 := (&ProgramBuilder{client: suite.client, EditorIDs: testUser1.GroupID}).MustNew(testUser1.UserCtx, t)
 	program2 := (&ProgramBuilder{client: suite.client, EditorIDs: testUser1.GroupID}).MustNew(testUser1.UserCtx, t)
 	control := (&ControlBuilder{client: suite.client, ProgramID: program1.ID}).MustNew(testUser1.UserCtx, t)
@@ -880,20 +882,20 @@ func (suite *GraphTestSuite) TestMutationUpdateControl() {
 
 	// create another admin user and add them to the same organization and group as testUser1
 	// this will allow us to test the group editor/viewer permissions
-	anotherAdminUser := suite.userBuilder(context.Background())
-	suite.addUserToOrganization(testUser1.UserCtx, &anotherAdminUser, enums.RoleAdmin, testUser1.OrganizationID)
+	anotherAdminUser := suite.userBuilder(context.Background(), t)
+	suite.addUserToOrganization(testUser1.UserCtx, t, &anotherAdminUser, enums.RoleAdmin, testUser1.OrganizationID)
 
 	groupMember := (&GroupMemberBuilder{client: suite.client, UserID: anotherAdminUser.ID}).MustNew(testUser1.UserCtx, t)
 
 	// ensure the user does not currently have access to the control
 	res, err := suite.client.api.GetControlByID(anotherAdminUser.UserCtx, control.ID)
-	require.Error(t, err)
-	require.Nil(t, res)
+	assert.ErrorContains(t, err, notFoundErrorMsg)
+	assert.Assert(t, is.Nil(res))
 
 	testCases := []struct {
 		name        string
 		request     openlaneclient.UpdateControlInput
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -1013,15 +1015,15 @@ func (suite *GraphTestSuite) TestMutationUpdateControl() {
 		t.Run("Update "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.UpdateControl(tc.ctx, control.ID, tc.request)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
 			if tc.request.Description != nil {
 				assert.Equal(t, *tc.request.Description, *resp.UpdateControl.Control.Description)
@@ -1032,7 +1034,7 @@ func (suite *GraphTestSuite) TestMutationUpdateControl() {
 			}
 
 			if tc.request.Tags != nil {
-				assert.ElementsMatch(t, tc.request.Tags, resp.UpdateControl.Control.Tags)
+				assert.DeepEqual(t, tc.request.Tags, resp.UpdateControl.Control.Tags)
 			}
 
 			if tc.request.Source != nil {
@@ -1056,63 +1058,62 @@ func (suite *GraphTestSuite) TestMutationUpdateControl() {
 			}
 
 			if tc.request.AppendMappedCategories != nil {
-				assert.ElementsMatch(t, tc.request.AppendMappedCategories, resp.UpdateControl.Control.MappedCategories)
+				assert.DeepEqual(t, tc.request.AppendMappedCategories, resp.UpdateControl.Control.MappedCategories)
 			}
 
 			if tc.request.AppendControlQuestions != nil {
-				assert.ElementsMatch(t, tc.request.AppendControlQuestions, resp.UpdateControl.Control.ControlQuestions)
+				assert.DeepEqual(t, tc.request.AppendControlQuestions, resp.UpdateControl.Control.ControlQuestions)
 			}
 
 			if tc.request.AppendAssessmentObjectives != nil {
-				assert.ElementsMatch(t, tc.request.AppendAssessmentObjectives, resp.UpdateControl.Control.AssessmentObjectives)
+				assert.DeepEqual(t, tc.request.AppendAssessmentObjectives, resp.UpdateControl.Control.AssessmentObjectives)
 			}
 
 			if tc.request.AppendAssessmentMethods != nil {
-				assert.ElementsMatch(t, tc.request.AppendAssessmentMethods, resp.UpdateControl.Control.AssessmentMethods)
+				assert.DeepEqual(t, tc.request.AppendAssessmentMethods, resp.UpdateControl.Control.AssessmentMethods)
 			}
 
 			if tc.request.AppendImplementationGuidance != nil {
-				assert.ElementsMatch(t, tc.request.AppendImplementationGuidance, resp.UpdateControl.Control.ImplementationGuidance)
+				assert.DeepEqual(t, tc.request.AppendImplementationGuidance, resp.UpdateControl.Control.ImplementationGuidance)
 			}
 
 			if tc.request.AppendExampleEvidence != nil {
-				assert.ElementsMatch(t, tc.request.AppendExampleEvidence, resp.UpdateControl.Control.ExampleEvidence)
+				assert.DeepEqual(t, tc.request.AppendExampleEvidence, resp.UpdateControl.Control.ExampleEvidence)
 			}
 
 			if tc.request.ControlOwnerID != nil {
-				require.NotNil(t, resp.UpdateControl.Control.ControlOwner)
+				assert.Assert(t, resp.UpdateControl.Control.ControlOwner != nil)
 				assert.Equal(t, *tc.request.ControlOwnerID, resp.UpdateControl.Control.ControlOwner.ID)
 			}
 
 			if tc.request.DelegateID != nil {
-				require.NotNil(t, resp.UpdateControl.Control.Delegate)
+				assert.Assert(t, resp.UpdateControl.Control.Delegate != nil)
 				assert.Equal(t, *tc.request.DelegateID, resp.UpdateControl.Control.Delegate.ID)
 			}
 
 			if tc.request.AppendReferences != nil {
-				assert.ElementsMatch(t, tc.request.AppendReferences, resp.UpdateControl.Control.References)
+				assert.DeepEqual(t, tc.request.AppendReferences, resp.UpdateControl.Control.References)
 			}
 
 			if tc.request.ClearReferences != nil && *tc.request.ClearReferences {
-				assert.Empty(t, resp.UpdateControl.Control.References)
+				assert.Check(t, is.Len(resp.UpdateControl.Control.References, 0))
 			}
 
 			if tc.request.ClearMappedCategories != nil && *tc.request.ClearMappedCategories {
-				assert.Empty(t, resp.UpdateControl.Control.MappedCategories)
+				assert.Check(t, is.Len(resp.UpdateControl.Control.MappedCategories, 0))
 			}
 
 			if tc.request.AddControlImplementationIDs != nil {
-				require.Len(t, resp.UpdateControl.Control.ControlImplementations.Edges, len(tc.request.AddControlImplementationIDs))
+				assert.Assert(t, is.Len(resp.UpdateControl.Control.ControlImplementations.Edges, len(tc.request.AddControlImplementationIDs)))
 			}
 
 			// ensure the program is set
 			if len(tc.request.AddProgramIDs) > 0 {
-				require.NotEmpty(t, resp.UpdateControl.Control.Programs)
-				require.Len(t, resp.UpdateControl.Control.Programs.Edges, len(tc.request.AddProgramIDs))
+				assert.Assert(t, is.Len(resp.UpdateControl.Control.Programs.Edges, len(tc.request.AddProgramIDs)))
 			}
 
 			if len(tc.request.AddViewerIDs) > 0 {
-				require.Len(t, resp.UpdateControl.Control.Viewers, 1)
+				assert.Assert(t, is.Len(resp.UpdateControl.Control.Viewers, 1))
 				found := false
 				for _, edge := range resp.UpdateControl.Control.Viewers {
 					if edge.ID == tc.request.AddViewerIDs[0] {
@@ -1121,58 +1122,58 @@ func (suite *GraphTestSuite) TestMutationUpdateControl() {
 					}
 				}
 
-				assert.True(t, found)
+				assert.Check(t, found)
 
 				// ensure the user has access to the control now
 				res, err := suite.client.api.GetControlByID(anotherAdminUser.UserCtx, control.ID)
-				require.NoError(t, err)
-				require.NotEmpty(t, res)
+				assert.NilError(t, err)
+				assert.Assert(t, res != nil)
 				assert.Equal(t, control.ID, res.Control.ID)
 			}
 		})
 	}
 
-	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, ID: control.ID}).MustDelete(testUser1.UserCtx, suite)
-	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, IDs: []string{program1.ID, program2.ID}}).MustDelete(testUser1.UserCtx, suite)
+	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, ID: control.ID}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, IDs: []string{program1.ID, program2.ID}}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.ControlImplementationDeleteOne]{client: suite.client.db.ControlImplementation, ID: controlImplementation.ID}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.GroupDeleteOne]{client: suite.client.db.Group, IDs: []string{ownerGroup.ID, delegateGroup.ID, groupMember.GroupID}}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationDeleteControl() {
-	t := suite.T()
-
+func TestMutationDeleteControl(t *testing.T) {
 	// create objects to be deleted
-	Control1 := (&ControlBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
-	Control2 := (&ControlBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	control1 := (&ControlBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	control2 := (&ControlBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
 		{
 			name:        "not authorized, delete",
-			idToDelete:  Control1.ID,
+			idToDelete:  control1.ID,
 			client:      suite.client.api,
 			ctx:         testUser2.UserCtx,
 			expectedErr: notFoundErrorMsg,
 		},
 		{
 			name:       "happy path, delete",
-			idToDelete: Control1.ID,
+			idToDelete: control1.ID,
 			client:     suite.client.api,
 			ctx:        testUser1.UserCtx,
 		},
 		{
 			name:        "already deleted, not found",
-			idToDelete:  Control1.ID,
+			idToDelete:  control1.ID,
 			client:      suite.client.api,
 			ctx:         testUser1.UserCtx,
 			expectedErr: "not found",
 		},
 		{
 			name:       "happy path, delete using personal access token",
-			idToDelete: Control2.ID,
+			idToDelete: control2.ID,
 			client:     suite.client.apiWithPAT,
 			ctx:        context.Background(),
 		},
@@ -1189,15 +1190,15 @@ func (suite *GraphTestSuite) TestMutationDeleteControl() {
 		t.Run("Delete "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.DeleteControl(tc.ctx, tc.idToDelete)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 			assert.Equal(t, tc.idToDelete, resp.DeleteControl.DeletedID)
 		})
 	}

--- a/internal/graphapi/controlimplementation_test.go
+++ b/internal/graphapi/controlimplementation_test.go
@@ -131,7 +131,6 @@ func TestQueryControlImplementation(t *testing.T) {
 			resp, err := tc.client.GetControlImplementationByID(tc.ctx, tc.queryID)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 
@@ -364,7 +363,6 @@ func TestMutationCreateControlImplementation(t *testing.T) {
 		t.Run("Create "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.CreateControlImplementation(tc.ctx, tc.request)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 
@@ -588,7 +586,6 @@ func TestMutationUpdateControlImplementation(t *testing.T) {
 		t.Run("Update "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.UpdateControlImplementation(tc.ctx, tc.id, tc.request)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 
@@ -700,7 +697,6 @@ func TestMutationDeleteControlImplementation(t *testing.T) {
 		t.Run("Delete "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.DeleteControlImplementation(tc.ctx, tc.idToDelete)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 

--- a/internal/graphapi/controlimplementation_test.go
+++ b/internal/graphapi/controlimplementation_test.go
@@ -42,7 +42,7 @@ func TestQueryControlImplementation(t *testing.T) {
 	testCases := []struct {
 		name                  string
 		queryID               string
-		client                openlaneclient.OpenlaneClient
+		client                *openlaneclient.OpenlaneClient
 		ctx                   context.Context
 		shouldHaveControls    bool
 		shouldHaveSubcontrols bool
@@ -193,7 +193,7 @@ func TestQueryControlImplementations(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		client          openlaneclient.OpenlaneClient
+		client          *openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int
 	}{
@@ -275,7 +275,7 @@ func TestMutationCreateControlImplementation(t *testing.T) {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.CreateControlImplementationInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -474,7 +474,7 @@ func TestMutationUpdateControlImplementation(t *testing.T) {
 		name        string
 		request     openlaneclient.UpdateControlImplementationInput
 		id          string
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -654,7 +654,7 @@ func TestMutationDeleteControlImplementation(t *testing.T) {
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{

--- a/internal/graphapi/controlobjective_test.go
+++ b/internal/graphapi/controlobjective_test.go
@@ -100,7 +100,6 @@ func TestQueryControlObjective(t *testing.T) {
 
 			assert.Check(t, is.Equal(tc.queryID, resp.ControlObjective.ID))
 			assert.Check(t, len(resp.ControlObjective.Name) != 0)
-
 		})
 	}
 

--- a/internal/graphapi/controlobjective_test.go
+++ b/internal/graphapi/controlobjective_test.go
@@ -28,7 +28,7 @@ func TestQueryControlObjective(t *testing.T) {
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   openlaneclient.OpenlaneClient
+		client   *openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{
@@ -120,7 +120,7 @@ func TestQueryControlObjectives(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		client          openlaneclient.OpenlaneClient
+		client          *openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int
 	}{
@@ -190,7 +190,7 @@ func TestMutationCreateControlObjective(t *testing.T) {
 		name          string
 		request       openlaneclient.CreateControlObjectiveInput
 		addGroupToOrg bool
-		client        openlaneclient.OpenlaneClient
+		client        *openlaneclient.OpenlaneClient
 		ctx           context.Context
 		expectedErr   string
 	}{
@@ -406,7 +406,7 @@ func TestMutationUpdateControlObjective(t *testing.T) {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.UpdateControlObjectiveInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -555,7 +555,7 @@ func TestMutationDeleteControlObjective(t *testing.T) {
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{

--- a/internal/graphapi/controlobjective_test.go
+++ b/internal/graphapi/controlobjective_test.go
@@ -5,19 +5,17 @@ import (
 	"testing"
 
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 
+	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/models"
 	"github.com/theopenlane/core/pkg/openlaneclient"
-	"github.com/theopenlane/iam/auth"
 	"github.com/theopenlane/utils/ulids"
 )
 
-func (suite *GraphTestSuite) TestQueryControlObjective() {
-	t := suite.T()
-
+func TestQueryControlObjective(t *testing.T) {
 	program := (&ProgramBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	// add adminUser to the program so that they can create a ControlObjective
@@ -25,11 +23,12 @@ func (suite *GraphTestSuite) TestQueryControlObjective() {
 		UserID: adminUser.ID, Role: enums.RoleAdmin.String()}).
 		MustNew(testUser1.UserCtx, t)
 
+	controlObjectiveIDs := []string{}
 	// add test cases for querying the ControlObjective
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   *openlaneclient.OpenlaneClient
+		client   openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{
@@ -79,50 +78,50 @@ func (suite *GraphTestSuite) TestQueryControlObjective() {
 						ProgramIDs: []string{program.ID},
 					})
 
-				require.NoError(t, err)
-				require.NotNil(t, resp)
+				assert.NilError(t, err)
+				assert.Assert(t, resp != nil)
 
 				tc.queryID = resp.CreateControlObjective.ControlObjective.ID
+
+				controlObjectiveIDs = append(controlObjectiveIDs, tc.queryID)
 			}
 
 			resp, err := tc.client.GetControlObjectiveByID(tc.ctx, tc.queryID)
 
 			if tc.errorMsg != "" {
-				require.Error(t, err)
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
-			require.NotEmpty(t, resp.ControlObjective)
+			assert.Check(t, is.Equal(tc.queryID, resp.ControlObjective.ID))
+			assert.Check(t, len(resp.ControlObjective.Name) != 0)
 
-			assert.Equal(t, tc.queryID, resp.ControlObjective.ID)
-			assert.NotEmpty(t, resp.ControlObjective.Name)
 		})
 	}
+
+	(&Cleanup[*generated.ControlObjectiveDeleteOne]{client: suite.client.db.ControlObjective, IDs: controlObjectiveIDs}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, ID: program.ID}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestQueryControlObjectives() {
-	t := suite.T()
-
+func TestQueryControlObjectives(t *testing.T) {
 	// create multiple objects to be queried using testUser1
-	(&ControlObjectiveBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
-	(&ControlObjectiveBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	co1 := (&ControlObjectiveBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	co2 := (&ControlObjectiveBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
-	org := (&OrganizationBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
-	userCtxAnotherOrg := auth.NewTestContextWithOrgID(testUser1.ID, org.ID)
+	userAnotherOrg := suite.userBuilder(context.Background(), t)
 
 	// add control objective for the user to another org; this should not be returned for JWT auth, since it's
 	// restricted to a single org. PAT auth would return it if both orgs are authorized on the token
-	(&ControlObjectiveBuilder{client: suite.client}).MustNew(userCtxAnotherOrg, t)
+	(&ControlObjectiveBuilder{client: suite.client}).MustNew(userAnotherOrg.UserCtx, t)
 
 	testCases := []struct {
 		name            string
-		client          *openlaneclient.OpenlaneClient
+		client          openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int
 	}{
@@ -161,17 +160,17 @@ func (suite *GraphTestSuite) TestQueryControlObjectives() {
 	for _, tc := range testCases {
 		t.Run("List "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.GetAllControlObjectives(tc.ctx)
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
-			assert.Len(t, resp.ControlObjectives.Edges, tc.expectedResults)
+			assert.Check(t, is.Len(resp.ControlObjectives.Edges, tc.expectedResults))
 		})
 	}
+
+	(&Cleanup[*generated.ControlObjectiveDeleteOne]{client: suite.client.db.ControlObjective, IDs: []string{co1.ID, co2.ID}}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationCreateControlObjective() {
-	t := suite.T()
-
+func TestMutationCreateControlObjective(t *testing.T) {
 	program1 := (&ProgramBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	program2 := (&ProgramBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	programAnotherUser := (&ProgramBuilder{client: suite.client}).MustNew(testUser2.UserCtx, t)
@@ -192,7 +191,7 @@ func (suite *GraphTestSuite) TestMutationCreateControlObjective() {
 		name          string
 		request       openlaneclient.CreateControlObjectiveInput
 		addGroupToOrg bool
-		client        *openlaneclient.OpenlaneClient
+		client        openlaneclient.OpenlaneClient
 		ctx           context.Context
 		expectedErr   string
 	}{
@@ -310,101 +309,105 @@ func (suite *GraphTestSuite) TestMutationCreateControlObjective() {
 					openlaneclient.UpdateOrganizationInput{
 						AddControlObjectiveCreatorIDs: []string{groupMember.GroupID},
 					}, nil)
-				require.NoError(t, err)
+				assert.NilError(t, err)
 			}
 
 			resp, err := tc.client.CreateControlObjective(tc.ctx, tc.request)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
 			// check required fields
-			require.NotEmpty(t, resp.CreateControlObjective.ControlObjective.ID)
-			assert.Equal(t, tc.request.Name, resp.CreateControlObjective.ControlObjective.Name)
+			assert.Assert(t, len(resp.CreateControlObjective.ControlObjective.ID) != 0)
+			assert.Check(t, is.Equal(tc.request.Name, resp.CreateControlObjective.ControlObjective.Name))
 
-			assert.NotEmpty(t, resp.CreateControlObjective.ControlObjective.DisplayID)
-			assert.Contains(t, resp.CreateControlObjective.ControlObjective.DisplayID, "CLO-")
+			assert.Check(t, len(resp.CreateControlObjective.ControlObjective.DisplayID) != 0)
+			assert.Check(t, is.Contains(resp.CreateControlObjective.ControlObjective.DisplayID, "CLO-"))
 
 			if tc.request.DesiredOutcome != nil {
-				assert.Equal(t, *tc.request.DesiredOutcome, *resp.CreateControlObjective.ControlObjective.DesiredOutcome)
+				assert.Check(t, is.Equal(*tc.request.DesiredOutcome, *resp.CreateControlObjective.ControlObjective.DesiredOutcome))
 			} else {
-				assert.Empty(t, resp.CreateControlObjective.ControlObjective.DesiredOutcome)
+				assert.Check(t, is.Equal(*resp.CreateControlObjective.ControlObjective.DesiredOutcome, ""))
 			}
 
 			if tc.request.Status != nil {
-				assert.Equal(t, *tc.request.Status, *resp.CreateControlObjective.ControlObjective.Status)
+				assert.Check(t, is.Equal(*tc.request.Status, *resp.CreateControlObjective.ControlObjective.Status))
 			}
 
 			if tc.request.Category != nil {
-				assert.Equal(t, *tc.request.Category, *resp.CreateControlObjective.ControlObjective.Category)
+				assert.Check(t, is.Equal(*tc.request.Category, *resp.CreateControlObjective.ControlObjective.Category))
 			} else {
-				assert.Empty(t, resp.CreateControlObjective.ControlObjective.Category)
+				assert.Check(t, is.Equal(*resp.CreateControlObjective.ControlObjective.Category, ""))
 			}
 
 			if tc.request.Subcategory != nil {
-				assert.Equal(t, *tc.request.Subcategory, *resp.CreateControlObjective.ControlObjective.Subcategory)
+				assert.Check(t, is.Equal(*tc.request.Subcategory, *resp.CreateControlObjective.ControlObjective.Subcategory))
 			} else {
-				assert.Empty(t, resp.CreateControlObjective.ControlObjective.Subcategory)
+				assert.Check(t, is.Equal(*resp.CreateControlObjective.ControlObjective.Subcategory, ""))
 			}
 
 			if tc.request.ControlObjectiveType != nil {
-				assert.Equal(t, *tc.request.ControlObjectiveType, *resp.CreateControlObjective.ControlObjective.ControlObjectiveType)
+				assert.Check(t, is.Equal(*tc.request.ControlObjectiveType, *resp.CreateControlObjective.ControlObjective.ControlObjectiveType))
 			} else {
-				assert.Empty(t, resp.CreateControlObjective.ControlObjective.ControlObjectiveType)
+				assert.Check(t, is.Equal(*resp.CreateControlObjective.ControlObjective.ControlObjectiveType, ""))
 			}
 
 			if tc.request.Revision != nil {
-				assert.Equal(t, *tc.request.Revision, *resp.CreateControlObjective.ControlObjective.Revision)
+				assert.Check(t, is.Equal(*tc.request.Revision, *resp.CreateControlObjective.ControlObjective.Revision))
 			} else {
-				assert.Equal(t, models.DefaultRevision, *resp.CreateControlObjective.ControlObjective.Revision)
+				assert.Check(t, is.Equal(models.DefaultRevision, *resp.CreateControlObjective.ControlObjective.Revision))
 			}
 
 			if tc.request.Source != nil {
-				assert.Equal(t, *tc.request.Source, *resp.CreateControlObjective.ControlObjective.Source)
+				assert.Check(t, is.Equal(*tc.request.Source, *resp.CreateControlObjective.ControlObjective.Source))
 			} else {
-				assert.Equal(t, enums.ControlSourceUserDefined, *resp.CreateControlObjective.ControlObjective.Source)
+				assert.Check(t, is.Equal(enums.ControlSourceUserDefined, *resp.CreateControlObjective.ControlObjective.Source))
 			}
 
 			// ensure the org owner has access to the control objective that was created by an api token
 			if tc.client == suite.client.apiWithToken {
 				res, err := suite.client.api.GetControlObjectiveByID(testUser1.UserCtx, resp.CreateControlObjective.ControlObjective.ID)
-				require.NoError(t, err)
-				require.NotEmpty(t, res)
-				assert.Equal(t, resp.CreateControlObjective.ControlObjective.ID, res.ControlObjective.ID)
+				assert.NilError(t, err)
+				assert.Assert(t, res != nil)
+				assert.Check(t, is.Equal(resp.CreateControlObjective.ControlObjective.ID, res.ControlObjective.ID))
 			}
+
+			(&Cleanup[*generated.ControlObjectiveDeleteOne]{client: suite.client.db.ControlObjective, ID: resp.CreateControlObjective.ControlObjective.ID}).MustDelete(testUser1.UserCtx, t)
 		})
 	}
+
+	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, IDs: []string{program1.ID, program2.ID}}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, ID: programAnotherUser.ID}).MustDelete(testUser2.UserCtx, t)
+	(&Cleanup[*generated.GroupDeleteOne]{client: suite.client.db.Group, IDs: []string{blockedGroup.ID, viewerGroup.ID, groupMember.GroupID}}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationUpdateControlObjective() {
-	t := suite.T()
-
+func TestMutationUpdateControlObjective(t *testing.T) {
 	program := (&ProgramBuilder{client: suite.client, EditorIDs: testUser1.GroupID}).MustNew(testUser1.UserCtx, t)
 	controlObjective := (&ControlObjectiveBuilder{client: suite.client, ProgramID: program.ID}).MustNew(testUser1.UserCtx, t)
 
 	// create another admin user and add them to the same organization and group as testUser1
 	// this will allow us to test the group editor/viewer permissions
-	anotherAdminUser := suite.userBuilder(context.Background())
-	suite.addUserToOrganization(testUser1.UserCtx, &anotherAdminUser, enums.RoleAdmin, testUser1.OrganizationID)
+	anotherAdminUser := suite.userBuilder(context.Background(), t)
+	suite.addUserToOrganization(testUser1.UserCtx, t, &anotherAdminUser, enums.RoleAdmin, testUser1.OrganizationID)
 
 	groupMember := (&GroupMemberBuilder{client: suite.client, UserID: anotherAdminUser.ID}).MustNew(testUser1.UserCtx, t)
 
 	// ensure the user does not currently have access to the control objective
 	res, err := suite.client.api.GetControlObjectiveByID(anotherAdminUser.UserCtx, controlObjective.ID)
-	require.Error(t, err)
-	require.Nil(t, res)
+	assert.ErrorContains(t, err, notFoundErrorMsg)
+	assert.Assert(t, is.Nil(res))
 
 	testCases := []struct {
 		name        string
 		request     openlaneclient.UpdateControlObjectiveInput
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -474,54 +477,54 @@ func (suite *GraphTestSuite) TestMutationUpdateControlObjective() {
 		t.Run("Update "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.UpdateControlObjective(tc.ctx, controlObjective.ID, tc.request)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Check(t, resp != nil)
 
 			if tc.request.DesiredOutcome != nil {
-				assert.Equal(t, *tc.request.DesiredOutcome, *resp.UpdateControlObjective.ControlObjective.DesiredOutcome)
+				assert.Check(t, is.Equal(*tc.request.DesiredOutcome, *resp.UpdateControlObjective.ControlObjective.DesiredOutcome))
 			}
 
 			if tc.request.Status != nil {
-				assert.Equal(t, *tc.request.Status, *resp.UpdateControlObjective.ControlObjective.Status)
+				assert.Check(t, is.Equal(*tc.request.Status, *resp.UpdateControlObjective.ControlObjective.Status))
 			}
 
 			if tc.request.Tags != nil {
-				assert.ElementsMatch(t, tc.request.Tags, resp.UpdateControlObjective.ControlObjective.Tags)
+				assert.DeepEqual(t, tc.request.Tags, resp.UpdateControlObjective.ControlObjective.Tags)
 			}
 
 			if tc.request.Revision != nil {
-				assert.Equal(t, *tc.request.Revision, *resp.UpdateControlObjective.ControlObjective.Revision)
+				assert.Check(t, is.Equal(*tc.request.Revision, *resp.UpdateControlObjective.ControlObjective.Revision))
 			}
 
 			if tc.request.RevisionBump == &models.Major {
-				assert.NotEqual(t, "v1.0.0", *resp.UpdateControlObjective.ControlObjective.Revision)
+				assert.Check(t, "v1.0.0" != *resp.UpdateControlObjective.ControlObjective.Revision)
 			}
 
 			if tc.request.Category != nil {
-				assert.Equal(t, *tc.request.Category, *resp.UpdateControlObjective.ControlObjective.Category)
+				assert.Check(t, is.Equal(*tc.request.Category, *resp.UpdateControlObjective.ControlObjective.Category))
 			}
 
 			if tc.request.Subcategory != nil {
-				assert.Equal(t, *tc.request.Subcategory, *resp.UpdateControlObjective.ControlObjective.Subcategory)
+				assert.Check(t, is.Equal(*tc.request.Subcategory, *resp.UpdateControlObjective.ControlObjective.Subcategory))
 			}
 
 			if tc.request.ControlObjectiveType != nil {
-				assert.Equal(t, *tc.request.ControlObjectiveType, *resp.UpdateControlObjective.ControlObjective.ControlObjectiveType)
+				assert.Check(t, is.Equal(*tc.request.ControlObjectiveType, *resp.UpdateControlObjective.ControlObjective.ControlObjectiveType))
 			}
 
 			if tc.request.Source != nil {
-				assert.Equal(t, *tc.request.Source, *resp.UpdateControlObjective.ControlObjective.Source)
+				assert.Check(t, is.Equal(*tc.request.Source, *resp.UpdateControlObjective.ControlObjective.Source))
 			}
 
 			if len(tc.request.AddViewerIDs) > 0 {
-				require.Len(t, resp.UpdateControlObjective.ControlObjective.Viewers, 1)
+				assert.Check(t, is.Len(resp.UpdateControlObjective.ControlObjective.Viewers, 1))
 				found := false
 				for _, edge := range resp.UpdateControlObjective.ControlObjective.Viewers {
 					if edge.ID == tc.request.AddViewerIDs[0] {
@@ -530,55 +533,56 @@ func (suite *GraphTestSuite) TestMutationUpdateControlObjective() {
 					}
 				}
 
-				assert.True(t, found)
+				assert.Check(t, found)
 
 				// ensure the user has access to the control objective now
 				res, err := suite.client.api.GetControlObjectiveByID(anotherAdminUser.UserCtx, controlObjective.ID)
-				require.NoError(t, err)
-				require.NotEmpty(t, res)
-				assert.Equal(t, controlObjective.ID, res.ControlObjective.ID)
+				assert.NilError(t, err)
+				assert.Check(t, res != nil)
+				assert.Check(t, is.Equal(controlObjective.ID, res.ControlObjective.ID))
 			}
 		})
 	}
+	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, ID: program.ID}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.ControlObjectiveDeleteOne]{client: suite.client.db.ControlObjective, ID: controlObjective.ID}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.GroupDeleteOne]{client: suite.client.db.Group, ID: groupMember.GroupID}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationDeleteControlObjective() {
-	t := suite.T()
-
+func TestMutationDeleteControlObjective(t *testing.T) {
 	// create objects to be deleted
-	ControlObjective1 := (&ControlObjectiveBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
-	ControlObjective2 := (&ControlObjectiveBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	controlObjective1 := (&ControlObjectiveBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	controlObjective2 := (&ControlObjectiveBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
 		{
 			name:        "not authorized, delete",
-			idToDelete:  ControlObjective1.ID,
+			idToDelete:  controlObjective1.ID,
 			client:      suite.client.api,
 			ctx:         testUser2.UserCtx,
 			expectedErr: notFoundErrorMsg,
 		},
 		{
 			name:       "happy path, delete",
-			idToDelete: ControlObjective1.ID,
+			idToDelete: controlObjective1.ID,
 			client:     suite.client.api,
 			ctx:        testUser1.UserCtx,
 		},
 		{
 			name:        "already deleted, not found",
-			idToDelete:  ControlObjective1.ID,
+			idToDelete:  controlObjective1.ID,
 			client:      suite.client.api,
 			ctx:         testUser1.UserCtx,
 			expectedErr: "not found",
 		},
 		{
 			name:       "happy path, delete using personal access token",
-			idToDelete: ControlObjective2.ID,
+			idToDelete: controlObjective2.ID,
 			client:     suite.client.apiWithPAT,
 			ctx:        context.Background(),
 		},
@@ -595,16 +599,16 @@ func (suite *GraphTestSuite) TestMutationDeleteControlObjective() {
 		t.Run("Delete "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.DeleteControlObjective(tc.ctx, tc.idToDelete)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			assert.Equal(t, tc.idToDelete, resp.DeleteControlObjective.DeletedID)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Check(t, is.Equal(tc.idToDelete, resp.DeleteControlObjective.DeletedID))
 		})
 	}
 }

--- a/internal/graphapi/customdomain_test.go
+++ b/internal/graphapi/customdomain_test.go
@@ -19,7 +19,7 @@ func TestQueryCustomDomainByID(t *testing.T) {
 		name           string
 		expectedDomain string
 		queryID        string
-		client         openlaneclient.OpenlaneClient
+		client         *openlaneclient.OpenlaneClient
 		ctx            context.Context
 		errorMsg       string
 	}{
@@ -87,7 +87,7 @@ func TestQueryCustomDomains(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		client          openlaneclient.OpenlaneClient
+		client          *openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int64
 		where           *openlaneclient.CustomDomainWhereInput
@@ -169,7 +169,7 @@ func TestMutationCreateCustomDomain(t *testing.T) {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.CreateCustomDomainInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -264,7 +264,7 @@ func TestMutationDeleteCustomDomain(t *testing.T) {
 	testCases := []struct {
 		name        string
 		id          string
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -326,7 +326,7 @@ func TestUpdateCustomDomain(t *testing.T) {
 	testCases := []struct {
 		name        string
 		queryID     string
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		errorMsg    string
 		updateInput openlaneclient.UpdateCustomDomainInput
@@ -376,7 +376,7 @@ func TestMutationCreateBulkCustomDomain(t *testing.T) {
 	testCases := []struct {
 		name        string
 		requests    []*openlaneclient.CreateCustomDomainInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 		numExpected int
@@ -530,7 +530,7 @@ func TestGetAllCustomDomains(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		client          openlaneclient.OpenlaneClient
+		client          *openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int64
 		expectedErr     string

--- a/internal/graphapi/customdomain_test.go
+++ b/internal/graphapi/customdomain_test.go
@@ -59,7 +59,6 @@ func TestQueryCustomDomainByID(t *testing.T) {
 			resp, err := tc.client.GetCustomDomainByID(tc.ctx, tc.queryID)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 
@@ -232,7 +231,6 @@ func TestMutationCreateCustomDomain(t *testing.T) {
 		t.Run("Create "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.CreateCustomDomain(tc.ctx, tc.request)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 
@@ -300,10 +298,8 @@ func TestMutationDeleteCustomDomain(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run("Delete "+tc.name, func(t *testing.T) {
-
 			resp, err := tc.client.DeleteCustomDomain(tc.ctx, tc.id)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 
@@ -317,7 +313,6 @@ func TestMutationDeleteCustomDomain(t *testing.T) {
 
 			// Verify the domain is deleted
 			_, err = tc.client.GetCustomDomainByID(tc.ctx, tc.id)
-
 			assert.ErrorContains(t, err, notFoundErrorMsg)
 		})
 	}
@@ -362,7 +357,6 @@ func TestUpdateCustomDomain(t *testing.T) {
 			resp, err := tc.client.UpdateCustomDomain(tc.ctx, tc.queryID, tc.updateInput)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 
@@ -480,7 +474,6 @@ func TestMutationCreateBulkCustomDomain(t *testing.T) {
 		t.Run("Create "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.CreateBulkCustomDomain(tc.ctx, tc.requests)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 
@@ -573,7 +566,6 @@ func TestGetAllCustomDomains(t *testing.T) {
 			resp, err := tc.client.GetAllCustomDomains(tc.ctx)
 
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 				return

--- a/internal/graphapi/customdomain_test.go
+++ b/internal/graphapi/customdomain_test.go
@@ -5,23 +5,21 @@ import (
 	"testing"
 
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/openlaneclient"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
-func (suite *GraphTestSuite) TestQueryCustomDomainByID() {
-	t := suite.T()
-
+func TestQueryCustomDomainByID(t *testing.T) {
 	customDomain := (&CustomDomainBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t, nil)
 
 	testCases := []struct {
 		name           string
 		expectedDomain string
 		queryID        string
-		client         *openlaneclient.OpenlaneClient
+		client         openlaneclient.OpenlaneClient
 		ctx            context.Context
 		errorMsg       string
 	}{
@@ -61,38 +59,38 @@ func (suite *GraphTestSuite) TestQueryCustomDomainByID() {
 			resp, err := tc.client.GetCustomDomainByID(tc.ctx, tc.queryID)
 
 			if tc.errorMsg != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.NotEmpty(t, resp.CustomDomain)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
-			assert.Equal(t, tc.queryID, resp.CustomDomain.ID)
-			assert.Equal(t, tc.expectedDomain, resp.CustomDomain.CnameRecord)
+			assert.Check(t, is.Equal(tc.queryID, resp.CustomDomain.ID))
+			assert.Check(t, is.Equal(tc.expectedDomain, resp.CustomDomain.CnameRecord))
 		})
 	}
-	(&Cleanup[*generated.MappableDomainDeleteOne]{client: suite.client.db.MappableDomain, ID: customDomain.MappableDomainID}).MustDelete(t.Context(), suite)
+	(&Cleanup[*generated.MappableDomainDeleteOne]{client: suite.client.db.MappableDomain, ID: customDomain.MappableDomainID}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.CustomDomainDeleteOne]{client: suite.client.db.CustomDomain, ID: customDomain.ID}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestQueryCustomDomains() {
-	t := suite.T()
-
+func TestQueryCustomDomains(t *testing.T) {
 	mappableDomain := (&MappableDomainBuilder{client: suite.client}).MustNew(systemAdminUser.UserCtx, t)
 	mappableDomain2 := (&MappableDomainBuilder{client: suite.client}).MustNew(systemAdminUser.UserCtx, t)
+
 	customDomain1 := (&CustomDomainBuilder{client: suite.client, MappableDomainID: mappableDomain2.ID}).MustNew(testUser1.UserCtx, t, nil)
-	(&CustomDomainBuilder{client: suite.client, MappableDomainID: mappableDomain.ID}).MustNew(testUser1.UserCtx, t, lo.ToPtr(enums.CustomDomainStatusVerified))
-	(&CustomDomainBuilder{client: suite.client, MappableDomainID: mappableDomain.ID}).MustNew(testUser2.UserCtx, t, lo.ToPtr(enums.CustomDomainStatusVerified))
+	customDomain2 := (&CustomDomainBuilder{client: suite.client, MappableDomainID: mappableDomain.ID}).MustNew(testUser1.UserCtx, t, lo.ToPtr(enums.CustomDomainStatusVerified))
+	customDomain3 := (&CustomDomainBuilder{client: suite.client, MappableDomainID: mappableDomain.ID}).MustNew(testUser2.UserCtx, t, lo.ToPtr(enums.CustomDomainStatusVerified))
+
 	nonExistentDomain := "nonexistent.example.com"
 
 	testCases := []struct {
 		name            string
-		client          *openlaneclient.OpenlaneClient
+		client          openlaneclient.OpenlaneClient
 		ctx             context.Context
-		expectedResults int
+		expectedResults int64
 		where           *openlaneclient.CustomDomainWhereInput
 	}{
 		{
@@ -149,28 +147,30 @@ func (suite *GraphTestSuite) TestQueryCustomDomains() {
 		t.Run("Get "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.GetCustomDomains(tc.ctx, nil, nil, tc.where)
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.NotEmpty(t, resp.CustomDomains)
-			assert.Equal(t, int64(tc.expectedResults), resp.CustomDomains.TotalCount)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+
+			assert.Check(t, is.Equal(tc.expectedResults, resp.CustomDomains.TotalCount))
+
 			for _, domain := range resp.CustomDomains.Edges {
-				assert.Equal(t, *domain.Node.OwnerID, testUser1.OrganizationID)
+				assert.Check(t, is.Equal(*domain.Node.OwnerID, testUser1.OrganizationID))
 			}
 		})
 	}
-	(&Cleanup[*generated.MappableDomainDeleteOne]{client: suite.client.db.MappableDomain, ID: mappableDomain.ID}).MustDelete(t.Context(), suite)
-	(&Cleanup[*generated.MappableDomainDeleteOne]{client: suite.client.db.MappableDomain, ID: mappableDomain2.ID}).MustDelete(t.Context(), suite)
+
+	(&Cleanup[*generated.MappableDomainDeleteOne]{client: suite.client.db.MappableDomain, IDs: []string{mappableDomain.ID, mappableDomain2.ID}}).MustDelete(testUser1.UserCtx, t)
+
+	(&Cleanup[*generated.CustomDomainDeleteOne]{client: suite.client.db.CustomDomain, IDs: []string{customDomain1.ID, customDomain2.ID}}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.CustomDomainDeleteOne]{client: suite.client.db.CustomDomain, ID: customDomain3.ID}).MustDelete(testUser2.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationCreateCustomDomain() {
-	t := suite.T()
-
+func TestMutationCreateCustomDomain(t *testing.T) {
 	mappableDomain := (&MappableDomainBuilder{client: suite.client}).MustNew(systemAdminUser.UserCtx, t)
 
 	testCases := []struct {
 		name        string
 		request     openlaneclient.CreateCustomDomainInput
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -232,33 +232,32 @@ func (suite *GraphTestSuite) TestMutationCreateCustomDomain() {
 		t.Run("Create "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.CreateCustomDomain(tc.ctx, tc.request)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
-			assert.Equal(t, tc.request.CnameRecord, resp.CreateCustomDomain.CustomDomain.CnameRecord)
-			assert.Equal(t, tc.request.MappableDomainID, resp.CreateCustomDomain.CustomDomain.MappableDomainID)
-			assert.Equal(t, enums.CustomDomainStatusPending, resp.CreateCustomDomain.CustomDomain.Status)
-			assert.Equal(t, resp.CreateCustomDomain.CustomDomain.TxtRecordSubdomain, "_olverify")
-			assert.NotEmpty(t, resp.CreateCustomDomain.CustomDomain.TxtRecordSubdomain)
-			assert.NotEmpty(t, resp.CreateCustomDomain.CustomDomain.TxtRecordValue)
+			assert.Check(t, is.Equal(tc.request.CnameRecord, resp.CreateCustomDomain.CustomDomain.CnameRecord))
+			assert.Check(t, is.Equal(tc.request.MappableDomainID, resp.CreateCustomDomain.CustomDomain.MappableDomainID))
+			assert.Check(t, is.Equal(enums.CustomDomainStatusPending, resp.CreateCustomDomain.CustomDomain.Status))
+			assert.Check(t, is.Equal(resp.CreateCustomDomain.CustomDomain.TxtRecordSubdomain, "_olverify"))
+			assert.Check(t, len(resp.CreateCustomDomain.CustomDomain.TxtRecordSubdomain) != 0)
+			assert.Check(t, len(resp.CreateCustomDomain.CustomDomain.TxtRecordValue) != 0)
 
 			// Clean up
-			(&Cleanup[*generated.CustomDomainDeleteOne]{client: suite.client.db.CustomDomain, ID: resp.CreateCustomDomain.CustomDomain.ID}).MustDelete(tc.ctx, suite)
+			(&Cleanup[*generated.CustomDomainDeleteOne]{client: suite.client.db.CustomDomain, ID: resp.CreateCustomDomain.CustomDomain.ID}).MustDelete(tc.ctx, t)
 		})
 	}
-	(&Cleanup[*generated.MappableDomainDeleteOne]{client: suite.client.db.MappableDomain, ID: mappableDomain.ID}).MustDelete(t.Context(), suite)
+
+	(&Cleanup[*generated.MappableDomainDeleteOne]{client: suite.client.db.MappableDomain, ID: mappableDomain.ID}).MustDelete(t.Context(), t)
 }
 
-func (suite *GraphTestSuite) TestMutationDeleteCustomDomain() {
-	t := suite.T()
-
+func TestMutationDeleteCustomDomain(t *testing.T) {
 	customDomain := (&CustomDomainBuilder{client: suite.client, OwnerID: testUser1.OrganizationID}).MustNew(testUser1.UserCtx, t, nil)
 	customDomain2 := (&CustomDomainBuilder{client: suite.client, OwnerID: testUser1.OrganizationID}).MustNew(testUser1.UserCtx, t, nil)
 	customDomain3 := (&CustomDomainBuilder{client: suite.client, OwnerID: testUser1.OrganizationID}).MustNew(testUser1.UserCtx, t, nil)
@@ -267,7 +266,7 @@ func (suite *GraphTestSuite) TestMutationDeleteCustomDomain() {
 	testCases := []struct {
 		name        string
 		id          string
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -304,38 +303,35 @@ func (suite *GraphTestSuite) TestMutationDeleteCustomDomain() {
 
 			resp, err := tc.client.DeleteCustomDomain(tc.ctx, tc.id)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
-			assert.Equal(t, tc.id, resp.DeleteCustomDomain.DeletedID)
+			assert.Check(t, is.Equal(tc.id, resp.DeleteCustomDomain.DeletedID))
 
 			// Verify the domain is deleted
 			_, err = tc.client.GetCustomDomainByID(tc.ctx, tc.id)
-			require.Error(t, err)
+
 			assert.ErrorContains(t, err, notFoundErrorMsg)
 		})
 	}
-	(&Cleanup[*generated.MappableDomainDeleteOne]{client: suite.client.db.MappableDomain, ID: customDomain.MappableDomainID}).MustDelete(t.Context(), suite)
-	(&Cleanup[*generated.MappableDomainDeleteOne]{client: suite.client.db.MappableDomain, ID: customDomain2.MappableDomainID}).MustDelete(t.Context(), suite)
-	(&Cleanup[*generated.MappableDomainDeleteOne]{client: suite.client.db.MappableDomain, ID: customDomain3.MappableDomainID}).MustDelete(t.Context(), suite)
+	(&Cleanup[*generated.MappableDomainDeleteOne]{client: suite.client.db.MappableDomain, IDs: []string{customDomain.MappableDomainID, customDomain2.MappableDomainID, customDomain3.MappableDomainID}}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.CustomDomainDeleteOne]{client: suite.client.db.CustomDomain, ID: customDomain3.ID}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestUpdateCustomDomain() {
-	t := suite.T()
-
+func TestUpdateCustomDomain(t *testing.T) {
 	customDomain := (&CustomDomainBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t, nil)
 
 	testCases := []struct {
 		name        string
 		queryID     string
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		errorMsg    string
 		updateInput openlaneclient.UpdateCustomDomainInput
@@ -366,28 +362,27 @@ func (suite *GraphTestSuite) TestUpdateCustomDomain() {
 			resp, err := tc.client.UpdateCustomDomain(tc.ctx, tc.queryID, tc.updateInput)
 
 			if tc.errorMsg != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 		})
 	}
-	(&Cleanup[*generated.MappableDomainDeleteOne]{client: suite.client.db.MappableDomain, ID: customDomain.MappableDomainID}).MustDelete(t.Context(), suite)
+	(&Cleanup[*generated.MappableDomainDeleteOne]{client: suite.client.db.MappableDomain, ID: customDomain.MappableDomainID}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.CustomDomainDeleteOne]{client: suite.client.db.CustomDomain, ID: customDomain.ID}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationCreateBulkCustomDomain() {
-	t := suite.T()
-
+func TestMutationCreateBulkCustomDomain(t *testing.T) {
 	mappableDomain := (&MappableDomainBuilder{client: suite.client}).MustNew(systemAdminUser.UserCtx, t)
 
 	testCases := []struct {
 		name        string
 		requests    []*openlaneclient.CreateCustomDomainInput
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 		numExpected int
@@ -485,24 +480,24 @@ func (suite *GraphTestSuite) TestMutationCreateBulkCustomDomain() {
 		t.Run("Create "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.CreateBulkCustomDomain(tc.ctx, tc.requests)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.Len(t, resp.CreateBulkCustomDomain.CustomDomains, tc.numExpected)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Check(t, is.Len(resp.CreateBulkCustomDomain.CustomDomains, tc.numExpected))
 
 			// Verify each domain was created correctly
 			for i, request := range tc.requests {
-				assert.Equal(t, request.CnameRecord, resp.CreateBulkCustomDomain.CustomDomains[i].CnameRecord)
-				assert.Equal(t, request.MappableDomainID, resp.CreateBulkCustomDomain.CustomDomains[i].MappableDomainID)
-				assert.Equal(t, enums.CustomDomainStatusPending, resp.CreateBulkCustomDomain.CustomDomains[i].Status)
-				assert.Equal(t, resp.CreateBulkCustomDomain.CustomDomains[i].TxtRecordSubdomain, "_olverify")
-				assert.NotEmpty(t, resp.CreateBulkCustomDomain.CustomDomains[i].TxtRecordValue)
+				assert.Check(t, is.Equal(request.CnameRecord, resp.CreateBulkCustomDomain.CustomDomains[i].CnameRecord))
+				assert.Check(t, is.Equal(request.MappableDomainID, resp.CreateBulkCustomDomain.CustomDomains[i].MappableDomainID))
+				assert.Check(t, is.Equal(enums.CustomDomainStatusPending, resp.CreateBulkCustomDomain.CustomDomains[i].Status))
+				assert.Check(t, is.Equal(resp.CreateBulkCustomDomain.CustomDomains[i].TxtRecordSubdomain, "_olverify"))
+				assert.Check(t, len(resp.CreateBulkCustomDomain.CustomDomains[i].TxtRecordValue) != 0)
 			}
 
 			// Clean up created domains
@@ -510,16 +505,14 @@ func (suite *GraphTestSuite) TestMutationCreateBulkCustomDomain() {
 				(&Cleanup[*generated.CustomDomainDeleteOne]{
 					client: suite.client.db.CustomDomain,
 					ID:     domain.ID,
-				}).MustDelete(tc.ctx, suite)
+				}).MustDelete(tc.ctx, t)
 			}
 		})
 	}
-	(&Cleanup[*generated.MappableDomainDeleteOne]{client: suite.client.db.MappableDomain, ID: mappableDomain.ID}).MustDelete(t.Context(), suite)
+	(&Cleanup[*generated.MappableDomainDeleteOne]{client: suite.client.db.MappableDomain, ID: mappableDomain.ID}).MustDelete(systemAdminUser.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestGetAllCustomDomains() {
-	t := suite.T()
-
+func TestGetAllCustomDomains(t *testing.T) {
 	// Create test mappable domain
 	mappableDomain := (&MappableDomainBuilder{client: suite.client}).MustNew(systemAdminUser.UserCtx, t)
 
@@ -544,9 +537,9 @@ func (suite *GraphTestSuite) TestGetAllCustomDomains() {
 
 	testCases := []struct {
 		name            string
-		client          *openlaneclient.OpenlaneClient
+		client          openlaneclient.OpenlaneClient
 		ctx             context.Context
-		expectedResults int
+		expectedResults int64
 		expectedErr     string
 	}{
 		{
@@ -580,53 +573,51 @@ func (suite *GraphTestSuite) TestGetAllCustomDomains() {
 			resp, err := tc.client.GetAllCustomDomains(tc.ctx)
 
 			if tc.expectedErr != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.NotNil(t, resp.CustomDomains)
-			require.NotNil(t, resp.CustomDomains.Edges)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Check(t, resp.CustomDomains.Edges != nil)
 
 			// Verify the number of results
-			assert.Len(t, resp.CustomDomains.Edges, tc.expectedResults)
-			assert.Equal(t, int64(tc.expectedResults), resp.CustomDomains.TotalCount)
+			assert.Check(t, is.Len(resp.CustomDomains.Edges, int(tc.expectedResults)))
+			assert.Check(t, is.Equal(tc.expectedResults, resp.CustomDomains.TotalCount))
 
 			// Verify pagination info
-			assert.NotNil(t, resp.CustomDomains.PageInfo)
+			assert.Check(t, resp.CustomDomains.PageInfo.StartCursor != nil)
 
 			// If we have results, verify the structure of the first result
 			if tc.expectedResults > 0 {
 				firstNode := resp.CustomDomains.Edges[0].Node
-				assert.NotEmpty(t, firstNode.ID)
-				assert.NotEmpty(t, firstNode.CnameRecord)
-				assert.NotEmpty(t, firstNode.MappableDomainID)
-				assert.NotEmpty(t, firstNode.OwnerID)
-				assert.NotNil(t, firstNode.CreatedAt)
-				assert.NotEmpty(t, firstNode.Status)
-				assert.NotEmpty(t, firstNode.TxtRecordSubdomain)
-				assert.NotEmpty(t, firstNode.TxtRecordValue)
+				assert.Check(t, len(firstNode.ID) != 0)
+				assert.Check(t, len(firstNode.CnameRecord) != 0)
+				assert.Check(t, len(firstNode.MappableDomainID) != 0)
+				assert.Check(t, firstNode.OwnerID != nil)
+				assert.Check(t, firstNode.CreatedAt != nil)
+				assert.Check(t, len(firstNode.Status) != 0)
+				assert.Check(t, len(firstNode.TxtRecordSubdomain) != 0)
+				assert.Check(t, len(firstNode.TxtRecordValue) != 0)
 			}
 
 			// Verify that users only see domains from their organization
 			if tc.ctx == testUser1.UserCtx || tc.ctx == viewOnlyUser.UserCtx {
 				for _, edge := range resp.CustomDomains.Edges {
-					assert.Equal(t, testUser1.OrganizationID, *edge.Node.OwnerID)
+					assert.Check(t, is.Equal(testUser1.OrganizationID, *edge.Node.OwnerID))
 				}
 			} else if tc.ctx == testUser2.UserCtx {
 				for _, edge := range resp.CustomDomains.Edges {
-					assert.Equal(t, testUser2.OrganizationID, *edge.Node.OwnerID)
+					assert.Check(t, is.Equal(testUser2.OrganizationID, *edge.Node.OwnerID))
 				}
 			}
 		})
 	}
 
 	// Clean up created domains
-	(&Cleanup[*generated.CustomDomainDeleteOne]{client: suite.client.db.CustomDomain, ID: customDomain1.ID}).MustDelete(testUser1.UserCtx, suite)
-	(&Cleanup[*generated.CustomDomainDeleteOne]{client: suite.client.db.CustomDomain, ID: customDomain2.ID}).MustDelete(testUser1.UserCtx, suite)
-	(&Cleanup[*generated.CustomDomainDeleteOne]{client: suite.client.db.CustomDomain, ID: customDomain3.ID}).MustDelete(testUser2.UserCtx, suite)
-	(&Cleanup[*generated.MappableDomainDeleteOne]{client: suite.client.db.MappableDomain, ID: mappableDomain.ID}).MustDelete(systemAdminUser.UserCtx, suite)
+	(&Cleanup[*generated.CustomDomainDeleteOne]{client: suite.client.db.CustomDomain, IDs: []string{customDomain1.ID, customDomain2.ID}}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.CustomDomainDeleteOne]{client: suite.client.db.CustomDomain, ID: customDomain3.ID}).MustDelete(testUser2.UserCtx, t)
+	(&Cleanup[*generated.MappableDomainDeleteOne]{client: suite.client.db.MappableDomain, ID: mappableDomain.ID}).MustDelete(systemAdminUser.UserCtx, t)
 }

--- a/internal/graphapi/entity_test.go
+++ b/internal/graphapi/entity_test.go
@@ -56,7 +56,6 @@ func TestQueryEntity(t *testing.T) {
 			resp, err := tc.client.GetEntityByID(tc.ctx, tc.queryID)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 
@@ -457,7 +456,6 @@ func TestMutationDeleteEntity(t *testing.T) {
 		t.Run("Delete "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.DeleteEntity(tc.ctx, tc.idToDelete)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 

--- a/internal/graphapi/entity_test.go
+++ b/internal/graphapi/entity_test.go
@@ -20,7 +20,7 @@ func TestQueryEntity(t *testing.T) {
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   openlaneclient.OpenlaneClient
+		client   *openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{
@@ -80,7 +80,7 @@ func TestQueryEntities(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		client          openlaneclient.OpenlaneClient
+		client          *openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int
 	}{
@@ -131,7 +131,7 @@ func TestMutationCreateEntity(t *testing.T) {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.CreateEntityInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -283,7 +283,7 @@ func TestMutationUpdateEntity(t *testing.T) {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.UpdateEntityInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -407,7 +407,7 @@ func TestMutationDeleteEntity(t *testing.T) {
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{

--- a/internal/graphapi/entitytype_test.go
+++ b/internal/graphapi/entitytype_test.go
@@ -20,7 +20,7 @@ func TestQueryEntityType(t *testing.T) {
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   openlaneclient.OpenlaneClient
+		client   *openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{
@@ -78,7 +78,7 @@ func TestQueryEntityTypes(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		client          openlaneclient.OpenlaneClient
+		client          *openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int
 	}{
@@ -125,7 +125,7 @@ func TestMutationCreateEntityType(t *testing.T) {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.CreateEntityTypeInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -198,7 +198,7 @@ func TestMutationUpdateEntityType(t *testing.T) {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.UpdateEntityTypeInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -264,7 +264,7 @@ func TestMutationDeleteEntityType(t *testing.T) {
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{

--- a/internal/graphapi/entitytype_test.go
+++ b/internal/graphapi/entitytype_test.go
@@ -56,7 +56,6 @@ func TestQueryEntityType(t *testing.T) {
 			resp, err := tc.client.GetEntityTypeByID(tc.ctx, tc.queryID)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 
@@ -177,7 +176,6 @@ func TestMutationCreateEntityType(t *testing.T) {
 		t.Run("Create "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.CreateEntityType(tc.ctx, tc.request)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 
@@ -243,7 +241,6 @@ func TestMutationUpdateEntityType(t *testing.T) {
 		t.Run("Update "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.UpdateEntityType(tc.ctx, entityType.ID, tc.request)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 
@@ -323,7 +320,6 @@ func TestMutationDeleteEntityType(t *testing.T) {
 		t.Run("Delete "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.DeleteEntityType(tc.ctx, tc.idToDelete)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 

--- a/internal/graphapi/entitytype_test.go
+++ b/internal/graphapi/entitytype_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 
 	"github.com/theopenlane/utils/ulids"
 
@@ -14,15 +14,13 @@ import (
 	"github.com/theopenlane/core/pkg/openlaneclient"
 )
 
-func (suite *GraphTestSuite) TestQueryEntityType() {
-	t := suite.T()
-
+func TestQueryEntityType(t *testing.T) {
 	entityType := (&EntityTypeBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   *openlaneclient.OpenlaneClient
+		client   openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{
@@ -58,32 +56,30 @@ func (suite *GraphTestSuite) TestQueryEntityType() {
 			resp, err := tc.client.GetEntityTypeByID(tc.ctx, tc.queryID)
 
 			if tc.errorMsg != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.NotNil(t, resp.EntityType)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Assert(t, resp.EntityType.ID != "")
 		})
 	}
 
 	// delete created entityType
-	(&Cleanup[*generated.EntityTypeDeleteOne]{client: suite.client.db.EntityType, ID: entityType.ID}).MustDelete(testUser1.UserCtx, suite)
+	(&Cleanup[*generated.EntityTypeDeleteOne]{client: suite.client.db.EntityType, ID: entityType.ID}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestQueryEntityTypes() {
-	t := suite.T()
-
-	_ = (&EntityTypeBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
-	_ = (&EntityTypeBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+func TestQueryEntityTypes(t *testing.T) {
+	e1 := (&EntityTypeBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	e2 := (&EntityTypeBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	testCases := []struct {
 		name            string
-		client          *openlaneclient.OpenlaneClient
+		client          openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int
 	}{
@@ -116,21 +112,21 @@ func (suite *GraphTestSuite) TestQueryEntityTypes() {
 	for _, tc := range testCases {
 		t.Run("List "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.GetAllEntityTypes(tc.ctx)
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
-			assert.Len(t, resp.EntityTypes.Edges, tc.expectedResults)
+			assert.Check(t, is.Len(resp.EntityTypes.Edges, tc.expectedResults), "expected %d entity types, got %d", tc.expectedResults, len(resp.EntityTypes.Edges))
 		})
 	}
+
+	(&Cleanup[*generated.EntityTypeDeleteOne]{client: suite.client.db.EntityType, IDs: []string{e1.ID, e2.ID}}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationCreateEntityType() {
-	t := suite.T()
-
+func TestMutationCreateEntityType(t *testing.T) {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.CreateEntityTypeInput
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -181,30 +177,30 @@ func (suite *GraphTestSuite) TestMutationCreateEntityType() {
 		t.Run("Create "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.CreateEntityType(tc.ctx, tc.request)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
-			assert.Equal(t, tc.request.Name, resp.CreateEntityType.EntityType.Name)
+			assert.Check(t, is.Equal(tc.request.Name, resp.CreateEntityType.EntityType.Name))
+
+			(&Cleanup[*generated.EntityTypeDeleteOne]{client: suite.client.db.EntityType, ID: resp.CreateEntityType.EntityType.ID}).MustDelete(testUser1.UserCtx, t)
 		})
 	}
 }
 
-func (suite *GraphTestSuite) TestMutationUpdateEntityType() {
-	t := suite.T()
-
+func TestMutationUpdateEntityType(t *testing.T) {
 	entityType := (&EntityTypeBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	testCases := []struct {
 		name        string
 		request     openlaneclient.UpdateEntityTypeInput
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -247,23 +243,23 @@ func (suite *GraphTestSuite) TestMutationUpdateEntityType() {
 		t.Run("Update "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.UpdateEntityType(tc.ctx, entityType.ID, tc.request)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			assert.Equal(t, *tc.request.Name, resp.UpdateEntityType.EntityType.Name)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Check(t, is.Equal(*tc.request.Name, resp.UpdateEntityType.EntityType.Name))
 		})
 	}
+
+	(&Cleanup[*generated.EntityTypeDeleteOne]{client: suite.client.db.EntityType, ID: entityType.ID}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationDeleteEntityType() {
-	t := suite.T()
-
+func TestMutationDeleteEntityType(t *testing.T) {
 	entityType1 := (&EntityTypeBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	entityType2 := (&EntityTypeBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	entityType3 := (&EntityTypeBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
@@ -271,7 +267,7 @@ func (suite *GraphTestSuite) TestMutationDeleteEntityType() {
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -327,16 +323,16 @@ func (suite *GraphTestSuite) TestMutationDeleteEntityType() {
 		t.Run("Delete "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.DeleteEntityType(tc.ctx, tc.idToDelete)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			assert.Equal(t, tc.idToDelete, resp.DeleteEntityType.DeletedID)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Check(t, is.Equal(tc.idToDelete, resp.DeleteEntityType.DeletedID))
 		})
 	}
 }

--- a/internal/graphapi/evidence_test.go
+++ b/internal/graphapi/evidence_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/pkg/objects"
 	"github.com/theopenlane/core/pkg/openlaneclient"
+	"github.com/theopenlane/utils/ulids"
 )
 
 func TestQueryEvidence(t *testing.T) {
-
 	program := (&ProgramBuilder{client: suite.client}).MustNew(adminUser.UserCtx, t)
 
 	(&ProgramMemberBuilder{client: suite.client, UserID: viewOnlyUser.ID, ProgramID: program.ID}).MustNew(adminUser.UserCtx, t)
@@ -96,7 +96,6 @@ func TestQueryEvidence(t *testing.T) {
 			resp, err := tc.client.GetEvidenceByID(tc.ctx, tc.queryID)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 
@@ -522,7 +521,6 @@ func TestMutationUpdateEvidence(t *testing.T) {
 
 			resp, err := tc.client.UpdateEvidence(tc.ctx, evidence.ID, tc.request, tc.files)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 
@@ -559,67 +557,67 @@ func TestMutationUpdateEvidence(t *testing.T) {
 	(&Cleanup[*generated.EvidenceDeleteOne]{client: suite.client.db.Evidence, ID: evidence.ID}).MustDelete(testUser1.UserCtx, t)
 }
 
-// func TestMutationDeleteEvidence(t *testing.T) {
-// // 	// create objects to be deleted
-// 	evidence1 := (&EvidenceBuilder{client: suite.client}).MustNew(adminUser.UserCtx, t)
-// 	evidence2 := (&EvidenceBuilder{client: suite.client}).MustNew(adminUser.UserCtx, t)
+func TestMutationDeleteEvidence(t *testing.T) {
+	// 	// create objects to be deleted
+	evidence1 := (&EvidenceBuilder{client: suite.client}).MustNew(adminUser.UserCtx, t)
+	evidence2 := (&EvidenceBuilder{client: suite.client}).MustNew(adminUser.UserCtx, t)
 
-// 	testCases := []struct {
-// 		name        string
-// 		idToDelete  string
-// 		client      openlaneclient.OpenlaneClient
-// 		ctx         context.Context
-// 		expectedErr string
-// 	}{
-// 		{
-// 			name:        "not authorized, delete",
-// 			idToDelete:  evidence1.ID,
-// 			client:      suite.client.api,
-// 			ctx:         testUser2.UserCtx,
-// 			expectedErr: notFoundErrorMsg,
-// 		},
-// 		{
-// 			name:       "happy path, delete",
-// 			idToDelete: evidence1.ID,
-// 			client:     suite.client.api,
-// 			ctx:        adminUser.UserCtx,
-// 		},
-// 		{
-// 			name:        "already deleted, not found",
-// 			idToDelete:  evidence1.ID,
-// 			client:      suite.client.api,
-// 			ctx:         testUser1.UserCtx,
-// 			expectedErr: "not found",
-// 		},
-// 		{
-// 			name:       "happy path, delete using personal access token",
-// 			idToDelete: evidence2.ID,
-// 			client:     suite.client.apiWithPAT,
-// 			ctx:        context.Background(),
-// 		},
-// 		{
-// 			name:        "unknown id, not found",
-// 			idToDelete:  ulids.New().String(),
-// 			client:      suite.client.api,
-// 			ctx:         testUser1.UserCtx,
-// 			expectedErr: notFoundErrorMsg,
-// 		},
-// 	}
+	testCases := []struct {
+		name        string
+		idToDelete  string
+		client      openlaneclient.OpenlaneClient
+		ctx         context.Context
+		expectedErr string
+	}{
+		{
+			name:        "not authorized, delete",
+			idToDelete:  evidence1.ID,
+			client:      suite.client.api,
+			ctx:         testUser2.UserCtx,
+			expectedErr: notFoundErrorMsg,
+		},
+		{
+			name:       "happy path, delete",
+			idToDelete: evidence1.ID,
+			client:     suite.client.api,
+			ctx:        adminUser.UserCtx,
+		},
+		{
+			name:        "already deleted, not found",
+			idToDelete:  evidence1.ID,
+			client:      suite.client.api,
+			ctx:         testUser1.UserCtx,
+			expectedErr: "not found",
+		},
+		{
+			name:       "happy path, delete using personal access token",
+			idToDelete: evidence2.ID,
+			client:     suite.client.apiWithPAT,
+			ctx:        context.Background(),
+		},
+		{
+			name:        "unknown id, not found",
+			idToDelete:  ulids.New().String(),
+			client:      suite.client.api,
+			ctx:         testUser1.UserCtx,
+			expectedErr: notFoundErrorMsg,
+		},
+	}
 
-// 	for _, tc := range testCases {
-// 		t.Run("Delete "+tc.name, func(t *testing.T) {
-// // 			resp, err := tc.client.DeleteEvidence(tc.ctx, tc.idToDelete)
-// 			if tc.expectedErr != "" {
+	for _, tc := range testCases {
+		t.Run("Delete "+tc.name, func(t *testing.T) {
+			resp, err := tc.client.DeleteEvidence(tc.ctx, tc.idToDelete)
+			if tc.expectedErr != "" {
 
-// 				assert.ErrorContains(t, err, tc.expectedErr)
-// 				assert.Check(t, is.Nil(resp))
+				assert.ErrorContains(t, err, tc.expectedErr)
+				assert.Check(t, is.Nil(resp))
 
-// 				return
-// 			}
+				return
+			}
 
-// 			assert.NilError(t, err)
-// 			assert.Assert(t, resp != nil)
-// 			assert.Check(t, is.Equal(tc.idToDelete, resp.DeleteEvidence.DeletedID))
-// 		})
-// 	}
-// }
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Check(t, is.Equal(tc.idToDelete, resp.DeleteEvidence.DeletedID))
+		})
+	}
+}

--- a/internal/graphapi/evidence_test.go
+++ b/internal/graphapi/evidence_test.go
@@ -558,7 +558,7 @@ func TestMutationUpdateEvidence(t *testing.T) {
 }
 
 func TestMutationDeleteEvidence(t *testing.T) {
-	// 	// create objects to be deleted
+	// create objects to be deleted
 	evidence1 := (&EvidenceBuilder{client: suite.client}).MustNew(adminUser.UserCtx, t)
 	evidence2 := (&EvidenceBuilder{client: suite.client}).MustNew(adminUser.UserCtx, t)
 

--- a/internal/graphapi/evidence_test.go
+++ b/internal/graphapi/evidence_test.go
@@ -34,7 +34,7 @@ func TestQueryEvidence(t *testing.T) {
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   openlaneclient.OpenlaneClient
+		client   *openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{
@@ -133,7 +133,7 @@ func TestQueryEvidences(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		client          openlaneclient.OpenlaneClient
+		client          *openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int
 	}{
@@ -212,7 +212,7 @@ func TestMutationCreateEvidence(t *testing.T) {
 		name        string
 		request     openlaneclient.CreateEvidenceInput
 		files       []*graphql.Upload
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -462,7 +462,7 @@ func TestMutationUpdateEvidence(t *testing.T) {
 		name        string
 		request     openlaneclient.UpdateEvidenceInput
 		files       []*graphql.Upload
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -565,7 +565,7 @@ func TestMutationDeleteEvidence(t *testing.T) {
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{

--- a/internal/graphapi/group_test.go
+++ b/internal/graphapi/group_test.go
@@ -31,7 +31,7 @@ func TestQueryGroup(t *testing.T) {
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   openlaneclient.OpenlaneClient
+		client   *openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{
@@ -243,7 +243,7 @@ func TestMutationCreateGroup(t *testing.T) {
 		owner         string
 		settings      *openlaneclient.CreateGroupSettingInput
 		addGroupToOrg bool
-		client        openlaneclient.OpenlaneClient
+		client        *openlaneclient.OpenlaneClient
 		ctx           context.Context
 		errorMsg      string
 	}{
@@ -409,7 +409,7 @@ func TestMutationCreateGroupWithMembers(t *testing.T) {
 		name     string
 		group    openlaneclient.CreateGroupInput
 		members  []*openlaneclient.GroupMembersInput
-		client   openlaneclient.OpenlaneClient
+		client   *openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{
@@ -550,7 +550,7 @@ func TestMutationCreateGroupByClone(t *testing.T) {
 		groupPermissionsClone *string
 		groupMembersClone     *string
 		members               []*openlaneclient.GroupMembersInput
-		client                openlaneclient.OpenlaneClient
+		client                *openlaneclient.OpenlaneClient
 		ctx                   context.Context
 		errorMsg              string
 	}{
@@ -697,7 +697,7 @@ func TestMutationUpdateGroup(t *testing.T) {
 		name        string
 		updateInput openlaneclient.UpdateGroupInput
 		expectedRes openlaneclient.UpdateGroup_UpdateGroup_Group
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		errorMsg    string
 	}{
@@ -1014,7 +1014,7 @@ func TestMutationDeleteGroup(t *testing.T) {
 	testCases := []struct {
 		name     string
 		groupID  string
-		client   openlaneclient.OpenlaneClient
+		client   *openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{

--- a/internal/graphapi/group_test.go
+++ b/internal/graphapi/group_test.go
@@ -360,7 +360,6 @@ func TestMutationCreateGroup(t *testing.T) {
 			resp, err := tc.client.CreateGroup(tc.ctx, input)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 
@@ -909,7 +908,6 @@ func TestMutationUpdateGroup(t *testing.T) {
 			resp, err := tc.client.UpdateGroup(tc.ctx, group.ID, tc.updateInput)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 
@@ -1058,7 +1056,6 @@ func TestMutationDeleteGroup(t *testing.T) {
 			resp, err := tc.client.DeleteGroup(tc.ctx, tc.groupID)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 

--- a/internal/graphapi/groupmembers_test.go
+++ b/internal/graphapi/groupmembers_test.go
@@ -79,7 +79,6 @@ func TestQueryGroupMembers(t *testing.T) {
 			resp, err := tc.client.GetGroupMembersByGroupID(tc.ctx, &whereInput)
 
 			if tc.errExpected {
-
 				assert.ErrorContains(t, err, notFoundErrorMsg)
 
 				return
@@ -227,7 +226,6 @@ func TestMutationCreateGroupMembers(t *testing.T) {
 			resp, err := tc.client.AddUserToGroupWithRole(tc.ctx, input)
 
 			if tc.errMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errMsg)
 
 				return
@@ -329,7 +327,6 @@ func TestMutationUpdateGroupMembers(t *testing.T) {
 			resp, err := tc.client.UpdateUserRoleInGroup(tc.ctx, tc.groupMemberID, input)
 
 			if tc.errMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errMsg)
 
 				return
@@ -433,7 +430,6 @@ func TestMutationDeleteGroupMembers(t *testing.T) {
 		t.Run("Delete "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.RemoveUserFromGroup(tc.ctx, tc.idToDelete)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 

--- a/internal/graphapi/groupmembers_test.go
+++ b/internal/graphapi/groupmembers_test.go
@@ -26,7 +26,7 @@ func TestQueryGroupMembers(t *testing.T) {
 	testCases := []struct {
 		name        string
 		queryID     string
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expected    *ent.GroupMembership
 		errExpected bool
@@ -121,7 +121,7 @@ func TestMutationCreateGroupMembers(t *testing.T) {
 		groupID string
 		userID  string
 		role    enums.Role
-		client  openlaneclient.OpenlaneClient
+		client  *openlaneclient.OpenlaneClient
 		ctx     context.Context
 		errMsg  string
 	}{
@@ -266,7 +266,7 @@ func TestMutationUpdateGroupMembers(t *testing.T) {
 		name          string
 		groupMemberID string
 		role          enums.Role
-		client        openlaneclient.OpenlaneClient
+		client        *openlaneclient.OpenlaneClient
 		ctx           context.Context
 		errMsg        string
 	}{
@@ -367,7 +367,7 @@ func TestMutationDeleteGroupMembers(t *testing.T) {
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{

--- a/internal/graphapi/groupmembers_test.go
+++ b/internal/graphapi/groupmembers_test.go
@@ -4,32 +4,29 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/theopenlane/core/internal/ent/generated"
 	ent "github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
 	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/openlaneclient"
 	"github.com/theopenlane/utils/ulids"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
-func (suite *GraphTestSuite) TestQueryGroupMembers() {
-	t := suite.T()
-
+func TestQueryGroupMembers(t *testing.T) {
 	group := (&GroupBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	checkCtx := privacy.DecisionContext(testUser1.UserCtx, privacy.Allow)
 
 	groupMember, err := group.Members(checkCtx)
-	require.NoError(t, err)
-	require.Len(t, groupMember, 1)
+	assert.NilError(t, err)
+	assert.Assert(t, is.Len(groupMember, 1))
 
 	testCases := []struct {
 		name        string
 		queryID     string
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expected    *ent.GroupMembership
 		errExpected bool
@@ -82,41 +79,39 @@ func (suite *GraphTestSuite) TestQueryGroupMembers() {
 			resp, err := tc.client.GetGroupMembersByGroupID(tc.ctx, &whereInput)
 
 			if tc.errExpected {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, notFoundErrorMsg)
 
 				return
 			}
 
-			require.NoError(t, err)
+			assert.NilError(t, err)
 
 			if tc.expected == nil {
-				assert.Empty(t, resp.GroupMemberships.Edges)
+				assert.Check(t, is.Len(resp.GroupMemberships.Edges, 0))
 
 				return
 			}
 
-			require.NotNil(t, resp)
-			require.NotNil(t, resp.GroupMemberships)
-			assert.Equal(t, tc.expected.UserID, resp.GroupMemberships.Edges[0].Node.GetUser().GetID())
-			assert.Equal(t, tc.expected.Role, resp.GroupMemberships.Edges[0].Node.Role)
+			assert.Assert(t, resp != nil)
+			assert.Assert(t, resp.GroupMemberships.Edges != nil)
+			assert.Check(t, is.Equal(tc.expected.UserID, resp.GroupMemberships.Edges[0].Node.GetUser().GetID()))
+			assert.Check(t, is.Equal(tc.expected.Role, resp.GroupMemberships.Edges[0].Node.Role))
 		})
 	}
 
 	// delete created group
-	(&Cleanup[*generated.GroupDeleteOne]{client: suite.client.db.Group, ID: group.ID}).MustDelete(testUser1.UserCtx, suite)
+	(&Cleanup[*generated.GroupDeleteOne]{client: suite.client.db.Group, ID: group.ID}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationCreateGroupMembers() {
-	t := suite.T()
-
+func TestMutationCreateGroupMembers(t *testing.T) {
 	group1 := (&GroupBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	checkCtx := privacy.DecisionContext(testUser1.UserCtx, privacy.Allow)
 
 	groupMember, err := group1.Members(checkCtx)
-	require.NoError(t, err)
-	require.Len(t, groupMember, 1)
+	assert.NilError(t, err)
+	assert.Assert(t, is.Len(groupMember, 1))
 
 	orgMember1 := (&OrgMemberBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	orgMember2 := (&OrgMemberBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
@@ -127,7 +122,7 @@ func (suite *GraphTestSuite) TestMutationCreateGroupMembers() {
 		groupID string
 		userID  string
 		role    enums.Role
-		client  *openlaneclient.OpenlaneClient
+		client  openlaneclient.OpenlaneClient
 		ctx     context.Context
 		errMsg  string
 	}{
@@ -232,29 +227,26 @@ func (suite *GraphTestSuite) TestMutationCreateGroupMembers() {
 			resp, err := tc.client.AddUserToGroupWithRole(tc.ctx, input)
 
 			if tc.errMsg != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.errMsg)
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.NotNil(t, resp.CreateGroupMembership)
-			assert.Equal(t, tc.userID, resp.CreateGroupMembership.GroupMembership.UserID)
-			assert.Equal(t, tc.groupID, resp.CreateGroupMembership.GroupMembership.GroupID)
-			assert.Equal(t, tc.role, resp.CreateGroupMembership.GroupMembership.Role)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Check(t, is.Equal(tc.userID, resp.CreateGroupMembership.GroupMembership.UserID))
+			assert.Check(t, is.Equal(tc.groupID, resp.CreateGroupMembership.GroupMembership.GroupID))
+			assert.Check(t, is.Equal(tc.role, resp.CreateGroupMembership.GroupMembership.Role))
 		})
 	}
 
 	// delete created groups and org members
-	(&Cleanup[*generated.GroupDeleteOne]{client: suite.client.db.Group, ID: group1.ID}).MustDelete(testUser1.UserCtx, suite)
-	(&Cleanup[*generated.OrgMembershipDeleteOne]{client: suite.client.db.OrgMembership, IDs: []string{orgMember1.ID, orgMember2.ID, orgMember3.ID}}).MustDelete(testUser1.UserCtx, suite)
+	(&Cleanup[*generated.GroupDeleteOne]{client: suite.client.db.Group, ID: group1.ID}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.OrgMembershipDeleteOne]{client: suite.client.db.OrgMembership, IDs: []string{orgMember1.ID, orgMember2.ID, orgMember3.ID}}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationUpdateGroupMembers() {
-	t := suite.T()
-
+func TestMutationUpdateGroupMembers(t *testing.T) {
 	gm := (&GroupMemberBuilder{client: suite.client, GroupID: testUser1.GroupID}).MustNew(testUser1.UserCtx, t)
 
 	// get all group members so we know the id of the test user group member
@@ -262,7 +254,7 @@ func (suite *GraphTestSuite) TestMutationUpdateGroupMembers() {
 		GroupID: &testUser1.GroupID,
 	})
 
-	require.NoError(t, err)
+	assert.NilError(t, err)
 
 	testUser1GroupMember := ""
 	for _, gm := range groupMembers.GroupMemberships.Edges {
@@ -276,7 +268,7 @@ func (suite *GraphTestSuite) TestMutationUpdateGroupMembers() {
 		name          string
 		groupMemberID string
 		role          enums.Role
-		client        *openlaneclient.OpenlaneClient
+		client        openlaneclient.OpenlaneClient
 		ctx           context.Context
 		errMsg        string
 	}{
@@ -337,23 +329,25 @@ func (suite *GraphTestSuite) TestMutationUpdateGroupMembers() {
 			resp, err := tc.client.UpdateUserRoleInGroup(tc.ctx, tc.groupMemberID, input)
 
 			if tc.errMsg != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.errMsg)
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.NotNil(t, resp.UpdateGroupMembership)
-			assert.Equal(t, tc.role, resp.UpdateGroupMembership.GroupMembership.Role)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Check(t, is.Equal(tc.role, resp.UpdateGroupMembership.GroupMembership.Role))
 		})
 	}
+
+	// delete created group member
+	(&Cleanup[*generated.GroupMembershipDeleteOne]{client: suite.client.db.GroupMembership, ID: gm.ID}).MustDelete(testUser1.UserCtx, t)
+	// delete org member
+	(&Cleanup[*generated.OrgMembershipDeleteOne]{client: suite.client.db.OrgMembership, IDs: []string{gm.Edges.Orgmembership.ID}}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationDeleteGroupMembers() {
-	t := suite.T()
-
+func TestMutationDeleteGroupMembers(t *testing.T) {
 	gm1 := (&GroupMemberBuilder{client: suite.client, GroupID: testUser1.GroupID}).MustNew(testUser1.UserCtx, t)
 	gm2 := (&GroupMemberBuilder{client: suite.client, GroupID: testUser1.GroupID}).MustNew(testUser1.UserCtx, t)
 	gm3 := (&GroupMemberBuilder{client: suite.client, GroupID: testUser1.GroupID}).MustNew(testUser1.UserCtx, t)
@@ -363,7 +357,7 @@ func (suite *GraphTestSuite) TestMutationDeleteGroupMembers() {
 		GroupID: &testUser1.GroupID,
 	})
 
-	require.NoError(t, err)
+	assert.NilError(t, err)
 
 	testUser1GroupMember := ""
 	for _, gm := range groupMembers.GroupMemberships.Edges {
@@ -376,7 +370,7 @@ func (suite *GraphTestSuite) TestMutationDeleteGroupMembers() {
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -439,17 +433,19 @@ func (suite *GraphTestSuite) TestMutationDeleteGroupMembers() {
 		t.Run("Delete "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.RemoveUserFromGroup(tc.ctx, tc.idToDelete)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.NotNil(t, resp.DeleteGroupMembership)
-			assert.Equal(t, tc.idToDelete, resp.DeleteGroupMembership.DeletedID)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Check(t, is.Equal(tc.idToDelete, resp.DeleteGroupMembership.DeletedID))
 		})
 	}
+
+	// delete org members
+	(&Cleanup[*generated.OrgMembershipDeleteOne]{client: suite.client.db.OrgMembership, IDs: []string{gm1.Edges.Orgmembership.ID, gm2.Edges.Orgmembership.ID, gm3.Edges.Orgmembership.ID}}).MustDelete(testUser1.UserCtx, t)
 }

--- a/internal/graphapi/helpers_test.go
+++ b/internal/graphapi/helpers_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestStripOperation(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		input    string
@@ -60,6 +62,8 @@ func TestStripOperation(t *testing.T) {
 }
 
 func TestRetrieveObjectDetails(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name        string
 		fieldName   string
@@ -160,6 +164,8 @@ func TestRetrieveObjectDetails(t *testing.T) {
 	}
 }
 func TestGetOrgOwnerFromInput(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name        string
 		input       any
@@ -216,6 +222,8 @@ func TestGetOrgOwnerFromInput(t *testing.T) {
 	}
 }
 func TestGetBulkUploadOwnerInput(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name        string
 		input       []*generated.CreateProcedureInput // used as an example, should work with any type

--- a/internal/graphapi/helpers_test.go
+++ b/internal/graphapi/helpers_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/vektah/gqlparser/v2/ast"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/pkg/objects"
@@ -54,7 +54,7 @@ func TestStripOperation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := stripOperation(tt.input)
-			assert.Equal(t, tt.expected, result)
+			assert.Check(t, is.Equal(tt.expected, result))
 		})
 	}
 }
@@ -149,14 +149,13 @@ func TestRetrieveObjectDetails(t *testing.T) {
 
 			result, err := retrieveObjectDetails(rctx, tt.key, upload)
 			if tt.expectedErr != nil {
-				require.Error(t, err)
 
 				return
 			}
 
-			require.NoError(t, err)
-			assert.Equal(t, tt.expected.CorrelatedObjectType, result.CorrelatedObjectType)
-			assert.Equal(t, tt.expected.Key, result.Key)
+			assert.NilError(t, err)
+			assert.Check(t, is.Equal(tt.expected.CorrelatedObjectType, result.CorrelatedObjectType))
+			assert.Check(t, is.Equal(tt.expected.Key, result.Key))
 		})
 	}
 }
@@ -206,13 +205,13 @@ func TestGetOrgOwnerFromInput(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := getOrgOwnerFromInput(&tt.input)
 			if tt.expectedErr != nil {
-				require.Error(t, err)
-				assert.Nil(t, result)
+
+				assert.Check(t, is.Nil(result))
 				return
 			}
 
-			require.NoError(t, err)
-			assert.Equal(t, tt.expected, result)
+			assert.NilError(t, err)
+			assert.Check(t, is.DeepEqual(tt.expected, result))
 		})
 	}
 }
@@ -275,13 +274,13 @@ func TestGetBulkUploadOwnerInput(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := getBulkUploadOwnerInput(tt.input)
 			if tt.expectedErr != nil {
-				require.Error(t, err)
-				assert.Nil(t, result)
+
+				assert.Check(t, is.Nil(result))
 				return
 			}
 
-			require.NoError(t, err)
-			assert.Equal(t, tt.expected, result)
+			assert.NilError(t, err)
+			assert.Check(t, is.DeepEqual(tt.expected, result))
 		})
 	}
 }

--- a/internal/graphapi/internalpolicy_test.go
+++ b/internal/graphapi/internalpolicy_test.go
@@ -67,7 +67,6 @@ func TestQueryInternalPolicy(t *testing.T) {
 			resp, err := tc.client.GetInternalPolicyByID(tc.ctx, tc.queryID)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 
@@ -321,7 +320,6 @@ func TestMutationCreateInternalPolicy(t *testing.T) {
 
 			resp, err := tc.client.CreateInternalPolicy(tc.ctx, tc.request)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 
@@ -526,7 +524,6 @@ func TestMutationUpdateInternalPolicy(t *testing.T) {
 		t.Run("Update "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.UpdateInternalPolicy(tc.ctx, internalPolicy.ID, tc.request)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 
@@ -626,7 +623,6 @@ func TestMutationDeleteInternalPolicy(t *testing.T) {
 		t.Run("Delete "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.DeleteInternalPolicy(tc.ctx, tc.idToDelete)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 

--- a/internal/graphapi/internalpolicy_test.go
+++ b/internal/graphapi/internalpolicy_test.go
@@ -24,7 +24,7 @@ func TestQueryInternalPolicy(t *testing.T) {
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   openlaneclient.OpenlaneClient
+		client   *openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{
@@ -92,7 +92,7 @@ func TestQueryInternalPolicies(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		client          openlaneclient.OpenlaneClient
+		client          *openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int
 	}{
@@ -161,7 +161,7 @@ func TestMutationCreateInternalPolicy(t *testing.T) {
 		name          string
 		request       openlaneclient.CreateInternalPolicyInput
 		addGroupToOrg bool
-		client        openlaneclient.OpenlaneClient
+		client        *openlaneclient.OpenlaneClient
 		ctx           context.Context
 		expectedErr   string
 	}{
@@ -416,7 +416,7 @@ func TestMutationUpdateInternalPolicy(t *testing.T) {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.UpdateInternalPolicyInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -580,7 +580,7 @@ func TestMutationDeleteInternalPolicy(t *testing.T) {
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{

--- a/internal/graphapi/invite_test.go
+++ b/internal/graphapi/invite_test.go
@@ -22,7 +22,7 @@ func TestQueryInvite(t *testing.T) {
 	testCases := []struct {
 		name    string
 		queryID string
-		client  openlaneclient.OpenlaneClient
+		client  *openlaneclient.OpenlaneClient
 		ctx     context.Context
 		wantErr bool
 	}{
@@ -103,7 +103,7 @@ func TestMutationCreateInvite(t *testing.T) {
 		recipient        string
 		orgID            string
 		role             enums.Role
-		client           openlaneclient.OpenlaneClient
+		client           *openlaneclient.OpenlaneClient
 		ctx              context.Context
 		requestorID      string
 		expectedStatus   enums.InviteStatus
@@ -290,7 +290,7 @@ func TestMutationCreateBulkInvite(t *testing.T) {
 	testCases := []struct {
 		name             string
 		recipients       []string
-		client           openlaneclient.OpenlaneClient
+		client           *openlaneclient.OpenlaneClient
 		ctx              context.Context
 		requestorID      string
 		expectedStatus   enums.InviteStatus
@@ -379,7 +379,7 @@ func TestMutationDeleteInvite(t *testing.T) {
 	testCases := []struct {
 		name    string
 		queryID string
-		client  openlaneclient.OpenlaneClient
+		client  *openlaneclient.OpenlaneClient
 		ctx     context.Context
 		wantErr bool
 	}{

--- a/internal/graphapi/mappabledomain_test.go
+++ b/internal/graphapi/mappabledomain_test.go
@@ -17,7 +17,7 @@ func TestQueryMappableDomainByID(t *testing.T) {
 		name         string
 		expectedName string
 		queryID      string
-		client       openlaneclient.OpenlaneClient
+		client       *openlaneclient.OpenlaneClient
 		ctx          context.Context
 		errorMsg     string
 	}{
@@ -65,7 +65,7 @@ func TestQueryMappableDomains(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		client          openlaneclient.OpenlaneClient
+		client          *openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int
 		where           *openlaneclient.MappableDomainWhereInput
@@ -115,7 +115,7 @@ func TestMutationCreateMappableDomain(t *testing.T) {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.CreateMappableDomainInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -170,7 +170,7 @@ func TestMutationCreateBulkMappableDomain(t *testing.T) {
 	testCases := []struct {
 		name        string
 		requests    []*openlaneclient.CreateMappableDomainInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 		numExpected int
@@ -273,7 +273,7 @@ func TestUpdateMappableDomain(t *testing.T) {
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   openlaneclient.OpenlaneClient
+		client   *openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 		input    openlaneclient.UpdateMappableDomainInput
@@ -337,7 +337,7 @@ func TestGetAllMappableDomains(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		client          openlaneclient.OpenlaneClient
+		client          *openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int
 		expectedErr     string

--- a/internal/graphapi/mappabledomain_test.go
+++ b/internal/graphapi/mappabledomain_test.go
@@ -42,7 +42,6 @@ func TestQueryMappableDomainByID(t *testing.T) {
 			resp, err := tc.client.GetMappableDomainByID(tc.ctx, tc.queryID)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 
@@ -151,7 +150,6 @@ func TestMutationCreateMappableDomain(t *testing.T) {
 		t.Run("Create "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.CreateMappableDomain(tc.ctx, tc.request)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 
@@ -243,7 +241,6 @@ func TestMutationCreateBulkMappableDomain(t *testing.T) {
 		t.Run("Create "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.CreateBulkMappableDomain(tc.ctx, tc.requests)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 
@@ -317,12 +314,12 @@ func TestUpdateMappableDomain(t *testing.T) {
 			resp, err := tc.client.UpdateMappableDomain(tc.ctx, tc.queryID, tc.input)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 
 				return
 			}
+
 			assert.NilError(t, err)
 			assert.Assert(t, resp != nil)
 			assert.Check(t, is.DeepEqual(tc.input.Tags, resp.UpdateMappableDomain.MappableDomain.Tags))

--- a/internal/graphapi/narrative_test.go
+++ b/internal/graphapi/narrative_test.go
@@ -28,7 +28,7 @@ func TestQueryNarrative(t *testing.T) {
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   openlaneclient.OpenlaneClient
+		client   *openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{
@@ -126,7 +126,7 @@ func TestQueryNarratives(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		client          openlaneclient.OpenlaneClient
+		client          *openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int
 	}{
@@ -199,7 +199,7 @@ func TestMutationCreateNarrative(t *testing.T) {
 		name          string
 		request       openlaneclient.CreateNarrativeInput
 		addGroupToOrg bool
-		client        openlaneclient.OpenlaneClient
+		client        *openlaneclient.OpenlaneClient
 		ctx           context.Context
 		expectedErr   string
 	}{
@@ -415,7 +415,7 @@ func TestMutationUpdateNarrative(t *testing.T) {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.UpdateNarrativeInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -533,7 +533,7 @@ func TestMutationDeleteNarrative(t *testing.T) {
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{

--- a/internal/graphapi/notes_test.go
+++ b/internal/graphapi/notes_test.go
@@ -16,7 +16,7 @@ func TestMutationUpdateNote(t *testing.T) {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.UpdateTaskInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -108,7 +108,7 @@ func TestMutationDeleteNote(t *testing.T) {
 	testCases := []struct {
 		name        string
 		request     func() openlaneclient.UpdateTaskInput // changed to function to get fresh note ID each time
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -204,7 +204,7 @@ func TestQueryNote(t *testing.T) {
 	testCases := []struct {
 		name        string
 		noteID      string
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{

--- a/internal/graphapi/notes_test.go
+++ b/internal/graphapi/notes_test.go
@@ -77,10 +77,8 @@ func TestMutationUpdateNote(t *testing.T) {
 
 	for idx, tc := range testCases {
 		t.Run("Create "+tc.name, func(t *testing.T) {
-
 			resp, err := tc.client.UpdateTask(tc.ctx, task.ID, tc.request)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 
@@ -171,7 +169,6 @@ func TestMutationDeleteNote(t *testing.T) {
 			request := tc.request() // get fresh request with new note
 			resp, err := tc.client.UpdateTask(tc.ctx, task.ID, request)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 				return
@@ -243,7 +240,6 @@ func TestQueryNote(t *testing.T) {
 		t.Run("Query "+tc.name, func(t *testing.T) {
 			note, err := tc.client.GetNoteByID(tc.ctx, tc.noteID)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(note))
 				return

--- a/internal/graphapi/onboarding_test.go
+++ b/internal/graphapi/onboarding_test.go
@@ -24,7 +24,7 @@ func TestMutationCreateOnboarding(t *testing.T) {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.CreateOnboardingInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{

--- a/internal/graphapi/onboarding_test.go
+++ b/internal/graphapi/onboarding_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestMutationCreateOnboarding(t *testing.T) {
+	t.Parallel()
+
 	// create another user for this test
 	// so it doesn't interfere with the other tests
 	onboardingUser := suite.userBuilder(context.Background(), t)

--- a/internal/graphapi/organization_test.go
+++ b/internal/graphapi/organization_test.go
@@ -26,6 +26,8 @@ import (
 )
 
 func TestQueryOrganization(t *testing.T) {
+	t.Parallel()
+
 	// create another user for this test
 	// so it doesn't interfere with the other tests
 	orgUser := suite.userBuilder(context.Background(), t)
@@ -109,6 +111,8 @@ func TestQueryOrganization(t *testing.T) {
 }
 
 func TestQueryOrganizations(t *testing.T) {
+	t.Parallel()
+
 	// create another user for this test
 	// so it doesn't interfere with the other tests
 	orgUser := suite.userBuilder(context.Background(), t)
@@ -147,6 +151,8 @@ func TestQueryOrganizations(t *testing.T) {
 }
 
 func TestMutationCreateOrganization(t *testing.T) {
+	t.Parallel()
+
 	// create another user for this test
 	// so it doesn't interfere with the other tests
 	orgUser := suite.userBuilder(context.Background(), t)
@@ -502,6 +508,8 @@ func TestMutationCreateOrganization(t *testing.T) {
 }
 
 func TestMutationUpdateOrganization(t *testing.T) {
+	t.Parallel()
+
 	// create another user for this test
 	// so it doesn't interfere with the other tests
 	orgUser := suite.userBuilder(context.Background(), t)
@@ -815,6 +823,8 @@ func TestMutationUpdateOrganization(t *testing.T) {
 }
 
 func TestMutationDeleteOrganization(t *testing.T) {
+	t.Parallel()
+
 	// create another user for this test
 	// so it doesn't interfere with the other tests
 	orgUser := suite.userBuilder(context.Background(), t)
@@ -914,6 +924,8 @@ func TestMutationDeleteOrganization(t *testing.T) {
 }
 
 func TestMutationOrganizationCascadeDelete(t *testing.T) {
+	t.Parallel()
+
 	// create another user for this test
 	// so it doesn't interfere with the other tests
 	orgUser := suite.userBuilder(context.Background(), t)

--- a/internal/graphapi/organization_test.go
+++ b/internal/graphapi/organization_test.go
@@ -53,7 +53,7 @@ func TestQueryOrganization(t *testing.T) {
 		{
 			name:               "happy path, get organization",
 			queryID:            orgUser.OrganizationID,
-			client:             &suite.client.api,
+			client:             suite.client.api,
 			ctx:                orgUser.UserCtx,
 			orgMembersExpected: 2, // owner and 1 member
 		},
@@ -74,7 +74,7 @@ func TestQueryOrganization(t *testing.T) {
 		{
 			name:     "invalid-id",
 			queryID:  "tacos-for-dinner",
-			client:   &suite.client.api,
+			client:   suite.client.api,
 			ctx:      orgUser.UserCtx,
 			errorMsg: notFoundErrorMsg,
 		},
@@ -182,7 +182,7 @@ func TestMutationCreateOrganization(t *testing.T) {
 		parentOrgID              string
 		avatarFile               *graphql.Upload
 		settings                 *openlaneclient.CreateOrganizationSettingInput
-		client                   openlaneclient.OpenlaneClient
+		client                   *openlaneclient.OpenlaneClient
 		ctx                      context.Context
 		expectedDefaultOrgUpdate bool
 		errorMsg                 string
@@ -245,7 +245,7 @@ func TestMutationCreateOrganization(t *testing.T) {
 			orgName:        gofakeit.Name(),
 			orgDescription: gofakeit.HipsterSentence(10),
 			parentOrgID:    orgUser.OrganizationID,
-			client:         *patClient,
+			client:         patClient,
 			ctx:            context.Background(),
 			errorMsg:       graphapi.ErrResourceNotAccessibleWithToken.Error(),
 		},
@@ -254,7 +254,7 @@ func TestMutationCreateOrganization(t *testing.T) {
 			orgName:        gofakeit.Name(),
 			orgDescription: gofakeit.HipsterSentence(10),
 			parentOrgID:    testUser2.OrganizationID,
-			client:         *patClient,
+			client:         patClient,
 			ctx:            context.Background(),
 			errorMsg:       graphapi.ErrResourceNotAccessibleWithToken.Error(),
 		},
@@ -262,7 +262,7 @@ func TestMutationCreateOrganization(t *testing.T) {
 			name:           "organization create with api token not allowed",
 			orgName:        gofakeit.Name(),
 			orgDescription: gofakeit.HipsterSentence(10),
-			client:         *tokenClient,
+			client:         tokenClient,
 			ctx:            context.Background(),
 			errorMsg:       graphapi.ErrResourceNotAccessibleWithToken.Error(),
 		},
@@ -550,7 +550,7 @@ func TestMutationUpdateOrganization(t *testing.T) {
 		orgID       string
 		updateInput openlaneclient.UpdateOrganizationInput
 		avatarFile  *graphql.Upload
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedRes openlaneclient.UpdateOrganization_UpdateOrganization_Organization
 		errorMsg    string

--- a/internal/graphapi/organization_test.go
+++ b/internal/graphapi/organization_test.go
@@ -8,14 +8,16 @@ import (
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/brianvoe/gofakeit/v7"
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/theopenlane/entx"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 
 	"github.com/theopenlane/iam/auth"
 
 	"github.com/theopenlane/core/internal/ent/generated"
+	ent "github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
+	"github.com/theopenlane/core/internal/ent/privacy/rule"
 	"github.com/theopenlane/core/internal/graphapi"
 	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/models"
@@ -23,8 +25,20 @@ import (
 	"github.com/theopenlane/core/pkg/openlaneclient"
 )
 
-func (suite *GraphTestSuite) TestQueryOrganization() {
-	t := suite.T()
+func TestQueryOrganization(t *testing.T) {
+	// create another user for this test
+	// so it doesn't interfere with the other tests
+	orgUser := suite.userBuilder(context.Background(), t)
+	apiTokenClient := suite.setupAPITokenClient(orgUser.UserCtx, t)
+	patTokenClient := suite.setupPatClient(orgUser, t)
+
+	// create api token for the user
+	(&APITokenBuilder{client: suite.client}).MustNew(orgUser.UserCtx, t)
+	// create personal access token for the user
+	(&PersonalAccessTokenBuilder{client: suite.client}).MustNew(orgUser.UserCtx, t)
+
+	// add org members
+	om := (&OrgMemberBuilder{client: suite.client}).MustNew(orgUser.UserCtx, t)
 
 	testCases := []struct {
 		name               string
@@ -36,30 +50,30 @@ func (suite *GraphTestSuite) TestQueryOrganization() {
 	}{
 		{
 			name:               "happy path, get organization",
-			queryID:            testUser1.OrganizationID,
-			client:             suite.client.api,
-			ctx:                testUser1.UserCtx,
-			orgMembersExpected: 4, // owner, admin, and 2 view only users
+			queryID:            orgUser.OrganizationID,
+			client:             &suite.client.api,
+			ctx:                orgUser.UserCtx,
+			orgMembersExpected: 2, // owner and 1 member
 		},
 		{
 			name:               "happy path, get using api token",
-			queryID:            testUser1.OrganizationID,
-			client:             suite.client.apiWithToken,
+			queryID:            orgUser.OrganizationID,
+			client:             apiTokenClient,
 			ctx:                context.Background(),
-			orgMembersExpected: 4, // owner, admin, and 2 view only users
+			orgMembersExpected: 2, // owner and 1 member
 		},
 		{
 			name:               "happy path, get using personal access token",
-			queryID:            testUser1.OrganizationID,
-			client:             suite.client.apiWithPAT,
+			queryID:            orgUser.OrganizationID,
+			client:             patTokenClient,
 			ctx:                context.Background(),
-			orgMembersExpected: 4, // owner, admin, and 2 view only users
+			orgMembersExpected: 2, // owner and 1 member
 		},
 		{
 			name:     "invalid-id",
 			queryID:  "tacos-for-dinner",
-			client:   suite.client.api,
-			ctx:      testUser1.UserCtx,
+			client:   &suite.client.api,
+			ctx:      orgUser.UserCtx,
 			errorMsg: notFoundErrorMsg,
 		},
 	}
@@ -69,50 +83,49 @@ func (suite *GraphTestSuite) TestQueryOrganization() {
 			resp, err := tc.client.GetOrganizationByID(tc.ctx, tc.queryID)
 
 			if tc.errorMsg != "" {
-				require.Error(t, err)
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.NotNil(t, resp.Organization)
-			require.NotNil(t, resp.Organization.Members)
-			assert.Len(t, resp.Organization.Members.Edges, tc.orgMembersExpected)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Check(t, is.Len(resp.Organization.Members.Edges, tc.orgMembersExpected), "expected %d org members, got %d", tc.orgMembersExpected, len(resp.Organization.Members.Edges))
 
 			if tc.orgMembersExpected > 1 {
 				orgMemberFound := false
 
 				for _, m := range resp.Organization.Members.Edges {
-					if m.Node.User.ID == viewOnlyUser.ID {
+					if m.Node.User.ID == om.UserID {
 						orgMemberFound = true
 					}
 				}
 
-				assert.True(t, orgMemberFound)
+				assert.Check(t, orgMemberFound)
 			}
 		})
 	}
 }
 
-func (suite *GraphTestSuite) TestQueryOrganizations() {
-	t := suite.T()
+func TestQueryOrganizations(t *testing.T) {
+	// create another user for this test
+	// so it doesn't interfere with the other tests
+	orgUser := suite.userBuilder(context.Background(), t)
 
-	org1 := (&OrganizationBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
-	org2 := (&OrganizationBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	org1 := (&OrganizationBuilder{client: suite.client}).MustNew(orgUser.UserCtx, t)
+	org2 := (&OrganizationBuilder{client: suite.client}).MustNew(orgUser.UserCtx, t)
 
 	t.Run("Get Organizations", func(t *testing.T) {
-		resp, err := suite.client.api.GetAllOrganizations(testUser1.UserCtx)
+		resp, err := suite.client.api.GetAllOrganizations(orgUser.UserCtx)
 
-		require.NoError(t, err)
-		require.NotNil(t, resp)
-		require.NotNil(t, resp.Organizations.Edges)
+		assert.NilError(t, err)
+		assert.Assert(t, resp != nil)
+		assert.Assert(t, resp.Organizations.Edges != nil)
 
 		// make sure two organizations are returned, the two created and
 		// the personal org and test org created at suite setup
-		assert.Equal(t, 4, len(resp.Organizations.Edges))
+		assert.Check(t, is.Equal(4, len(resp.Organizations.Edges)))
 
 		org1Found := false
 		org2Found := false
@@ -125,28 +138,35 @@ func (suite *GraphTestSuite) TestQueryOrganizations() {
 			}
 		}
 
-		assert.True(t, org1Found)
-		assert.True(t, org2Found)
+		assert.Check(t, org1Found)
+		assert.Check(t, org2Found)
 	})
+
+	// cleanup orgs
+	(&Cleanup[*generated.OrganizationDeleteOne]{client: suite.client.db.Organization, IDs: []string{org1.ID, org2.ID}}).MustDelete(orgUser.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationCreateOrganization() {
-	t := suite.T()
+func TestMutationCreateOrganization(t *testing.T) {
+	// create another user for this test
+	// so it doesn't interfere with the other tests
+	orgUser := suite.userBuilder(context.Background(), t)
+	patClient := suite.setupPatClient(orgUser, t)
+	tokenClient := suite.setupAPITokenClient(orgUser.UserCtx, t)
 
-	parentOrg, err := suite.client.api.GetOrganizationByID(testUser1.UserCtx, testUser1.OrganizationID)
-	require.NoError(t, err)
+	parentOrg, err := suite.client.api.GetOrganizationByID(orgUser.UserCtx, orgUser.OrganizationID)
+	assert.NilError(t, err)
 
 	// setup deleted org
-	orgToDelete := (&OrganizationBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	orgToDelete := (&OrganizationBuilder{client: suite.client}).MustNew(orgUser.UserCtx, t)
 	// delete said org
-	(&Cleanup[*generated.OrganizationDeleteOne]{client: suite.client.db.Organization, ID: orgToDelete.ID}).MustDelete(testUser1.UserCtx, suite)
+	(&Cleanup[*generated.OrganizationDeleteOne]{client: suite.client.db.Organization, ID: orgToDelete.ID}).MustDelete(orgUser.UserCtx, t)
 
 	// avatar file setup
 	avatarFile, err := objects.NewUploadFile("testdata/uploads/logo.png")
-	require.NoError(t, err)
+	assert.NilError(t, err)
 
 	invalidAvatarFile, err := objects.NewUploadFile("testdata/uploads/hello.txt")
-	require.NoError(t, err)
+	assert.NilError(t, err)
 
 	testCases := []struct {
 		name                     string
@@ -156,7 +176,7 @@ func (suite *GraphTestSuite) TestMutationCreateOrganization() {
 		parentOrgID              string
 		avatarFile               *graphql.Upload
 		settings                 *openlaneclient.CreateOrganizationSettingInput
-		client                   *openlaneclient.OpenlaneClient
+		client                   openlaneclient.OpenlaneClient
 		ctx                      context.Context
 		expectedDefaultOrgUpdate bool
 		errorMsg                 string
@@ -169,7 +189,7 @@ func (suite *GraphTestSuite) TestMutationCreateOrganization() {
 			expectedDefaultOrgUpdate: true, // only the first org created should update the default org
 			parentOrgID:              "",   // root org
 			client:                   suite.client.api,
-			ctx:                      testUser1.UserCtx,
+			ctx:                      orgUser.UserCtx,
 		},
 		{
 			name:           "happy path organization with settings and avatar",
@@ -195,15 +215,15 @@ func (suite *GraphTestSuite) TestMutationCreateOrganization() {
 			},
 			parentOrgID: "", // root org
 			client:      suite.client.api,
-			ctx:         testUser1.UserCtx,
+			ctx:         orgUser.UserCtx,
 		},
 		{
 			name:           "happy path organization with parent org",
 			orgName:        gofakeit.Name(),
 			orgDescription: gofakeit.HipsterSentence(10),
-			parentOrgID:    testUser1.OrganizationID,
+			parentOrgID:    orgUser.OrganizationID,
 			client:         suite.client.api,
-			ctx:            testUser1.UserCtx,
+			ctx:            orgUser.UserCtx,
 		},
 		{
 			name:           "organization with parent org, no access",
@@ -211,15 +231,15 @@ func (suite *GraphTestSuite) TestMutationCreateOrganization() {
 			orgDescription: gofakeit.HipsterSentence(10),
 			parentOrgID:    testUser2.OrganizationID,
 			client:         suite.client.api,
-			ctx:            testUser1.UserCtx,
+			ctx:            orgUser.UserCtx,
 			errorMsg:       notAuthorizedErrorMsg,
 		},
 		{
 			name:           "organization with parent org using personal access token, not allowed",
 			orgName:        gofakeit.Name(),
 			orgDescription: gofakeit.HipsterSentence(10),
-			parentOrgID:    testUser1.OrganizationID,
-			client:         suite.client.apiWithPAT,
+			parentOrgID:    orgUser.OrganizationID,
+			client:         *patClient,
 			ctx:            context.Background(),
 			errorMsg:       graphapi.ErrResourceNotAccessibleWithToken.Error(),
 		},
@@ -228,7 +248,7 @@ func (suite *GraphTestSuite) TestMutationCreateOrganization() {
 			orgName:        gofakeit.Name(),
 			orgDescription: gofakeit.HipsterSentence(10),
 			parentOrgID:    testUser2.OrganizationID,
-			client:         suite.client.apiWithPAT,
+			client:         *patClient,
 			ctx:            context.Background(),
 			errorMsg:       graphapi.ErrResourceNotAccessibleWithToken.Error(),
 		},
@@ -236,7 +256,7 @@ func (suite *GraphTestSuite) TestMutationCreateOrganization() {
 			name:           "organization create with api token not allowed",
 			orgName:        gofakeit.Name(),
 			orgDescription: gofakeit.HipsterSentence(10),
-			client:         suite.client.apiWithToken,
+			client:         *tokenClient,
 			ctx:            context.Background(),
 			errorMsg:       graphapi.ErrResourceNotAccessibleWithToken.Error(),
 		},
@@ -244,10 +264,10 @@ func (suite *GraphTestSuite) TestMutationCreateOrganization() {
 			name:           "organization with parent personal org",
 			orgName:        gofakeit.Name(),
 			orgDescription: gofakeit.HipsterSentence(10),
-			parentOrgID:    testUser1.PersonalOrgID,
+			parentOrgID:    orgUser.PersonalOrgID,
 			errorMsg:       "personal organizations are not allowed to have child organizations",
 			client:         suite.client.api,
-			ctx:            testUser1.UserCtx,
+			ctx:            orgUser.UserCtx,
 		},
 		{
 			name:           "empty organization name",
@@ -255,7 +275,7 @@ func (suite *GraphTestSuite) TestMutationCreateOrganization() {
 			orgDescription: gofakeit.HipsterSentence(10),
 			errorMsg:       "value is less than the required length",
 			client:         suite.client.api,
-			ctx:            testUser1.UserCtx,
+			ctx:            orgUser.UserCtx,
 		},
 		{
 			name:           "long organization name",
@@ -263,15 +283,15 @@ func (suite *GraphTestSuite) TestMutationCreateOrganization() {
 			orgDescription: gofakeit.HipsterSentence(10),
 			errorMsg:       "value is greater than the required length",
 			client:         suite.client.api,
-			ctx:            testUser1.UserCtx,
+			ctx:            orgUser.UserCtx,
 		},
 		{
 			name:           "organization with no description",
 			orgName:        gofakeit.Name(),
 			orgDescription: "",
-			parentOrgID:    testUser1.OrganizationID,
+			parentOrgID:    orgUser.OrganizationID,
 			client:         suite.client.api,
-			ctx:            testUser1.UserCtx,
+			ctx:            orgUser.UserCtx,
 		},
 		{
 			name:           "duplicate organization name",
@@ -279,7 +299,7 @@ func (suite *GraphTestSuite) TestMutationCreateOrganization() {
 			orgDescription: gofakeit.HipsterSentence(10),
 			errorMsg:       "already exists",
 			client:         suite.client.api,
-			ctx:            testUser1.UserCtx,
+			ctx:            orgUser.UserCtx,
 		},
 		{
 			name:           "duplicate organization name, case insensitive",
@@ -287,21 +307,21 @@ func (suite *GraphTestSuite) TestMutationCreateOrganization() {
 			orgDescription: gofakeit.HipsterSentence(10),
 			errorMsg:       "already exists",
 			client:         suite.client.api,
-			ctx:            testUser1.UserCtx,
+			ctx:            orgUser.UserCtx,
 		},
 		{
 			name:           "duplicate organization name, but other was deleted, should pass",
 			orgName:        orgToDelete.Name,
 			orgDescription: gofakeit.HipsterSentence(10),
 			client:         suite.client.api,
-			ctx:            testUser1.UserCtx,
+			ctx:            orgUser.UserCtx,
 		},
 		{
 			name:           "organization name with trailing space should work with trailing space removed",
 			orgName:        "orgname ",
 			orgDescription: gofakeit.HipsterSentence(10),
 			client:         suite.client.api,
-			ctx:            testUser1.UserCtx,
+			ctx:            orgUser.UserCtx,
 		},
 		{
 			name:           "invalid organization name, too short",
@@ -309,7 +329,7 @@ func (suite *GraphTestSuite) TestMutationCreateOrganization() {
 			orgDescription: gofakeit.HipsterSentence(10),
 			errorMsg:       "value is less than the required length",
 			client:         suite.client.api,
-			ctx:            testUser1.UserCtx,
+			ctx:            orgUser.UserCtx,
 		},
 		{
 
@@ -318,7 +338,7 @@ func (suite *GraphTestSuite) TestMutationCreateOrganization() {
 			orgDescription: gofakeit.HipsterSentence(10),
 			errorMsg:       "invalid or unparsable field: name, field cannot contain special characters",
 			client:         suite.client.api,
-			ctx:            testUser1.UserCtx,
+			ctx:            orgUser.UserCtx,
 		},
 		{
 			name:           "duplicate display name, should be allowed",
@@ -326,7 +346,7 @@ func (suite *GraphTestSuite) TestMutationCreateOrganization() {
 			displayName:    parentOrg.Organization.DisplayName,
 			orgDescription: gofakeit.HipsterSentence(10),
 			client:         suite.client.api,
-			ctx:            testUser1.UserCtx,
+			ctx:            orgUser.UserCtx,
 		},
 		{
 			name:           "display name with spaces should pass",
@@ -334,7 +354,7 @@ func (suite *GraphTestSuite) TestMutationCreateOrganization() {
 			displayName:    gofakeit.Sentence(3),
 			orgDescription: gofakeit.HipsterSentence(10),
 			client:         suite.client.api,
-			ctx:            testUser1.UserCtx,
+			ctx:            orgUser.UserCtx,
 		},
 		{
 			name:    "invalid avatar file",
@@ -346,7 +366,7 @@ func (suite *GraphTestSuite) TestMutationCreateOrganization() {
 				ContentType: invalidAvatarFile.ContentType,
 			},
 			client:   suite.client.api,
-			ctx:      testUser1.UserCtx,
+			ctx:      orgUser.UserCtx,
 			errorMsg: "unsupported mime type uploaded: text/plain",
 		},
 		{
@@ -356,7 +376,7 @@ func (suite *GraphTestSuite) TestMutationCreateOrganization() {
 				AllowedEmailDomains: []string{"theopenlane"},
 			},
 			client:   suite.client.api,
-			ctx:      testUser1.UserCtx,
+			ctx:      orgUser.UserCtx,
 			errorMsg: "invalid or unparsable field: domains",
 		},
 		{
@@ -366,7 +386,7 @@ func (suite *GraphTestSuite) TestMutationCreateOrganization() {
 				Domains: []string{"theopenlane"},
 			},
 			client:   suite.client.api,
-			ctx:      testUser1.UserCtx,
+			ctx:      orgUser.UserCtx,
 			errorMsg: "invalid or unparsable field: domains",
 		},
 	}
@@ -401,73 +421,71 @@ func (suite *GraphTestSuite) TestMutationCreateOrganization() {
 			resp, err := tc.client.CreateOrganization(tc.ctx, input, tc.avatarFile)
 
 			if tc.errorMsg != "" {
-				require.Error(t, err)
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.NotNil(t, resp.CreateOrganization.Organization)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
 			// Make sure provided values match
-			assert.Equal(t, strings.TrimSpace(tc.orgName), resp.CreateOrganization.Organization.Name)
-			assert.Equal(t, tc.orgDescription, *resp.CreateOrganization.Organization.Description)
+			assert.Check(t, is.Equal(strings.TrimSpace(tc.orgName), resp.CreateOrganization.Organization.Name))
+			assert.Check(t, is.Equal(tc.orgDescription, *resp.CreateOrganization.Organization.Description))
 
 			if tc.parentOrgID == "" {
-				assert.Nil(t, resp.CreateOrganization.Organization.Parent)
+				assert.Check(t, is.Nil(resp.CreateOrganization.Organization.Parent))
 			} else {
 				parent := resp.CreateOrganization.Organization.GetParent()
-				assert.Equal(t, tc.parentOrgID, parent.ID)
+				assert.Check(t, is.Equal(tc.parentOrgID, parent.ID))
 			}
 
 			// Ensure org settings is not null
-			assert.NotNil(t, resp.CreateOrganization.Organization.Setting.ID)
+			assert.Check(t, resp.CreateOrganization.Organization.Setting.ID != "")
 
 			// Ensure display name is not empty
-			assert.NotEmpty(t, resp.CreateOrganization.Organization.DisplayName)
+			assert.Check(t, len(resp.CreateOrganization.Organization.DisplayName) != 0)
 
 			// Ensure avatar file is not empty
 			if tc.avatarFile != nil {
-				assert.NotNil(t, resp.CreateOrganization.Organization.AvatarLocalFileID)
-				assert.NotNil(t, resp.CreateOrganization.Organization.AvatarFile.PresignedURL)
+				assert.Check(t, resp.CreateOrganization.Organization.AvatarLocalFileID != nil)
+				assert.Check(t, resp.CreateOrganization.Organization.AvatarFile.PresignedURL != nil)
 			}
 
 			if tc.settings != nil {
-				assert.Len(t, resp.CreateOrganization.Organization.Setting.Domains, 1)
+				assert.Check(t, is.Len(resp.CreateOrganization.Organization.Setting.Domains, 1))
 
 				// make sure default org is updated if it's the first org created
-				userResp, err := tc.client.GetUserByID(tc.ctx, testUser1.ID)
-				require.NoError(t, err)
+				userResp, err := tc.client.GetUserByID(tc.ctx, orgUser.ID)
+				assert.NilError(t, err)
 
 				if tc.expectedDefaultOrgUpdate {
-					assert.Equal(t, resp.CreateOrganization.Organization.ID, userResp.User.Setting.DefaultOrg.ID)
+					assert.Check(t, is.Equal(resp.CreateOrganization.Organization.ID, userResp.User.Setting.DefaultOrg.ID))
 				} else {
-					assert.NotEqual(t, resp.CreateOrganization.Organization.ID, userResp.User.Setting.DefaultOrg.ID)
+					assert.Check(t, resp.CreateOrganization.Organization.ID != userResp.User.Setting.DefaultOrg.ID)
 				}
 
 				if tc.settings.BillingAddress != nil {
-					assert.Equal(t, tc.settings.BillingAddress.Line1, resp.CreateOrganization.Organization.Setting.BillingAddress.Line1)
-					assert.Equal(t, tc.settings.BillingAddress.City, resp.CreateOrganization.Organization.Setting.BillingAddress.City)
-					assert.Equal(t, tc.settings.BillingAddress.State, resp.CreateOrganization.Organization.Setting.BillingAddress.State)
-					assert.Equal(t, tc.settings.BillingAddress.PostalCode, resp.CreateOrganization.Organization.Setting.BillingAddress.PostalCode)
-					assert.Equal(t, tc.settings.BillingAddress.Country, resp.CreateOrganization.Organization.Setting.BillingAddress.Country)
+					assert.Check(t, is.Equal(tc.settings.BillingAddress.Line1, resp.CreateOrganization.Organization.Setting.BillingAddress.Line1))
+					assert.Check(t, is.Equal(tc.settings.BillingAddress.City, resp.CreateOrganization.Organization.Setting.BillingAddress.City))
+					assert.Check(t, is.Equal(tc.settings.BillingAddress.State, resp.CreateOrganization.Organization.Setting.BillingAddress.State))
+					assert.Check(t, is.Equal(tc.settings.BillingAddress.PostalCode, resp.CreateOrganization.Organization.Setting.BillingAddress.PostalCode))
+					assert.Check(t, is.Equal(tc.settings.BillingAddress.Country, resp.CreateOrganization.Organization.Setting.BillingAddress.Country))
 				}
 			}
 
 			// ensure entity types are created
-			newCtx := auth.NewTestContextWithOrgID(testUser1.ID, resp.CreateOrganization.Organization.ID)
+			newCtx := auth.NewTestContextWithOrgID(orgUser.ID, resp.CreateOrganization.Organization.ID)
 
 			et, err := suite.client.api.GetEntityTypes(newCtx, &openlaneclient.EntityTypeWhereInput{
 				OwnerID: &resp.CreateOrganization.Organization.ID,
 			})
-			require.NoError(t, err)
+			assert.NilError(t, err)
 
-			require.Len(t, et.EntityTypes.Edges, 1)
-			assert.Equal(t, "vendor", et.EntityTypes.Edges[0].Node.Name)
-			assert.Equal(t, resp.CreateOrganization.Organization.ID, *et.EntityTypes.Edges[0].Node.OwnerID)
+			assert.Assert(t, is.Len(et.EntityTypes.Edges, 1))
+			assert.Check(t, is.Equal("vendor", et.EntityTypes.Edges[0].Node.Name))
+			assert.Check(t, is.Equal(resp.CreateOrganization.Organization.ID, *et.EntityTypes.Edges[0].Node.OwnerID))
 
 			// ensure managed groups are created
 			managedGroups, err := suite.client.api.GetGroups(newCtx, &openlaneclient.GroupWhereInput{
@@ -475,26 +493,28 @@ func (suite *GraphTestSuite) TestMutationCreateOrganization() {
 			})
 
 			// admins, viewers, all users should be created
-			require.Len(t, managedGroups.Groups.Edges, 3)
+			assert.Check(t, is.Len(managedGroups.Groups.Edges, 3))
 
 			// cleanup org
-			(&Cleanup[*generated.OrganizationDeleteOne]{client: suite.client.db.Organization, ID: resp.CreateOrganization.Organization.ID}).MustDelete(testUser1.UserCtx, suite)
+			(&Cleanup[*generated.OrganizationDeleteOne]{client: suite.client.db.Organization, ID: resp.CreateOrganization.Organization.ID}).MustDelete(orgUser.UserCtx, t)
 		})
 	}
 }
 
-func (suite *GraphTestSuite) TestMutationUpdateOrganization() {
-	t := suite.T()
+func TestMutationUpdateOrganization(t *testing.T) {
+	// create another user for this test
+	// so it doesn't interfere with the other tests
+	orgUser := suite.userBuilder(context.Background(), t)
 
 	nameUpdate := gofakeit.Name()
 	displayNameUpdate := gofakeit.LetterN(40)
 	descriptionUpdate := gofakeit.HipsterSentence(10)
 	nameUpdateLong := gofakeit.LetterN(200)
 
-	org := (&OrganizationBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
-	user1 := (&UserBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	org := (&OrganizationBuilder{client: suite.client}).MustNew(orgUser.UserCtx, t)
+	user1 := (&UserBuilder{client: suite.client}).MustNew(orgUser.UserCtx, t)
 
-	reqCtx := auth.NewTestContextWithOrgID(testUser1.ID, org.ID)
+	reqCtx := auth.NewTestContextWithOrgID(orgUser.ID, org.ID)
 
 	// create groups for creator permissions tests and add a member
 	// group created by org owner
@@ -507,22 +527,22 @@ func (suite *GraphTestSuite) TestMutationUpdateOrganization() {
 	(&GroupMemberBuilder{client: suite.client, GroupID: groupProcedureCreators.ID}).MustNew(reqCtx, t)
 
 	// add a member to the org, to test permissions
-	om := (&OrgMemberBuilder{client: suite.client, Role: string(enums.RoleMember)}).MustNew(reqCtx, t)
+	om := (&OrgMemberBuilder{client: suite.client}).MustNew(reqCtx, t)
 	memberUserCtx := auth.NewTestContextWithOrgID(om.UserID, org.ID)
 
 	// avatar file setup
 	avatarFile, err := objects.NewUploadFile("testdata/uploads/logo.png")
-	require.NoError(t, err)
+	assert.NilError(t, err)
 
 	invalidAvatarFile, err := objects.NewUploadFile("testdata/uploads/hello.txt")
-	require.NoError(t, err)
+	assert.NilError(t, err)
 
 	testCases := []struct {
 		name        string
 		orgID       string
 		updateInput openlaneclient.UpdateOrganizationInput
 		avatarFile  *graphql.Upload
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedRes openlaneclient.UpdateOrganization_UpdateOrganization_Organization
 		errorMsg    string
@@ -722,12 +742,12 @@ func (suite *GraphTestSuite) TestMutationUpdateOrganization() {
 		},
 		{
 			name:  "update name, no access",
-			orgID: viewOnlyUser.OrganizationID,
+			orgID: org.ID,
 			updateInput: openlaneclient.UpdateOrganizationInput{
 				Name: &nameUpdate,
 			},
 			client:   suite.client.api,
-			ctx:      viewOnlyUser.UserCtx,
+			ctx:      memberUserCtx,
 			errorMsg: notAuthorizedErrorMsg,
 		},
 		{
@@ -755,61 +775,59 @@ func (suite *GraphTestSuite) TestMutationUpdateOrganization() {
 			resp, err := tc.client.UpdateOrganization(tc.ctx, tc.orgID, tc.updateInput, tc.avatarFile)
 
 			if tc.errorMsg != "" {
-				require.Error(t, err)
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.NotNil(t, resp.UpdateOrganization.Organization)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
 			// Make sure provided values match
 			updatedOrg := resp.GetUpdateOrganization().Organization
-			assert.Equal(t, tc.expectedRes.Name, updatedOrg.Name)
-			assert.Equal(t, tc.expectedRes.DisplayName, updatedOrg.DisplayName)
-			assert.Equal(t, tc.expectedRes.Description, updatedOrg.Description)
+			assert.Check(t, is.Equal(tc.expectedRes.Name, updatedOrg.Name))
+			assert.Check(t, is.Equal(tc.expectedRes.DisplayName, updatedOrg.DisplayName))
+			assert.Check(t, is.DeepEqual(tc.expectedRes.Description, updatedOrg.Description))
 
 			if tc.updateInput.AddOrgMembers != nil {
 				// Adding a member to an org will make it 3 users, there is an owner
 				// assigned to the org automatically and an another member added in the test and
 				// 3 created as part of the group member logic
-				assert.Len(t, updatedOrg.Members.Edges, 6)
-				assert.Equal(t, tc.expectedRes.Members.Edges[0].Node.Role, updatedOrg.Members.Edges[5].Node.Role)
-				assert.Equal(t, tc.expectedRes.Members.Edges[0].Node.UserID, updatedOrg.Members.Edges[5].Node.UserID)
+				assert.Check(t, is.Len(updatedOrg.Members.Edges, 6))
+				assert.Check(t, is.Equal(tc.expectedRes.Members.Edges[0].Node.Role, updatedOrg.Members.Edges[5].Node.Role))
+				assert.Check(t, is.Equal(tc.expectedRes.Members.Edges[0].Node.UserID, updatedOrg.Members.Edges[5].Node.UserID))
 			}
 
 			if tc.updateInput.UpdateOrgSettings != nil {
-				assert.Len(t, updatedOrg.GetSetting().Domains, 2)
+				assert.Check(t, is.Len(updatedOrg.GetSetting().Domains, 2))
 			}
 
 			if tc.avatarFile != nil {
-				assert.NotNil(t, updatedOrg.AvatarLocalFileID)
-				assert.NotNil(t, updatedOrg.AvatarFile.PresignedURL)
+				assert.Check(t, updatedOrg.AvatarLocalFileID != nil)
+				assert.Check(t, updatedOrg.AvatarFile.PresignedURL != nil)
 			}
 		})
 	}
 
-	(&Cleanup[*generated.OrganizationDeleteOne]{client: suite.client.db.Organization, ID: org.ID}).MustDelete(reqCtx, suite)
-	(&Cleanup[*generated.UserDeleteOne]{client: suite.client.db.User, ID: user1.ID}).MustDelete(reqCtx, suite)
+	(&Cleanup[*generated.OrganizationDeleteOne]{client: suite.client.db.Organization, ID: org.ID}).MustDelete(reqCtx, t)
+	(&Cleanup[*generated.UserDeleteOne]{client: suite.client.db.User, ID: user1.ID}).MustDelete(reqCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationDeleteOrganization() {
-	t := suite.T()
+func TestMutationDeleteOrganization(t *testing.T) {
+	// create another user for this test
+	// so it doesn't interfere with the other tests
+	orgUser := suite.userBuilder(context.Background(), t)
 
-	org := (&OrganizationBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	reqCtx := orgUser.UserCtx
 
-	reqCtx := auth.NewTestContextWithOrgID(testUser1.ID, org.ID)
-
-	setting, err := suite.client.api.UpdateUserSetting(reqCtx, testUser1.UserInfo.Edges.Setting.ID,
+	setting, err := suite.client.api.UpdateUserSetting(reqCtx, orgUser.UserInfo.Edges.Setting.ID,
 		openlaneclient.UpdateUserSettingInput{
-			DefaultOrgID: &org.ID,
+			DefaultOrgID: &orgUser.OrganizationID,
 		},
 	)
-	require.NoError(t, err)
-	require.Equal(t, org.ID, setting.UpdateUserSetting.UserSetting.DefaultOrg.ID)
+	assert.NilError(t, err)
+	assert.Equal(t, orgUser.OrganizationID, setting.UpdateUserSetting.UserSetting.DefaultOrg.ID)
 
 	testCases := []struct {
 		name     string
@@ -825,25 +843,25 @@ func (suite *GraphTestSuite) TestMutationDeleteOrganization() {
 		},
 		{
 			name:     "delete org, not found",
-			orgID:    org.ID,
+			orgID:    orgUser.OrganizationID,
 			ctx:      testUser2.UserCtx,
 			errorMsg: notFoundErrorMsg,
 		},
 		{
 			name:  "delete org, happy path",
-			orgID: org.ID,
-			ctx:   testUser1.UserCtx,
+			orgID: orgUser.OrganizationID,
+			ctx:   orgUser.UserCtx,
 		},
 		{
 			name:     "delete org, personal org not allowed",
-			orgID:    testUser1.PersonalOrgID,
-			ctx:      testUser1.UserCtx,
+			orgID:    orgUser.PersonalOrgID,
+			ctx:      orgUser.UserCtx,
 			errorMsg: "cannot delete personal organizations",
 		},
 		{
 			name:     "delete org, not found",
 			orgID:    "tacos-tuesday",
-			ctx:      testUser1.UserCtx,
+			ctx:      orgUser.UserCtx,
 			errorMsg: notFoundErrorMsg,
 		},
 	}
@@ -853,33 +871,33 @@ func (suite *GraphTestSuite) TestMutationDeleteOrganization() {
 			resp, err := suite.client.api.DeleteOrganization(tc.ctx, tc.orgID)
 
 			if tc.errorMsg != "" {
-				require.Error(t, err)
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.NotNil(t, resp.DeleteOrganization.DeletedID)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Assert(t, resp.DeleteOrganization.DeletedID != "")
 
 			// make sure the deletedID matches the ID we wanted to delete
-			assert.Equal(t, tc.orgID, resp.DeleteOrganization.DeletedID)
+			assert.Check(t, is.Equal(tc.orgID, resp.DeleteOrganization.DeletedID))
 
 			// update the context to have the correct org after the org is deleted
-			reqCtx := auth.NewTestContextWithOrgID(testUser1.ID, testUser1.OrganizationID)
+			reqCtx := auth.NewTestContextWithOrgID(orgUser.ID, orgUser.OrganizationID)
 
 			// make sure the default org is reset
-			settingUpdated, err := suite.client.api.GetUserSettingByID(reqCtx, testUser1.UserInfo.Edges.Setting.ID)
-			require.NoError(t, err)
-			require.NotNil(t, settingUpdated.UserSetting.DefaultOrg)
-			assert.NotEqual(t, org.ID, settingUpdated.UserSetting.DefaultOrg.ID)
+			settingUpdated, err := suite.client.api.GetUserSettingByID(reqCtx, orgUser.UserInfo.Edges.Setting.ID)
+			assert.NilError(t, err)
+			assert.Assert(t, settingUpdated.UserSetting.DefaultOrg != nil)
+			assert.Check(t, orgUser.OrganizationID != settingUpdated.UserSetting.DefaultOrg.ID)
 
-			o, err := suite.client.api.GetOrganizationByID(reqCtx, tc.orgID)
+			// allow ctx to ensure the org no longer exists after deletion
+			allowCtx := ent.NewContext(rule.WithInternalContext(reqCtx), suite.client.db)
 
-			require.Nil(t, o)
-			require.Error(t, err)
+			o, err := suite.client.api.GetOrganizationByID(allowCtx, tc.orgID)
+			assert.Assert(t, is.Nil(o))
 			assert.ErrorContains(t, err, notFoundErrorMsg)
 
 			// tuples and entity are deleted, so we need to skip soft delete and privacy checks
@@ -887,20 +905,22 @@ func (suite *GraphTestSuite) TestMutationDeleteOrganization() {
 			ctx = privacy.DecisionContext(ctx, privacy.Allow)
 
 			o, err = suite.client.api.GetOrganizationByID(ctx, tc.orgID)
-			require.NoError(t, err)
-			require.NotNil(t, o)
+			assert.NilError(t, err)
+			assert.Assert(t, o != nil)
 
-			require.Equal(t, o.Organization.ID, tc.orgID)
+			assert.Equal(t, o.Organization.ID, tc.orgID)
 		})
 	}
 }
 
-func (suite *GraphTestSuite) TestMutationOrganizationCascadeDelete() {
-	t := suite.T()
+func TestMutationOrganizationCascadeDelete(t *testing.T) {
+	// create another user for this test
+	// so it doesn't interfere with the other tests
+	orgUser := suite.userBuilder(context.Background(), t)
 
-	org := (&OrganizationBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	org := (&OrganizationBuilder{client: suite.client}).MustNew(orgUser.UserCtx, t)
 
-	reqCtx := auth.NewTestContextWithOrgID(testUser1.ID, org.ID)
+	reqCtx := auth.NewTestContextWithOrgID(orgUser.ID, org.ID)
 	group1 := (&GroupBuilder{client: suite.client}).MustNew(reqCtx, t)
 
 	// add child org
@@ -909,29 +929,26 @@ func (suite *GraphTestSuite) TestMutationOrganizationCascadeDelete() {
 	// delete org
 	resp, err := suite.client.api.DeleteOrganization(reqCtx, org.ID)
 
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-	require.NotNil(t, resp.DeleteOrganization.DeletedID)
+	assert.NilError(t, err)
+	assert.Assert(t, resp != nil)
+	assert.Assert(t, resp.DeleteOrganization.DeletedID != "")
 
 	// make sure the deletedID matches the ID we wanted to delete
-	assert.Equal(t, org.ID, resp.DeleteOrganization.DeletedID)
+	assert.Check(t, is.Equal(org.ID, resp.DeleteOrganization.DeletedID))
 
 	o, err := suite.client.api.GetOrganizationByID(reqCtx, org.ID)
 
-	require.Nil(t, o)
-	require.Error(t, err)
+	assert.Assert(t, is.Nil(o))
 	assert.ErrorContains(t, err, notFoundErrorMsg)
 
 	co, err := suite.client.api.GetOrganizationByID(reqCtx, childOrg.ID)
 
-	require.Nil(t, co)
-	require.Error(t, err)
+	assert.Assert(t, is.Nil(co))
 	assert.ErrorContains(t, err, notFoundErrorMsg)
 
 	g, err := suite.client.api.GetGroupByID(reqCtx, group1.ID)
 
-	require.Nil(t, g)
-	require.Error(t, err)
+	assert.Assert(t, is.Nil(g))
 	assert.ErrorContains(t, err, notFoundErrorMsg)
 
 	// allow after tuples have been deleted
@@ -940,15 +957,15 @@ func (suite *GraphTestSuite) TestMutationOrganizationCascadeDelete() {
 
 	o, err = suite.client.api.GetOrganizationByID(ctx, org.ID)
 
-	require.NoError(t, err)
-	require.Equal(t, o.Organization.ID, org.ID)
+	assert.NilError(t, err)
+	assert.Equal(t, o.Organization.ID, org.ID)
 
 	// allow after tuples have been deleted
 	ctx = privacy.DecisionContext(ctx, privacy.Allow)
 	ctx = entx.SkipSoftDelete(ctx)
 
 	co, err = suite.client.api.GetOrganizationByID(ctx, childOrg.ID)
-	require.NoError(t, err)
+	assert.NilError(t, err)
 
-	require.Equal(t, co.Organization.ID, childOrg.ID)
+	assert.Equal(t, co.Organization.ID, childOrg.ID)
 }

--- a/internal/graphapi/orgmembers_test.go
+++ b/internal/graphapi/orgmembers_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestQueryOrgMembers(t *testing.T) {
+	t.Parallel()
+
 	testOrgMemberUser := suite.userBuilder(context.Background(), t)
 	org1Member := (&OrgMemberBuilder{client: suite.client}).MustNew(testOrgMemberUser.UserCtx, t)
 
@@ -218,7 +220,6 @@ func TestMutationCreateOrgMembers(t *testing.T) {
 			resp, err := suite.client.api.AddUserToOrgWithRole(tc.ctx, input)
 
 			if tc.errMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errMsg)
 
 				return
@@ -301,7 +302,6 @@ func TestMutationUpdateOrgMembers(t *testing.T) {
 			resp, err := suite.client.api.UpdateUserRoleInOrg(testUser1.UserCtx, tc.orgMemberID, input)
 
 			if tc.errMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errMsg)
 
 				return

--- a/internal/graphapi/orgmembers_test.go
+++ b/internal/graphapi/orgmembers_test.go
@@ -31,7 +31,7 @@ func TestQueryOrgMembers(t *testing.T) {
 	testCases := []struct {
 		name        string
 		queryID     string
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedLen int
 		expectErr   bool

--- a/internal/graphapi/personalaccesstoken_test.go
+++ b/internal/graphapi/personalaccesstoken_test.go
@@ -7,17 +7,16 @@ import (
 
 	"github.com/brianvoe/gofakeit/v7"
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 
+	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/pkg/openlaneclient"
 
 	"github.com/theopenlane/core/pkg/testutils"
 )
 
-func (suite *GraphTestSuite) TestQueryPersonalAccessToken() {
-	t := suite.T()
-
+func TestQueryPersonalAccessToken(t *testing.T) {
 	token := (&PersonalAccessTokenBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	testCases := []struct {
@@ -50,29 +49,32 @@ func (suite *GraphTestSuite) TestQueryPersonalAccessToken() {
 			resp, err := suite.client.api.GetPersonalAccessTokenByID(tc.ctx, tc.queryID)
 
 			if tc.errorMsg != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.NotNil(t, resp.PersonalAccessToken)
-			assert.Equal(t, redacted, resp.PersonalAccessToken.Token)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Check(t, is.Equal(redacted, resp.PersonalAccessToken.Token))
 		})
 	}
+
+	// cleanup
+	(*&Cleanup[*generated.PersonalAccessTokenDeleteOne]{
+		client: suite.client.db.PersonalAccessToken,
+		ID:     token.ID,
+	}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestQueryPersonalAccessTokens() {
-	t := suite.T()
-
+func TestQueryPersonalAccessTokens(t *testing.T) {
 	(&PersonalAccessTokenBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	(&PersonalAccessTokenBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	// create a token for another user
-	(&PersonalAccessTokenBuilder{client: suite.client}).MustNew(testUser2.UserCtx, t)
+	(&PersonalAccessTokenBuilder{client: suite.client, OrganizationIDs: []string{testUser2.OrganizationID}}).MustNew(testUser2.UserCtx, t)
 
 	testCases := []struct {
 		name     string
@@ -88,24 +90,21 @@ func (suite *GraphTestSuite) TestQueryPersonalAccessTokens() {
 			resp, err := suite.client.api.GetAllPersonalAccessTokens(testUser1.UserCtx)
 
 			if tc.errorMsg != "" {
-				require.Error(t, err)
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
-			assert.Len(t, resp.PersonalAccessTokens.Edges, 3) // there is an additional token from the seed test data for this user
+			assert.Check(t, is.Len(resp.PersonalAccessTokens.Edges, 3)) // there is an additional token from the seed test data for this user
 		})
 	}
 }
 
-func (suite *GraphTestSuite) TestMutationCreatePersonalAccessToken() {
-	t := suite.T()
-
+func TestMutationCreatePersonalAccessToken(t *testing.T) {
 	tokenDescription := gofakeit.Sentence(5)
 	expiration30Days := time.Now().Add(time.Hour * 24 * 30)
 
@@ -165,52 +164,54 @@ func (suite *GraphTestSuite) TestMutationCreatePersonalAccessToken() {
 			resp, err := suite.client.api.CreatePersonalAccessToken(testUser1.UserCtx, tc.input)
 
 			if tc.errorMsg != "" {
-				require.Error(t, err)
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.NotNil(t, resp.CreatePersonalAccessToken.PersonalAccessToken)
-			assert.Equal(t, resp.CreatePersonalAccessToken.PersonalAccessToken.Name, tc.input.Name)
-			assert.Equal(t, resp.CreatePersonalAccessToken.PersonalAccessToken.Description, tc.input.Description)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Check(t, is.Equal(resp.CreatePersonalAccessToken.PersonalAccessToken.Name, tc.input.Name))
+			assert.Check(t, is.DeepEqual(resp.CreatePersonalAccessToken.PersonalAccessToken.Description, tc.input.Description))
 
 			// check expiration if set
 			if tc.input.ExpiresAt == nil {
-				assert.Empty(t, resp.CreatePersonalAccessToken.PersonalAccessToken.ExpiresAt)
+				assert.Check(t, resp.CreatePersonalAccessToken.PersonalAccessToken.ExpiresAt == nil)
 			} else {
-				assert.True(t, tc.input.ExpiresAt.Equal(*resp.CreatePersonalAccessToken.PersonalAccessToken.ExpiresAt))
+				assert.Check(t, tc.input.ExpiresAt.Equal(*resp.CreatePersonalAccessToken.PersonalAccessToken.ExpiresAt))
 			}
 
 			// check organization is set if provided
 			if tc.input.OrganizationIDs != nil {
-				assert.Len(t, resp.CreatePersonalAccessToken.PersonalAccessToken.Organizations.Edges, len(tc.input.OrganizationIDs))
+				assert.Check(t, is.Len(resp.CreatePersonalAccessToken.PersonalAccessToken.Organizations.Edges, len(tc.input.OrganizationIDs)))
 
 				for _, orgID := range resp.CreatePersonalAccessToken.PersonalAccessToken.Organizations.Edges {
-					assert.Contains(t, tc.input.OrganizationIDs, orgID.Node.ID)
+					assert.Check(t, is.Contains(tc.input.OrganizationIDs, orgID.Node.ID))
 				}
 			} else {
-				assert.Len(t, resp.CreatePersonalAccessToken.PersonalAccessToken.Organizations.Edges, 0)
+				assert.Check(t, is.Len(resp.CreatePersonalAccessToken.PersonalAccessToken.Organizations.Edges, 0))
 			}
 
 			// ensure the owner is the user that made the request
-			assert.Equal(t, testUser1.ID, resp.CreatePersonalAccessToken.PersonalAccessToken.Owner.ID)
+			assert.Check(t, is.Equal(testUser1.ID, resp.CreatePersonalAccessToken.PersonalAccessToken.Owner.ID))
 
 			// token should not be redacted on create
-			assert.NotEqual(t, redacted, resp.CreatePersonalAccessToken.PersonalAccessToken.Token)
+			assert.Check(t, redacted != resp.CreatePersonalAccessToken.PersonalAccessToken.Token)
 
 			// ensure the token is prefixed
-			assert.Contains(t, resp.CreatePersonalAccessToken.PersonalAccessToken.Token, "tolp_")
+			assert.Check(t, is.Contains(resp.CreatePersonalAccessToken.PersonalAccessToken.Token, "tolp_"))
+
+			// cleanup
+			(*&Cleanup[*generated.PersonalAccessTokenDeleteOne]{
+				client: suite.client.db.PersonalAccessToken,
+				ID:     resp.CreatePersonalAccessToken.PersonalAccessToken.ID,
+			}).MustDelete(testUser1.UserCtx, t)
 		})
 	}
 }
 
-func (suite *GraphTestSuite) TestMutationUpdatePersonalAccessToken() {
-	t := suite.T()
-
+func TestMutationUpdatePersonalAccessToken(t *testing.T) {
 	token := (&PersonalAccessTokenBuilder{
 		client:          suite.client,
 		OrganizationIDs: []string{testUser1.PersonalOrgID},
@@ -218,7 +219,7 @@ func (suite *GraphTestSuite) TestMutationUpdatePersonalAccessToken() {
 		MustNew(testUser1.UserCtx, t)
 
 	tokenOther := (&PersonalAccessTokenBuilder{
-		client: suite.client}).
+		client: suite.client, OrganizationIDs: []string{testUser2.OrganizationID}}).
 		MustNew(testUser2.UserCtx, t)
 
 	tokenDescription := gofakeit.Sentence(5)
@@ -281,54 +282,62 @@ func (suite *GraphTestSuite) TestMutationUpdatePersonalAccessToken() {
 			resp, err := suite.client.api.UpdatePersonalAccessToken(testUser1.UserCtx, tc.tokenID, tc.input)
 
 			if tc.errorMsg != "" {
-				require.Error(t, err)
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.NotNil(t, resp.UpdatePersonalAccessToken.PersonalAccessToken)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
 			if tc.input.Name != nil {
-				assert.Equal(t, resp.UpdatePersonalAccessToken.PersonalAccessToken.Name, *tc.input.Name)
+				assert.Check(t, is.Equal(resp.UpdatePersonalAccessToken.PersonalAccessToken.Name, *tc.input.Name))
 			}
 
 			if tc.input.Description != nil {
-				assert.Equal(t, resp.UpdatePersonalAccessToken.PersonalAccessToken.Description, tc.input.Description)
+				assert.Check(t, is.DeepEqual(resp.UpdatePersonalAccessToken.PersonalAccessToken.Description, tc.input.Description))
 			}
 
 			// make sure these fields did not get updated
 			if token.ExpiresAt != nil {
-				assert.WithinDuration(t, *token.ExpiresAt, *resp.UpdatePersonalAccessToken.PersonalAccessToken.ExpiresAt, 1*time.Second)
+				assert.Assert(t, resp.UpdatePersonalAccessToken.PersonalAccessToken.ExpiresAt != nil)
+				diff := resp.UpdatePersonalAccessToken.PersonalAccessToken.ExpiresAt.Sub(*token.ExpiresAt)
+				assert.Check(t, diff >= -1*time.Second && diff <= 1*time.Second, "time difference is not within 1 second, got %v", diff)
 			} else {
-				assert.Empty(t, resp.UpdatePersonalAccessToken.PersonalAccessToken.ExpiresAt)
+				assert.Check(t, resp.UpdatePersonalAccessToken.PersonalAccessToken.ExpiresAt == nil)
 			}
 
-			assert.Len(t, resp.UpdatePersonalAccessToken.PersonalAccessToken.Organizations.Edges, len(tc.input.AddOrganizationIDs)+1)
+			assert.Check(t, is.Len(resp.UpdatePersonalAccessToken.PersonalAccessToken.Organizations.Edges, len(tc.input.AddOrganizationIDs)+1))
 
 			// Ensure its removed
 			if tc.input.RemoveOrganizationIDs != nil {
-				assert.Len(t, resp.UpdatePersonalAccessToken.PersonalAccessToken.Organizations.Edges, 1)
+				assert.Check(t, is.Len(resp.UpdatePersonalAccessToken.PersonalAccessToken.Organizations.Edges, 1))
 			}
 
-			assert.Equal(t, testUser1.ID, resp.UpdatePersonalAccessToken.PersonalAccessToken.Owner.ID)
+			assert.Check(t, is.Equal(testUser1.ID, resp.UpdatePersonalAccessToken.PersonalAccessToken.Owner.ID))
 
 			// token should be redacted on update
-			assert.Equal(t, redacted, resp.UpdatePersonalAccessToken.PersonalAccessToken.Token)
+			assert.Check(t, is.Equal(redacted, resp.UpdatePersonalAccessToken.PersonalAccessToken.Token))
 		})
 	}
+
+	// cleanup
+	(*&Cleanup[*generated.PersonalAccessTokenDeleteOne]{
+		client: suite.client.db.PersonalAccessToken,
+		ID:     token.ID,
+	}).MustDelete(testUser1.UserCtx, t)
+	(*&Cleanup[*generated.PersonalAccessTokenDeleteOne]{
+		client: suite.client.db.PersonalAccessToken,
+		ID:     tokenOther.ID,
+	}).MustDelete(testUser2.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationDeletePersonalAccessToken() {
-	t := suite.T()
-
+func TestMutationDeletePersonalAccessToken(t *testing.T) {
 	token := (&PersonalAccessTokenBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	// token for another user
-	tokenOther := (&PersonalAccessTokenBuilder{client: suite.client}).MustNew(testUser2.UserCtx, t)
+	tokenOther := (&PersonalAccessTokenBuilder{client: suite.client, OrganizationIDs: []string{testUser2.OrganizationID}}).MustNew(testUser2.UserCtx, t)
 
 	testCases := []struct {
 		name     string
@@ -351,30 +360,33 @@ func (suite *GraphTestSuite) TestMutationDeletePersonalAccessToken() {
 			resp, err := suite.client.api.DeletePersonalAccessToken(testUser1.UserCtx, tc.tokenID)
 
 			if tc.errorMsg != "" {
-				require.Error(t, err)
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.Equal(t, tc.tokenID, resp.DeletePersonalAccessToken.DeletedID)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Equal(t, tc.tokenID, resp.DeletePersonalAccessToken.DeletedID)
 		})
 	}
+
+	// cleanup
+	(*&Cleanup[*generated.PersonalAccessTokenDeleteOne]{
+		client: suite.client.db.PersonalAccessToken,
+		ID:     tokenOther.ID,
+	}).MustDelete(testUser2.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestLastUsedPersonalAccessToken() {
-	t := suite.T()
-
+func TestLastUsedPersonalAccessToken(t *testing.T) {
 	// create new personal access token
 	token := (&PersonalAccessTokenBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	// check that the last used is empty
 	res, err := suite.client.api.GetPersonalAccessTokenByID(testUser1.UserCtx, token.ID)
-	require.NoError(t, err)
-	assert.Empty(t, res.PersonalAccessToken.LastUsedAt)
+	assert.NilError(t, err)
+	assert.Check(t, res.PersonalAccessToken.LastUsedAt == nil)
 
 	// setup graph client using the personal access token
 	authHeader := openlaneclient.Authorization{
@@ -382,10 +394,16 @@ func (suite *GraphTestSuite) TestLastUsedPersonalAccessToken() {
 	}
 
 	graphClient, err := testutils.TestClientWithAuth(suite.client.db, suite.client.objectStore, openlaneclient.WithCredentials(authHeader))
-	require.NoError(t, err)
+	assert.NilError(t, err)
 
 	// get the token to make sure the last used is updated using the token
 	out, err := graphClient.GetPersonalAccessTokenByID(context.Background(), token.ID)
-	require.NoError(t, err)
-	assert.NotEmpty(t, out.PersonalAccessToken.LastUsedAt)
+	assert.NilError(t, err)
+	assert.Check(t, !out.PersonalAccessToken.LastUsedAt.IsZero())
+
+	// cleanup
+	(*&Cleanup[*generated.PersonalAccessTokenDeleteOne]{
+		client: suite.client.db.PersonalAccessToken,
+		ID:     token.ID,
+	}).MustDelete(testUser1.UserCtx, t)
 }

--- a/internal/graphapi/personalaccesstoken_test.go
+++ b/internal/graphapi/personalaccesstoken_test.go
@@ -49,7 +49,6 @@ func TestQueryPersonalAccessToken(t *testing.T) {
 			resp, err := suite.client.api.GetPersonalAccessTokenByID(tc.ctx, tc.queryID)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 

--- a/internal/graphapi/procedure_test.go
+++ b/internal/graphapi/procedure_test.go
@@ -24,7 +24,7 @@ func TestQueryProcedure(t *testing.T) {
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   openlaneclient.OpenlaneClient
+		client   *openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{
@@ -96,7 +96,7 @@ func TestQueryProcedures(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		client          openlaneclient.OpenlaneClient
+		client          *openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int
 	}{
@@ -160,7 +160,7 @@ func TestMutationCreateProcedure(t *testing.T) {
 		name          string
 		request       openlaneclient.CreateProcedureInput
 		addGroupToOrg bool
-		client        openlaneclient.OpenlaneClient
+		client        *openlaneclient.OpenlaneClient
 		ctx           context.Context
 		expectedErr   string
 	}{
@@ -382,7 +382,7 @@ func TestMutationUpdateProcedure(t *testing.T) {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.UpdateProcedureInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -559,7 +559,7 @@ func TestMutationDeleteProcedure(t *testing.T) {
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{

--- a/internal/graphapi/procedure_test.go
+++ b/internal/graphapi/procedure_test.go
@@ -500,7 +500,6 @@ func TestMutationUpdateProcedure(t *testing.T) {
 		t.Run("Update "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.UpdateProcedure(tc.ctx, procedure.ID, tc.request)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 
@@ -603,7 +602,6 @@ func TestMutationDeleteProcedure(t *testing.T) {
 		t.Run("Delete "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.DeleteProcedure(tc.ctx, tc.idToDelete)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 

--- a/internal/graphapi/program_test.go
+++ b/internal/graphapi/program_test.go
@@ -21,7 +21,7 @@ func TestQueryProgram(t *testing.T) {
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   openlaneclient.OpenlaneClient
+		client   *openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{
@@ -104,7 +104,7 @@ func TestQueryPrograms(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		client          openlaneclient.OpenlaneClient
+		client          *openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int
 		errorMsg        string
@@ -222,7 +222,7 @@ func TestMutationCreateProgram(t *testing.T) {
 		name          string
 		request       openlaneclient.CreateProgramInput
 		addGroupToOrg bool
-		client        openlaneclient.OpenlaneClient
+		client        *openlaneclient.OpenlaneClient
 		ctx           context.Context
 		expectedErr   string
 	}{
@@ -582,7 +582,7 @@ func TestMutationUpdateProgram(t *testing.T) {
 	testCases := []struct {
 		name              string
 		request           openlaneclient.UpdateProgramInput
-		client            openlaneclient.OpenlaneClient
+		client            *openlaneclient.OpenlaneClient
 		ctx               context.Context
 		expectedErr       string
 		expectedEdgeCount int
@@ -869,7 +869,7 @@ func TestMutationDeleteProgram(t *testing.T) {
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{

--- a/internal/graphapi/program_test.go
+++ b/internal/graphapi/program_test.go
@@ -6,23 +6,22 @@ import (
 	"time"
 
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/openlaneclient"
 	"github.com/theopenlane/utils/ulids"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
-func (suite *GraphTestSuite) TestQueryProgram() {
-	t := suite.T()
-
+func TestQueryProgram(t *testing.T) {
 	// create program with a linked procedure and policy
 	program := (&ProgramBuilder{client: suite.client, WithProcedure: true, WithPolicy: true}).MustNew(testUser1.UserCtx, t)
 
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   *openlaneclient.OpenlaneClient
+		client   openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{
@@ -59,40 +58,53 @@ func (suite *GraphTestSuite) TestQueryProgram() {
 			resp, err := tc.client.GetProgramByID(tc.ctx, tc.queryID)
 
 			if tc.errorMsg != "" {
-				require.Error(t, err)
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
-			assert.Equal(t, program.ID, resp.Program.ID)
-			assert.Equal(t, program.Name, resp.Program.Name)
-			assert.Len(t, resp.Program.Procedures.Edges, 1)
-			assert.Len(t, resp.Program.InternalPolicies.Edges, 1)
+			assert.Check(t, is.Equal(program.ID, resp.Program.ID))
+			assert.Check(t, is.Equal(program.Name, resp.Program.Name))
+			assert.Check(t, is.Len(resp.Program.Procedures.Edges, 1))
+			assert.Check(t, is.Len(resp.Program.InternalPolicies.Edges, 1))
 		})
 	}
+
+	// cleanup
+	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, ID: program.ID}).MustDelete(testUser1.UserCtx, t)
+	// cleanup procedure and policy
+	procedureIDs := []string{}
+	for _, p := range program.Edges.Procedures {
+		procedureIDs = append(procedureIDs, p.ID)
+	}
+	policyIDs := []string{}
+	for _, p := range program.Edges.InternalPolicies {
+		policyIDs = append(policyIDs, p.ID)
+	}
+
+	(&Cleanup[*generated.ProcedureDeleteOne]{client: suite.client.db.Procedure, IDs: procedureIDs}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.InternalPolicyDeleteOne]{client: suite.client.db.InternalPolicy, IDs: policyIDs}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestQueryPrograms() {
-	t := suite.T()
-
+func TestQueryPrograms(t *testing.T) {
 	// programs for the first organization with a linked procedure and policy
-	(&ProgramBuilder{client: suite.client, WithProcedure: true, WithPolicy: true}).MustNew(testUser1.UserCtx, t)
-	(&ProgramBuilder{client: suite.client, WithProcedure: true, WithPolicy: true}).MustNew(testUser1.UserCtx, t)
+	program1 := (&ProgramBuilder{client: suite.client, WithProcedure: true, WithPolicy: true}).MustNew(testUser1.UserCtx, t)
+	program2 := (&ProgramBuilder{client: suite.client, WithProcedure: true, WithPolicy: true}).MustNew(testUser1.UserCtx, t)
 
 	// program created by an admin user of the first organization with a linked procedure and policy
-	(&ProgramBuilder{client: suite.client, WithProcedure: true, WithPolicy: true}).MustNew(adminUser.UserCtx, t)
+	program3 := (&ProgramBuilder{client: suite.client, WithProcedure: true, WithPolicy: true}).MustNew(adminUser.UserCtx, t)
 
 	// program for the other organization with a linked procedure and policy
-	(&ProgramBuilder{client: suite.client, WithProcedure: true, WithPolicy: true}).MustNew(testUser2.UserCtx, t)
+	anotherUser := suite.userBuilder(context.Background(), t)
+	program4 := (&ProgramBuilder{client: suite.client, WithProcedure: true, WithPolicy: true}).MustNew(anotherUser.UserCtx, t)
 
 	testCases := []struct {
 		name            string
-		client          *openlaneclient.OpenlaneClient
+		client          openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int
 		errorMsg        string
@@ -124,7 +136,7 @@ func (suite *GraphTestSuite) TestQueryPrograms() {
 		{
 			name:            "owner of the other organization should see the program they created",
 			client:          suite.client.api,
-			ctx:             testUser2.UserCtx,
+			ctx:             anotherUser.UserCtx,
 			expectedResults: 1,
 		},
 	}
@@ -134,29 +146,64 @@ func (suite *GraphTestSuite) TestQueryPrograms() {
 			resp, err := tc.client.GetAllPrograms(tc.ctx)
 
 			if tc.errorMsg != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			assert.Len(t, resp.Programs.Edges, tc.expectedResults)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Check(t, is.Len(resp.Programs.Edges, tc.expectedResults))
 
 			for _, edge := range resp.Programs.Edges {
-				require.NotNil(t, edge.Node)
-				assert.Len(t, edge.Node.Procedures.Edges, 1)
-				assert.Len(t, edge.Node.InternalPolicies.Edges, 1)
+				assert.Assert(t, edge.Node != nil)
+				assert.Check(t, is.Len(edge.Node.Procedures.Edges, 1))
+				assert.Check(t, is.Len(edge.Node.InternalPolicies.Edges, 1))
 			}
 		})
 	}
+
+	// cleanup
+	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, IDs: []string{program1.ID, program2.ID, program3.ID}}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, ID: program4.ID}).MustDelete(anotherUser.UserCtx, t)
+
+	// cleanup procedures and policies
+	procedureIDs := []string{}
+	for _, p := range program1.Edges.Procedures {
+		procedureIDs = append(procedureIDs, p.ID)
+	}
+
+	for _, p := range program2.Edges.Procedures {
+		procedureIDs = append(procedureIDs, p.ID)
+	}
+
+	for _, p := range program3.Edges.Procedures {
+		procedureIDs = append(procedureIDs, p.ID)
+	}
+
+	policyIDs := []string{}
+	for _, p := range program1.Edges.InternalPolicies {
+		policyIDs = append(policyIDs, p.ID)
+	}
+
+	for _, p := range program2.Edges.InternalPolicies {
+		policyIDs = append(policyIDs, p.ID)
+	}
+
+	for _, p := range program3.Edges.InternalPolicies {
+		policyIDs = append(policyIDs, p.ID)
+	}
+
+	(&Cleanup[*generated.ProcedureDeleteOne]{client: suite.client.db.Procedure, IDs: procedureIDs}).MustDelete(testUser1.UserCtx, t)
+
+	(&Cleanup[*generated.InternalPolicyDeleteOne]{client: suite.client.db.InternalPolicy, IDs: policyIDs}).MustDelete(testUser1.UserCtx, t)
+
+	// we can ignore the cleanup for the new user, it won't conflict with other tests
 }
 
-func (suite *GraphTestSuite) TestMutationCreateProgram() {
-	t := suite.T()
-
+func TestMutationCreateProgram(t *testing.T) {
 	startDate := time.Now().AddDate(0, 0, 1)
 	endDate := time.Now().AddDate(0, 0, 360)
 
@@ -165,6 +212,7 @@ func (suite *GraphTestSuite) TestMutationCreateProgram() {
 	// Create some edge objects
 	procedure := (&ProcedureBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	policy := (&InternalPolicyBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+
 	blockedGroup := (&GroupBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	viewerGroup := (&GroupBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
@@ -175,7 +223,7 @@ func (suite *GraphTestSuite) TestMutationCreateProgram() {
 		name          string
 		request       openlaneclient.CreateProgramInput
 		addGroupToOrg bool
-		client        *openlaneclient.OpenlaneClient
+		client        openlaneclient.OpenlaneClient
 		ctx           context.Context
 		expectedErr   string
 	}{
@@ -277,7 +325,7 @@ func (suite *GraphTestSuite) TestMutationCreateProgram() {
 			ctx:           viewOnlyUser.UserCtx,
 		},
 		{
-			name: "user not authorized, no permissions",
+			name: "user not authorized, no permissions, owner id set to correct org",
 			request: openlaneclient.CreateProgramInput{
 				Name:    "mitb program",
 				OwnerID: &testUser1.OrganizationID,
@@ -313,154 +361,168 @@ func (suite *GraphTestSuite) TestMutationCreateProgram() {
 					openlaneclient.UpdateOrganizationInput{
 						AddProgramCreatorIDs: []string{groupMember.GroupID},
 					}, nil)
-				require.NoError(t, err)
+				assert.NilError(t, err)
 			}
 
 			resp, err := tc.client.CreateProgram(tc.ctx, tc.request)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
 			// check required fields
-			assert.Equal(t, tc.request.Name, resp.CreateProgram.Program.Name)
+			assert.Check(t, is.Equal(tc.request.Name, resp.CreateProgram.Program.Name))
 
-			assert.NotEmpty(t, resp.CreateProgram.Program.DisplayID)
-			assert.Contains(t, resp.CreateProgram.Program.DisplayID, "PRG-")
+			assert.Check(t, len(resp.CreateProgram.Program.DisplayID) != 0)
+			assert.Check(t, is.Contains(resp.CreateProgram.Program.DisplayID, "PRG-"))
 
 			// ensure the owner is set to the user's organization, not the  input
 			if tc.request.OwnerID != nil && tc.ctx == testUser2.UserCtx {
-				assert.Equal(t, testUser2.OrganizationID, *resp.CreateProgram.Program.OwnerID)
+				assert.Check(t, is.Equal(testUser2.OrganizationID, *resp.CreateProgram.Program.OwnerID))
 			}
 
 			// check optional fields
 			if tc.request.Description == nil {
-				assert.Empty(t, resp.CreateProgram.Program.Description)
+				assert.Check(t, is.Len(*resp.CreateProgram.Program.Description, 0))
 			} else {
-				assert.Equal(t, tc.request.Description, resp.CreateProgram.Program.Description)
+				assert.Check(t, is.Equal(*tc.request.Description, *resp.CreateProgram.Program.Description))
 			}
 
 			if tc.request.ProgramType == nil {
-				assert.Equal(t, enums.ProgramTypeFramework, resp.CreateProgram.Program.ProgramType)
+				assert.Check(t, is.Equal(enums.ProgramTypeFramework, resp.CreateProgram.Program.ProgramType))
 			} else {
-				assert.Equal(t, *tc.request.ProgramType, resp.CreateProgram.Program.ProgramType)
+				assert.Check(t, is.Equal(*tc.request.ProgramType, resp.CreateProgram.Program.ProgramType))
 			}
 
 			if tc.request.FrameworkName == nil {
-				assert.Empty(t, resp.CreateProgram.Program.FrameworkName)
+				assert.Check(t, is.Len(*resp.CreateProgram.Program.FrameworkName, 0))
 			} else {
-				assert.Equal(t, tc.request.FrameworkName, resp.CreateProgram.Program.FrameworkName)
+				assert.Check(t, is.Equal(*tc.request.FrameworkName, *resp.CreateProgram.Program.FrameworkName))
 			}
 
 			if tc.request.Status == nil {
-				assert.Equal(t, enums.ProgramStatusNotStarted, resp.CreateProgram.Program.Status)
+				assert.Check(t, is.Equal(enums.ProgramStatusNotStarted, resp.CreateProgram.Program.Status))
 			} else {
-				assert.Equal(t, *tc.request.Status, resp.CreateProgram.Program.Status)
+				assert.Check(t, is.Equal(*tc.request.Status, resp.CreateProgram.Program.Status))
 			}
 
 			if tc.request.StartDate == nil {
-				assert.Empty(t, resp.CreateProgram.Program.StartDate)
+				assert.Check(t, resp.CreateProgram.Program.StartDate == nil)
 			} else {
-				assert.WithinDuration(t, startDate, *resp.CreateProgram.Program.StartDate, 2*time.Minute)
+				assert.Assert(t, resp.CreateProgram.Program.StartDate != nil)
+				diff := resp.CreateProgram.Program.StartDate.Sub(startDate)
+				assert.Check(t, diff >= -2*time.Minute && diff <= 2*time.Minute, "time difference is not within 2 minutes")
 			}
 
 			if tc.request.EndDate == nil {
-				assert.Empty(t, resp.CreateProgram.Program.EndDate)
+				assert.Check(t, resp.CreateProgram.Program.EndDate == nil)
 			} else {
-				assert.WithinDuration(t, endDate, *resp.CreateProgram.Program.EndDate, 2*time.Minute)
+				assert.Assert(t, resp.CreateProgram.Program.EndDate != nil)
+				diff := resp.CreateProgram.Program.EndDate.Sub(endDate)
+				assert.Check(t, diff >= -2*time.Minute && diff <= 2*time.Minute, "time difference is not within 2 minutes")
 			}
 
 			if tc.request.AuditorReady == nil {
-				assert.False(t, resp.CreateProgram.Program.AuditorReady)
+				assert.Check(t, !resp.CreateProgram.Program.AuditorReady)
 			} else {
-				assert.Equal(t, *tc.request.AuditorReady, resp.CreateProgram.Program.AuditorReady)
+				assert.Check(t, is.Equal(*tc.request.AuditorReady, resp.CreateProgram.Program.AuditorReady))
 			}
 
 			if tc.request.AuditorWriteComments == nil {
-				assert.False(t, resp.CreateProgram.Program.AuditorWriteComments)
+				assert.Check(t, !resp.CreateProgram.Program.AuditorWriteComments)
 			} else {
-				assert.Equal(t, *tc.request.AuditorWriteComments, resp.CreateProgram.Program.AuditorWriteComments)
+				assert.Check(t, is.Equal(*tc.request.AuditorWriteComments, resp.CreateProgram.Program.AuditorWriteComments))
 			}
 
 			if tc.request.AuditorReadComments == nil {
-				assert.False(t, resp.CreateProgram.Program.AuditorReadComments)
+				assert.Check(t, !resp.CreateProgram.Program.AuditorReadComments)
 			} else {
-				assert.Equal(t, *tc.request.AuditorReadComments, resp.CreateProgram.Program.AuditorReadComments)
+				assert.Check(t, is.Equal(*tc.request.AuditorReadComments, resp.CreateProgram.Program.AuditorReadComments))
 			}
 
 			if tc.request.AuditFirm == nil {
-				assert.Empty(t, resp.CreateProgram.Program.AuditFirm)
+				assert.Check(t, is.Len(*resp.CreateProgram.Program.AuditFirm, 0))
 			} else {
-				assert.Equal(t, tc.request.AuditFirm, resp.CreateProgram.Program.AuditFirm)
+				assert.Check(t, is.Equal(*tc.request.AuditFirm, *resp.CreateProgram.Program.AuditFirm))
 			}
 
 			if tc.request.Auditor == nil {
-				assert.Empty(t, resp.CreateProgram.Program.Auditor)
+				assert.Check(t, is.Len(*resp.CreateProgram.Program.Auditor, 0))
 			} else {
-				assert.Equal(t, tc.request.Auditor, resp.CreateProgram.Program.Auditor)
+				assert.Check(t, is.Equal(*tc.request.Auditor, *resp.CreateProgram.Program.Auditor))
 			}
 
 			if tc.request.AuditorEmail == nil {
-				assert.Empty(t, resp.CreateProgram.Program.AuditorEmail)
+				assert.Check(t, is.Len(*resp.CreateProgram.Program.AuditorEmail, 0))
 			} else {
-				assert.Equal(t, tc.request.AuditorEmail, resp.CreateProgram.Program.AuditorEmail)
+				assert.Check(t, is.Equal(*tc.request.AuditorEmail, *resp.CreateProgram.Program.AuditorEmail))
 			}
 
 			// check edges
 			if len(tc.request.ProcedureIDs) > 0 {
-				require.Len(t, resp.CreateProgram.Program.Procedures.Edges, 1)
+				assert.Assert(t, is.Len(resp.CreateProgram.Program.Procedures.Edges, 1))
 				for _, edge := range resp.CreateProgram.Program.Procedures.Edges {
-					assert.Equal(t, procedure.ID, edge.Node.ID)
+					assert.Check(t, is.Equal(procedure.ID, edge.Node.ID))
 				}
 			}
 
 			if len(tc.request.InternalPolicyIDs) > 0 {
-				require.Len(t, resp.CreateProgram.Program.InternalPolicies.Edges, 1)
+				assert.Assert(t, is.Len(resp.CreateProgram.Program.InternalPolicies.Edges, 1))
 				for _, edge := range resp.CreateProgram.Program.InternalPolicies.Edges {
-					assert.Equal(t, policy.ID, edge.Node.ID)
+					assert.Check(t, is.Equal(policy.ID, edge.Node.ID))
 				}
 			}
 
 			if len(tc.request.EditorIDs) > 0 {
-				require.Len(t, resp.CreateProgram.Program.Editors, 1)
+				assert.Assert(t, is.Len(resp.CreateProgram.Program.Editors, 1))
 				for _, edge := range resp.CreateProgram.Program.Editors {
-					assert.Equal(t, testUser1.GroupID, edge.ID)
+					assert.Check(t, is.Equal(testUser1.GroupID, edge.ID))
 				}
 			}
 
 			if len(tc.request.BlockedGroupIDs) > 0 {
-				require.Len(t, resp.CreateProgram.Program.BlockedGroups, 1)
+				assert.Assert(t, is.Len(resp.CreateProgram.Program.BlockedGroups, 1))
 				for _, edge := range resp.CreateProgram.Program.BlockedGroups {
-					assert.Equal(t, blockedGroup.ID, edge.ID)
+					assert.Check(t, is.Equal(blockedGroup.ID, edge.ID))
 				}
 			}
 
 			if len(tc.request.ViewerIDs) > 0 {
-				require.Len(t, resp.CreateProgram.Program.Viewers, 1)
+				assert.Assert(t, is.Len(resp.CreateProgram.Program.Viewers, 1))
 				for _, edge := range resp.CreateProgram.Program.Viewers {
-					assert.Equal(t, viewerGroup.ID, edge.ID)
+					assert.Check(t, is.Equal(viewerGroup.ID, edge.ID))
 				}
 			}
+
+			// cleanup program
+			if tc.ctx == context.Background() {
+				tc.ctx = testUser1.UserCtx
+			}
+
+			(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, ID: resp.CreateProgram.Program.ID}).MustDelete(tc.ctx, t)
 		})
 	}
+
+	// cleanup policy and procedure
+	(&Cleanup[*generated.ProcedureDeleteOne]{client: suite.client.db.Procedure, ID: procedure.ID}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.InternalPolicyDeleteOne]{client: suite.client.db.InternalPolicy, ID: policy.ID}).MustDelete(testUser1.UserCtx, t)
+	// cleanup group
+	(&Cleanup[*generated.GroupDeleteOne]{client: suite.client.db.Group, IDs: []string{groupMember.GroupID, blockedGroup.ID, viewerGroup.ID}}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.GroupDeleteOne]{client: suite.client.db.Group, ID: anotherGroup.ID}).MustDelete(testUser2.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationUpdateProgram() {
-	t := suite.T()
-
+func TestMutationUpdateProgram(t *testing.T) {
 	program := (&ProgramBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	programMembers, err := suite.client.api.GetProgramMembersByProgramID(testUser1.UserCtx, &openlaneclient.ProgramMembershipWhereInput{
 		ProgramID: &program.ID,
 	})
-
-	require.NoError(t, err)
+	assert.NilError(t, err)
 
 	testUserProgramMemberID := ""
 	for _, pm := range programMembers.ProgramMemberships.Edges {
@@ -470,8 +532,8 @@ func (suite *GraphTestSuite) TestMutationUpdateProgram() {
 	}
 
 	// create program user to remove
-	programUser := suite.userBuilder(context.Background())
-	(&OrgMemberBuilder{client: suite.client, UserID: programUser.ID}).MustNew(testUser1.UserCtx, t)
+	programUser := suite.userBuilder(context.Background(), t)
+	om := (&OrgMemberBuilder{client: suite.client, UserID: programUser.ID}).MustNew(testUser1.UserCtx, t)
 
 	pm := (&ProgramMemberBuilder{client: suite.client, UserID: programUser.ID, ProgramID: program.ID}).MustNew(testUser1.UserCtx, t)
 
@@ -485,43 +547,43 @@ func (suite *GraphTestSuite) TestMutationUpdateProgram() {
 
 	// create another admin user and add them to the same organization and group as testUser1
 	// this will allow us to test the group editor permissions
-	anotherAdminUser := suite.userBuilder(context.Background())
-	suite.addUserToOrganization(testUser1.UserCtx, &anotherAdminUser, enums.RoleAdmin, testUser1.OrganizationID)
+	anotherAdminUser := suite.userBuilder(context.Background(), t)
+	suite.addUserToOrganization(testUser1.UserCtx, t, &anotherAdminUser, enums.RoleAdmin, testUser1.OrganizationID)
 
-	(&GroupMemberBuilder{client: suite.client, UserID: anotherAdminUser.ID, GroupID: testUser1.GroupID}).MustNew(testUser1.UserCtx, t)
+	gm1 := (&GroupMemberBuilder{client: suite.client, UserID: anotherAdminUser.ID, GroupID: testUser1.GroupID}).MustNew(testUser1.UserCtx, t)
 
 	// create a viewer user and add them to the same organization as testUser1
 	// also add them to the same group as testUser1, this should still allow them to edit the policy
 	// despite not not being an organization admin
-	anotherViewerUser := suite.userBuilder(context.Background())
-	suite.addUserToOrganization(testUser1.UserCtx, &anotherViewerUser, enums.RoleMember, testUser1.OrganizationID)
+	anotherViewerUser := suite.userBuilder(context.Background(), t)
+	suite.addUserToOrganization(testUser1.UserCtx, t, &anotherViewerUser, enums.RoleMember, testUser1.OrganizationID)
 
-	(&GroupMemberBuilder{client: suite.client, UserID: anotherViewerUser.ID, GroupID: testUser1.GroupID}).MustNew(testUser1.UserCtx, t)
+	gm2 := (&GroupMemberBuilder{client: suite.client, UserID: anotherViewerUser.ID, GroupID: testUser1.GroupID}).MustNew(testUser1.UserCtx, t)
 
 	// create one more group that will be used to test the blocked group permissions and add anotherViewerUser to it
 	blockGroup := (&GroupBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	(&GroupMemberBuilder{client: suite.client, UserID: anotherViewerUser.ID, GroupID: blockGroup.ID}).MustNew(testUser1.UserCtx, t)
 
 	// create a view only user and add them to the same organization as testUser1
-	meowViewerUser := suite.userBuilder(context.Background())
-	suite.addUserToOrganization(testUser1.UserCtx, &meowViewerUser, enums.RoleMember, testUser1.OrganizationID)
+	meowViewerUser := suite.userBuilder(context.Background(), t)
+	suite.addUserToOrganization(testUser1.UserCtx, t, &meowViewerUser, enums.RoleMember, testUser1.OrganizationID)
 
 	// create one more group that will be used to test the blocked group permissions and add anotherViewerUser to it
 	viewerGroup := (&GroupBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
-	(&GroupMemberBuilder{client: suite.client, UserID: meowViewerUser.ID, GroupID: blockGroup.ID}).MustNew(testUser1.UserCtx, t)
+	gm3 := (&GroupMemberBuilder{client: suite.client, UserID: meowViewerUser.ID, GroupID: blockGroup.ID}).MustNew(testUser1.UserCtx, t)
 
 	// add add user to the viewer group
-	(&GroupMemberBuilder{client: suite.client, UserID: viewOnlyUser.ID, GroupID: viewerGroup.ID}).MustNew(testUser1.UserCtx, t)
+	gm4 := (&GroupMemberBuilder{client: suite.client, UserID: viewOnlyUser.ID, GroupID: viewerGroup.ID}).MustNew(testUser1.UserCtx, t)
 
 	// ensure the user does not currently have access to the program
 	res, err := suite.client.api.GetProgramByID(viewOnlyUser.UserCtx, program.ID)
-	require.Error(t, err)
-	require.Nil(t, res)
+	assert.ErrorContains(t, err, notFoundErrorMsg)
+	assert.Assert(t, is.Nil(res))
 
 	testCases := []struct {
 		name              string
 		request           openlaneclient.UpdateProgramInput
-		client            *openlaneclient.OpenlaneClient
+		client            openlaneclient.OpenlaneClient
 		ctx               context.Context
 		expectedErr       string
 		expectedEdgeCount int
@@ -664,130 +726,144 @@ func (suite *GraphTestSuite) TestMutationUpdateProgram() {
 		t.Run("Update "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.UpdateProgram(tc.ctx, program.ID, tc.request)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
 			// add checks for the updated fields if they were set in the request
 			if tc.request.Description != nil {
-				assert.Equal(t, *tc.request.Description, *resp.UpdateProgram.Program.Description)
+				assert.Check(t, is.Equal(*tc.request.Description, *resp.UpdateProgram.Program.Description))
 			}
 
 			if tc.request.Status != nil {
-				assert.Equal(t, *tc.request.Status, resp.UpdateProgram.Program.Status)
+				assert.Check(t, is.Equal(*tc.request.Status, resp.UpdateProgram.Program.Status))
 			}
 
 			if tc.request.ProgramType != nil {
-				assert.Equal(t, *tc.request.ProgramType, resp.UpdateProgram.Program.ProgramType)
+				assert.Check(t, is.Equal(*tc.request.ProgramType, resp.UpdateProgram.Program.ProgramType))
 			}
 
 			if tc.request.FrameworkName != nil {
-				assert.Equal(t, tc.request.FrameworkName, resp.UpdateProgram.Program.FrameworkName)
+				assert.Check(t, is.DeepEqual(tc.request.FrameworkName, resp.UpdateProgram.Program.FrameworkName))
 			}
 
 			if tc.request.StartDate != nil {
-				assert.WithinDuration(t, *tc.request.StartDate, *resp.UpdateProgram.Program.StartDate, 2*time.Minute)
+				assert.Assert(t, resp.UpdateProgram.Program.StartDate != nil)
+				diff := resp.UpdateProgram.Program.StartDate.Sub(*tc.request.StartDate)
+				assert.Assert(t, diff >= -2*time.Minute && diff <= 2*time.Minute, "time difference is not within 2 minutes")
 			}
 
 			if tc.request.EndDate != nil {
-				assert.WithinDuration(t, *tc.request.EndDate, *resp.UpdateProgram.Program.EndDate, 2*time.Minute)
+				assert.Assert(t, resp.UpdateProgram.Program.EndDate != nil)
+				diff := resp.UpdateProgram.Program.EndDate.Sub(*tc.request.EndDate)
+				assert.Assert(t, diff >= -2*time.Minute && diff <= 2*time.Minute, "time difference is not within 2 minutes")
 			}
 
 			if tc.request.AuditorReady != nil {
-				assert.Equal(t, *tc.request.AuditorReady, resp.UpdateProgram.Program.AuditorReady)
+				assert.Check(t, is.Equal(*tc.request.AuditorReady, resp.UpdateProgram.Program.AuditorReady))
 			}
 
 			if tc.request.AuditorWriteComments != nil {
-				assert.Equal(t, *tc.request.AuditorWriteComments, resp.UpdateProgram.Program.AuditorWriteComments)
+				assert.Check(t, is.Equal(*tc.request.AuditorWriteComments, resp.UpdateProgram.Program.AuditorWriteComments))
 			}
 
 			if tc.request.AuditorReadComments != nil {
-				assert.Equal(t, *tc.request.AuditorReadComments, resp.UpdateProgram.Program.AuditorReadComments)
+				assert.Check(t, is.Equal(*tc.request.AuditorReadComments, resp.UpdateProgram.Program.AuditorReadComments))
 			}
 
 			if tc.request.AuditFirm != nil {
-				assert.Equal(t, tc.request.AuditFirm, resp.UpdateProgram.Program.AuditFirm)
+				assert.Check(t, is.DeepEqual(tc.request.AuditFirm, resp.UpdateProgram.Program.AuditFirm))
 			}
 
 			if tc.request.Auditor != nil {
-				assert.Equal(t, tc.request.Auditor, resp.UpdateProgram.Program.Auditor)
+				assert.Check(t, is.DeepEqual(tc.request.Auditor, resp.UpdateProgram.Program.Auditor))
 			}
 
 			if tc.request.AuditorEmail != nil {
-				assert.Equal(t, tc.request.AuditorEmail, resp.UpdateProgram.Program.AuditorEmail)
+				assert.Check(t, is.DeepEqual(tc.request.AuditorEmail, resp.UpdateProgram.Program.AuditorEmail))
 			}
 
 			// check edges
 			if len(tc.request.AddProcedureIDs) > 0 {
-				require.Len(t, resp.UpdateProgram.Program.Procedures.Edges, 1)
+				assert.Assert(t, is.Len(resp.UpdateProgram.Program.Procedures.Edges, 1))
 				for _, edge := range resp.UpdateProgram.Program.Procedures.Edges {
-					assert.Equal(t, procedure1.ID, edge.Node.ID)
+					assert.Check(t, is.Equal(procedure1.ID, edge.Node.ID))
 				}
 			}
 
 			if len(tc.request.AddInternalPolicyIDs) > 0 {
-				require.Len(t, resp.UpdateProgram.Program.InternalPolicies.Edges, 1)
+				assert.Assert(t, is.Len(resp.UpdateProgram.Program.InternalPolicies.Edges, 1))
 				for _, edge := range resp.UpdateProgram.Program.InternalPolicies.Edges {
-					assert.Equal(t, policy1.ID, edge.Node.ID)
+					assert.Check(t, is.Equal(policy1.ID, edge.Node.ID))
 				}
 			}
 
 			if len(tc.request.AddEditorIDs) > 0 {
-				require.Len(t, resp.UpdateProgram.Program.Editors, 1)
+				assert.Assert(t, is.Len(resp.UpdateProgram.Program.Editors, 1))
 				for _, edge := range resp.UpdateProgram.Program.Editors {
-					assert.Equal(t, testUser1.GroupID, edge.ID)
+					assert.Check(t, is.Equal(testUser1.GroupID, edge.ID))
 				}
 			}
 
 			if len(tc.request.AddBlockedGroupIDs) > 0 {
-				require.Len(t, resp.UpdateProgram.Program.BlockedGroups, 1)
+				assert.Assert(t, is.Len(resp.UpdateProgram.Program.BlockedGroups, 1))
 				for _, edge := range resp.UpdateProgram.Program.BlockedGroups {
-					assert.Equal(t, blockGroup.ID, edge.ID)
+					assert.Check(t, is.Equal(blockGroup.ID, edge.ID))
 				}
 			}
 
 			if len(tc.request.AddViewerIDs) > 0 {
-				require.Len(t, resp.UpdateProgram.Program.Viewers, 1)
+				assert.Assert(t, is.Len(resp.UpdateProgram.Program.Viewers, 1))
 				for _, edge := range resp.UpdateProgram.Program.Viewers {
-					assert.Equal(t, viewerGroup.ID, edge.ID)
+					assert.Check(t, is.Equal(viewerGroup.ID, edge.ID))
 				}
 
 				// ensure the user has access to the program now
 				res, err := suite.client.api.GetProgramByID(viewOnlyUser.UserCtx, program.ID)
-				require.NoError(t, err)
-				require.NotEmpty(t, res)
-				assert.Equal(t, program.ID, res.Program.ID)
+				assert.NilError(t, err)
+				assert.Assert(t, res != nil)
+				assert.Check(t, is.Equal(program.ID, res.Program.ID))
 			}
 
 			if len(tc.request.AddProgramMembers) > 0 {
-				require.Len(t, resp.UpdateProgram.Program.Members.Edges, 3)
+				assert.Assert(t, is.Len(resp.UpdateProgram.Program.Members.Edges, 3))
 
 				// it should have the owner and the admin user and the other user added in the test setup
-				require.Equal(t, testUser1.ID, resp.UpdateProgram.Program.Members.Edges[0].Node.User.ID)
-				require.Equal(t, programUser.ID, resp.UpdateProgram.Program.Members.Edges[1].Node.User.ID)
-				require.Equal(t, adminUser.ID, resp.UpdateProgram.Program.Members.Edges[2].Node.User.ID)
+				assert.Equal(t, testUser1.ID, resp.UpdateProgram.Program.Members.Edges[0].Node.User.ID)
+				assert.Equal(t, programUser.ID, resp.UpdateProgram.Program.Members.Edges[1].Node.User.ID)
+				assert.Equal(t, adminUser.ID, resp.UpdateProgram.Program.Members.Edges[2].Node.User.ID)
 			}
 
 			// member was removed, ensure there are two members left
 			if len(tc.request.RemoveProgramMembers) > 0 {
-				require.Len(t, resp.UpdateProgram.Program.Members.Edges, 2)
+				assert.Assert(t, is.Len(resp.UpdateProgram.Program.Members.Edges, 2))
 
 				// it should have the owner and the admin user
-				require.Equal(t, testUser1.ID, resp.UpdateProgram.Program.Members.Edges[0].Node.User.ID)
+				assert.Equal(t, testUser1.ID, resp.UpdateProgram.Program.Members.Edges[0].Node.User.ID)
 			}
 		})
 	}
+
+	// cleanup program
+	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, ID: program.ID}).MustDelete(testUser1.UserCtx, t)
+	// cleanup policy and procedure
+	(&Cleanup[*generated.ProcedureDeleteOne]{client: suite.client.db.Procedure, ID: procedure1.ID}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.InternalPolicyDeleteOne]{client: suite.client.db.InternalPolicy, ID: policy1.ID}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.ProcedureDeleteOne]{client: suite.client.db.Procedure, ID: procedure2.ID}).MustDelete(testUser2.UserCtx, t)
+	(&Cleanup[*generated.InternalPolicyDeleteOne]{client: suite.client.db.InternalPolicy, ID: policy2.ID}).MustDelete(testUser2.UserCtx, t)
+	// cleanup group
+	(&Cleanup[*generated.GroupDeleteOne]{client: suite.client.db.Group, IDs: []string{blockGroup.ID, viewerGroup.ID}}).MustDelete(testUser1.UserCtx, t)
+	// org member cleanup
+	(&Cleanup[*generated.OrgMembershipDeleteOne]{client: suite.client.db.OrgMembership, IDs: []string{om.ID, gm1.Edges.Orgmembership.ID, gm2.Edges.Orgmembership.ID, gm3.Edges.Orgmembership.ID, gm4.Edges.Orgmembership.ID}}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationDeleteProgram() {
-	t := suite.T()
-
+func TestMutationDeleteProgram(t *testing.T) {
 	// create Programs to be deleted
 	program1 := (&ProgramBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	program2 := (&ProgramBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
@@ -795,7 +871,7 @@ func (suite *GraphTestSuite) TestMutationDeleteProgram() {
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -813,7 +889,7 @@ func (suite *GraphTestSuite) TestMutationDeleteProgram() {
 			ctx:        testUser1.UserCtx,
 		},
 		{
-			name:        "Program already deleted, not found",
+			name:        "program already deleted, not found",
 			idToDelete:  program1.ID,
 			client:      suite.client.api,
 			ctx:         testUser1.UserCtx,
@@ -838,16 +914,15 @@ func (suite *GraphTestSuite) TestMutationDeleteProgram() {
 		t.Run("Delete "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.DeleteProgram(tc.ctx, tc.idToDelete)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			assert.Equal(t, tc.idToDelete, resp.DeleteProgram.DeletedID)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Check(t, is.Equal(tc.idToDelete, resp.DeleteProgram.DeletedID))
 		})
 	}
 }

--- a/internal/graphapi/program_test.go
+++ b/internal/graphapi/program_test.go
@@ -146,7 +146,6 @@ func TestQueryPrograms(t *testing.T) {
 			resp, err := tc.client.GetAllPrograms(tc.ctx)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 
@@ -726,7 +725,6 @@ func TestMutationUpdateProgram(t *testing.T) {
 		t.Run("Update "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.UpdateProgram(tc.ctx, program.ID, tc.request)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 

--- a/internal/graphapi/programextended_test.go
+++ b/internal/graphapi/programextended_test.go
@@ -5,23 +5,27 @@ import (
 	"testing"
 
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/openlaneclient"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
-func (suite *GraphTestSuite) TestMutationCreateProgramWithMembers() {
-	t := suite.T()
+func TestMutationCreateProgramWithMembers(t *testing.T) {
+	// setup a separate user
+	user := suite.userBuilder(context.Background(), t)
+
+	member := (&OrgMemberBuilder{client: suite.client}).MustNew(user.UserCtx, t)
+	admin := (&OrgMemberBuilder{client: suite.client, Role: enums.RoleAdmin.String()}).MustNew(user.UserCtx, t)
 
 	members := []*openlaneclient.CreateMemberWithProgramInput{
 		{
-			UserID: viewOnlyUser.ID,
+			UserID: member.UserID,
 			Role:   &enums.RoleMember,
 		},
 		{
-			UserID: adminUser.ID,
+			UserID: admin.UserID,
 			Role:   &enums.RoleAdmin,
 		},
 	}
@@ -38,7 +42,7 @@ func (suite *GraphTestSuite) TestMutationCreateProgramWithMembers() {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.CreateProgramWithMembersInput
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -63,7 +67,7 @@ func (suite *GraphTestSuite) TestMutationCreateProgramWithMembers() {
 				Members: members,
 			},
 			client: suite.client.api,
-			ctx:    testUser1.UserCtx,
+			ctx:    user.UserCtx,
 		},
 		{
 			name: "happy path, minimal input, no member should work",
@@ -73,7 +77,7 @@ func (suite *GraphTestSuite) TestMutationCreateProgramWithMembers() {
 				},
 			},
 			client: suite.client.api,
-			ctx:    testUser1.UserCtx,
+			ctx:    user.UserCtx,
 		},
 		{
 			name: "happy path, minimal input, nil members should work",
@@ -84,7 +88,7 @@ func (suite *GraphTestSuite) TestMutationCreateProgramWithMembers() {
 				Members: nil,
 			},
 			client: suite.client.api,
-			ctx:    testUser1.UserCtx,
+			ctx:    user.UserCtx,
 		},
 	}
 
@@ -92,43 +96,48 @@ func (suite *GraphTestSuite) TestMutationCreateProgramWithMembers() {
 		t.Run("Create "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.CreateProgramWithMembers(tc.ctx, tc.request)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
 			// check required fields
-			assert.Equal(t, tc.request.Program.Name, resp.CreateProgramWithMembers.Program.Name)
+			assert.Check(t, is.Equal(tc.request.Program.Name, resp.CreateProgramWithMembers.Program.Name))
 
 			// the creator is automatically added as an admin, and the members are added in addition
-			assert.Len(t, resp.CreateProgramWithMembers.Program.Members.Edges, len(tc.request.Members)+1)
+			assert.Check(t, is.Len(resp.CreateProgramWithMembers.Program.Members.Edges, len(tc.request.Members)+1))
 		})
 	}
 
-	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: adminControlIDs}).MustDelete(systemAdminUser.UserCtx, suite)
-	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: publicStandard.ID}).MustDelete(systemAdminUser.UserCtx, suite)
+	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: adminControlIDs}).MustDelete(systemAdminUser.UserCtx, t)
+	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: publicStandard.ID}).MustDelete(systemAdminUser.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationCreateFullProgram() {
-	t := suite.T()
+func TestMutationCreateFullProgram(t *testing.T) {
+	// setup a separate user
+	user := suite.userBuilder(context.Background(), t)
+
+	member := (&OrgMemberBuilder{client: suite.client}).MustNew(user.UserCtx, t)
+	admin := (&OrgMemberBuilder{client: suite.client, Role: enums.RoleAdmin.String()}).MustNew(user.UserCtx, t)
 
 	numControls := 5
 	controlIDs := []string{}
 	for range numControls {
-		control := (&ControlBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+		control := (&ControlBuilder{client: suite.client}).MustNew(user.UserCtx, t)
 		controlIDs = append(controlIDs, control.ID)
 	}
 
-	resp, err := suite.client.api.CreateStandard(testUser1.UserCtx, openlaneclient.CreateStandardInput{
+	resp, err := suite.client.api.CreateStandard(user.UserCtx, openlaneclient.CreateStandardInput{
 		Name:       "Super Awesome Standard",
 		ControlIDs: controlIDs,
 	})
-	require.NoError(t, err)
+	assert.NilError(t, err)
+
+	orgStandard := resp.CreateStandard.Standard
 
 	publicStandard := (&StandardBuilder{client: suite.client, IsPublic: true}).MustNew(systemAdminUser.UserCtx, t)
 
@@ -141,11 +150,11 @@ func (suite *GraphTestSuite) TestMutationCreateFullProgram() {
 
 	members := []*openlaneclient.CreateMemberWithProgramInput{
 		{
-			UserID: viewOnlyUser.ID,
+			UserID: member.UserID,
 			Role:   &enums.RoleMember,
 		},
 		{
-			UserID: adminUser.ID,
+			UserID: admin.UserID,
 			Role:   &enums.RoleAdmin,
 		},
 	}
@@ -153,7 +162,7 @@ func (suite *GraphTestSuite) TestMutationCreateFullProgram() {
 	testCases := []struct {
 		name                 string
 		request              openlaneclient.CreateFullProgramInput
-		client               *openlaneclient.OpenlaneClient
+		client               openlaneclient.OpenlaneClient
 		ctx                  context.Context
 		expectedControlCount int
 		expectedErr          string
@@ -168,7 +177,7 @@ func (suite *GraphTestSuite) TestMutationCreateFullProgram() {
 				StandardID: lo.ToPtr(publicStandard.ID),
 			},
 			client:               suite.client.api,
-			ctx:                  testUser1.UserCtx,
+			ctx:                  user.UserCtx,
 			expectedControlCount: numAdminControls,
 		},
 		{
@@ -178,10 +187,10 @@ func (suite *GraphTestSuite) TestMutationCreateFullProgram() {
 					Name: "test program",
 				},
 				Members:    members,
-				StandardID: lo.ToPtr(resp.CreateStandard.Standard.ID),
+				StandardID: &orgStandard.ID,
 			},
 			client:               suite.client.api,
-			ctx:                  testUser1.UserCtx,
+			ctx:                  user.UserCtx,
 			expectedControlCount: numControls,
 		},
 		{
@@ -229,7 +238,7 @@ func (suite *GraphTestSuite) TestMutationCreateFullProgram() {
 				},
 			},
 			client: suite.client.api,
-			ctx:    testUser1.UserCtx,
+			ctx:    user.UserCtx,
 		},
 	}
 
@@ -237,41 +246,43 @@ func (suite *GraphTestSuite) TestMutationCreateFullProgram() {
 		t.Run("Create "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.CreateFullProgram(tc.ctx, tc.request)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
 			// check required fields
-			assert.Equal(t, tc.request.Program.Name, resp.CreateFullProgram.Program.Name)
+			assert.Check(t, is.Equal(tc.request.Program.Name, resp.CreateFullProgram.Program.Name))
 
 			// the creator is automatically added as an admin, and the members are added in addition
-			assert.Len(t, resp.CreateFullProgram.Program.Members.Edges, len(tc.request.Members)+1)
+			assert.Check(t, is.Len(resp.CreateFullProgram.Program.Members.Edges, len(tc.request.Members)+1))
 
 			if tc.request.StandardID == nil {
-				require.NotNil(t, resp.CreateFullProgram.Program.Controls.Edges)
-				assert.Len(t, resp.CreateFullProgram.Program.Controls.Edges, len(tc.request.Controls))
+				assert.Assert(t, resp.CreateFullProgram.Program.Controls.Edges != nil)
+				assert.Check(t, is.Len(resp.CreateFullProgram.Program.Controls.Edges, len(tc.request.Controls)))
 
-				assert.NotNil(t, resp.CreateFullProgram.Program.Controls.Edges[0].Node.Subcontrols)
-				assert.Equal(t, 2, len(resp.CreateFullProgram.Program.Controls.Edges[0].Node.Subcontrols.Edges))
+				assert.Check(t, resp.CreateFullProgram.Program.Controls.Edges[0].Node.Subcontrols.Edges != nil)
+				assert.Check(t, is.Equal(2, len(resp.CreateFullProgram.Program.Controls.Edges[0].Node.Subcontrols.Edges)))
 			} else {
-				assert.Len(t, resp.CreateFullProgram.Program.Controls.Edges, tc.expectedControlCount)
+				assert.Check(t, is.Len(resp.CreateFullProgram.Program.Controls.Edges, tc.expectedControlCount))
 			}
 
-			require.NotNil(t, resp.CreateFullProgram.Program.Risks.Edges)
-			assert.Len(t, resp.CreateFullProgram.Program.Risks.Edges, len(tc.request.Risks))
+			assert.Assert(t, resp.CreateFullProgram.Program.Risks.Edges != nil)
+			assert.Check(t, is.Len(resp.CreateFullProgram.Program.Risks.Edges, len(tc.request.Risks)))
 
-			require.NotNil(t, resp.CreateFullProgram.Program.InternalPolicies.Edges)
-			assert.Len(t, resp.CreateFullProgram.Program.InternalPolicies.Edges, len(tc.request.InternalPolicies))
+			assert.Assert(t, resp.CreateFullProgram.Program.InternalPolicies.Edges != nil)
+			assert.Check(t, is.Len(resp.CreateFullProgram.Program.InternalPolicies.Edges, len(tc.request.InternalPolicies)))
 		})
 	}
 
-	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: controlIDs}).MustDelete(testUser1.UserCtx, suite)
-	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: adminControlIDs}).MustDelete(systemAdminUser.UserCtx, suite)
-	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: publicStandard.ID}).MustDelete(systemAdminUser.UserCtx, suite)
+	// cleanup seeded input
+	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: controlIDs}).MustDelete(user.UserCtx, t)
+	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: adminControlIDs}).MustDelete(systemAdminUser.UserCtx, t)
+	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: orgStandard.ID}).MustDelete(user.UserCtx, t)
+	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: publicStandard.ID}).MustDelete(systemAdminUser.UserCtx, t)
 }

--- a/internal/graphapi/programextended_test.go
+++ b/internal/graphapi/programextended_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestMutationCreateProgramWithMembers(t *testing.T) {
+	t.Parallel()
+
 	// setup a separate user
 	user := suite.userBuilder(context.Background(), t)
 
@@ -118,6 +120,8 @@ func TestMutationCreateProgramWithMembers(t *testing.T) {
 }
 
 func TestMutationCreateFullProgram(t *testing.T) {
+	t.Parallel()
+
 	// setup a separate user
 	user := suite.userBuilder(context.Background(), t)
 
@@ -246,7 +250,6 @@ func TestMutationCreateFullProgram(t *testing.T) {
 		t.Run("Create "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.CreateFullProgram(tc.ctx, tc.request)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 

--- a/internal/graphapi/programextended_test.go
+++ b/internal/graphapi/programextended_test.go
@@ -53,10 +53,10 @@ func TestMutationCreateProgramWithMembers(t *testing.T) {
 					Name: "mitb program",
 				},
 				Members:    members,
-				StandardID: lo.ToPtr(publicStandard.ID),
+				StandardID: &publicStandard.ID,
 			},
 			client: suite.client.api,
-			ctx:    testUser1.UserCtx,
+			ctx:    user.UserCtx,
 		},
 		{
 			name: "happy path, minimal input",

--- a/internal/graphapi/programextended_test.go
+++ b/internal/graphapi/programextended_test.go
@@ -44,7 +44,7 @@ func TestMutationCreateProgramWithMembers(t *testing.T) {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.CreateProgramWithMembersInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -166,7 +166,7 @@ func TestMutationCreateFullProgram(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		request              openlaneclient.CreateFullProgramInput
-		client               openlaneclient.OpenlaneClient
+		client               *openlaneclient.OpenlaneClient
 		ctx                  context.Context
 		expectedControlCount int
 		expectedErr          string

--- a/internal/graphapi/programmembers_test.go
+++ b/internal/graphapi/programmembers_test.go
@@ -4,15 +4,14 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/openlaneclient"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
-func (suite *GraphTestSuite) TestMutationCreateProgramMembers() {
-	t := suite.T()
-
+func TestMutationCreateProgramMembers(t *testing.T) {
 	program := (&ProgramBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	orgMember1 := (&OrgMemberBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
@@ -24,7 +23,7 @@ func (suite *GraphTestSuite) TestMutationCreateProgramMembers() {
 		programID string
 		userID    string
 		role      enums.Role
-		client    *openlaneclient.OpenlaneClient
+		client    openlaneclient.OpenlaneClient
 		ctx       context.Context
 		errMsg    string
 	}{
@@ -121,32 +120,34 @@ func (suite *GraphTestSuite) TestMutationCreateProgramMembers() {
 			resp, err := tc.client.AddUserToProgramWithRole(tc.ctx, input)
 
 			if tc.errMsg != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.errMsg)
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.NotNil(t, resp.CreateProgramMembership)
-			assert.Equal(t, tc.userID, resp.CreateProgramMembership.ProgramMembership.UserID)
-			assert.Equal(t, tc.programID, resp.CreateProgramMembership.ProgramMembership.ProgramID)
-			assert.Equal(t, tc.role, resp.CreateProgramMembership.ProgramMembership.Role)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Check(t, is.Equal(tc.userID, resp.CreateProgramMembership.ProgramMembership.UserID))
+			assert.Check(t, is.Equal(tc.programID, resp.CreateProgramMembership.ProgramMembership.ProgramID))
+			assert.Check(t, is.Equal(tc.role, resp.CreateProgramMembership.ProgramMembership.Role))
 		})
 	}
+
+	// cleanup program
+	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, ID: program.ID}).MustDelete(testUser1.UserCtx, t)
+	// cleanup org members
+	(&Cleanup[*generated.OrgMembershipDeleteOne]{client: suite.client.db.OrgMembership, IDs: []string{orgMember1.ID, orgMember2.ID, orgMember3.ID}}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationUpdateProgramMembers() {
-	t := suite.T()
-
+func TestMutationUpdateProgramMembers(t *testing.T) {
 	pm := (&ProgramMemberBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	// get all program members so we know the id of the test user program member
 	programMembers, err := suite.client.api.GetProgramMembersByProgramID(testUser1.UserCtx, &openlaneclient.ProgramMembershipWhereInput{
 		ProgramID: &pm.ProgramID,
 	})
-	require.NoError(t, err)
+	assert.NilError(t, err)
 
 	testUser1ProgramMember := ""
 	for _, pm := range programMembers.ProgramMemberships.Edges {
@@ -160,7 +161,7 @@ func (suite *GraphTestSuite) TestMutationUpdateProgramMembers() {
 		name            string
 		programMemberID string
 		role            enums.Role
-		client          *openlaneclient.OpenlaneClient
+		client          openlaneclient.OpenlaneClient
 		ctx             context.Context
 		errMsg          string
 	}{
@@ -212,18 +213,21 @@ func (suite *GraphTestSuite) TestMutationUpdateProgramMembers() {
 			}
 
 			resp, err := tc.client.UpdateUserRoleInProgram(tc.ctx, tc.programMemberID, input)
-
 			if tc.errMsg != "" {
-				require.Error(t, err)
 				assert.ErrorContains(t, err, tc.errMsg)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.NotNil(t, resp.UpdateProgramMembership)
-			assert.Equal(t, tc.role, resp.UpdateProgramMembership.ProgramMembership.Role)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Check(t, is.Equal(tc.role, resp.UpdateProgramMembership.ProgramMembership.Role))
 		})
 	}
+
+	// cleanup program
+	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, ID: pm.ProgramID}).MustDelete(testUser1.UserCtx, t)
+	// cleanup org members
+	(&Cleanup[*generated.OrgMembershipDeleteOne]{client: suite.client.db.OrgMembership, IDs: []string{pm.Edges.Orgmembership.ID}}).MustDelete(testUser1.UserCtx, t)
 }

--- a/internal/graphapi/programmembers_test.go
+++ b/internal/graphapi/programmembers_test.go
@@ -23,7 +23,7 @@ func TestMutationCreateProgramMembers(t *testing.T) {
 		programID string
 		userID    string
 		role      enums.Role
-		client    openlaneclient.OpenlaneClient
+		client    *openlaneclient.OpenlaneClient
 		ctx       context.Context
 		errMsg    string
 	}{
@@ -160,7 +160,7 @@ func TestMutationUpdateProgramMembers(t *testing.T) {
 		name            string
 		programMemberID string
 		role            enums.Role
-		client          openlaneclient.OpenlaneClient
+		client          *openlaneclient.OpenlaneClient
 		ctx             context.Context
 		errMsg          string
 	}{

--- a/internal/graphapi/programmembers_test.go
+++ b/internal/graphapi/programmembers_test.go
@@ -120,7 +120,6 @@ func TestMutationCreateProgramMembers(t *testing.T) {
 			resp, err := tc.client.AddUserToProgramWithRole(tc.ctx, input)
 
 			if tc.errMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errMsg)
 
 				return

--- a/internal/graphapi/query/entity.graphql
+++ b/internal/graphapi/query/entity.graphql
@@ -17,6 +17,7 @@ mutation CreateBulkCSVEntity($input: Upload!) {
         }
       }
       entityType {
+        id
         name
       }
       id
@@ -48,6 +49,7 @@ mutation CreateBulkEntity($input: [CreateEntityInput!]) {
         }
       }
       entityType {
+        id
         name
       }
       id
@@ -79,6 +81,7 @@ mutation CreateEntity($input: CreateEntityInput!) {
         }
       }
       entityType {
+        id
         name
       }
       id
@@ -117,6 +120,7 @@ query GetAllEntities {
           }
         }
         entityType {
+          id
           name
         }
         id
@@ -150,6 +154,7 @@ query GetEntities($where: EntityWhereInput) {
           }
         }
         entityType {
+          id
           name
         }
         id
@@ -181,6 +186,7 @@ query GetEntityByID($entityId: ID!) {
       }
     }
     entityType {
+      id
       name
     }
     id
@@ -224,6 +230,7 @@ mutation UpdateEntity($updateEntityId: ID!, $input: UpdateEntityInput!) {
         }
       }
       entityType {
+        id
         name
       }
       id

--- a/internal/graphapi/query/group.graphql
+++ b/internal/graphapi/query/group.graphql
@@ -250,6 +250,37 @@ query GetGroupByID($groupId: ID!) {
   }
 }
 
+query GetGroupInfo($where: GroupWhereInput) {
+  groups(where: $where) {
+    edges {
+      node {
+        description
+        displayName
+        id
+        logoURL
+        name
+        tags
+        isManaged
+        setting {
+          createdAt
+          createdBy
+          id
+          joinPolicy
+          syncToGithub
+          syncToSlack
+          updatedAt
+          updatedBy
+          visibility
+        }
+        createdAt
+        createdBy
+        updatedAt
+        updatedBy
+      }
+    }
+  }
+}
+
 query GetGroups($where: GroupWhereInput) {
   groups(where: $where) {
     edges {

--- a/internal/graphapi/query/tfasetting.graphql
+++ b/internal/graphapi/query/tfasetting.graphql
@@ -28,6 +28,7 @@ query GetAllTFASettings {
 
 query GetTFASetting {
   tfaSetting {
+    id
     totpAllowed
     verified
     owner {

--- a/internal/graphapi/risk_test.go
+++ b/internal/graphapi/risk_test.go
@@ -5,17 +5,17 @@ import (
 	"testing"
 
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 
+	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/openlaneclient"
+	"github.com/theopenlane/iam/auth"
 	"github.com/theopenlane/utils/ulids"
 )
 
-func (suite *GraphTestSuite) TestQueryRisk() {
-	t := suite.T()
-
+func TestQueryRisk(t *testing.T) {
 	program := (&ProgramBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	// add adminUser to the program so that they can create a Risk
@@ -23,11 +23,12 @@ func (suite *GraphTestSuite) TestQueryRisk() {
 		UserID: adminUser.ID, Role: enums.RoleAdmin.String()}).
 		MustNew(testUser1.UserCtx, t)
 
+	riskIDs := []string{}
 	// add test cases for querying the Risk
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   *openlaneclient.OpenlaneClient
+		client   openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{
@@ -77,46 +78,47 @@ func (suite *GraphTestSuite) TestQueryRisk() {
 						ProgramIDs: []string{program.ID},
 					})
 
-				require.NoError(t, err)
-				require.NotNil(t, resp)
+				assert.NilError(t, err)
+				assert.Assert(t, resp != nil)
 
 				tc.queryID = resp.CreateRisk.Risk.ID
+				riskIDs = append(riskIDs, tc.queryID)
 			}
 
 			resp, err := tc.client.GetRiskByID(tc.ctx, tc.queryID)
 
 			if tc.errorMsg != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
-			require.NotEmpty(t, resp.Risk)
+			assert.Check(t, is.Equal(tc.queryID, resp.Risk.ID))
+			assert.Check(t, len(resp.Risk.Name) != 0)
 
-			assert.Equal(t, tc.queryID, resp.Risk.ID)
-			assert.NotEmpty(t, resp.Risk.Name)
-
-			require.Len(t, resp.Risk.Programs.Edges, 1)
-			assert.NotEmpty(t, resp.Risk.Programs.Edges[0].Node.ID)
+			assert.Assert(t, is.Len(resp.Risk.Programs.Edges, 1))
+			assert.Check(t, len(resp.Risk.Programs.Edges[0].Node.ID) != 0)
 		})
 	}
+
+	// cleanup
+	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, ID: program.ID}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.RiskDeleteOne]{client: suite.client.db.Risk, IDs: riskIDs}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestQueryRisks() {
-	t := suite.T()
-
+func TestQueryRisks(t *testing.T) {
 	// create multiple objects to be queried using testUser1
-	(&RiskBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
-	(&RiskBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	risk1 := (&RiskBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	risk2 := (&RiskBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	testCases := []struct {
 		name            string
-		client          *openlaneclient.OpenlaneClient
+		client          openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int
 	}{
@@ -155,23 +157,26 @@ func (suite *GraphTestSuite) TestQueryRisks() {
 	for _, tc := range testCases {
 		t.Run("List "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.GetAllRisks(tc.ctx)
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
-			assert.Len(t, resp.Risks.Edges, tc.expectedResults)
+			assert.Check(t, is.Len(resp.Risks.Edges, tc.expectedResults))
 		})
 	}
+
+	// cleanup
+	(&Cleanup[*generated.RiskDeleteOne]{client: suite.client.db.Risk, IDs: []string{risk1.ID, risk2.ID}}).
+		MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationCreateRisk() {
-	t := suite.T()
-
+func TestMutationCreateRisk(t *testing.T) {
 	program1 := (&ProgramBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	program2 := (&ProgramBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	programAnotherUser := (&ProgramBuilder{client: suite.client}).MustNew(testUser2.UserCtx, t)
 
-	// group for the view only user
-	groupMember := (&GroupMemberBuilder{client: suite.client, UserID: viewOnlyUser.ID}).MustNew(testUser1.UserCtx, t)
+	// group to be used for checking access, defaulting to a read only user
+	groupMember := (&GroupMemberBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	groupMemberCtx := auth.NewTestContextWithOrgID(groupMember.UserID, groupMember.Edges.Orgmembership.OrganizationID)
 
 	// add adminUser to the program so that they can create a risk associated with the program1
 	(&ProgramMemberBuilder{client: suite.client, ProgramID: program1.ID,
@@ -189,7 +194,7 @@ func (suite *GraphTestSuite) TestMutationCreateRisk() {
 		name          string
 		request       openlaneclient.CreateRiskInput
 		addGroupToOrg bool
-		client        *openlaneclient.OpenlaneClient
+		client        openlaneclient.OpenlaneClient
 		ctx           context.Context
 		expectedErr   string
 	}{
@@ -254,7 +259,7 @@ func (suite *GraphTestSuite) TestMutationCreateRisk() {
 				Name: "Risk",
 			},
 			client:      suite.client.api,
-			ctx:         viewOnlyUser.UserCtx,
+			ctx:         groupMemberCtx,
 			expectedErr: notAuthorizedErrorMsg,
 		},
 		{
@@ -264,7 +269,7 @@ func (suite *GraphTestSuite) TestMutationCreateRisk() {
 			},
 			addGroupToOrg: true,
 			client:        suite.client.api,
-			ctx:           viewOnlyUser.UserCtx,
+			ctx:           groupMemberCtx,
 		},
 		{
 			name: "user authorized, they were added to the program",
@@ -311,142 +316,144 @@ func (suite *GraphTestSuite) TestMutationCreateRisk() {
 					openlaneclient.UpdateOrganizationInput{
 						AddRiskCreatorIDs: []string{groupMember.GroupID},
 					}, nil)
-				require.NoError(t, err)
+				assert.NilError(t, err)
 			}
 
 			resp, err := tc.client.CreateRisk(tc.ctx, tc.request)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
 			// check required fields
-			require.NotEmpty(t, resp.CreateRisk.Risk.ID)
-			assert.Equal(t, tc.request.Name, resp.CreateRisk.Risk.Name)
+			assert.Assert(t, len(resp.CreateRisk.Risk.ID) != 0)
+			assert.Check(t, is.Equal(tc.request.Name, resp.CreateRisk.Risk.Name))
 
-			assert.NotEmpty(t, resp.CreateRisk.Risk.DisplayID)
-			assert.Contains(t, resp.CreateRisk.Risk.DisplayID, "RSK-")
+			assert.Check(t, len(resp.CreateRisk.Risk.DisplayID) != 0)
+			assert.Check(t, is.Contains(resp.CreateRisk.Risk.DisplayID, "RSK-"))
 
 			// ensure the program is set
 			if len(tc.request.ProgramIDs) > 0 {
-				require.NotEmpty(t, resp.CreateRisk.Risk.Programs.Edges)
-				require.Len(t, resp.CreateRisk.Risk.Programs.Edges, len(tc.request.ProgramIDs))
+				assert.Check(t, is.Len(resp.CreateRisk.Risk.Programs.Edges, len(tc.request.ProgramIDs)))
 
 				for i, p := range resp.CreateRisk.Risk.Programs.Edges {
-					assert.Equal(t, tc.request.ProgramIDs[i], p.Node.ID)
+					assert.Check(t, is.Equal(tc.request.ProgramIDs[i], p.Node.ID))
 				}
 			} else {
-				assert.Empty(t, resp.CreateRisk.Risk.Programs.Edges)
+				assert.Check(t, is.Len(resp.CreateRisk.Risk.Programs.Edges, 0))
 			}
 
 			if tc.request.Status != nil {
-				assert.Equal(t, *tc.request.Status, *resp.CreateRisk.Risk.Status)
+				assert.Check(t, is.Equal(*tc.request.Status, *resp.CreateRisk.Risk.Status))
 			} else {
-				assert.Equal(t, enums.RiskOpen, *resp.CreateRisk.Risk.Status)
+				assert.Check(t, is.Equal(enums.RiskOpen, *resp.CreateRisk.Risk.Status))
 			}
 
 			if tc.request.RiskType != nil {
-				assert.Equal(t, *tc.request.RiskType, *resp.CreateRisk.Risk.RiskType)
+				assert.Check(t, is.Equal(*tc.request.RiskType, *resp.CreateRisk.Risk.RiskType))
 			} else {
-				assert.Empty(t, resp.CreateRisk.Risk.RiskType)
+				assert.Check(t, is.Len(*resp.CreateRisk.Risk.RiskType, 0))
 			}
 
 			if tc.request.BusinessCosts != nil {
-				assert.Equal(t, *tc.request.BusinessCosts, *resp.CreateRisk.Risk.BusinessCosts)
+				assert.Check(t, is.Equal(*tc.request.BusinessCosts, *resp.CreateRisk.Risk.BusinessCosts))
 			} else {
-				assert.Empty(t, resp.CreateRisk.Risk.BusinessCosts)
+				assert.Check(t, is.Len(*resp.CreateRisk.Risk.BusinessCosts, 0))
 			}
 
 			if tc.request.Impact != nil {
-				assert.Equal(t, *tc.request.Impact, *resp.CreateRisk.Risk.Impact)
+				assert.Check(t, is.Equal(*tc.request.Impact, *resp.CreateRisk.Risk.Impact))
 			} else {
-				assert.Equal(t, enums.RiskImpactModerate, *resp.CreateRisk.Risk.Impact)
+				assert.Check(t, is.Equal(enums.RiskImpactModerate, *resp.CreateRisk.Risk.Impact))
 			}
 
 			if tc.request.Likelihood != nil {
-				assert.Equal(t, *tc.request.Likelihood, *resp.CreateRisk.Risk.Likelihood)
+				assert.Check(t, is.Equal(*tc.request.Likelihood, *resp.CreateRisk.Risk.Likelihood))
 			} else {
-				assert.Equal(t, enums.RiskLikelihoodMid, *resp.CreateRisk.Risk.Likelihood)
+				assert.Check(t, is.Equal(enums.RiskLikelihoodMid, *resp.CreateRisk.Risk.Likelihood))
 			}
 
 			if tc.request.Mitigation != nil {
-				assert.Equal(t, *tc.request.Mitigation, *resp.CreateRisk.Risk.Mitigation)
+				assert.Check(t, is.Equal(*tc.request.Mitigation, *resp.CreateRisk.Risk.Mitigation))
 			} else {
-				assert.Empty(t, resp.CreateRisk.Risk.Mitigation)
+				assert.Check(t, is.Len(*resp.CreateRisk.Risk.Mitigation, 0))
 			}
 
 			if tc.request.Score != nil {
-				assert.Equal(t, *tc.request.Score, *resp.CreateRisk.Risk.Score)
+				assert.Check(t, is.Equal(*tc.request.Score, *resp.CreateRisk.Risk.Score))
 			} else {
-				assert.Empty(t, resp.CreateRisk.Risk.Score)
+				assert.Check(t, is.Equal(*resp.CreateRisk.Risk.Score, int64(0)))
 			}
 
 			if tc.request.Details != nil {
-				assert.Equal(t, tc.request.Details, resp.CreateRisk.Risk.Details)
+				assert.Check(t, is.Equal(*tc.request.Details, *resp.CreateRisk.Risk.Details))
 			} else {
-				assert.Empty(t, resp.CreateRisk.Risk.Details)
+				assert.Check(t, is.Len(*resp.CreateRisk.Risk.Details, 0))
 			}
 
 			if len(tc.request.EditorIDs) > 0 {
-				require.Len(t, resp.CreateRisk.Risk.Editors, 1)
+				assert.Assert(t, is.Len(resp.CreateRisk.Risk.Editors, 1))
 				for _, edge := range resp.CreateRisk.Risk.Editors {
-					assert.Equal(t, testUser1.GroupID, edge.ID)
+					assert.Check(t, is.Equal(testUser1.GroupID, edge.ID))
 				}
 			}
 
 			if len(tc.request.BlockedGroupIDs) > 0 {
-				require.Len(t, resp.CreateRisk.Risk.BlockedGroups, 1)
+				assert.Assert(t, is.Len(resp.CreateRisk.Risk.BlockedGroups, 1))
 				for _, edge := range resp.CreateRisk.Risk.BlockedGroups {
-					assert.Equal(t, blockedGroup.ID, edge.ID)
+					assert.Check(t, is.Equal(blockedGroup.ID, edge.ID))
 				}
 			}
 
 			if len(tc.request.ViewerIDs) > 0 {
-				require.Len(t, resp.CreateRisk.Risk.Viewers, 1)
+				assert.Assert(t, is.Len(resp.CreateRisk.Risk.Viewers, 1))
 				for _, edge := range resp.CreateRisk.Risk.Viewers {
-					assert.Equal(t, viewerGroup.ID, edge.ID)
+					assert.Check(t, is.Equal(viewerGroup.ID, edge.ID))
 				}
 			}
 
 			if tc.request.StakeholderID != nil {
-				assert.Equal(t, *tc.request.StakeholderID, *&resp.CreateRisk.Risk.Stakeholder.ID)
+				assert.Check(t, is.Equal(*tc.request.StakeholderID, *&resp.CreateRisk.Risk.Stakeholder.ID))
 			} else {
-				assert.Empty(t, resp.CreateRisk.Risk.Stakeholder)
+				assert.Check(t, is.Nil(resp.CreateRisk.Risk.Stakeholder))
 			}
 
 			if tc.request.DelegateID != nil {
-				assert.Equal(t, *tc.request.DelegateID, *&resp.CreateRisk.Risk.Delegate.ID)
+				assert.Check(t, is.Equal(*tc.request.DelegateID, *&resp.CreateRisk.Risk.Delegate.ID))
 			} else {
-				assert.Empty(t, resp.CreateRisk.Risk.Delegate)
+				assert.Check(t, is.Nil(resp.CreateRisk.Risk.Delegate))
 			}
 
 			// ensure the org owner has access to the risk that was created by an api token
 			if tc.client == suite.client.apiWithToken {
 				res, err := suite.client.api.GetRiskByID(testUser1.UserCtx, resp.CreateRisk.Risk.ID)
-				require.NoError(t, err)
-				require.NotEmpty(t, res)
-				assert.Equal(t, resp.CreateRisk.Risk.ID, res.Risk.ID)
+				assert.NilError(t, err)
+				assert.Assert(t, res != nil)
+				assert.Check(t, is.Equal(resp.CreateRisk.Risk.ID, res.Risk.ID))
 			}
 		})
 	}
+
+	// cleanup
+	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, IDs: []string{program1.ID, program2.ID}}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, ID: programAnotherUser.ID}).MustDelete(testUser2.UserCtx, t)
+	(&Cleanup[*generated.GroupDeleteOne]{client: suite.client.db.Group, IDs: []string{blockedGroup.ID, viewerGroup.ID, groupMember.GroupID, stakeholderGroup.ID, delegateGroup.ID}}).MustDelete(testUser1.UserCtx, t)
+
 }
 
-func (suite *GraphTestSuite) TestMutationUpdateRisk() {
-	t := suite.T()
-
+func TestMutationUpdateRisk(t *testing.T) {
 	program := (&ProgramBuilder{client: suite.client, EditorIDs: testUser1.GroupID}).MustNew(testUser1.UserCtx, t)
 	risk := (&RiskBuilder{client: suite.client, ProgramID: program.ID}).MustNew(testUser1.UserCtx, t)
 
 	// create another admin user and add them to the same organization and group as testUser1
 	// this will allow us to test the group editor/viewer permissions
-	anotherAdminUser := suite.userBuilder(context.Background())
-	suite.addUserToOrganization(testUser1.UserCtx, &anotherAdminUser, enums.RoleAdmin, testUser1.OrganizationID)
+	anotherAdminUser := suite.userBuilder(context.Background(), t)
+	suite.addUserToOrganization(testUser1.UserCtx, t, &anotherAdminUser, enums.RoleAdmin, testUser1.OrganizationID)
 
 	groupMember := (&GroupMemberBuilder{client: suite.client, UserID: anotherAdminUser.ID}).MustNew(testUser1.UserCtx, t)
 
@@ -457,13 +464,13 @@ func (suite *GraphTestSuite) TestMutationUpdateRisk() {
 
 	// ensure the user does not currently have access to the risk
 	res, err := suite.client.api.GetRiskByID(anotherAdminUser.UserCtx, risk.ID)
-	require.Error(t, err)
-	require.Nil(t, res)
+	assert.ErrorContains(t, err, notFoundErrorMsg)
+	assert.Assert(t, is.Nil(res))
 
 	testCases := []struct {
 		name        string
 		request     openlaneclient.UpdateRiskInput
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -515,46 +522,46 @@ func (suite *GraphTestSuite) TestMutationUpdateRisk() {
 		t.Run("Update "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.UpdateRisk(tc.ctx, risk.ID, tc.request)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
 			if tc.request.Status != nil {
-				assert.Equal(t, *tc.request.Status, *resp.UpdateRisk.Risk.Status)
+				assert.Check(t, is.Equal(*tc.request.Status, *resp.UpdateRisk.Risk.Status))
 			}
 
 			if tc.request.Tags != nil {
-				assert.ElementsMatch(t, tc.request.Tags, resp.UpdateRisk.Risk.Tags)
+				assert.DeepEqual(t, tc.request.Tags, resp.UpdateRisk.Risk.Tags)
 			}
 
 			if tc.request.Mitigation != nil {
-				assert.Equal(t, *tc.request.Mitigation, *resp.UpdateRisk.Risk.Mitigation)
+				assert.Check(t, is.Equal(*tc.request.Mitigation, *resp.UpdateRisk.Risk.Mitigation))
 			}
 
 			if tc.request.Impact != nil {
-				assert.Equal(t, *tc.request.Impact, *resp.UpdateRisk.Risk.Impact)
+				assert.Check(t, is.Equal(*tc.request.Impact, *resp.UpdateRisk.Risk.Impact))
 			}
 
 			if tc.request.Likelihood != nil {
-				assert.Equal(t, *tc.request.Likelihood, *resp.UpdateRisk.Risk.Likelihood)
+				assert.Check(t, is.Equal(*tc.request.Likelihood, *resp.UpdateRisk.Risk.Likelihood))
 			}
 
 			if tc.request.Details != nil {
-				assert.Equal(t, tc.request.Details, resp.UpdateRisk.Risk.Details)
+				assert.Check(t, is.DeepEqual(tc.request.Details, resp.UpdateRisk.Risk.Details))
 			}
 
 			if tc.request.Score != nil {
-				assert.Equal(t, *tc.request.Score, *resp.UpdateRisk.Risk.Score)
+				assert.Check(t, is.Equal(*tc.request.Score, *resp.UpdateRisk.Risk.Score))
 			}
 
 			if len(tc.request.AddViewerIDs) > 0 {
-				require.Len(t, resp.UpdateRisk.Risk.Viewers, 1)
+				assert.Assert(t, is.Len(resp.UpdateRisk.Risk.Viewers, 1))
 				found := false
 				for _, edge := range resp.UpdateRisk.Risk.Viewers {
 					if edge.ID == tc.request.AddViewerIDs[0] {
@@ -563,55 +570,58 @@ func (suite *GraphTestSuite) TestMutationUpdateRisk() {
 					}
 				}
 
-				assert.True(t, found)
+				assert.Check(t, found)
 
 				// ensure the user has access to the risk now
 				res, err := suite.client.api.GetRiskByID(anotherAdminUser.UserCtx, risk.ID)
-				require.NoError(t, err)
-				require.NotEmpty(t, res)
-				assert.Equal(t, risk.ID, res.Risk.ID)
+				assert.NilError(t, err)
+				assert.Assert(t, res != nil)
+				assert.Check(t, is.Equal(risk.ID, res.Risk.ID))
 			}
 		})
 	}
+
+	// cleanup
+	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, ID: program.ID}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.RiskDeleteOne]{client: suite.client.db.Risk, ID: risk.ID}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.GroupDeleteOne]{client: suite.client.db.Group, IDs: []string{stakeholderGroup.ID, delegateGroup.ID, anotherStakeholderGroup.ID, groupMember.GroupID}}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationDeleteRisk() {
-	t := suite.T()
-
+func TestMutationDeleteRisk(t *testing.T) {
 	// create objects to be deleted
-	Risk1 := (&RiskBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
-	Risk2 := (&RiskBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	risk1 := (&RiskBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	risk2 := (&RiskBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
 		{
 			name:        "not authorized, delete",
-			idToDelete:  Risk1.ID,
+			idToDelete:  risk1.ID,
 			client:      suite.client.api,
 			ctx:         testUser2.UserCtx,
 			expectedErr: notFoundErrorMsg,
 		},
 		{
 			name:       "happy path, delete",
-			idToDelete: Risk1.ID,
+			idToDelete: risk1.ID,
 			client:     suite.client.api,
 			ctx:        testUser1.UserCtx,
 		},
 		{
 			name:        "already deleted, not found",
-			idToDelete:  Risk1.ID,
+			idToDelete:  risk1.ID,
 			client:      suite.client.api,
 			ctx:         testUser1.UserCtx,
 			expectedErr: "not found",
 		},
 		{
 			name:       "happy path, delete using personal access token",
-			idToDelete: Risk2.ID,
+			idToDelete: risk2.ID,
 			client:     suite.client.apiWithPAT,
 			ctx:        context.Background(),
 		},
@@ -628,16 +638,16 @@ func (suite *GraphTestSuite) TestMutationDeleteRisk() {
 		t.Run("Delete "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.DeleteRisk(tc.ctx, tc.idToDelete)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			assert.Equal(t, tc.idToDelete, resp.DeleteRisk.DeletedID)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Check(t, is.Equal(tc.idToDelete, resp.DeleteRisk.DeletedID))
 		})
 	}
 }

--- a/internal/graphapi/risk_test.go
+++ b/internal/graphapi/risk_test.go
@@ -28,7 +28,7 @@ func TestQueryRisk(t *testing.T) {
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   openlaneclient.OpenlaneClient
+		client   *openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{
@@ -117,7 +117,7 @@ func TestQueryRisks(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		client          openlaneclient.OpenlaneClient
+		client          *openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int
 	}{
@@ -193,7 +193,7 @@ func TestMutationCreateRisk(t *testing.T) {
 		name          string
 		request       openlaneclient.CreateRiskInput
 		addGroupToOrg bool
-		client        openlaneclient.OpenlaneClient
+		client        *openlaneclient.OpenlaneClient
 		ctx           context.Context
 		expectedErr   string
 	}{
@@ -469,7 +469,7 @@ func TestMutationUpdateRisk(t *testing.T) {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.UpdateRiskInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -593,7 +593,7 @@ func TestMutationDeleteRisk(t *testing.T) {
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{

--- a/internal/graphapi/risk_test.go
+++ b/internal/graphapi/risk_test.go
@@ -88,7 +88,6 @@ func TestQueryRisk(t *testing.T) {
 			resp, err := tc.client.GetRiskByID(tc.ctx, tc.queryID)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 
@@ -522,7 +521,6 @@ func TestMutationUpdateRisk(t *testing.T) {
 		t.Run("Update "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.UpdateRisk(tc.ctx, risk.ID, tc.request)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 
@@ -638,7 +636,6 @@ func TestMutationDeleteRisk(t *testing.T) {
 		t.Run("Delete "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.DeleteRisk(tc.ctx, tc.idToDelete)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 

--- a/internal/graphapi/search_test.go
+++ b/internal/graphapi/search_test.go
@@ -5,39 +5,52 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
+	"github.com/theopenlane/core/internal/ent/generated"
+	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/openlaneclient"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
-func (suite *GraphTestSuite) TestGlobalSearch() {
-	t := suite.T()
+func TestGlobalSearch(t *testing.T) {
+	// create a new user for this test
+	testSearchUser := suite.userBuilder(context.Background(), t)
 
-	// create multiple objects to be searched by testUser1
+	testViewOnlyUser := suite.userBuilder(context.Background(), t)
+	suite.addUserToOrganization(testSearchUser.UserCtx, t, &testViewOnlyUser, enums.RoleMember, testSearchUser.OrganizationID)
+
+	// create multiple objects to be searched by testSearchUser
 	numGroups := 12
+	groupIDs := []string{}
 	for i := range numGroups {
-		(&GroupBuilder{client: suite.client, Name: fmt.Sprintf("Test Group %d", i)}).MustNew(testUser1.UserCtx, t)
+		group := (&GroupBuilder{client: suite.client, Name: fmt.Sprintf("Test Group %d", i)}).MustNew(testSearchUser.UserCtx, t)
+		groupIDs = append(groupIDs, group.ID)
 	}
 
 	numContacts := 3
+	contactIDs := []string{}
 	for i := range numContacts {
-		(&ContactBuilder{client: suite.client, Name: fmt.Sprintf("Test Contact %d", i)}).MustNew(testUser1.UserCtx, t)
+		contact := (&ContactBuilder{client: suite.client, Name: fmt.Sprintf("Test Contact %d", i)}).MustNew(testSearchUser.UserCtx, t)
+		contactIDs = append(contactIDs, contact.ID)
 	}
 
 	numPrograms := 3
+	programIDs := []string{}
 	for i := range numPrograms {
-		(&ProgramBuilder{client: suite.client, Name: fmt.Sprintf("Test Program %d", i)}).MustNew(testUser1.UserCtx, t)
+		program := (&ProgramBuilder{client: suite.client, Name: fmt.Sprintf("Test Program %d", i)}).MustNew(testSearchUser.UserCtx, t)
+		programIDs = append(programIDs, program.ID)
 	}
 
 	numControls := 3
+	controlIDs := []string{}
 	for i := range numControls {
-		(&ControlBuilder{client: suite.client, Name: fmt.Sprintf("Test Control %d", i)}).MustNew(testUser1.UserCtx, t)
+		control := (&ControlBuilder{client: suite.client, Name: fmt.Sprintf("Test Control %d", i)}).MustNew(testSearchUser.UserCtx, t)
+		controlIDs = append(controlIDs, control.ID)
 	}
 
 	testCases := []struct {
 		name             string
-		client           *openlaneclient.OpenlaneClient
+		client           openlaneclient.OpenlaneClient
 		ctx              context.Context
 		query            string
 		expectedResults  int
@@ -50,7 +63,7 @@ func (suite *GraphTestSuite) TestGlobalSearch() {
 		{
 			name:             "happy path",
 			client:           suite.client.api,
-			ctx:              testUser1.UserCtx,
+			ctx:              testSearchUser.UserCtx,
 			query:            "Test",
 			expectedResults:  21, // this is total count of all objects searched
 			expectedGroups:   10, // 12 groups created by max results in tests is 10 and we are testing len of edges
@@ -61,7 +74,7 @@ func (suite *GraphTestSuite) TestGlobalSearch() {
 		{
 			name:             "happy path, case insensitive",
 			client:           suite.client.api,
-			ctx:              testUser1.UserCtx,
+			ctx:              testSearchUser.UserCtx,
 			query:            "TEST",
 			expectedResults:  21, // this is total count of all objects searched
 			expectedGroups:   10, // 12 groups created by max results in tests is 10 and we are testing len of edges
@@ -72,7 +85,7 @@ func (suite *GraphTestSuite) TestGlobalSearch() {
 		{
 			name:             "happy path, case insensitive",
 			client:           suite.client.api,
-			ctx:              testUser1.UserCtx,
+			ctx:              testSearchUser.UserCtx,
 			query:            "con",
 			expectedResults:  6, // this is total count of all objects searched
 			expectedGroups:   0,
@@ -83,7 +96,7 @@ func (suite *GraphTestSuite) TestGlobalSearch() {
 		{
 			name:             "happy path, view only user",
 			client:           suite.client.api,
-			ctx:              viewOnlyUser.UserCtx,
+			ctx:              testViewOnlyUser.UserCtx,
 			query:            "Test",
 			expectedResults:  15, // this is total count of all objects searched
 			expectedGroups:   10, // 12 groups created by max results in tests is 10 and we are testing len of edges
@@ -94,7 +107,7 @@ func (suite *GraphTestSuite) TestGlobalSearch() {
 		{
 			name:            "no results",
 			client:          suite.client.api,
-			ctx:             testUser1.UserCtx,
+			ctx:             testSearchUser.UserCtx,
 			query:           "NonExistent",
 			expectedResults: 0,
 		},
@@ -108,7 +121,7 @@ func (suite *GraphTestSuite) TestGlobalSearch() {
 		{
 			name:        "empty query",
 			client:      suite.client.api,
-			ctx:         testUser1.UserCtx,
+			ctx:         testSearchUser.UserCtx,
 			query:       "",
 			errExpected: "search query is too short",
 		},
@@ -118,49 +131,59 @@ func (suite *GraphTestSuite) TestGlobalSearch() {
 		t.Run("List "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.GlobalSearch(tc.ctx, tc.query)
 			if tc.errExpected != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.errExpected)
+
+				assert.Assert(t, is.Contains(err.Error(), tc.errExpected))
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
 			if tc.expectedResults > 0 {
-				assert.Equal(t, resp.Search.TotalCount, int64(tc.expectedResults))
+				assert.Check(t, is.Equal(resp.Search.TotalCount, int64(tc.expectedResults)))
 
 				if tc.expectedGroups > 0 {
-					assert.Len(t, resp.Search.Groups.Edges, tc.expectedGroups)
-					assert.Equal(t, resp.Search.Groups.TotalCount, int64(numGroups))
-					assert.True(t, resp.Search.Groups.PageInfo.HasNextPage)
-					assert.False(t, resp.Search.Groups.PageInfo.HasPreviousPage)
+					assert.Assert(t, resp.Search.Groups != nil)
+					assert.Check(t, is.Len(resp.Search.Groups.Edges, tc.expectedGroups))
+					assert.Check(t, is.Equal(resp.Search.Groups.TotalCount, int64(numGroups)))
+					assert.Check(t, resp.Search.Groups.PageInfo.HasNextPage)
+					assert.Check(t, !resp.Search.Groups.PageInfo.HasPreviousPage)
 				} else {
-					assert.Empty(t, resp.Search.Groups)
+					assert.Check(t, is.Nil(resp.Search.Groups))
 				}
 
 				if tc.expectedContacts > 0 {
-					assert.Len(t, resp.Search.Contacts.Edges, tc.expectedContacts)
+					assert.Assert(t, resp.Search.Contacts != nil)
+					assert.Check(t, is.Len(resp.Search.Contacts.Edges, tc.expectedContacts))
 				} else {
-					assert.Empty(t, resp.Search.Contacts)
+					assert.Check(t, is.Nil(resp.Search.Contacts))
 				}
 
 				if tc.expectedPrograms > 0 {
-					assert.Len(t, resp.Search.Programs.Edges, tc.expectedPrograms)
+					assert.Assert(t, resp.Search.Programs != nil)
+					assert.Check(t, is.Len(resp.Search.Programs.Edges, tc.expectedPrograms))
 				} else {
-					assert.Empty(t, resp.Search.Programs)
+					assert.Check(t, is.Nil(resp.Search.Programs))
 				}
 
 				if tc.expectedControls > 0 {
-					assert.Len(t, resp.Search.Controls.Edges, tc.expectedControls)
+					assert.Assert(t, resp.Search.Controls != nil)
+					assert.Check(t, is.Len(resp.Search.Controls.Edges, tc.expectedControls))
 				} else {
-					assert.Empty(t, resp.Search.Controls)
+					assert.Check(t, is.Nil(resp.Search.Controls))
 				}
 			} else {
-				assert.Empty(t, resp.Search.Groups)
-				assert.Empty(t, resp.Search.Contacts)
-				assert.Empty(t, resp.Search.Programs)
-				assert.Empty(t, resp.Search.Controls)
+				assert.Check(t, is.Nil(resp.Search.Groups))
+				assert.Check(t, is.Nil(resp.Search.Contacts))
+				assert.Check(t, is.Nil(resp.Search.Programs))
+				assert.Check(t, is.Nil(resp.Search.Controls))
 			}
 		})
 	}
+
+	// clean up the created objects
+	(&Cleanup[*generated.GroupDeleteOne]{client: suite.client.db.Group, IDs: groupIDs}).MustDelete(testSearchUser.UserCtx, t)
+	(&Cleanup[*generated.ContactDeleteOne]{client: suite.client.db.Contact, IDs: contactIDs}).MustDelete(testSearchUser.UserCtx, t)
+	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, IDs: programIDs}).MustDelete(testSearchUser.UserCtx, t)
+	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: controlIDs}).MustDelete(testSearchUser.UserCtx, t)
 }

--- a/internal/graphapi/search_test.go
+++ b/internal/graphapi/search_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestGlobalSearch(t *testing.T) {
+	t.Parallel()
+
 	// create a new user for this test
 	testSearchUser := suite.userBuilder(context.Background(), t)
 

--- a/internal/graphapi/search_test.go
+++ b/internal/graphapi/search_test.go
@@ -52,7 +52,7 @@ func TestGlobalSearch(t *testing.T) {
 
 	testCases := []struct {
 		name             string
-		client           openlaneclient.OpenlaneClient
+		client           *openlaneclient.OpenlaneClient
 		ctx              context.Context
 		query            string
 		expectedResults  int

--- a/internal/graphapi/seed_test.go
+++ b/internal/graphapi/seed_test.go
@@ -105,9 +105,8 @@ func (suite *GraphTestSuite) setupTestData(ctx context.Context, t *testing.T) {
 	adminUser = suite.userBuilder(ctx, t)
 	suite.addUserToOrganization(testUser1.UserCtx, t, &adminUser, enums.RoleAdmin, testUser1.OrganizationID)
 
-	suite.client.apiWithPAT = *suite.setupPatClient(testUser1, t)
-
-	suite.client.apiWithToken = *suite.setupAPITokenClient(testUser1.UserCtx, t)
+	suite.client.apiWithPAT = suite.setupPatClient(testUser1, t)
+	suite.client.apiWithToken = suite.setupAPITokenClient(testUser1.UserCtx, t)
 }
 
 func (suite *GraphTestSuite) setupPatClient(user testUserDetails, t *testing.T) *openlaneclient.OpenlaneClient {

--- a/internal/graphapi/standard_test.go
+++ b/internal/graphapi/standard_test.go
@@ -119,7 +119,6 @@ func TestQueryStandard(t *testing.T) {
 			resp, err := tc.client.GetStandardByID(tc.ctx, tc.queryID)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 
@@ -390,7 +389,6 @@ func TestMutationCreateStandard(t *testing.T) {
 		t.Run("Create "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.CreateStandard(tc.ctx, tc.request)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 
@@ -638,7 +636,6 @@ func TestMutationUpdateStandard(t *testing.T) {
 		t.Run("Update "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.UpdateStandard(tc.ctx, tc.id, tc.request)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 
@@ -789,7 +786,6 @@ func TestMutationDeleteStandard(t *testing.T) {
 		t.Run("Delete "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.DeleteStandard(tc.ctx, tc.idToDelete)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 

--- a/internal/graphapi/standard_test.go
+++ b/internal/graphapi/standard_test.go
@@ -36,7 +36,7 @@ func TestQueryStandard(t *testing.T) {
 		name                 string
 		queryID              string
 		expectedControlCount int64
-		client               openlaneclient.OpenlaneClient
+		client               *openlaneclient.OpenlaneClient
 		ctx                  context.Context
 		errorMsg             string
 	}{
@@ -186,7 +186,7 @@ func TestQueryStandards(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		client          openlaneclient.OpenlaneClient
+		client          *openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int
 	}{
@@ -266,7 +266,7 @@ func TestMutationCreateStandard(t *testing.T) {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.CreateStandardInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -517,7 +517,7 @@ func TestMutationUpdateStandard(t *testing.T) {
 		name        string
 		id          string
 		request     openlaneclient.UpdateStandardInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -717,7 +717,7 @@ func TestMutationDeleteStandard(t *testing.T) {
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{

--- a/internal/graphapi/standard_test.go
+++ b/internal/graphapi/standard_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/pkg/enums"
@@ -16,9 +16,7 @@ import (
 	"github.com/theopenlane/utils/ulids"
 )
 
-func (suite *GraphTestSuite) TestQueryStandard() {
-	t := suite.T()
-
+func TestQueryStandard(t *testing.T) {
 	publicStandard := (&StandardBuilder{client: suite.client, IsPublic: true}).MustNew(systemAdminUser.UserCtx, t)
 
 	numControls := 20
@@ -38,7 +36,7 @@ func (suite *GraphTestSuite) TestQueryStandard() {
 		name                 string
 		queryID              string
 		expectedControlCount int64
-		client               *openlaneclient.OpenlaneClient
+		client               openlaneclient.OpenlaneClient
 		ctx                  context.Context
 		errorMsg             string
 	}{
@@ -121,56 +119,50 @@ func (suite *GraphTestSuite) TestQueryStandard() {
 			resp, err := tc.client.GetStandardByID(tc.ctx, tc.queryID)
 
 			if tc.errorMsg != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
-			require.NotEmpty(t, resp.Standard)
-
-			require.Equal(t, tc.queryID, resp.Standard.ID)
-			require.NotEmpty(t, resp.Standard.Name)
+			assert.Check(t, is.Equal(tc.queryID, resp.Standard.ID))
+			assert.Check(t, resp.Standard.Name != "")
 
 			if tc.queryID == orgOwnedStandard.ID {
-				assert.Equal(t, orgStandardName, resp.Standard.Name)
+				assert.Check(t, is.Equal(orgStandardName, resp.Standard.Name))
+				assert.Check(t, !*resp.Standard.SystemOwned)
+			} else {
+				assert.Check(t, *resp.Standard.SystemOwned)
 			}
 
-			assert.NotEmpty(t, resp.Standard.Framework)
+			assert.Check(t, resp.Standard.Framework != nil)
 
 			if tc.queryID == publicStandard.ID {
-				assert.True(t, *resp.Standard.IsPublic)
+				assert.Check(t, *resp.Standard.IsPublic)
+
 			} else {
-				assert.False(t, *resp.Standard.IsPublic)
+				assert.Check(t, !*resp.Standard.IsPublic)
 			}
 
-			if tc.queryID != orgOwnedStandard.ID {
-				assert.True(t, *resp.Standard.SystemOwned)
-			} else {
-				assert.False(t, *resp.Standard.SystemOwned)
-			}
-
-			assert.Equal(t, tc.expectedControlCount, resp.Standard.Controls.TotalCount)
+			assert.Check(t, is.Equal(tc.expectedControlCount, resp.Standard.Controls.TotalCount))
 
 			// only check edges if we expect them
 			if tc.expectedControlCount > 0 {
-				assert.Equal(t, testutils.MaxResultLimit, len(resp.Standard.Controls.Edges))
+				assert.Check(t, is.Equal(testutils.MaxResultLimit, len(resp.Standard.Controls.Edges)))
 			}
 
 		})
 	}
 
-	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, IDs: []string{publicStandard.ID, notPublicStandard.ID}}).MustDelete(systemAdminUser.UserCtx, suite)
-	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: orgOwnedStandard.ID}).MustDelete(testUser1.UserCtx, suite)
+	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, IDs: []string{publicStandard.ID, notPublicStandard.ID}}).MustDelete(systemAdminUser.UserCtx, t)
+	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: orgOwnedStandard.ID}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestQueryStandards() {
-	t := suite.T()
-
+func TestQueryStandards(t *testing.T) {
 	// create multiple org owned standards
 	countOrgOwned := 2
 	orgOwnedStandardIDs := []string{}
@@ -195,7 +187,7 @@ func (suite *GraphTestSuite) TestQueryStandards() {
 
 	testCases := []struct {
 		name            string
-		client          *openlaneclient.OpenlaneClient
+		client          openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int
 	}{
@@ -240,26 +232,24 @@ func (suite *GraphTestSuite) TestQueryStandards() {
 	for _, tc := range testCases {
 		t.Run("List "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.GetAllStandards(tc.ctx)
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
-			assert.Len(t, resp.Standards.Edges, tc.expectedResults)
-			assert.Equal(t, int64(tc.expectedResults), resp.Standards.TotalCount)
+			assert.Check(t, is.Len(resp.Standards.Edges, tc.expectedResults))
+			assert.Check(t, is.Equal(int64(tc.expectedResults), resp.Standards.TotalCount))
 
 			// under the max results in tests (10), has next should be false
-			assert.False(t, resp.Standards.PageInfo.HasNextPage)
+			assert.Check(t, !resp.Standards.PageInfo.HasNextPage)
 		})
 	}
 
 	systemOwnedIDs := append(notPublicStandardIDs, publicStandardIDs...)
 
-	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, IDs: systemOwnedIDs}).MustDelete(systemAdminUser.UserCtx, suite)
-	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, IDs: orgOwnedStandardIDs}).MustDelete(testUser1.UserCtx, suite)
+	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, IDs: systemOwnedIDs}).MustDelete(systemAdminUser.UserCtx, t)
+	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, IDs: orgOwnedStandardIDs}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationCreateStandard() {
-	t := suite.T()
-
+func TestMutationCreateStandard(t *testing.T) {
 	numControls := 20
 	controlIDs := []string{}
 	for range numControls {
@@ -277,7 +267,7 @@ func (suite *GraphTestSuite) TestMutationCreateStandard() {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.CreateStandardInput
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -400,42 +390,42 @@ func (suite *GraphTestSuite) TestMutationCreateStandard() {
 		t.Run("Create "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.CreateStandard(tc.ctx, tc.request)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
-			assert.NotEmpty(t, resp.CreateStandard.Standard.Name)
+			assert.Check(t, len(resp.CreateStandard.Standard.Name) != 0)
 
 			expectedRevision := "v0.0.1" //default
 			if tc.request.Revision != nil {
 				expectedRevision = *tc.request.Revision
 			}
 
-			assert.Equal(t, expectedRevision, *resp.CreateStandard.Standard.Revision)
+			assert.Check(t, is.Equal(expectedRevision, *resp.CreateStandard.Standard.Revision))
 
 			expectedStatus := enums.StandardActive
 			if tc.request.Status != nil {
 				expectedStatus = *tc.request.Status
 			}
-			assert.Equal(t, expectedStatus, *resp.CreateStandard.Standard.Status)
+			assert.Check(t, is.Equal(expectedStatus, *resp.CreateStandard.Standard.Status))
 
 			expectedSystemOwned := false
 			if tc.ctx == systemAdminUser.UserCtx {
 				expectedSystemOwned = true
 			}
-			assert.Equal(t, expectedSystemOwned, *resp.CreateStandard.Standard.SystemOwned)
+			assert.Check(t, is.Equal(expectedSystemOwned, *resp.CreateStandard.Standard.SystemOwned))
 
 			expectedIsPublic := false
 			if tc.request.IsPublic != nil {
 				expectedIsPublic = *tc.request.IsPublic
 			}
-			assert.Equal(t, expectedIsPublic, *resp.CreateStandard.Standard.IsPublic)
+			assert.Check(t, is.Equal(expectedIsPublic, *resp.CreateStandard.Standard.IsPublic))
 
 			// this field isn't currently used to enforce anything, it may change to restrict
 			// usage on tiers + features
@@ -443,64 +433,64 @@ func (suite *GraphTestSuite) TestMutationCreateStandard() {
 			if tc.request.FreeToUse != nil {
 				expectedFreeToUse = *tc.request.FreeToUse
 			}
-			assert.Equal(t, expectedFreeToUse, *resp.CreateStandard.Standard.FreeToUse)
+			assert.Check(t, is.Equal(expectedFreeToUse, *resp.CreateStandard.Standard.FreeToUse))
 
 			expectedTags := []string{}
 			if tc.request.Tags != nil {
 				expectedTags = tc.request.Tags
 			}
-			assert.Equal(t, expectedTags, resp.CreateStandard.Standard.Tags)
+			assert.Check(t, is.DeepEqual(expectedTags, resp.CreateStandard.Standard.Tags))
 
 			expectedFramework := ""
 			if tc.request.Framework != nil {
 				expectedFramework = *tc.request.Framework
 			}
-			assert.Equal(t, expectedFramework, *resp.CreateStandard.Standard.Framework)
+			assert.Check(t, is.Equal(expectedFramework, *resp.CreateStandard.Standard.Framework))
 
 			// short name defaults to the name
 			expectedShortName := tc.request.Name
 			if tc.request.ShortName != nil {
 				expectedShortName = *tc.request.ShortName
 			}
-			assert.Equal(t, expectedShortName, *resp.CreateStandard.Standard.ShortName)
+			assert.Check(t, is.Equal(expectedShortName, *resp.CreateStandard.Standard.ShortName))
 
 			expectedDescription := ""
 			if tc.request.Description != nil {
 				expectedDescription = *tc.request.Description
 			}
-			assert.Equal(t, expectedDescription, *resp.CreateStandard.Standard.Description)
+			assert.Check(t, is.Equal(expectedDescription, *resp.CreateStandard.Standard.Description))
 
 			expectedGoverningBodyLogoURL := ""
 			if tc.request.GoverningBodyLogoURL != nil {
 				expectedGoverningBodyLogoURL = *tc.request.GoverningBodyLogoURL
 			}
-			assert.Equal(t, expectedGoverningBodyLogoURL, *resp.CreateStandard.Standard.GoverningBodyLogoURL)
+			assert.Check(t, is.Equal(expectedGoverningBodyLogoURL, *resp.CreateStandard.Standard.GoverningBodyLogoURL))
 
 			expectedGoverningBody := ""
 			if tc.request.GoverningBody != nil {
 				expectedGoverningBody = *tc.request.GoverningBody
 			}
-			assert.Equal(t, expectedGoverningBody, *resp.CreateStandard.Standard.GoverningBody)
+			assert.Check(t, is.Equal(expectedGoverningBody, *resp.CreateStandard.Standard.GoverningBody))
 
-			assert.Equal(t, tc.request.Domains, resp.CreateStandard.Standard.Domains)
+			assert.Check(t, is.DeepEqual(tc.request.Domains, resp.CreateStandard.Standard.Domains))
 
 			expectedLink := ""
 			if tc.request.Link != nil {
 				expectedLink = *tc.request.Link
 			}
-			assert.Equal(t, expectedLink, *resp.CreateStandard.Standard.Link)
+			assert.Check(t, is.Equal(expectedLink, *resp.CreateStandard.Standard.Link))
 
 			expectedStandardType := ""
 			if tc.request.StandardType != nil {
 				expectedStandardType = *tc.request.StandardType
 			}
-			assert.Equal(t, expectedStandardType, *resp.CreateStandard.Standard.StandardType)
+			assert.Check(t, is.Equal(expectedStandardType, *resp.CreateStandard.Standard.StandardType))
 
 			expectedVersion := ""
 			if tc.request.Version != nil {
 				expectedVersion = *tc.request.Version
 			}
-			assert.Equal(t, expectedVersion, *resp.CreateStandard.Standard.Version)
+			assert.Check(t, is.Equal(expectedVersion, *resp.CreateStandard.Standard.Version))
 
 			// cleanup the created standard
 			ctx := tc.ctx
@@ -508,30 +498,28 @@ func (suite *GraphTestSuite) TestMutationCreateStandard() {
 				ctx = testUser1.UserCtx
 			}
 
-			(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: resp.CreateStandard.Standard.ID}).MustDelete(ctx, suite)
+			(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: resp.CreateStandard.Standard.ID}).MustDelete(ctx, t)
 		})
 	}
 
-	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: controlIDs}).MustDelete(testUser1.UserCtx, suite)
-	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: adminControlIDs}).MustDelete(systemAdminUser.UserCtx, suite)
+	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: controlIDs}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: adminControlIDs}).MustDelete(systemAdminUser.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationUpdateStandard() {
-	t := suite.T()
-
+func TestMutationUpdateStandard(t *testing.T) {
 	standardOrgOwned := (&StandardBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	standardSystemOwned := (&StandardBuilder{client: suite.client}).MustNew(systemAdminUser.UserCtx, t)
 
 	// users should not be able to get the system owned standard because its not public
 	std, err := suite.client.api.GetStandardByID(testUser1.UserCtx, standardSystemOwned.ID)
-	require.Error(t, err)
-	require.Nil(t, std)
+	assert.ErrorContains(t, err, notFoundErrorMsg)
+	assert.Assert(t, is.Nil(std))
 
 	testCases := []struct {
 		name        string
 		id          string
 		request     openlaneclient.UpdateStandardInput
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -650,81 +638,79 @@ func (suite *GraphTestSuite) TestMutationUpdateStandard() {
 		t.Run("Update "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.UpdateStandard(tc.ctx, tc.id, tc.request)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
 			if tc.request.GoverningBodyLogoURL != nil {
-				assert.Equal(t, *tc.request.GoverningBodyLogoURL, *resp.UpdateStandard.Standard.GoverningBodyLogoURL)
+				assert.Check(t, is.Equal(*tc.request.GoverningBodyLogoURL, *resp.UpdateStandard.Standard.GoverningBodyLogoURL))
 			}
 
 			if tc.request.AppendTags != nil {
 				for _, tag := range tc.request.AppendTags {
-					assert.Contains(t, resp.UpdateStandard.Standard.Tags, tag)
+					assert.Check(t, is.Contains(resp.UpdateStandard.Standard.Tags, tag))
 				}
 			}
 
 			if tc.request.GoverningBody != nil {
-				assert.Equal(t, *tc.request.GoverningBody, *resp.UpdateStandard.Standard.GoverningBody)
+				assert.Check(t, is.Equal(*tc.request.GoverningBody, *resp.UpdateStandard.Standard.GoverningBody))
 			}
 
 			if tc.request.ShortName != nil {
-				assert.Equal(t, *tc.request.ShortName, *resp.UpdateStandard.Standard.ShortName)
+				assert.Check(t, is.Equal(*tc.request.ShortName, *resp.UpdateStandard.Standard.ShortName))
 			}
 
 			if tc.request.Description != nil {
-				assert.Equal(t, *tc.request.Description, *resp.UpdateStandard.Standard.Description)
+				assert.Check(t, is.Equal(*tc.request.Description, *resp.UpdateStandard.Standard.Description))
 			}
 
 			if tc.request.Link != nil {
-				assert.Equal(t, *tc.request.Link, *resp.UpdateStandard.Standard.Link)
+				assert.Check(t, is.Equal(*tc.request.Link, *resp.UpdateStandard.Standard.Link))
 			}
 
 			if tc.request.Status != nil {
-				assert.Equal(t, *tc.request.Status, *resp.UpdateStandard.Standard.Status)
+				assert.Check(t, is.Equal(*tc.request.Status, *resp.UpdateStandard.Standard.Status))
 			}
 
 			if tc.request.StandardType != nil {
-				assert.Equal(t, *tc.request.StandardType, *resp.UpdateStandard.Standard.StandardType)
+				assert.Check(t, is.Equal(*tc.request.StandardType, *resp.UpdateStandard.Standard.StandardType))
 			}
 
 			if tc.request.RevisionBump == &models.Major {
-				assert.Equal(t, "v1.0.0", *resp.UpdateStandard.Standard.Revision)
+				assert.Check(t, is.Equal("v1.0.0", *resp.UpdateStandard.Standard.Revision))
 			}
 
 			if tc.request.RevisionBump == &models.Minor {
-				assert.Equal(t, "v0.1.0", *resp.UpdateStandard.Standard.Revision)
+				assert.Check(t, is.Equal("v0.1.0", *resp.UpdateStandard.Standard.Revision))
 			}
 
 			if tc.request.IsPublic != nil && *tc.request.IsPublic {
-				assert.True(t, *resp.UpdateStandard.Standard.IsPublic)
+				assert.Check(t, *resp.UpdateStandard.Standard.IsPublic)
 
 				// users should now be be able to get the system owned standard because its not public
 				std, err := suite.client.api.GetStandardByID(testUser1.UserCtx, standardSystemOwned.ID)
-				require.NoError(t, err)
-				require.NotNil(t, std)
-				require.Equal(t, standardSystemOwned.ID, std.Standard.ID)
+				assert.NilError(t, err)
+				assert.Assert(t, std != nil)
+				assert.Equal(t, standardSystemOwned.ID, std.Standard.ID)
 			}
 
 			if tc.request.Tags != nil {
-				assert.Equal(t, tc.request.Tags, resp.UpdateStandard.Standard.Tags)
+				assert.Check(t, is.DeepEqual(tc.request.Tags, resp.UpdateStandard.Standard.Tags))
 			}
 		})
 	}
 
-	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: standardOrgOwned.ID}).MustDelete(testUser1.UserCtx, suite)
-	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: standardSystemOwned.ID}).MustDelete(testUser1.UserCtx, suite)
+	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: standardOrgOwned.ID}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: standardSystemOwned.ID}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationDeleteStandard() {
-	t := suite.T()
-
+func TestMutationDeleteStandard(t *testing.T) {
 	standardOrgOwned1 := (&StandardBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	standardOrgOwned2 := (&StandardBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	standardOrgOwned3 := (&StandardBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
@@ -734,7 +720,7 @@ func (suite *GraphTestSuite) TestMutationDeleteStandard() {
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -803,16 +789,16 @@ func (suite *GraphTestSuite) TestMutationDeleteStandard() {
 		t.Run("Delete "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.DeleteStandard(tc.ctx, tc.idToDelete)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			assert.Equal(t, tc.idToDelete, resp.DeleteStandard.DeletedID)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Check(t, is.Equal(tc.idToDelete, resp.DeleteStandard.DeletedID))
 		})
 	}
 }

--- a/internal/graphapi/subcontrol_test.go
+++ b/internal/graphapi/subcontrol_test.go
@@ -29,7 +29,7 @@ func TestQuerySubcontrol(t *testing.T) {
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   openlaneclient.OpenlaneClient
+		client   *openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{
@@ -135,7 +135,7 @@ func TestQuerySubcontrols(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		client          openlaneclient.OpenlaneClient
+		client          *openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int
 	}{
@@ -208,7 +208,7 @@ func TestMutationCreateSubcontrol(t *testing.T) {
 		name                string
 		request             openlaneclient.CreateSubcontrolInput
 		createParentControl bool
-		client              openlaneclient.OpenlaneClient
+		client              *openlaneclient.OpenlaneClient
 		ctx                 context.Context
 		expectedErr         string
 	}{
@@ -465,7 +465,7 @@ func TestMutationUpdateSubcontrol(t *testing.T) {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.UpdateSubcontrolInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -582,7 +582,7 @@ func TestMutationDeleteSubcontrol(t *testing.T) {
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{

--- a/internal/graphapi/subcontrol_test.go
+++ b/internal/graphapi/subcontrol_test.go
@@ -384,7 +384,6 @@ func TestMutationCreateSubcontrol(t *testing.T) {
 
 			resp, err := tc.client.CreateSubcontrol(tc.ctx, tc.request)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 

--- a/internal/graphapi/subcontrol_test.go
+++ b/internal/graphapi/subcontrol_test.go
@@ -5,18 +5,17 @@ import (
 	"testing"
 
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 
+	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/models"
 	"github.com/theopenlane/core/pkg/openlaneclient"
 	"github.com/theopenlane/utils/ulids"
 )
 
-func (suite *GraphTestSuite) TestQuerySubcontrol() {
-	t := suite.T()
-
+func TestQuerySubcontrol(t *testing.T) {
 	program := (&ProgramBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	// add adminUser to the program so that they can create a subcontrol
@@ -24,11 +23,13 @@ func (suite *GraphTestSuite) TestQuerySubcontrol() {
 		UserID: adminUser.ID, Role: enums.RoleAdmin.String()}).
 		MustNew(testUser1.UserCtx, t)
 
+	createdControlIDs := []string{}
+	createdSubcontrolIDs := []string{}
 	// add test cases for querying the subcontrol
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   *openlaneclient.OpenlaneClient
+		client   openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{
@@ -79,8 +80,10 @@ func (suite *GraphTestSuite) TestQuerySubcontrol() {
 						ProgramIDs: []string{program.ID},
 					})
 
-				require.NoError(t, err)
-				require.NotNil(t, control)
+				assert.NilError(t, err)
+				assert.Assert(t, control != nil)
+
+				createdControlIDs = append(createdControlIDs, control.CreateControl.Control.ID)
 
 				resp, err := suite.client.api.CreateSubcontrol(testUser1.UserCtx,
 					openlaneclient.CreateSubcontrolInput{
@@ -88,45 +91,51 @@ func (suite *GraphTestSuite) TestQuerySubcontrol() {
 						ControlID: control.CreateControl.Control.ID,
 					})
 
-				require.NoError(t, err)
-				require.NotNil(t, resp)
+				assert.NilError(t, err)
+				assert.Assert(t, resp != nil)
 
 				tc.queryID = resp.CreateSubcontrol.Subcontrol.ID
+				createdSubcontrolIDs = append(createdSubcontrolIDs, resp.CreateSubcontrol.Subcontrol.ID)
 			}
 
 			resp, err := tc.client.GetSubcontrolByID(tc.ctx, tc.queryID)
 
 			if tc.errorMsg != "" {
-				require.Error(t, err)
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
-			require.NotEmpty(t, resp.Subcontrol)
+			assert.Check(t, is.Equal(tc.queryID, resp.Subcontrol.ID))
+			assert.Check(t, len(resp.Subcontrol.RefCode) != 0)
 
-			assert.Equal(t, tc.queryID, resp.Subcontrol.ID)
-			assert.NotEmpty(t, resp.Subcontrol.RefCode)
-
-			assert.NotEmpty(t, resp.Subcontrol.ControlID)
+			assert.Check(t, len(resp.Subcontrol.ControlID) != 0)
 		})
 	}
+
+	// cleanup the program
+	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, ID: program.ID}).
+		MustDelete(testUser1.UserCtx, t)
+
+	// cleanup the controls
+	(&Cleanup[*generated.SubcontrolDeleteOne]{client: suite.client.db.Subcontrol, IDs: createdSubcontrolIDs}).
+		MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: createdControlIDs}).
+		MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestQuerySubcontrols() {
-	t := suite.T()
-
+func TestQuerySubcontrols(t *testing.T) {
 	// create multiple objects to be queried using testUser1
-	(&SubcontrolBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
-	(&SubcontrolBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	sc1 := (&SubcontrolBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	sc2 := (&SubcontrolBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	testCases := []struct {
 		name            string
-		client          *openlaneclient.OpenlaneClient
+		client          openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int
 	}{
@@ -165,17 +174,20 @@ func (suite *GraphTestSuite) TestQuerySubcontrols() {
 	for _, tc := range testCases {
 		t.Run("List "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.GetAllSubcontrols(tc.ctx)
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
-			assert.Len(t, resp.Subcontrols.Edges, tc.expectedResults)
+			assert.Check(t, is.Len(resp.Subcontrols.Edges, tc.expectedResults), "expected %d, got %d", tc.expectedResults, len(resp.Subcontrols.Edges))
 		})
 	}
+
+	// cleanup the controls
+	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: []string{sc1.ControlID, sc2.ControlID}}).MustDelete(testUser1.UserCtx, t)
+	// cleanup the subcontrols
+	(&Cleanup[*generated.SubcontrolDeleteOne]{client: suite.client.db.Subcontrol, IDs: []string{sc1.ID, sc2.ID}}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationCreateSubcontrol() {
-	t := suite.T()
-
+func TestMutationCreateSubcontrol(t *testing.T) {
 	program := (&ProgramBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	ownerGroup := (&GroupBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
@@ -196,7 +208,7 @@ func (suite *GraphTestSuite) TestMutationCreateSubcontrol() {
 		name                string
 		request             openlaneclient.CreateSubcontrolInput
 		createParentControl bool
-		client              *openlaneclient.OpenlaneClient
+		client              openlaneclient.OpenlaneClient
 		ctx                 context.Context
 		expectedErr         string
 	}{
@@ -364,86 +376,88 @@ func (suite *GraphTestSuite) TestMutationCreateSubcontrol() {
 						ProgramIDs: []string{program.ID},
 					})
 
-				require.NoError(t, err)
-				require.NotNil(t, control)
+				assert.NilError(t, err)
+				assert.Assert(t, control != nil)
 
 				tc.request.ControlID = control.CreateControl.Control.ID
 			}
 
 			resp, err := tc.client.CreateSubcontrol(tc.ctx, tc.request)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
 			// check required fields
-			require.NotEmpty(t, resp.CreateSubcontrol.Subcontrol.ID)
-			assert.Equal(t, tc.request.RefCode, resp.CreateSubcontrol.Subcontrol.RefCode)
-
-			assert.NotEmpty(t, resp.CreateSubcontrol.Subcontrol.DisplayID)
-			assert.Contains(t, resp.CreateSubcontrol.Subcontrol.DisplayID, "SCL-")
-
-			assert.NotEmpty(t, resp.CreateSubcontrol.Subcontrol.RefCode)
-			assert.Equal(t, tc.request.RefCode, resp.CreateSubcontrol.Subcontrol.RefCode)
+			assert.Check(t, resp.CreateSubcontrol.Subcontrol.ID != "")
+			assert.Check(t, is.Equal(tc.request.RefCode, resp.CreateSubcontrol.Subcontrol.RefCode))
+			assert.Check(t, is.Contains(resp.CreateSubcontrol.Subcontrol.DisplayID, "SCL-"))
+			assert.Check(t, is.Equal(tc.request.RefCode, resp.CreateSubcontrol.Subcontrol.RefCode))
 
 			// ensure the control is set
-			require.NotEmpty(t, resp.CreateSubcontrol.Subcontrol.ControlID)
-			assert.Equal(t, tc.request.ControlID, resp.CreateSubcontrol.Subcontrol.ControlID)
+			assert.Check(t, is.Equal(tc.request.ControlID, resp.CreateSubcontrol.Subcontrol.ControlID))
 
 			if tc.request.Description != nil {
-				assert.Equal(t, *tc.request.Description, *resp.CreateSubcontrol.Subcontrol.Description)
+				assert.Check(t, is.Equal(*tc.request.Description, *resp.CreateSubcontrol.Subcontrol.Description))
 			} else {
-				assert.Empty(t, resp.CreateSubcontrol.Subcontrol.Description)
+				assert.Check(t, is.Equal(*resp.CreateSubcontrol.Subcontrol.Description, ""))
 			}
 
-			assert.Equal(t, enums.ControlStatusPreparing, *resp.CreateSubcontrol.Subcontrol.Status)
+			assert.Check(t, is.Equal(enums.ControlStatusPreparing, *resp.CreateSubcontrol.Subcontrol.Status))
 
 			if tc.request.Source != nil {
-				assert.Equal(t, *tc.request.Source, *resp.CreateSubcontrol.Subcontrol.Source)
+				assert.Check(t, is.Equal(*tc.request.Source, *resp.CreateSubcontrol.Subcontrol.Source))
 			} else {
-				assert.Equal(t, enums.ControlSourceUserDefined, *resp.CreateSubcontrol.Subcontrol.Source)
+				assert.Check(t, is.Equal(enums.ControlSourceUserDefined, *resp.CreateSubcontrol.Subcontrol.Source))
 			}
 
 			if tc.request.ControlOwnerID != nil {
-				require.NotNil(t, resp.CreateSubcontrol.Subcontrol.ControlOwner)
-				assert.Equal(t, *tc.request.ControlOwnerID, resp.CreateSubcontrol.Subcontrol.ControlOwner.ID)
+				assert.Assert(t, resp.CreateSubcontrol.Subcontrol.ControlOwner != nil)
+				assert.Check(t, is.Equal(*tc.request.ControlOwnerID, resp.CreateSubcontrol.Subcontrol.ControlOwner.ID))
 			} else if tc.request.ControlID == controlWithOwner.ID {
 				// it should inherit the owner from the parent control if it was set
-				require.NotNil(t, resp.CreateSubcontrol.Subcontrol.ControlOwner)
-				assert.Equal(t, controlWithOwner.ControlOwnerID, resp.CreateSubcontrol.Subcontrol.ControlOwner.ID)
+				assert.Assert(t, resp.CreateSubcontrol.Subcontrol.ControlOwner != nil)
+				assert.Check(t, is.Equal(controlWithOwner.ControlOwnerID, resp.CreateSubcontrol.Subcontrol.ControlOwner.ID))
 			} else {
-				assert.Nil(t, resp.CreateSubcontrol.Subcontrol.ControlOwner)
+				assert.Check(t, is.Nil(resp.CreateSubcontrol.Subcontrol.ControlOwner))
 			}
 
 			if tc.request.DelegateID != nil {
-				require.NotNil(t, resp.CreateSubcontrol.Subcontrol.Delegate)
-				assert.Equal(t, *tc.request.DelegateID, resp.CreateSubcontrol.Subcontrol.Delegate.ID)
+				assert.Assert(t, resp.CreateSubcontrol.Subcontrol.Delegate != nil)
+				assert.Check(t, is.Equal(*tc.request.DelegateID, resp.CreateSubcontrol.Subcontrol.Delegate.ID))
 			} else {
-				assert.Nil(t, resp.CreateSubcontrol.Subcontrol.Delegate)
+				assert.Check(t, is.Nil(resp.CreateSubcontrol.Subcontrol.Delegate))
 			}
 
 			// ensure the org owner has access to the subcontrol that was created by an api token
 			if tc.client == suite.client.apiWithToken {
 				res, err := suite.client.api.GetSubcontrolByID(testUser1.UserCtx, resp.CreateSubcontrol.Subcontrol.ID)
-				require.NoError(t, err)
-				require.NotEmpty(t, res)
-				assert.Equal(t, resp.CreateSubcontrol.Subcontrol.ID, res.Subcontrol.ID)
+				assert.NilError(t, err)
+				assert.Assert(t, res != nil)
+				assert.Check(t, is.Equal(resp.CreateSubcontrol.Subcontrol.ID, res.Subcontrol.ID))
 			}
 		})
 	}
+
+	// cleanup the program
+	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, ID: program.ID}).
+		MustDelete(testUser1.UserCtx, t)
+	// cleanup the controls
+	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: []string{control1.ID, control2.ID, controlWithOwner.ID}}).
+		MustDelete(testUser1.UserCtx, t)
+	// cleanup the groups
+	(&Cleanup[*generated.GroupDeleteOne]{client: suite.client.db.Group, IDs: []string{ownerGroup.ID, anotherOwnerGroup.ID, delegateGroup.ID}}).
+		MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationUpdateSubcontrol() {
-	t := suite.T()
-
+func TestMutationUpdateSubcontrol(t *testing.T) {
 	control1 := (&ControlBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
-
 	subcontrol := (&SubcontrolBuilder{client: suite.client, ControlID: control1.ID}).MustNew(testUser1.UserCtx, t)
 
 	ownerGroup := (&GroupBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
@@ -452,7 +466,7 @@ func (suite *GraphTestSuite) TestMutationUpdateSubcontrol() {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.UpdateSubcontrolInput
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -509,52 +523,59 @@ func (suite *GraphTestSuite) TestMutationUpdateSubcontrol() {
 		t.Run("Update "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.UpdateSubcontrol(tc.ctx, subcontrol.ID, tc.request)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
 			if tc.request.Description != nil {
-				assert.Equal(t, *tc.request.Description, *resp.UpdateSubcontrol.Subcontrol.Description)
+				assert.Check(t, is.Equal(*tc.request.Description, *resp.UpdateSubcontrol.Subcontrol.Description))
 			}
 
 			if tc.request.Status != nil {
-				assert.Equal(t, *tc.request.Status, *resp.UpdateSubcontrol.Subcontrol.Status)
+				assert.Check(t, is.Equal(*tc.request.Status, *resp.UpdateSubcontrol.Subcontrol.Status))
 			}
 
 			if tc.request.Tags != nil {
-				assert.ElementsMatch(t, tc.request.Tags, resp.UpdateSubcontrol.Subcontrol.Tags)
+				assert.Check(t, is.DeepEqual(tc.request.Tags, resp.UpdateSubcontrol.Subcontrol.Tags))
 			}
 
 			if tc.request.Source != nil {
-				assert.Equal(t, *tc.request.Source, *resp.UpdateSubcontrol.Subcontrol.Source)
+				assert.Check(t, is.Equal(*tc.request.Source, *resp.UpdateSubcontrol.Subcontrol.Source))
 			}
 
 			if tc.request.ControlOwnerID != nil {
-				require.NotNil(t, resp.UpdateSubcontrol.Subcontrol.ControlOwner)
-				assert.Equal(t, *tc.request.ControlOwnerID, resp.UpdateSubcontrol.Subcontrol.ControlOwner.ID)
+				assert.Assert(t, resp.UpdateSubcontrol.Subcontrol.ControlOwner != nil)
+				assert.Check(t, is.Equal(*tc.request.ControlOwnerID, resp.UpdateSubcontrol.Subcontrol.ControlOwner.ID))
 			} else {
-				assert.Nil(t, resp.UpdateSubcontrol.Subcontrol.ControlOwner)
+				assert.Check(t, is.Nil(resp.UpdateSubcontrol.Subcontrol.ControlOwner))
 			}
 
 			if tc.request.DelegateID != nil {
-				require.NotNil(t, resp.UpdateSubcontrol.Subcontrol.Delegate)
-				assert.Equal(t, *tc.request.DelegateID, resp.UpdateSubcontrol.Subcontrol.Delegate.ID)
+				assert.Assert(t, resp.UpdateSubcontrol.Subcontrol.Delegate != nil)
+				assert.Check(t, is.Equal(*tc.request.DelegateID, resp.UpdateSubcontrol.Subcontrol.Delegate.ID))
 			} else {
-				assert.Nil(t, resp.UpdateSubcontrol.Subcontrol.Delegate)
+				assert.Check(t, is.Nil(resp.UpdateSubcontrol.Subcontrol.Delegate))
 			}
 		})
 	}
+
+	// cleanup the subcontrol
+	(&Cleanup[*generated.SubcontrolDeleteOne]{client: suite.client.db.Subcontrol, ID: subcontrol.ID}).
+		MustDelete(testUser1.UserCtx, t)
+	// cleanup the control
+	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: []string{control1.ID}}).
+		MustDelete(testUser1.UserCtx, t)
+	// cleanup the groups
+	(&Cleanup[*generated.GroupDeleteOne]{client: suite.client.db.Group, IDs: []string{ownerGroup.ID, delegateGroup.ID}}).
+		MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationDeleteSubcontrol() {
-	t := suite.T()
-
+func TestMutationDeleteSubcontrol(t *testing.T) {
 	// create objects to be deleted
 	subcontrol1 := (&SubcontrolBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	subcontrol2 := (&SubcontrolBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
@@ -562,7 +583,7 @@ func (suite *GraphTestSuite) TestMutationDeleteSubcontrol() {
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -605,16 +626,20 @@ func (suite *GraphTestSuite) TestMutationDeleteSubcontrol() {
 		t.Run("Delete "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.DeleteSubcontrol(tc.ctx, tc.idToDelete)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			assert.Equal(t, tc.idToDelete, resp.DeleteSubcontrol.DeletedID)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Check(t, is.Equal(tc.idToDelete, resp.DeleteSubcontrol.DeletedID))
 		})
 	}
+
+	// cleanup the controls
+	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: []string{subcontrol1.ControlID, subcontrol2.ControlID}}).
+		MustDelete(testUser1.UserCtx, t)
 }

--- a/internal/graphapi/subscriber_test.go
+++ b/internal/graphapi/subscriber_test.go
@@ -2,28 +2,29 @@ package graphapi_test
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 
+	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/graphapi/gqlerrors"
 	"github.com/theopenlane/core/pkg/openlaneclient"
 )
 
-func (suite *GraphTestSuite) TestQuerySubscriber() {
-	t := suite.T()
+func TestQuerySubscriber(t *testing.T) {
 
 	subscriber := (&SubscriberBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
-
 	subscriber2 := (&SubscriberBuilder{client: suite.client}).MustNew(testUser2.UserCtx, t)
 
 	testCases := []struct {
 		name    string
 		email   string
-		client  *openlaneclient.OpenlaneClient
+		client  openlaneclient.OpenlaneClient
 		ctx     context.Context
 		wantErr bool
 	}{
@@ -83,8 +84,8 @@ func (suite *GraphTestSuite) TestQuerySubscriber() {
 			resp, err := tc.client.GetSubscriberByEmail(tc.ctx, tc.email)
 
 			if tc.wantErr {
-				require.Error(t, err)
-				assert.Nil(t, resp)
+
+				assert.Check(t, is.Nil(resp))
 
 				errors := parseClientError(t, err)
 				for _, e := range errors {
@@ -95,24 +96,26 @@ func (suite *GraphTestSuite) TestQuerySubscriber() {
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.NotNil(t, resp.Subscriber)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Check(t, resp.Subscriber.ID != "")
 		})
 	}
+
+	// cleanup
+	(&Cleanup[*generated.SubscriberDeleteOne]{client: suite.client.db.Subscriber, ID: subscriber.ID}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.SubscriberDeleteOne]{client: suite.client.db.Subscriber, ID: subscriber2.ID}).MustDelete(testUser2.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestQuerySubscribers() {
-	t := suite.T()
+func TestQuerySubscribers(t *testing.T) {
 
-	(&SubscriberBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
-	(&SubscriberBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
-
-	(&SubscriberBuilder{client: suite.client}).MustNew(testUser2.UserCtx, t)
+	s1 := (&SubscriberBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	s2 := (&SubscriberBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	s3 := (&SubscriberBuilder{client: suite.client}).MustNew(testUser2.UserCtx, t)
 
 	testCases := []struct {
 		name        string
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		numExpected int
 	}{
@@ -146,20 +149,23 @@ func (suite *GraphTestSuite) TestQuerySubscribers() {
 		t.Run("Get "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.GetAllSubscribers(tc.ctx)
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.Len(t, resp.Subscribers.Edges, tc.numExpected)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Check(t, is.Len(resp.Subscribers.Edges, tc.numExpected))
 		})
 	}
+
+	// cleanup
+	(&Cleanup[*generated.SubscriberDeleteOne]{client: suite.client.db.Subscriber, IDs: []string{s1.ID, s2.ID}}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.SubscriberDeleteOne]{client: suite.client.db.Subscriber, IDs: []string{s3.ID}}).MustDelete(testUser2.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationCreateBulkSubscribers() {
-	t := suite.T()
+func TestMutationCreateBulkSubscribers(t *testing.T) {
 
 	testCases := []struct {
 		name    string
 		emails  []string
-		client  *openlaneclient.OpenlaneClient
+		client  openlaneclient.OpenlaneClient
 		ctx     context.Context
 		wantErr bool
 	}{
@@ -206,33 +212,37 @@ func (suite *GraphTestSuite) TestMutationCreateBulkSubscribers() {
 			resp, err := tc.client.CreateBulkSubscriber(tc.ctx, input)
 
 			if tc.wantErr {
-				require.Error(t, err)
-				assert.Nil(t, resp)
+
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
 			for k, v := range tc.emails {
-				assert.Equal(t, strings.ToLower(v), resp.CreateBulkSubscriber.Subscribers[k].Email)
-				assert.False(t, resp.CreateBulkSubscriber.Subscribers[k].Unsubscribed)
-				assert.False(t, resp.CreateBulkSubscriber.Subscribers[k].Active)
+				assert.Check(t, is.Equal(strings.ToLower(v), resp.CreateBulkSubscriber.Subscribers[k].Email))
+				assert.Check(t, !resp.CreateBulkSubscriber.Subscribers[k].Unsubscribed)
+				assert.Check(t, !resp.CreateBulkSubscriber.Subscribers[k].Active)
+			}
+
+			// cleanup
+			for _, v := range resp.CreateBulkSubscriber.Subscribers {
+				(&Cleanup[*generated.SubscriberDeleteOne]{client: suite.client.db.Subscriber, ID: v.ID}).MustDelete(testUser1.UserCtx, t)
 			}
 		})
 	}
 }
 
-func (suite *GraphTestSuite) TestMutationCreateSubscriber_Tokens() {
-	t := suite.T()
+func TestMutationCreateSubscriber_Tokens(t *testing.T) {
 
 	testCases := []struct {
 		name             string
 		email            string
 		ownerID          string
 		setUnsubscribed  bool
-		client           *openlaneclient.OpenlaneClient
+		client           openlaneclient.OpenlaneClient
 		ctx              context.Context
 		wantErr          bool
 		expectedAttempts int
@@ -273,32 +283,35 @@ func (suite *GraphTestSuite) TestMutationCreateSubscriber_Tokens() {
 			resp, err := tc.client.CreateSubscriber(tc.ctx, input)
 
 			if tc.wantErr {
-				require.Error(t, err)
-				assert.Nil(t, resp)
+				assert.ErrorContains(t, err, "email is required but not provided")
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
 			// Assert matching fields
 			// Since we convert to lower case already on insertion/update
-			assert.Equal(t, strings.ToLower(tc.email), resp.CreateSubscriber.Subscriber.Email)
-			assert.False(t, resp.CreateSubscriber.Subscriber.Unsubscribed)
+			assert.Check(t, is.Equal(strings.ToLower(tc.email), resp.CreateSubscriber.Subscriber.Email))
+			assert.Check(t, !resp.CreateSubscriber.Subscriber.Unsubscribed)
+
+			// cleanup
+			(&Cleanup[*generated.SubscriberDeleteOne]{client: suite.client.db.Subscriber, ID: resp.CreateSubscriber.Subscriber.ID}).MustDelete(testUser1.UserCtx, t)
 		})
 	}
 }
 
-func (suite *GraphTestSuite) TestMutationCreateSubscriber_SendAttempts() {
-	t := suite.T()
+func TestMutationCreateSubscriber_SendAttempts(t *testing.T) {
 
+	createdSubscriberEmails := []string{}
 	testCases := []struct {
 		name              string
 		email             string
 		ownerID           string
 		setUnsubscribed   bool
-		client            *openlaneclient.OpenlaneClient
+		client            openlaneclient.OpenlaneClient
 		ctx               context.Context
 		wantErr           bool
 		expectedMessage   string
@@ -387,8 +400,7 @@ func (suite *GraphTestSuite) TestMutationCreateSubscriber_SendAttempts() {
 			resp, err := tc.client.CreateSubscriber(tc.ctx, input)
 
 			if tc.wantErr {
-				require.Error(t, err)
-				assert.Nil(t, resp)
+				assert.Assert(t, is.Nil(resp))
 
 				errors := parseClientError(t, err)
 				for _, e := range errors {
@@ -399,41 +411,51 @@ func (suite *GraphTestSuite) TestMutationCreateSubscriber_SendAttempts() {
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
 			// Assert matching fields
 			// Since we convert to lower case already on insertion/update
-			assert.Equal(t, strings.ToLower(tc.email), resp.CreateSubscriber.Subscriber.Email)
-			assert.False(t, resp.CreateSubscriber.Subscriber.Unsubscribed)
+			assert.Check(t, is.Equal(strings.ToLower(tc.email), resp.CreateSubscriber.Subscriber.Email))
+			assert.Check(t, !resp.CreateSubscriber.Subscriber.Unsubscribed)
 
 			if tc.setUnsubscribed {
 				// Set the subscriber as unsubscribed to test for duplicate email
 				resp, err := tc.client.UpdateSubscriber(tc.ctx, resp.CreateSubscriber.Subscriber.Email, openlaneclient.UpdateSubscriberInput{
 					Unsubscribed: lo.ToPtr(true),
 				})
-				require.NoError(t, err)
-				require.NotNil(t, resp)
+				assert.NilError(t, err)
+				assert.Assert(t, resp != nil)
 
-				require.True(t, resp.UpdateSubscriber.Subscriber.Unsubscribed) // ensure the subscriber is unsubscribed now
-				require.False(t, resp.UpdateSubscriber.Subscriber.Active)      // ensure the subscriber is inactive now after unsubscribing
+				assert.Check(t, resp.UpdateSubscriber.Subscriber.Unsubscribed) // ensure the subscriber is unsubscribed now
+				assert.Check(t, !resp.UpdateSubscriber.Subscriber.Active)      // ensure the subscriber is inactive now after unsubscribing
+			}
+
+			// add the list to cleanup later
+			if !slices.Contains(createdSubscriberEmails, strings.ToLower(tc.email)) {
+				createdSubscriberEmails = append(createdSubscriberEmails, strings.ToLower(tc.email))
 			}
 
 			sub, err := tc.client.GetSubscriberByEmail(tc.ctx, strings.ToLower(tc.email))
-			require.NoError(t, err)
+			assert.NilError(t, err)
 
 			if tc.setUnsubscribed {
 				require.Zero(t, sub.Subscriber.SendAttempts) // reset attempts count to zero
 				return
 			}
 
-			require.Equal(t, tc.expectedAttempts, sub.Subscriber.SendAttempts)
+			assert.Equal(t, tc.expectedAttempts, sub.Subscriber.SendAttempts)
 		})
+	}
+
+	// cleanup
+	for _, v := range createdSubscriberEmails {
+		_, err := suite.client.api.DeleteSubscriber(testUser1.UserCtx, v, nil)
+		assert.NilError(t, err)
 	}
 }
 
-func (suite *GraphTestSuite) TestUpdateSubscriber() {
-	t := suite.T()
+func TestUpdateSubscriber(t *testing.T) {
 
 	subscriber := (&SubscriberBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	subscriber2 := (&SubscriberBuilder{client: suite.client}).MustNew(testUser2.UserCtx, t)
@@ -442,7 +464,7 @@ func (suite *GraphTestSuite) TestUpdateSubscriber() {
 		name        string
 		email       string
 		updateInput openlaneclient.UpdateSubscriberInput
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		wantErr     bool
 	}{
@@ -513,38 +535,41 @@ func (suite *GraphTestSuite) TestUpdateSubscriber() {
 			resp, err := tc.client.UpdateSubscriber(tc.ctx, tc.email, tc.updateInput)
 
 			if tc.wantErr {
-				require.Error(t, err)
-				assert.Nil(t, resp)
+				assert.Assert(t, is.Nil(resp))
+				assert.ErrorContains(t, err, "subscriber not found")
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.Equal(t, tc.email, resp.UpdateSubscriber.Subscriber.Email)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Equal(t, tc.email, resp.UpdateSubscriber.Subscriber.Email)
 
 			if tc.updateInput.PhoneNumber != nil {
-				require.Equal(t, tc.updateInput.PhoneNumber, resp.UpdateSubscriber.Subscriber.PhoneNumber)
+				assert.Check(t, is.Equal(*tc.updateInput.PhoneNumber, *resp.UpdateSubscriber.Subscriber.PhoneNumber))
 			}
 
 			if tc.updateInput.Unsubscribed != nil {
-				require.Equal(t, *tc.updateInput.Unsubscribed, resp.UpdateSubscriber.Subscriber.Unsubscribed)
+				assert.Check(t, *tc.updateInput.Unsubscribed, resp.UpdateSubscriber.Subscriber.Unsubscribed)
 
 				if *tc.updateInput.Unsubscribed {
 					// ensure I can create another subscriber with the same email
 					resp, err := tc.client.CreateSubscriber(tc.ctx, openlaneclient.CreateSubscriberInput{
 						Email: tc.email,
 					})
-					require.NoError(t, err)
-					require.NotNil(t, resp)
+					assert.NilError(t, err)
+					assert.Assert(t, resp != nil)
 				}
 			}
 		})
 	}
+
+	// cleanup
+	(&Cleanup[*generated.SubscriberDeleteOne]{client: suite.client.db.Subscriber, ID: subscriber.ID}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.SubscriberDeleteOne]{client: suite.client.db.Subscriber, ID: subscriber2.ID}).MustDelete(testUser2.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestDeleteSubscriber() {
-	t := suite.T()
+func TestDeleteSubscriber(t *testing.T) {
 
 	subscriber1 := (&SubscriberBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	subscriber2 := (&SubscriberBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
@@ -556,7 +581,7 @@ func (suite *GraphTestSuite) TestDeleteSubscriber() {
 		name           string
 		email          string
 		organizationID string
-		client         *openlaneclient.OpenlaneClient
+		client         openlaneclient.OpenlaneClient
 		ctx            context.Context
 		wantErr        bool
 	}{
@@ -603,27 +628,29 @@ func (suite *GraphTestSuite) TestDeleteSubscriber() {
 			resp, err := tc.client.DeleteSubscriber(tc.ctx, tc.email, &tc.organizationID)
 
 			if tc.wantErr {
-				require.Error(t, err)
-				assert.Nil(t, resp)
+				assert.ErrorContains(t, err, notFoundErrorMsg)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.Equal(t, tc.email, resp.DeleteSubscriber.Email)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Equal(t, tc.email, resp.DeleteSubscriber.Email)
 		})
 	}
+
+	// cleanup
+	(&Cleanup[*generated.SubscriberDeleteOne]{client: suite.client.db.Subscriber, ID: subscriberOtherOrg.ID}).MustDelete(testUser2.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestActiveSubscriber() {
-	t := suite.T()
+func TestActiveSubscriber(t *testing.T) {
 
 	testCases := []struct {
 		name       string
 		email      string
 		ownerID    string
-		client     *openlaneclient.OpenlaneClient
+		client     openlaneclient.OpenlaneClient
 		ctx        context.Context
 		wantErr    bool
 		markActive bool
@@ -659,16 +686,14 @@ func (suite *GraphTestSuite) TestActiveSubscriber() {
 			resp, err := tc.client.CreateSubscriber(tc.ctx, input)
 
 			if tc.wantErr {
-				require.Error(t, err)
-				assert.Nil(t, resp)
+				assert.Assert(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NotNil(t, resp)
+			assert.Assert(t, resp != nil)
 
 			if tc.markActive {
-
 				ctx := setContext(tc.ctx, suite.client.db)
 
 				// update the subscriber and mark active
@@ -677,19 +702,21 @@ func (suite *GraphTestSuite) TestActiveSubscriber() {
 					SetActive(true).
 					Save(ctx)
 
-				require.NoError(t, err)
+				assert.NilError(t, err)
 			}
 
 			_, err = tc.client.CreateSubscriber(tc.ctx, input)
-
 			if tc.markActive {
 				// if we marked the user as active, this should fail
-				require.Error(t, err)
+				assert.ErrorContains(t, err, "subscriber already exists")
 
 				return
 			}
 
-			require.NoError(t, err)
+			assert.NilError(t, err)
+
+			// cleanup
+			(&Cleanup[*generated.SubscriberDeleteOne]{client: suite.client.db.Subscriber, ID: resp.CreateSubscriber.Subscriber.ID}).MustDelete(tc.ctx, t)
 		})
 	}
 }

--- a/internal/graphapi/subscriber_test.go
+++ b/internal/graphapi/subscriber_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestQuerySubscriber(t *testing.T) {
-
 	subscriber := (&SubscriberBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	subscriber2 := (&SubscriberBuilder{client: suite.client}).MustNew(testUser2.UserCtx, t)
 
@@ -84,7 +83,6 @@ func TestQuerySubscriber(t *testing.T) {
 			resp, err := tc.client.GetSubscriberByEmail(tc.ctx, tc.email)
 
 			if tc.wantErr {
-
 				assert.Check(t, is.Nil(resp))
 
 				errors := parseClientError(t, err)
@@ -108,7 +106,6 @@ func TestQuerySubscriber(t *testing.T) {
 }
 
 func TestQuerySubscribers(t *testing.T) {
-
 	s1 := (&SubscriberBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	s2 := (&SubscriberBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	s3 := (&SubscriberBuilder{client: suite.client}).MustNew(testUser2.UserCtx, t)
@@ -212,7 +209,6 @@ func TestMutationCreateBulkSubscribers(t *testing.T) {
 			resp, err := tc.client.CreateBulkSubscriber(tc.ctx, input)
 
 			if tc.wantErr {
-
 				assert.Check(t, is.Nil(resp))
 
 				return
@@ -456,7 +452,6 @@ func TestMutationCreateSubscriber_SendAttempts(t *testing.T) {
 }
 
 func TestUpdateSubscriber(t *testing.T) {
-
 	subscriber := (&SubscriberBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	subscriber2 := (&SubscriberBuilder{client: suite.client}).MustNew(testUser2.UserCtx, t)
 
@@ -570,7 +565,6 @@ func TestUpdateSubscriber(t *testing.T) {
 }
 
 func TestDeleteSubscriber(t *testing.T) {
-
 	subscriber1 := (&SubscriberBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	subscriber2 := (&SubscriberBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	subscriber3 := (&SubscriberBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)

--- a/internal/graphapi/subscriber_test.go
+++ b/internal/graphapi/subscriber_test.go
@@ -23,7 +23,7 @@ func TestQuerySubscriber(t *testing.T) {
 	testCases := []struct {
 		name    string
 		email   string
-		client  openlaneclient.OpenlaneClient
+		client  *openlaneclient.OpenlaneClient
 		ctx     context.Context
 		wantErr bool
 	}{
@@ -112,7 +112,7 @@ func TestQuerySubscribers(t *testing.T) {
 
 	testCases := []struct {
 		name        string
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		numExpected int
 	}{
@@ -162,7 +162,7 @@ func TestMutationCreateBulkSubscribers(t *testing.T) {
 	testCases := []struct {
 		name    string
 		emails  []string
-		client  openlaneclient.OpenlaneClient
+		client  *openlaneclient.OpenlaneClient
 		ctx     context.Context
 		wantErr bool
 	}{
@@ -238,7 +238,7 @@ func TestMutationCreateSubscriber_Tokens(t *testing.T) {
 		email            string
 		ownerID          string
 		setUnsubscribed  bool
-		client           openlaneclient.OpenlaneClient
+		client           *openlaneclient.OpenlaneClient
 		ctx              context.Context
 		wantErr          bool
 		expectedAttempts int
@@ -307,7 +307,7 @@ func TestMutationCreateSubscriber_SendAttempts(t *testing.T) {
 		email             string
 		ownerID           string
 		setUnsubscribed   bool
-		client            openlaneclient.OpenlaneClient
+		client            *openlaneclient.OpenlaneClient
 		ctx               context.Context
 		wantErr           bool
 		expectedMessage   string
@@ -459,7 +459,7 @@ func TestUpdateSubscriber(t *testing.T) {
 		name        string
 		email       string
 		updateInput openlaneclient.UpdateSubscriberInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		wantErr     bool
 	}{
@@ -575,7 +575,7 @@ func TestDeleteSubscriber(t *testing.T) {
 		name           string
 		email          string
 		organizationID string
-		client         openlaneclient.OpenlaneClient
+		client         *openlaneclient.OpenlaneClient
 		ctx            context.Context
 		wantErr        bool
 	}{
@@ -644,7 +644,7 @@ func TestActiveSubscriber(t *testing.T) {
 		name       string
 		email      string
 		ownerID    string
-		client     openlaneclient.OpenlaneClient
+		client     *openlaneclient.OpenlaneClient
 		ctx        context.Context
 		wantErr    bool
 		markActive bool

--- a/internal/graphapi/subscriber_test.go
+++ b/internal/graphapi/subscriber_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 
@@ -436,7 +435,7 @@ func TestMutationCreateSubscriber_SendAttempts(t *testing.T) {
 			assert.NilError(t, err)
 
 			if tc.setUnsubscribed {
-				require.Zero(t, sub.Subscriber.SendAttempts) // reset attempts count to zero
+				assert.Equal(t, sub.Subscriber.SendAttempts, int64(0)) // reset attempts count to zero
 				return
 			}
 

--- a/internal/graphapi/task_test.go
+++ b/internal/graphapi/task_test.go
@@ -26,7 +26,7 @@ func TestQueryTask(t *testing.T) {
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   openlaneclient.OpenlaneClient
+		client   *openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{
@@ -100,7 +100,7 @@ func TestQueryTasks(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		client          openlaneclient.OpenlaneClient
+		client          *openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int
 		totalCount      int64
@@ -160,7 +160,7 @@ func TestMutationCreateTask(t *testing.T) {
 	testCases := []struct {
 		name        string
 		request     openlaneclient.CreateTaskInput
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -342,7 +342,7 @@ func TestMutationUpdateTask(t *testing.T) {
 		request              *openlaneclient.UpdateTaskInput
 		updateCommentRequest *openlaneclient.UpdateNoteInput
 		files                []*graphql.Upload
-		client               openlaneclient.OpenlaneClient
+		client               *openlaneclient.OpenlaneClient
 		ctx                  context.Context
 		expectedErr          string
 	}{
@@ -608,7 +608,7 @@ func TestMutationDeleteTask(t *testing.T) {
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      openlaneclient.OpenlaneClient
+		client      *openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{

--- a/internal/graphapi/task_test.go
+++ b/internal/graphapi/task_test.go
@@ -7,11 +7,12 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/theopenlane/iam/auth"
 	"github.com/theopenlane/utils/ulids"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 
+	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/models"
 	"github.com/theopenlane/core/pkg/objects"
@@ -19,15 +20,13 @@ import (
 	"github.com/theopenlane/core/pkg/testutils"
 )
 
-func (suite *GraphTestSuite) TestQueryTask() {
-	t := suite.T()
-
+func TestQueryTask(t *testing.T) {
 	task := (&TaskBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   *openlaneclient.OpenlaneClient
+		client   openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{
@@ -57,46 +56,52 @@ func (suite *GraphTestSuite) TestQueryTask() {
 			resp, err := tc.client.GetTaskByID(tc.ctx, tc.queryID)
 
 			if tc.errorMsg != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
-			assert.Equal(t, tc.queryID, resp.Task.ID)
-			assert.NotEmpty(t, resp.Task.Title)
-			assert.NotEmpty(t, resp.Task.Details)
-			assert.NotEmpty(t, resp.Task.Status)
+			assert.Check(t, is.Equal(tc.queryID, resp.Task.ID))
+			assert.Check(t, len(resp.Task.Title) != 0)
+			assert.Check(t, resp.Task.Details != nil)
+			assert.Check(t, len(resp.Task.Status) != 0)
 		})
 	}
+
+	// cleanup
+	(&Cleanup[*generated.TaskDeleteOne]{client: suite.client.db.Task, ID: task.ID}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestQueryTasks() {
-	t := suite.T()
-
+func TestQueryTasks(t *testing.T) {
 	// create a bunch to test the pagination with different users
 	// works with overfetching
 	numTasks := 10
+	org1TaskIDs := []string{}
+	org2TaskIDs := []string{}
 	for range numTasks {
-		(&TaskBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
-		(&TaskBuilder{client: suite.client}).MustNew(viewOnlyUser.UserCtx, t)
-		(&TaskBuilder{client: suite.client}).MustNew(testUser2.UserCtx, t)
-		(&TaskBuilder{client: suite.client}).MustNew(adminUser.UserCtx, t)
+		t1 := (&TaskBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+		t2 := (&TaskBuilder{client: suite.client}).MustNew(viewOnlyUser2.UserCtx, t)
+		t3 := (&TaskBuilder{client: suite.client}).MustNew(adminUser.UserCtx, t)
+		org1TaskIDs = append(org1TaskIDs, t1.ID, t2.ID, t3.ID)
+
+		t4 := (&TaskBuilder{client: suite.client}).MustNew(testUser2.UserCtx, t)
+		org2TaskIDs = append(org2TaskIDs, t4.ID)
 	}
 
 	userCtxPersonalOrg := auth.NewTestContextWithOrgID(testUser1.ID, testUser1.PersonalOrgID)
 
 	// add a task for the user to another org; this should not be returned for JWT auth, since it's
 	// restricted to a single org. PAT auth would return it if both orgs are authorized on the token
-	(&TaskBuilder{client: suite.client, AssigneeID: testUser1.ID}).MustNew(userCtxPersonalOrg, t)
+	taskPersonal := (&TaskBuilder{client: suite.client, AssigneeID: testUser1.ID}).MustNew(userCtxPersonalOrg, t)
 
 	testCases := []struct {
 		name            string
-		client          *openlaneclient.OpenlaneClient
+		client          openlaneclient.OpenlaneClient
 		ctx             context.Context
 		expectedResults int
 		totalCount      int64
@@ -109,9 +114,9 @@ func (suite *GraphTestSuite) TestQueryTasks() {
 			totalCount:      30,
 		},
 		{
-			name:            "happy path",
+			name:            "happy path, view only user",
 			client:          suite.client.api,
-			ctx:             viewOnlyUser.UserCtx,
+			ctx:             viewOnlyUser2.UserCtx,
 			expectedResults: testutils.MaxResultLimit,
 			totalCount:      10,
 		},
@@ -135,22 +140,29 @@ func (suite *GraphTestSuite) TestQueryTasks() {
 		t.Run("List "+tc.name, func(t *testing.T) {
 			first := int64(10)
 			resp, err := tc.client.GetTasks(tc.ctx, &first, nil, nil)
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
-			assert.Len(t, resp.Tasks.Edges, tc.expectedResults)
-			assert.Equal(t, tc.totalCount, resp.Tasks.TotalCount)
+			assert.Check(t, is.Len(resp.Tasks.Edges, tc.expectedResults))
+			assert.Check(t, is.Equal(tc.totalCount, resp.Tasks.TotalCount))
 		})
 	}
+
+	// cleanup
+	(&Cleanup[*generated.TaskDeleteOne]{client: suite.client.db.Task, ID: taskPersonal.ID}).MustDelete(userCtxPersonalOrg, t)
+	(&Cleanup[*generated.TaskDeleteOne]{client: suite.client.db.Task, IDs: org1TaskIDs}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.TaskDeleteOne]{client: suite.client.db.Task, IDs: org2TaskIDs}).MustDelete(testUser2.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationCreateTask() {
-	t := suite.T()
+func TestMutationCreateTask(t *testing.T) {
+
+	om := (&OrgMemberBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	userCtx := auth.NewTestContextWithOrgID(om.UserID, om.OrganizationID)
 
 	testCases := []struct {
 		name        string
 		request     openlaneclient.CreateTaskInput
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -170,7 +182,7 @@ func (suite *GraphTestSuite) TestMutationCreateTask() {
 				Status:     &enums.TaskStatusInProgress,
 				Category:   lo.ToPtr("evidence upload"),
 				Due:        lo.ToPtr(models.DateTime(time.Now().Add(time.Hour * 24))),
-				AssigneeID: &viewOnlyUser.ID, // assign the task to another user
+				AssigneeID: &om.UserID, // assign the task to another user
 			},
 			client: suite.client.api,
 			ctx:    testUser1.UserCtx,
@@ -217,106 +229,113 @@ func (suite *GraphTestSuite) TestMutationCreateTask() {
 		t.Run("Create "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.CreateTask(tc.ctx, tc.request)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
-			assert.Equal(t, tc.request.Title, resp.CreateTask.Task.Title)
+			assert.Check(t, is.Equal(tc.request.Title, resp.CreateTask.Task.Title))
 
-			assert.NotEmpty(t, resp.CreateTask.Task.DisplayID)
-			assert.Contains(t, resp.CreateTask.Task.DisplayID, "TSK-")
+			assert.Check(t, len(resp.CreateTask.Task.DisplayID) != 0)
+			assert.Check(t, is.Contains(resp.CreateTask.Task.DisplayID, "TSK-"))
 
-			assert.NotNil(t, resp.CreateTask.Task.OwnerID)
+			assert.Check(t, resp.CreateTask.Task.OwnerID != nil)
 
 			if tc.request.Details == nil {
-				assert.Empty(t, resp.CreateTask.Task.Details)
+				assert.Check(t, is.Equal(*resp.CreateTask.Task.Details, ""))
 			} else {
-				assert.Equal(t, tc.request.Details, resp.CreateTask.Task.Details)
+				assert.Check(t, is.Equal(*tc.request.Details, *resp.CreateTask.Task.Details))
 			}
 
 			if tc.request.Status == nil {
-				assert.Equal(t, enums.TaskStatusOpen, resp.CreateTask.Task.Status)
+				assert.Check(t, is.Equal(enums.TaskStatusOpen, resp.CreateTask.Task.Status))
 			} else {
-				assert.Equal(t, *tc.request.Status, resp.CreateTask.Task.Status)
+				assert.Check(t, is.Equal(*tc.request.Status, resp.CreateTask.Task.Status))
 			}
 
 			if tc.request.Details == nil {
-				assert.Empty(t, resp.CreateTask.Task.Details)
+				assert.Check(t, is.Equal(*resp.CreateTask.Task.Details, ""))
 			} else {
-				assert.Equal(t, tc.request.Details, resp.CreateTask.Task.Details)
+				assert.Check(t, is.Equal(*tc.request.Details, *resp.CreateTask.Task.Details))
 			}
 
 			if tc.request.Category == nil {
-				assert.Empty(t, resp.CreateTask.Task.Category)
+				assert.Check(t, is.Equal(*resp.CreateTask.Task.Category, ""))
 			} else {
-				assert.Equal(t, tc.request.Category, resp.CreateTask.Task.Category)
+				assert.Check(t, is.Equal(*tc.request.Category, *resp.CreateTask.Task.Category))
 			}
 
 			if tc.request.Due == nil {
-				assert.Empty(t, resp.CreateTask.Task.Due)
+				assert.Check(t, is.Equal(*resp.CreateTask.Task.Due, models.DateTime(time.Time{})))
 			} else {
-				assert.WithinDuration(t, time.Time(*tc.request.Due), time.Time(*resp.CreateTask.Task.Due), 10*time.Second)
+				assert.Assert(t, resp.CreateTask.Task.Due != nil)
+				diff := time.Time(*resp.CreateTask.Task.Due).Sub(time.Time(*tc.request.Due))
+				assert.Check(t, diff >= -10*time.Second && diff <= 10*time.Second, "time difference is not within 10 seconds")
 			}
 
 			// when using an API token, the assigner is not set
 			if tc.client == suite.client.apiWithToken {
-				assert.Nil(t, resp.CreateTask.Task.Assigner)
+				assert.Check(t, is.Nil(resp.CreateTask.Task.Assigner))
 			} else {
 				// otherwise it defaults to the authorized user
-				assert.NotNil(t, resp.CreateTask.Task.Assigner)
-				assert.Equal(t, testUser1.ID, resp.CreateTask.Task.Assigner.ID)
+				assert.Check(t, resp.CreateTask.Task.Assigner != nil)
+				assert.Check(t, is.Equal(testUser1.ID, resp.CreateTask.Task.Assigner.ID))
 			}
 
 			if tc.request.AssigneeID == nil {
-				assert.Nil(t, resp.CreateTask.Task.Assignee)
+				assert.Check(t, is.Nil(resp.CreateTask.Task.Assignee))
 			} else {
-				require.NotNil(t, resp.CreateTask.Task.Assignee)
-
-				assert.Equal(t, *tc.request.AssigneeID, resp.CreateTask.Task.Assignee.ID)
+				assert.Assert(t, resp.CreateTask.Task.Assignee != nil)
+				assert.Check(t, is.Equal(*tc.request.AssigneeID, resp.CreateTask.Task.Assignee.ID))
 
 				// make sure the assignee can see the task
-				taskResp, err := suite.client.api.GetTaskByID(viewOnlyUser.UserCtx, resp.CreateTask.Task.ID)
-				require.NoError(t, err)
-				assert.NotNil(t, taskResp)
+				taskResp, err := suite.client.api.GetTaskByID(userCtx, resp.CreateTask.Task.ID)
+				assert.NilError(t, err)
+				assert.Check(t, taskResp != nil)
 
 				// make sure the another org member cannot see the task
 				taskResp, err = suite.client.api.GetTaskByID(adminUser.UserCtx, resp.CreateTask.Task.ID)
-				require.Error(t, err)
-				assert.Nil(t, taskResp)
+
+				assert.Check(t, is.Nil(taskResp))
 			}
+
+			// cleanup
+			(&Cleanup[*generated.TaskDeleteOne]{client: suite.client.db.Task, ID: resp.CreateTask.Task.ID}).MustDelete(testUser1.UserCtx, t)
 		})
 	}
+
+	// cleanup
+	(&Cleanup[*generated.OrgMembershipDeleteOne]{client: suite.client.db.OrgMembership, ID: om.ID}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationUpdateTask() {
-	t := suite.T()
-
+func TestMutationUpdateTask(t *testing.T) {
 	task := (&TaskBuilder{client: suite.client}).MustNew(adminUser.UserCtx, t)
 	group := (&GroupBuilder{client: suite.client}).MustNew(adminUser.UserCtx, t)
 
 	pngFile, err := objects.NewUploadFile("testdata/uploads/logo.png")
-	require.NoError(t, err)
+	assert.NilError(t, err)
 
 	pdfFile, err := objects.NewUploadFile("testdata/uploads/hello.pdf")
-	require.NoError(t, err)
+	assert.NilError(t, err)
 
 	taskCommentID := ""
 
+	assignee := suite.userBuilder(context.Background(), t)
+	suite.addUserToOrganization(testUser1.UserCtx, t, &assignee, enums.RoleMember, testUser1.OrganizationID)
+
 	// make sure the user cannot can see the task before they are the assigner
 	taskResp, err := suite.client.api.GetTaskByID(viewOnlyUser2.UserCtx, task.ID)
-	require.Error(t, err)
-	assert.Nil(t, taskResp)
+	assert.ErrorContains(t, err, notFoundErrorMsg)
+	assert.Check(t, is.Nil(taskResp))
 
 	// make sure the user cannot can see the task before they are the assignee
-	taskResp, err = suite.client.api.GetTaskByID(viewOnlyUser.UserCtx, task.ID)
-	require.Error(t, err)
-	assert.Nil(t, taskResp)
+	taskResp, err = suite.client.api.GetTaskByID(assignee.UserCtx, task.ID)
+	assert.ErrorContains(t, err, notFoundErrorMsg)
+	assert.Check(t, is.Nil(taskResp))
 
 	// NOTE: the tests and checks are ordered due to dependencies between updates
 	// if you update cases, they will most likely need to be added to the end of the list
@@ -325,7 +344,7 @@ func (suite *GraphTestSuite) TestMutationUpdateTask() {
 		request              *openlaneclient.UpdateTaskInput
 		updateCommentRequest *openlaneclient.UpdateNoteInput
 		files                []*graphql.Upload
-		client               *openlaneclient.OpenlaneClient
+		client               openlaneclient.OpenlaneClient
 		ctx                  context.Context
 		expectedErr          string
 	}{
@@ -408,7 +427,7 @@ func (suite *GraphTestSuite) TestMutationUpdateTask() {
 		{
 			name: "update assignee to view only user",
 			request: &openlaneclient.UpdateTaskInput{
-				AssigneeID: lo.ToPtr(viewOnlyUser.ID),
+				AssigneeID: lo.ToPtr(assignee.ID),
 			},
 			client: suite.client.api,
 			ctx:    adminUser.UserCtx,
@@ -416,7 +435,7 @@ func (suite *GraphTestSuite) TestMutationUpdateTask() {
 		{
 			name: "update assignee to same user, should not error",
 			request: &openlaneclient.UpdateTaskInput{
-				AssigneeID: lo.ToPtr(viewOnlyUser.ID),
+				AssigneeID: lo.ToPtr(assignee.ID),
 			},
 			client: suite.client.api,
 			ctx:    adminUser.UserCtx,
@@ -475,9 +494,9 @@ func (suite *GraphTestSuite) TestMutationUpdateTask() {
 			if tc.request != nil {
 				resp, err = tc.client.UpdateTask(tc.ctx, task.ID, *tc.request)
 				if tc.expectedErr != "" {
-					require.Error(t, err)
+
 					assert.ErrorContains(t, err, tc.expectedErr)
-					assert.Nil(t, resp)
+					assert.Check(t, is.Nil(resp))
 
 					return
 				}
@@ -489,114 +508,115 @@ func (suite *GraphTestSuite) TestMutationUpdateTask() {
 			}
 
 			if tc.expectedErr != "" {
-				require.Error(t, err)
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
+			assert.NilError(t, err)
 
 			if tc.request != nil {
-				require.NotNil(t, resp)
+				assert.Assert(t, resp != nil)
 
 				if tc.request.Details != nil {
-					assert.Equal(t, *tc.request.Details, *resp.UpdateTask.Task.Details)
+					assert.Check(t, is.Equal(*tc.request.Details, *resp.UpdateTask.Task.Details))
 				}
 
 				if tc.request.Status != nil {
-					assert.Equal(t, *tc.request.Status, resp.UpdateTask.Task.Status)
+					assert.Check(t, is.Equal(*tc.request.Status, resp.UpdateTask.Task.Status))
 				}
 
 				if tc.request.Details != nil {
-					assert.Equal(t, tc.request.Details, resp.UpdateTask.Task.Details)
+					assert.Check(t, is.DeepEqual(tc.request.Details, resp.UpdateTask.Task.Details))
 				}
 
 				if tc.request.Category != nil {
-					assert.Equal(t, *tc.request.Category, *resp.UpdateTask.Task.Category)
+					assert.Check(t, is.Equal(*tc.request.Category, *resp.UpdateTask.Task.Category))
 				}
 
 				if tc.request.ClearAssignee != nil {
-					assert.Nil(t, resp.UpdateTask.Task.Assignee)
+					assert.Check(t, is.Nil(resp.UpdateTask.Task.Assignee))
 
 					// the previous assignee should no longer be able to see the task
-					taskResp, err := suite.client.api.GetTaskByID(viewOnlyUser.UserCtx, resp.UpdateTask.Task.ID)
-					assert.Error(t, err)
-					assert.Nil(t, taskResp)
+					taskResp, err := suite.client.api.GetTaskByID(assignee.UserCtx, resp.UpdateTask.Task.ID)
+					assert.Check(t, is.ErrorContains(err, ""))
+					assert.Check(t, is.Nil(taskResp))
 				}
 
 				if tc.request.ClearAssigner != nil {
-					assert.Nil(t, resp.UpdateTask.Task.Assignee)
+					assert.Check(t, is.Nil(resp.UpdateTask.Task.Assignee))
 
 					// the previous assigner should no longer be able to see the task
 					taskResp, err := suite.client.api.GetTaskByID(viewOnlyUser2.UserCtx, resp.UpdateTask.Task.ID)
-					assert.Error(t, err)
-					assert.Nil(t, taskResp)
+					assert.Check(t, is.ErrorContains(err, ""))
+					assert.Check(t, is.Nil(taskResp))
 				}
 
 				if tc.request.AssignerID != nil {
-					assert.NotNil(t, resp.UpdateTask.Task.Assigner)
-					assert.Equal(t, *tc.request.AssignerID, resp.UpdateTask.Task.Assigner.ID)
+					assert.Check(t, resp.UpdateTask.Task.Assigner != nil)
+					assert.Check(t, is.Equal(*tc.request.AssignerID, resp.UpdateTask.Task.Assigner.ID))
 
 					// make sure the assigner can see the task
 					taskResp, err := suite.client.api.GetTaskByID(viewOnlyUser2.UserCtx, resp.UpdateTask.Task.ID)
-					assert.NoError(t, err)
-					assert.NotNil(t, taskResp)
+					assert.Check(t, err)
+					assert.Check(t, taskResp != nil)
 
 					// make sure the original creator can still see the task
 					taskResp, err = suite.client.api.GetTaskByID(adminUser.UserCtx, resp.UpdateTask.Task.ID)
-					require.NoError(t, err)
-					assert.NotNil(t, taskResp)
+					assert.NilError(t, err)
+					assert.Check(t, taskResp != nil)
 				}
 
 				if tc.request.AddComment != nil {
-					assert.NotEmpty(t, resp.UpdateTask.Task.Comments.Edges)
-					assert.Equal(t, tc.request.AddComment.Text, resp.UpdateTask.Task.Comments.Edges[0].Node.Text)
+					assert.Check(t, len(resp.UpdateTask.Task.Comments.Edges) != 0)
+					assert.Check(t, is.Equal(tc.request.AddComment.Text, resp.UpdateTask.Task.Comments.Edges[0].Node.Text))
 
 					// there should only be one comment
-					require.Len(t, resp.UpdateTask.Task.Comments.Edges, 1)
+					assert.Assert(t, is.Len(resp.UpdateTask.Task.Comments.Edges, 1))
 					taskCommentID = resp.UpdateTask.Task.Comments.Edges[0].Node.ID
 
 					// user shouldn't be able to see the comment
-					checkResp, err := suite.client.api.GetNoteByID(viewOnlyUser.UserCtx, taskCommentID)
-					assert.Error(t, err)
-					assert.Nil(t, checkResp)
+					checkResp, err := suite.client.api.GetNoteByID(assignee.UserCtx, taskCommentID)
+					assert.Check(t, is.ErrorContains(err, ""))
+					assert.Check(t, is.Nil(checkResp))
 
 					// user should be able to see the comment since they created the task
 					checkResp, err = suite.client.api.GetNoteByID(adminUser.UserCtx, taskCommentID)
-					assert.NoError(t, err)
-					assert.NotNil(t, checkResp)
+					assert.Check(t, err)
+					assert.Check(t, checkResp != nil)
 
 					// org owner should be able to see the comment
 					checkResp, err = suite.client.api.GetNoteByID(testUser1.UserCtx, taskCommentID)
-					assert.NoError(t, err)
-					assert.NotNil(t, checkResp)
+					assert.Check(t, err)
+					assert.Check(t, checkResp != nil)
 				} else if tc.request.DeleteComment != nil {
 					// should not have any comments
-					assert.Len(t, resp.UpdateTask.Task.Comments.Edges, 0)
+					assert.Check(t, is.Len(resp.UpdateTask.Task.Comments.Edges, 0))
 				}
 			} else if tc.updateCommentRequest != nil {
-				require.NotNil(t, commentResp)
+				assert.Assert(t, commentResp != nil)
 
 				// should only have the original comment
-				require.Len(t, commentResp.UpdateTaskComment.Task.Comments.Edges, 1)
-				assert.Equal(t, *tc.updateCommentRequest.Text, commentResp.UpdateTaskComment.Task.Comments.Edges[0].Node.Text)
+				assert.Assert(t, is.Len(commentResp.UpdateTaskComment.Task.Comments.Edges, 1))
+				assert.Check(t, is.Equal(*tc.updateCommentRequest.Text, commentResp.UpdateTaskComment.Task.Comments.Edges[0].Node.Text))
 			}
 		})
 	}
+
+	// cleanup
+	(&Cleanup[*generated.TaskDeleteOne]{client: suite.client.db.Task, ID: task.ID}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.GroupDeleteOne]{client: suite.client.db.Group, ID: group.ID}).MustDelete(testUser1.UserCtx, t)
 }
 
-func (suite *GraphTestSuite) TestMutationDeleteTask() {
-	t := suite.T()
-
+func TestMutationDeleteTask(t *testing.T) {
 	task1 := (&TaskBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	task2 := (&TaskBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	testCases := []struct {
 		name        string
 		idToDelete  string
-		client      *openlaneclient.OpenlaneClient
+		client      openlaneclient.OpenlaneClient
 		ctx         context.Context
 		expectedErr string
 	}{
@@ -639,16 +659,16 @@ func (suite *GraphTestSuite) TestMutationDeleteTask() {
 		t.Run("Delete "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.DeleteTask(tc.ctx, tc.idToDelete)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.expectedErr)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			assert.Equal(t, tc.idToDelete, resp.DeleteTask.DeletedID)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Check(t, is.Equal(tc.idToDelete, resp.DeleteTask.DeletedID))
 		})
 	}
 }

--- a/internal/graphapi/task_test.go
+++ b/internal/graphapi/task_test.go
@@ -56,7 +56,6 @@ func TestQueryTask(t *testing.T) {
 			resp, err := tc.client.GetTaskByID(tc.ctx, tc.queryID)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 
@@ -155,7 +154,6 @@ func TestQueryTasks(t *testing.T) {
 }
 
 func TestMutationCreateTask(t *testing.T) {
-
 	om := (&OrgMemberBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	userCtx := auth.NewTestContextWithOrgID(om.UserID, om.OrganizationID)
 
@@ -493,17 +491,11 @@ func TestMutationUpdateTask(t *testing.T) {
 
 			if tc.request != nil {
 				resp, err = tc.client.UpdateTask(tc.ctx, task.ID, *tc.request)
-				if tc.expectedErr != "" {
-
-					assert.ErrorContains(t, err, tc.expectedErr)
-					assert.Check(t, is.Nil(resp))
-
-					return
-				}
 			} else if tc.updateCommentRequest != nil {
 				if len(tc.files) > 0 {
 					expectUploadNillable(t, suite.client.objectStore.Storage, tc.files)
 				}
+
 				commentResp, err = suite.client.api.UpdateTaskComment(testUser1.UserCtx, taskCommentID, *tc.updateCommentRequest, tc.files)
 			}
 
@@ -659,7 +651,6 @@ func TestMutationDeleteTask(t *testing.T) {
 		t.Run("Delete "+tc.name, func(t *testing.T) {
 			resp, err := tc.client.DeleteTask(tc.ctx, tc.idToDelete)
 			if tc.expectedErr != "" {
-
 				assert.ErrorContains(t, err, tc.expectedErr)
 				assert.Check(t, is.Nil(resp))
 

--- a/internal/graphapi/tfasetting_test.go
+++ b/internal/graphapi/tfasetting_test.go
@@ -1,297 +1,284 @@
 package graphapi_test
 
-import (
-	"context"
-	"testing"
+// func TestQueryTFASetting(t *testing.T) {
+// 	tfa := (&TFASettingBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
-	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+// 	testCases := []struct {
+// 		name     string
+// 		userID   string
+// 		client   openlaneclient.OpenlaneClient
+// 		ctx      context.Context
+// 		errorMsg string
+// 	}{
+// 		{
+// 			name:   "happy path user",
+// 			client: suite.client.api,
+// 			ctx:    testUser1.UserCtx,
+// 		},
+// 		{
+// 			name:   "happy path, using personal access token",
+// 			client: suite.client.apiWithPAT,
+// 			ctx:    context.Background(),
+// 		},
+// 		{
+// 			name:     "valid user, but not auth",
+// 			client:   suite.client.api,
+// 			ctx:      testUser2.UserCtx,
+// 			errorMsg: notFoundErrorMsg,
+// 		},
+// 	}
 
-	"github.com/theopenlane/utils/rout"
+// 	for _, tc := range testCases {
+// 		t.Run("Get "+tc.name, func(t *testing.T) {
+// 			resp, err := tc.client.GetTFASetting(tc.ctx)
 
-	"github.com/theopenlane/core/pkg/openlaneclient"
-)
+// 			if tc.errorMsg != "" {
 
-func (suite *GraphTestSuite) TestQueryTFASetting() {
-	t := suite.T()
+// 				assert.ErrorContains(t, err, tc.errorMsg)
+// 				assert.Check(t, is.Nil(resp))
 
-	(&TFASettingBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+// 				return
+// 			}
 
-	testCases := []struct {
-		name     string
-		userID   string
-		client   *openlaneclient.OpenlaneClient
-		ctx      context.Context
-		errorMsg string
-	}{
-		{
-			name:   "happy path user",
-			client: suite.client.api,
-			ctx:    testUser1.UserCtx,
-		},
-		{
-			name:   "happy path, using personal access token",
-			client: suite.client.apiWithPAT,
-			ctx:    context.Background(),
-		},
-		{
-			name:     "valid user, but not auth",
-			client:   suite.client.api,
-			ctx:      testUser2.UserCtx,
-			errorMsg: notFoundErrorMsg,
-		},
-	}
+// 			assert.NilError(t, err)
+// 			assert.Assert(t, resp != nil)
+// 		})
+// 	}
 
-	for _, tc := range testCases {
-		t.Run("Get "+tc.name, func(t *testing.T) {
-			resp, err := tc.client.GetTFASetting(tc.ctx)
+// 	// cleanup
+// 	(&Cleanup[*generated.TFASettingDeleteOne]{client: suite.client.db.TFASetting, ID: tfa.ID}).MustDelete(testUser1.UserCtx, t)
+// }
 
-			if tc.errorMsg != "" {
-				require.Error(t, err)
-				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+// func TestMutationCreateTFASetting(t *testing.T) {
+// 	testCases := []struct {
+// 		name   string
+// 		userID string
+// 		input  openlaneclient.CreateTFASettingInput
+// 		client openlaneclient.OpenlaneClient
+// 		ctx    context.Context
+// 		errMsg string
+// 	}{
+// 		{
+// 			name:   "happy path",
+// 			userID: testUser2.ID,
+// 			input: openlaneclient.CreateTFASettingInput{
+// 				TotpAllowed: lo.ToPtr(true),
+// 			},
+// 			client: suite.client.api,
+// 			ctx:    testUser2.UserCtx,
+// 		},
+// 		{
+// 			name:   "happy path, using personal access token",
+// 			userID: testUser1.ID,
+// 			input: openlaneclient.CreateTFASettingInput{
+// 				TotpAllowed: lo.ToPtr(true),
+// 			},
+// 			client: suite.client.apiWithPAT,
+// 			ctx:    context.Background(),
+// 		},
+// 		{
+// 			name:   "unable to create using api token",
+// 			userID: testUser1.ID,
+// 			input: openlaneclient.CreateTFASettingInput{
+// 				TotpAllowed: lo.ToPtr(true),
+// 			},
+// 			client: suite.client.apiWithToken,
+// 			ctx:    context.Background(),
+// 			errMsg: rout.ErrBadRequest.Error(),
+// 		},
+// 		{
+// 			name:   "already exists",
+// 			userID: testUser1.ID,
+// 			input: openlaneclient.CreateTFASettingInput{
+// 				TotpAllowed: lo.ToPtr(true),
+// 			},
+// 			client: suite.client.api,
+// 			ctx:    testUser1.UserCtx,
+// 			errMsg: "tfasetting already exists",
+// 		},
+// 		{
+// 			name:   "create with not enabling totp should not return qr code",
+// 			userID: viewOnlyUser.ID,
+// 			input: openlaneclient.CreateTFASettingInput{
+// 				TotpAllowed: lo.ToPtr(false),
+// 			},
+// 			client: suite.client.api,
+// 			ctx:    viewOnlyUser.UserCtx,
+// 		},
+// 	}
 
-				return
-			}
+// 	for _, tc := range testCases {
+// 		t.Run("Create "+tc.name, func(t *testing.T) {
+// 			// create tfa setting for user
+// 			resp, err := tc.client.CreateTFASetting(tc.ctx, tc.input)
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-		})
-	}
-}
+// 			if tc.errMsg != "" {
+// 				assert.ErrorContains(t, err, tc.errMsg)
+// 				assert.Check(t, is.Nil(resp))
 
-func (suite *GraphTestSuite) TestMutationCreateTFASetting() {
-	t := suite.T()
+// 				return
+// 			}
 
-	testCases := []struct {
-		name   string
-		userID string
-		input  openlaneclient.CreateTFASettingInput
-		client *openlaneclient.OpenlaneClient
-		ctx    context.Context
-		errMsg string
-	}{
-		{
-			name:   "happy path",
-			userID: testUser2.ID,
-			input: openlaneclient.CreateTFASettingInput{
-				TotpAllowed: lo.ToPtr(true),
-			},
-			client: suite.client.api,
-			ctx:    testUser2.UserCtx,
-		},
-		{
-			name:   "happy path, using personal access token",
-			userID: testUser1.ID,
-			input: openlaneclient.CreateTFASettingInput{
-				TotpAllowed: lo.ToPtr(true),
-			},
-			client: suite.client.apiWithPAT,
-			ctx:    context.Background(),
-		},
-		{
-			name:   "unable to create using api token",
-			userID: testUser1.ID,
-			input: openlaneclient.CreateTFASettingInput{
-				TotpAllowed: lo.ToPtr(true),
-			},
-			client: suite.client.apiWithToken,
-			ctx:    context.Background(),
-			errMsg: rout.ErrBadRequest.Error(),
-		},
-		{
-			name:   "already exists",
-			userID: testUser1.ID,
-			input: openlaneclient.CreateTFASettingInput{
-				TotpAllowed: lo.ToPtr(true),
-			},
-			client: suite.client.api,
-			ctx:    testUser1.UserCtx,
-			errMsg: "tfasetting already exists",
-		},
-		{
-			name:   "create with not enabling totp should not return qr code",
-			userID: viewOnlyUser.ID,
-			input: openlaneclient.CreateTFASettingInput{
-				TotpAllowed: lo.ToPtr(false),
-			},
-			client: suite.client.api,
-			ctx:    viewOnlyUser.UserCtx,
-		},
-	}
+// 			assert.NilError(t, err)
+// 			assert.Assert(t, resp != nil)
 
-	for _, tc := range testCases {
-		t.Run("Create "+tc.name, func(t *testing.T) {
-			// create tfa setting for user
-			resp, err := tc.client.CreateTFASetting(tc.ctx, tc.input)
+// 			// Make sure provided values match
+// 			assert.Check(t, is.DeepEqual(tc.input.TotpAllowed, resp.CreateTFASetting.TfaSetting.TotpAllowed))
 
-			if tc.errMsg != "" {
-				require.Error(t, err)
-				assert.ErrorContains(t, err, tc.errMsg)
-				assert.Nil(t, resp)
+// 			if *tc.input.TotpAllowed {
+// 				assert.Check(t, resp.CreateTFASetting.QRCode != nil)
+// 				assert.Check(t, resp.CreateTFASetting.TfaSecret != nil)
+// 			} else {
+// 				assert.Check(t, is.Equal(*resp.CreateTFASetting.QRCode, ""))
+// 				assert.Check(t, is.Equal(*resp.CreateTFASetting.TfaSecret, ""))
+// 			}
 
-				return
-			}
+// 			assert.Assert(t, resp.CreateTFASetting.TfaSetting.Owner != nil)
+// 			assert.Check(t, is.Equal(tc.userID, resp.CreateTFASetting.TfaSetting.Owner.ID))
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.NotNil(t, resp.CreateTFASetting.TfaSetting)
+// 			// make sure user setting was not updated
+// 			userSetting, err := testUser1.UserInfo.Setting(testUser1.UserCtx)
+// 			assert.NilError(t, err)
 
-			// Make sure provided values match
-			assert.Equal(t, tc.input.TotpAllowed, resp.CreateTFASetting.TfaSetting.TotpAllowed)
+// 			assert.Check(t, !userSetting.IsTfaEnabled)
+// 		})
+// 	}
 
-			if *tc.input.TotpAllowed {
-				assert.NotEmpty(t, resp.CreateTFASetting.QRCode)
-				assert.NotEmpty(t, resp.CreateTFASetting.TfaSecret)
-			} else {
-				assert.Empty(t, resp.CreateTFASetting.QRCode)
-				assert.Empty(t, resp.CreateTFASetting.TfaSecret)
-			}
+// 	// cleanup by setting totp to false
+// 	_, err := suite.client.api.UpdateTFASetting(testUser1.UserCtx, openlaneclient.UpdateTFASettingInput{
+// 		TotpAllowed: lo.ToPtr(false),
+// 	})
+// 	assert.NilError(t, err)
+// }
 
-			require.NotEmpty(t, resp.CreateTFASetting.TfaSetting.Owner)
-			assert.Equal(t, tc.userID, resp.CreateTFASetting.TfaSetting.Owner.ID)
+// func TestMutationUpdateTFASetting(t *testing.T) {
+// 	// create tfa settings for users
+// 	(&TFASettingBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
-			// make sure user setting was not updated
-			userSetting, err := testUser1.UserInfo.Setting(testUser1.UserCtx)
-			require.NoError(t, err)
+// 	// create one with not enabled by default
+// 	(&TFASettingBuilder{client: suite.client, totpAllowed: lo.ToPtr(false)}).MustNew(testUser2.UserCtx, t)
 
-			assert.False(t, userSetting.IsTfaEnabled)
-		})
-	}
-}
+// 	recoveryCodes := []string{}
 
-func (suite *GraphTestSuite) TestMutationUpdateTFASetting() {
-	t := suite.T()
+// 	testCases := []struct {
+// 		name   string
+// 		input  openlaneclient.UpdateTFASettingInput
+// 		client openlaneclient.OpenlaneClient
+// 		ctx    context.Context
+// 		errMsg string
+// 	}{
+// 		{
+// 			name: "update verify",
+// 			input: openlaneclient.UpdateTFASettingInput{
+// 				TotpAllowed: lo.ToPtr(true),
+// 				Verified:    lo.ToPtr(true),
+// 			},
+// 			client: suite.client.api,
+// 			ctx:    testUser1.UserCtx,
+// 		},
+// 		{
+// 			name: "regen codes using personal access token",
+// 			input: openlaneclient.UpdateTFASettingInput{
+// 				RegenBackupCodes: lo.ToPtr(true),
+// 			},
+// 			client: suite.client.apiWithPAT,
+// 			ctx:    context.Background(),
+// 		},
+// 		{
+// 			name: "regen codes using api token not allowed",
+// 			input: openlaneclient.UpdateTFASettingInput{
+// 				RegenBackupCodes: lo.ToPtr(true),
+// 			},
+// 			client: suite.client.apiWithToken,
+// 			ctx:    context.Background(),
+// 			errMsg: rout.ErrBadRequest.Error(),
+// 		},
+// 		{
+// 			name: "regen codes - false",
+// 			input: openlaneclient.UpdateTFASettingInput{
+// 				RegenBackupCodes: lo.ToPtr(false),
+// 			},
+// 			client: suite.client.api,
+// 			ctx:    testUser1.UserCtx,
+// 		},
+// 		{
+// 			name: "update totp to false should clear settings",
+// 			input: openlaneclient.UpdateTFASettingInput{
+// 				TotpAllowed: lo.ToPtr(false),
+// 			},
+// 			client: suite.client.api,
+// 			ctx:    testUser1.UserCtx,
+// 		},
+// 		{
+// 			name: "update TotpAllowed to true should enable TFA",
+// 			input: openlaneclient.UpdateTFASettingInput{
+// 				TotpAllowed: lo.ToPtr(true),
+// 			},
+// 			client: suite.client.api,
+// 			ctx:    testUser1.UserCtx,
+// 		},
+// 	}
 
-	// create tfa settings for users
-	(&TFASettingBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+// 	for _, tc := range testCases {
+// 		t.Run("Update "+tc.name, func(t *testing.T) {
+// 			// update tfa settings
+// 			resp, err := tc.client.UpdateTFASetting(tc.ctx, tc.input)
 
-	// create one with not enabled by default
-	(&TFASettingBuilder{client: suite.client, totpAllowed: lo.ToPtr(false)}).MustNew(testUser2.UserCtx, t)
+// 			if tc.errMsg != "" {
 
-	recoveryCodes := []string{}
+// 				assert.ErrorContains(t, err, tc.errMsg)
+// 				assert.Check(t, is.Nil(resp))
 
-	testCases := []struct {
-		name   string
-		input  openlaneclient.UpdateTFASettingInput
-		client *openlaneclient.OpenlaneClient
-		ctx    context.Context
-		errMsg string
-	}{
-		{
-			name: "update verify",
-			input: openlaneclient.UpdateTFASettingInput{
-				TotpAllowed: lo.ToPtr(true),
-				Verified:    lo.ToPtr(true),
-			},
-			client: suite.client.api,
-			ctx:    testUser1.UserCtx,
-		},
-		{
-			name: "regen codes using personal access token",
-			input: openlaneclient.UpdateTFASettingInput{
-				RegenBackupCodes: lo.ToPtr(true),
-			},
-			client: suite.client.apiWithPAT,
-			ctx:    context.Background(),
-		},
-		{
-			name: "regen codes using api token not allowed",
-			input: openlaneclient.UpdateTFASettingInput{
-				RegenBackupCodes: lo.ToPtr(true),
-			},
-			client: suite.client.apiWithToken,
-			ctx:    context.Background(),
-			errMsg: rout.ErrBadRequest.Error(),
-		},
-		{
-			name: "regen codes - false",
-			input: openlaneclient.UpdateTFASettingInput{
-				RegenBackupCodes: lo.ToPtr(false),
-			},
-			client: suite.client.api,
-			ctx:    testUser1.UserCtx,
-		},
-		{
-			name: "update totp to false should clear settings",
-			input: openlaneclient.UpdateTFASettingInput{
-				TotpAllowed: lo.ToPtr(false),
-			},
-			client: suite.client.api,
-			ctx:    testUser1.UserCtx,
-		},
-		{
-			name: "update TotpAllowed to true should enable TFA",
-			input: openlaneclient.UpdateTFASettingInput{
-				TotpAllowed: lo.ToPtr(true),
-			},
-			client: suite.client.api,
-			ctx:    testUser1.UserCtx,
-		},
-	}
+// 				return
+// 			}
 
-	for _, tc := range testCases {
-		t.Run("Update "+tc.name, func(t *testing.T) {
-			// update tfa settings
-			resp, err := tc.client.UpdateTFASetting(tc.ctx, tc.input)
+// 			assert.NilError(t, err)
+// 			assert.Assert(t, resp != nil)
 
-			if tc.errMsg != "" {
-				require.Error(t, err)
-				assert.ErrorContains(t, err, tc.errMsg)
-				assert.Nil(t, resp)
+// 			// backup codes should only be regenerated on explicit request
+// 			// and should only be returned on initial verification or regen request
+// 			if (tc.input.RegenBackupCodes != nil && *tc.input.RegenBackupCodes) ||
+// 				(tc.input.Verified != nil && *tc.input.Verified) {
+// 				// recovery codes should be returned
+// 				assert.Check(t, len(resp.UpdateTFASetting.RecoveryCodes) != 0)
 
-				return
-			}
+// 				if tc.input.RegenBackupCodes != nil {
+// 					if *tc.input.RegenBackupCodes {
+// 						assert.Assert(t, !reflect.DeepEqual(recoveryCodes, resp.UpdateTFASetting.RecoveryCodes))
+// 					} else {
+// 						assert.Check(t, is.DeepEqual(recoveryCodes, resp.UpdateTFASetting.RecoveryCodes))
+// 					}
+// 				}
+// 			} else {
+// 				assert.Check(t, is.Len(resp.UpdateTFASetting.RecoveryCodes, 0))
+// 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.NotNil(t, resp.UpdateTFASetting.TfaSetting)
+// 			if tc.input.TotpAllowed == nil || *tc.input.TotpAllowed {
+// 				assert.Check(t, resp.UpdateTFASetting.QRCode != nil)
+// 				assert.Check(t, resp.UpdateTFASetting.TfaSecret != nil)
+// 			} else if !*tc.input.TotpAllowed { // settings were cleared
+// 				assert.Check(t, is.Equal(*resp.UpdateTFASetting.QRCode, ""))
+// 				assert.Check(t, is.Equal(*resp.UpdateTFASetting.TfaSecret, ""))
+// 				assert.Check(t, is.Len(resp.UpdateTFASetting.RecoveryCodes, 0))
+// 				assert.Check(t, !resp.UpdateTFASetting.TfaSetting.Verified)
+// 				assert.Check(t, !*resp.UpdateTFASetting.TfaSetting.TotpAllowed)
+// 			}
 
-			// backup codes should only be regenerated on explicit request
-			// and should only be returned on initial verification or regen request
-			if (tc.input.RegenBackupCodes != nil && *tc.input.RegenBackupCodes) ||
-				(tc.input.Verified != nil && *tc.input.Verified) {
-				// recovery codes should be returned
-				assert.NotEmpty(t, resp.UpdateTFASetting.RecoveryCodes)
+// 			// make sure user setting is updated correctly
+// 			userSettings, err := suite.client.api.GetUserSettingByID(testUser1.UserCtx, testUser1.UserInfo.Edges.Setting.ID)
+// 			assert.NilError(t, err)
 
-				if tc.input.RegenBackupCodes != nil {
-					if *tc.input.RegenBackupCodes {
-						assert.NotEqual(t, recoveryCodes, resp.UpdateTFASetting.RecoveryCodes)
-					} else {
-						assert.Equal(t, recoveryCodes, resp.UpdateTFASetting.RecoveryCodes)
-					}
-				}
-			} else {
-				assert.Empty(t, resp.UpdateTFASetting.RecoveryCodes)
-			}
+// 			if resp.UpdateTFASetting.TfaSetting.Verified {
+// 				assert.Check(t, *userSettings.UserSetting.IsTfaEnabled)
+// 			}
 
-			if tc.input.TotpAllowed == nil || *tc.input.TotpAllowed {
-				assert.NotEmpty(t, resp.UpdateTFASetting.QRCode)
-				assert.NotEmpty(t, resp.UpdateTFASetting.TfaSecret)
-			} else if !*tc.input.TotpAllowed { // settings were cleared
-				assert.Empty(t, resp.UpdateTFASetting.QRCode)
-				assert.Empty(t, resp.UpdateTFASetting.TfaSecret)
-				assert.Empty(t, resp.UpdateTFASetting.RecoveryCodes)
-				assert.False(t, resp.UpdateTFASetting.TfaSetting.Verified)
-				assert.False(t, *resp.UpdateTFASetting.TfaSetting.TotpAllowed)
-			}
+// 			// ensure TFA is disabled if totp is not allowed
+// 			if !*resp.UpdateTFASetting.TfaSetting.TotpAllowed {
+// 				assert.Check(t, !*userSettings.UserSetting.IsTfaEnabled)
+// 			}
 
-			// make sure user setting is updated correctly
-			userSettings, err := suite.client.api.GetUserSettingByID(testUser1.UserCtx, testUser1.UserInfo.Edges.Setting.ID)
-			require.NoError(t, err)
-
-			if resp.UpdateTFASetting.TfaSetting.Verified {
-				assert.True(t, *userSettings.UserSetting.IsTfaEnabled)
-			}
-
-			// ensure TFA is disabled if totp is not allowed
-			if !*resp.UpdateTFASetting.TfaSetting.TotpAllowed {
-				assert.False(t, *userSettings.UserSetting.IsTfaEnabled)
-			}
-
-			// set at the end so we can compare later
-			recoveryCodes = resp.UpdateTFASetting.RecoveryCodes
-		})
-	}
-}
+// 			// set at the end so we can compare later
+// 			recoveryCodes = resp.UpdateTFASetting.RecoveryCodes
+// 		})
+// 	}
+// }

--- a/internal/graphapi/tfasetting_test.go
+++ b/internal/graphapi/tfasetting_test.go
@@ -297,7 +297,7 @@ func TestMutationUpdateTFASetting(t *testing.T) {
 			}
 
 			// make sure user setting is updated correctly
-			userSettings, err := suite.client.api.GetUserSettingByID(testUser1.UserCtx, testUser1.UserInfo.Edges.Setting.ID)
+			userSettings, err := suite.client.api.GetUserSettingByID(testUser.UserCtx, testUser.UserInfo.Edges.Setting.ID)
 			assert.NilError(t, err)
 
 			if resp.UpdateTFASetting.TfaSetting.Verified {

--- a/internal/graphapi/tfasetting_test.go
+++ b/internal/graphapi/tfasetting_test.go
@@ -27,7 +27,7 @@ func TestQueryTFASetting(t *testing.T) {
 	testCases := []struct {
 		name     string
 		userID   string
-		client   openlaneclient.OpenlaneClient
+		client   *openlaneclient.OpenlaneClient
 		ctx      context.Context
 		errorMsg string
 	}{
@@ -38,7 +38,7 @@ func TestQueryTFASetting(t *testing.T) {
 		},
 		{
 			name:   "happy path, using personal access token",
-			client: *patClient,
+			client: patClient,
 			ctx:    context.Background(),
 		},
 		{
@@ -83,7 +83,7 @@ func TestMutationCreateTFASetting(t *testing.T) {
 		name   string
 		userID string
 		input  openlaneclient.CreateTFASettingInput
-		client openlaneclient.OpenlaneClient
+		client *openlaneclient.OpenlaneClient
 		ctx    context.Context
 		errMsg string
 	}{
@@ -102,7 +102,7 @@ func TestMutationCreateTFASetting(t *testing.T) {
 			input: openlaneclient.CreateTFASettingInput{
 				TotpAllowed: lo.ToPtr(true),
 			},
-			client: *patClient,
+			client: patClient,
 			ctx:    context.Background(),
 		},
 		{
@@ -111,7 +111,7 @@ func TestMutationCreateTFASetting(t *testing.T) {
 			input: openlaneclient.CreateTFASettingInput{
 				TotpAllowed: lo.ToPtr(true),
 			},
-			client: *apiClient,
+			client: apiClient,
 			ctx:    context.Background(),
 			errMsg: rout.ErrBadRequest.Error(),
 		},
@@ -195,7 +195,7 @@ func TestMutationUpdateTFASetting(t *testing.T) {
 	testCases := []struct {
 		name   string
 		input  openlaneclient.UpdateTFASettingInput
-		client openlaneclient.OpenlaneClient
+		client *openlaneclient.OpenlaneClient
 		ctx    context.Context
 		errMsg string
 	}{
@@ -213,7 +213,7 @@ func TestMutationUpdateTFASetting(t *testing.T) {
 			input: openlaneclient.UpdateTFASettingInput{
 				RegenBackupCodes: lo.ToPtr(true),
 			},
-			client: *patClient,
+			client: patClient,
 			ctx:    context.Background(),
 		},
 		{
@@ -221,7 +221,7 @@ func TestMutationUpdateTFASetting(t *testing.T) {
 			input: openlaneclient.UpdateTFASettingInput{
 				RegenBackupCodes: lo.ToPtr(true),
 			},
-			client: *apiClient,
+			client: apiClient,
 			ctx:    context.Background(),
 			errMsg: rout.ErrBadRequest.Error(),
 		},

--- a/internal/graphapi/tfasetting_test.go
+++ b/internal/graphapi/tfasetting_test.go
@@ -257,7 +257,6 @@ func TestMutationUpdateTFASetting(t *testing.T) {
 			resp, err := tc.client.UpdateTFASetting(tc.ctx, tc.input)
 
 			if tc.errMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errMsg)
 				assert.Check(t, is.Nil(resp))
 

--- a/internal/graphapi/tools_test.go
+++ b/internal/graphapi/tools_test.go
@@ -78,7 +78,9 @@ func TestMain(m *testing.M) {
 	// Setup code here (e.g., initialize database connection)
 	suite.SetupSuite(t)
 
+	// Setup test data, most tests can reuse this same data
 	suite.setupTestData(context.Background(), t)
+
 	// Run the tests
 	exitCode := m.Run()
 

--- a/internal/graphapi/tools_test.go
+++ b/internal/graphapi/tools_test.go
@@ -59,9 +59,9 @@ type GraphTestSuite struct {
 // client contains all the clients the test need to interact with
 type client struct {
 	db           *ent.Client
-	api          openlaneclient.OpenlaneClient
-	apiWithPAT   openlaneclient.OpenlaneClient
-	apiWithToken openlaneclient.OpenlaneClient
+	api          *openlaneclient.OpenlaneClient
+	apiWithPAT   *openlaneclient.OpenlaneClient
+	apiWithToken *openlaneclient.OpenlaneClient
 	fga          *fgax.Client
 	objectStore  *objects.Objects
 }
@@ -174,10 +174,8 @@ func (suite *GraphTestSuite) SetupSuite(t *testing.T) {
 
 	// assign values
 	c.db = db
-	api, err := coreutils.TestClient(c.db, c.objectStore)
+	c.api, err = coreutils.TestClient(c.db, c.objectStore)
 	assert.NilError(t, err)
-
-	c.api = *api
 
 	suite.client = c
 }

--- a/internal/graphapi/user_test.go
+++ b/internal/graphapi/user_test.go
@@ -47,7 +47,6 @@ func TestQueryUser(t *testing.T) {
 			resp, err := suite.client.api.GetUserByID(testUser1.UserCtx, tc.queryID)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 
@@ -132,7 +131,6 @@ func TestMutationCreateUser(t *testing.T) {
 			resp, err := suite.client.api.CreateUser(testUser1.UserCtx, tc.userInput, tc.avatarFile)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 
@@ -302,7 +300,6 @@ func TestMutationUpdateUser(t *testing.T) {
 			// update user
 			resp, err := suite.client.api.UpdateUser(reqCtx, user.ID, tc.updateInput, tc.avatarFile)
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 
@@ -362,7 +359,6 @@ func TestMutationDeleteUser(t *testing.T) {
 			resp, err := suite.client.api.DeleteUser(reqCtx, tc.userID)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 

--- a/internal/graphapi/user_test.go
+++ b/internal/graphapi/user_test.go
@@ -6,9 +6,9 @@ import (
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/brianvoe/gofakeit/v7"
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/theopenlane/utils/rout"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 
 	auth "github.com/theopenlane/iam/auth"
 
@@ -18,13 +18,11 @@ import (
 	"github.com/theopenlane/core/pkg/openlaneclient"
 )
 
-func (suite *GraphTestSuite) TestQueryUser() {
-	t := suite.T()
-
+func TestQueryUser(t *testing.T) {
 	testCases := []struct {
 		name     string
 		queryID  string
-		expected *ent.User
+		expected ent.User
 		errorMsg string
 	}{
 		{
@@ -49,47 +47,45 @@ func (suite *GraphTestSuite) TestQueryUser() {
 			resp, err := suite.client.api.GetUserByID(testUser1.UserCtx, tc.queryID)
 
 			if tc.errorMsg != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.NotNil(t, resp.User)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
-			assert.NotEmpty(t, resp.User.DisplayID)
-			assert.Contains(t, resp.User.DisplayID, "USR-")
+			assert.Check(t, len(resp.User.DisplayID) != 0)
+			assert.Check(t, is.Contains(resp.User.DisplayID, "USR-"))
 		})
 	}
 }
 
-func (suite *GraphTestSuite) TestQueryUsers() {
-	t := suite.T()
+func TestQueryUsers(t *testing.T) {
 
 	t.Run("Get Users", func(t *testing.T) {
 		resp, err := suite.client.api.GetAllUsers(testUser1.UserCtx)
 
-		require.NoError(t, err)
-		require.NotNil(t, resp)
-		require.NotNil(t, resp.Users.Edges)
+		assert.NilError(t, err)
+		assert.Assert(t, resp != nil)
+		assert.Assert(t, resp.Users.Edges != nil)
 
 		// make sure only the current user is returned
-		assert.Len(t, resp.Users.Edges, 1)
+		assert.Check(t, is.Len(resp.Users.Edges, 1))
 
 		// setup valid user context
 		reqCtx := testUser1.UserCtx
 
 		resp, err = suite.client.api.GetAllUsers(reqCtx)
 
-		require.NoError(t, err)
-		require.NotNil(t, resp)
-		require.NotNil(t, resp.Users.Edges)
+		assert.NilError(t, err)
+		assert.Assert(t, resp != nil)
+		assert.Assert(t, resp.Users.Edges != nil)
 
 		// only user that is making the request should be returned
-		assert.Len(t, resp.Users.Edges, 1)
+		assert.Check(t, is.Len(resp.Users.Edges, 1))
 
 		user1Found := false
 		user2Found := false
@@ -103,15 +99,13 @@ func (suite *GraphTestSuite) TestQueryUsers() {
 		}
 
 		// only user 1 should be found
-		assert.True(t, user1Found)
+		assert.Check(t, user1Found)
 		// user 2 should not be found
-		assert.False(t, user2Found)
+		assert.Check(t, !user2Found)
 	})
 }
 
-func (suite *GraphTestSuite) TestMutationCreateUser() {
-	t := suite.T()
-
+func TestMutationCreateUser(t *testing.T) {
 	strongPassword := "my&supers3cr3tpassw0rd!"
 
 	testCases := []struct {
@@ -138,47 +132,41 @@ func (suite *GraphTestSuite) TestMutationCreateUser() {
 			resp, err := suite.client.api.CreateUser(testUser1.UserCtx, tc.userInput, tc.avatarFile)
 
 			if tc.errorMsg != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.NotNil(t, resp.CreateUser.User)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
 			// Make sure provided values match
-			assert.Equal(t, tc.userInput.FirstName, resp.CreateUser.User.FirstName)
-			assert.Equal(t, tc.userInput.LastName, resp.CreateUser.User.LastName)
-			assert.Equal(t, tc.userInput.Email, resp.CreateUser.User.Email)
+			assert.Check(t, is.DeepEqual(tc.userInput.FirstName, resp.CreateUser.User.FirstName))
+			assert.Check(t, is.DeepEqual(tc.userInput.LastName, resp.CreateUser.User.LastName))
+			assert.Check(t, is.Equal(tc.userInput.Email, resp.CreateUser.User.Email))
 
 			// display name defaults to email if not provided
 			if tc.userInput.DisplayName == "" {
-				assert.Equal(t, tc.userInput.Email, resp.CreateUser.User.DisplayName)
+				assert.Check(t, is.Equal(tc.userInput.Email, resp.CreateUser.User.DisplayName))
 			} else {
-				assert.Equal(t, tc.userInput.DisplayName, resp.CreateUser.User.DisplayName)
+				assert.Check(t, is.Equal(tc.userInput.DisplayName, resp.CreateUser.User.DisplayName))
 			}
-
-			// ensure a user setting was created
-			assert.NotNil(t, resp.CreateUser.User.Setting)
 
 			// ensure personal org is created
 			// default org will always be the personal org when the user is first created
 			personalOrgID := resp.CreateUser.User.Setting.DefaultOrg.ID
 
 			org, err := suite.client.api.GetOrganizationByID(testUser1.UserCtx, personalOrgID)
-			require.NoError(t, err)
-			assert.Equal(t, personalOrgID, org.Organization.ID)
-			assert.True(t, *org.Organization.PersonalOrg)
+			assert.NilError(t, err)
+			assert.Check(t, is.Equal(personalOrgID, org.Organization.ID))
+			assert.Check(t, *org.Organization.PersonalOrg)
 		})
 	}
 }
 
-func (suite *GraphTestSuite) TestMutationUpdateUser() {
-	t := suite.T()
-
+func TestMutationUpdateUser(t *testing.T) {
 	firstNameUpdate := gofakeit.FirstName()
 	lastNameUpdate := gofakeit.LastName()
 	emailUpdate := gofakeit.Email()
@@ -195,10 +183,10 @@ func (suite *GraphTestSuite) TestMutationUpdateUser() {
 	weakPassword := "notsecure"
 
 	avatarFile, err := objects.NewUploadFile("testdata/uploads/logo.png")
-	require.NoError(t, err)
+	assert.NilError(t, err)
 
 	invalidAvatarFile, err := objects.NewUploadFile("testdata/uploads/hello.txt")
-	require.NoError(t, err)
+	assert.NilError(t, err)
 
 	testCases := []struct {
 		name        string
@@ -314,35 +302,32 @@ func (suite *GraphTestSuite) TestMutationUpdateUser() {
 			// update user
 			resp, err := suite.client.api.UpdateUser(reqCtx, user.ID, tc.updateInput, tc.avatarFile)
 			if tc.errorMsg != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.NotNil(t, resp.UpdateUser.User)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
 			// Make sure provided values match
 			updatedUser := resp.GetUpdateUser().User
-			assert.Equal(t, tc.expectedRes.FirstName, updatedUser.FirstName)
-			assert.Equal(t, tc.expectedRes.LastName, updatedUser.LastName)
-			assert.Equal(t, tc.expectedRes.DisplayName, updatedUser.DisplayName)
-			assert.Equal(t, tc.expectedRes.Email, updatedUser.Email)
+			assert.Check(t, is.DeepEqual(tc.expectedRes.FirstName, updatedUser.FirstName))
+			assert.Check(t, is.DeepEqual(tc.expectedRes.LastName, updatedUser.LastName))
+			assert.Check(t, is.Equal(tc.expectedRes.DisplayName, updatedUser.DisplayName))
+			assert.Check(t, is.Equal(tc.expectedRes.Email, updatedUser.Email))
 
 			if tc.avatarFile != nil {
-				assert.NotNil(t, updatedUser.AvatarLocalFileID)
-				assert.NotNil(t, updatedUser.AvatarFile.PresignedURL)
+				assert.Check(t, updatedUser.AvatarLocalFileID != nil)
+				assert.Check(t, updatedUser.AvatarFile.PresignedURL != nil)
 			}
 		})
 	}
 }
 
-func (suite *GraphTestSuite) TestMutationDeleteUser() {
-	t := suite.T()
-
+func TestMutationDeleteUser(t *testing.T) {
 	// bypass auth on object creation
 	ctx := privacy.DecisionContext(testUser1.UserCtx, privacy.Allow)
 
@@ -377,65 +362,62 @@ func (suite *GraphTestSuite) TestMutationDeleteUser() {
 			resp, err := suite.client.api.DeleteUser(reqCtx, tc.userID)
 
 			if tc.errorMsg != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.NotNil(t, resp.DeleteUser.DeletedID)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Assert(t, resp.DeleteUser.DeletedID != "")
 
 			// make sure the personal org is deleted
 			// add allow context to bypass auth since the tuple will be deleted
 			reqCtx = privacy.DecisionContext(reqCtx, privacy.Allow)
 
 			org, err := suite.client.api.GetOrganizationByID(reqCtx, personalOrgID)
-			require.Nil(t, org)
-			require.Error(t, err)
+			assert.Assert(t, is.Nil(org))
+
 			assert.ErrorContains(t, err, notFoundErrorMsg)
 
 			// make sure the deletedID matches the ID we wanted to delete
-			assert.Equal(t, tc.userID, resp.DeleteUser.DeletedID)
+			assert.Check(t, is.Equal(tc.userID, resp.DeleteUser.DeletedID))
 
 			// make sure the user setting is deleted
 			out, err := suite.client.api.GetUserSettingByID(reqCtx, userSetting.ID)
-			require.Nil(t, out)
-			require.Error(t, err)
+			assert.Assert(t, is.Nil(out))
+
 			assert.ErrorContains(t, err, notFoundErrorMsg)
 		})
 	}
 }
 
-func (suite *GraphTestSuite) TestMutationUserCascadeDelete() {
-	t := suite.T()
-
+func TestMutationUserCascadeDelete(t *testing.T) {
 	user := (&UserBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	reqCtx := auth.NewTestContextWithOrgID(user.ID, user.Edges.Setting.Edges.DefaultOrg.ID)
 
-	token := (&PersonalAccessTokenBuilder{client: suite.client}).MustNew(reqCtx, t)
+	token := (&PersonalAccessTokenBuilder{client: suite.client, OrganizationIDs: []string{user.Edges.Setting.Edges.DefaultOrg.ID}}).MustNew(reqCtx, t)
 
 	resp, err := suite.client.api.DeleteUser(reqCtx, user.ID)
 
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-	require.NotNil(t, resp.DeleteUser.DeletedID)
+	assert.NilError(t, err)
+	assert.Assert(t, resp != nil)
+	assert.Assert(t, resp.DeleteUser.DeletedID != "")
 
 	// make sure the deletedID matches the ID we wanted to delete
-	assert.Equal(t, user.ID, resp.DeleteUser.DeletedID)
+	assert.Check(t, is.Equal(user.ID, resp.DeleteUser.DeletedID))
 
 	o, err := suite.client.api.GetUserByID(reqCtx, user.ID)
 
-	require.Nil(t, o)
-	require.Error(t, err)
+	assert.Assert(t, is.Nil(o))
+
 	assert.ErrorContains(t, err, notFoundErrorMsg)
 
 	g, err := suite.client.api.GetPersonalAccessTokenByID(reqCtx, token.ID)
-	require.Error(t, err)
 
-	require.Nil(t, g)
+	assert.Assert(t, is.Nil(g))
 	assert.ErrorContains(t, err, notFoundErrorMsg)
 }

--- a/internal/graphapi/usersetting_test.go
+++ b/internal/graphapi/usersetting_test.go
@@ -171,16 +171,16 @@ func TestMutationUpdateUserSetting(t *testing.T) {
 				},
 			},
 		},
-		// {
-		// 	name:          "update default org to org without access",
-		// 	userSettingID: testUser1.UserInfo.Edges.Setting.ID,
-		// 	updateInput: openlaneclient.UpdateUserSettingInput{
-		// 		DefaultOrgID: &org2.ID,
-		// 	},
-		// 	client:   suite.client.api,
-		// 	ctx:      testUser1.UserCtx,
-		// 	errorMsg: "Organization with the specified ID was not found",
-		// },
+		{
+			name:          "update default org to org without access",
+			userSettingID: testUser1.UserInfo.Edges.Setting.ID,
+			updateInput: openlaneclient.UpdateUserSettingInput{
+				DefaultOrgID: &org2.ID,
+			},
+			client:   suite.client.api,
+			ctx:      testUser1.UserCtx,
+			errorMsg: "Organization with the specified ID was not found",
+		},
 		{
 			name:          "update status to invalid",
 			userSettingID: testUser1.UserInfo.Edges.Setting.ID,
@@ -212,7 +212,6 @@ func TestMutationUpdateUserSetting(t *testing.T) {
 			resp, err := tc.client.UpdateUserSetting(tc.ctx, tc.userSettingID, tc.updateInput)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 

--- a/internal/graphapi/usersetting_test.go
+++ b/internal/graphapi/usersetting_test.go
@@ -30,7 +30,7 @@ func TestQueryUserSetting(t *testing.T) {
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   openlaneclient.OpenlaneClient
+		client   *openlaneclient.OpenlaneClient
 		ctx      context.Context
 		expected *openlaneclient.GetUserSettings_UserSettings_Edges_Node
 		errorMsg string
@@ -132,7 +132,7 @@ func TestMutationUpdateUserSetting(t *testing.T) {
 		name          string
 		userSettingID string
 		updateInput   openlaneclient.UpdateUserSettingInput
-		client        openlaneclient.OpenlaneClient
+		client        *openlaneclient.OpenlaneClient
 		ctx           context.Context
 		expectedRes   openlaneclient.UpdateUserSetting_UpdateUserSetting_UserSetting
 		errorMsg      string

--- a/internal/graphapi/usersetting_test.go
+++ b/internal/graphapi/usersetting_test.go
@@ -4,36 +4,33 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/pkg/enums"
 	"github.com/theopenlane/core/pkg/openlaneclient"
 	"github.com/theopenlane/iam/auth"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
-func (suite *GraphTestSuite) TestQueryUserSetting() {
-	t := suite.T()
-
+func TestQueryUserSetting(t *testing.T) {
 	// setup user context
 	reqCtx := testUser1.UserCtx
 
 	user2 := (&UserBuilder{client: suite.client}).MustNew(reqCtx, t)
 	user2Setting, err := user2.Setting(reqCtx)
-	require.NoError(t, err)
+	assert.NilError(t, err)
 
 	// setup valid user context
 	user1SettingResp, err := suite.client.api.GetUserSettings(reqCtx, openlaneclient.UserSettingWhereInput{})
-	require.NoError(t, err)
-	require.Len(t, user1SettingResp.UserSettings.Edges, 1)
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(user1SettingResp.UserSettings.Edges, 1))
 
 	user1Setting := user1SettingResp.UserSettings.Edges[0].Node
 
 	testCases := []struct {
 		name     string
 		queryID  string
-		client   *openlaneclient.OpenlaneClient
+		client   openlaneclient.OpenlaneClient
 		ctx      context.Context
 		expected *openlaneclient.GetUserSettings_UserSettings_Edges_Node
 		errorMsg string
@@ -73,32 +70,29 @@ func (suite *GraphTestSuite) TestQueryUserSetting() {
 			resp, err := tc.client.GetUserSettingByID(tc.ctx, tc.queryID)
 
 			if tc.errorMsg != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.NotNil(t, resp.UserSetting)
-			require.Equal(t, tc.expected.Status, resp.UserSetting.Status)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+			assert.Equal(t, tc.expected.Status, resp.UserSetting.Status)
 		})
 	}
 
-	(&Cleanup[*generated.UserDeleteOne]{client: suite.client.db.User, ID: user2.ID}).MustDelete(reqCtx, suite)
+	(&Cleanup[*generated.UserDeleteOne]{client: suite.client.db.User, ID: user2.ID}).MustDelete(reqCtx, t)
 }
 
-func (suite *GraphTestSuite) TestQueryUserSettings() {
-	t := suite.T()
-
+func TestQueryUserSettings(t *testing.T) {
 	// setup user context
 	reqCtx := testUser1.UserCtx
 
 	user1 := (&UserBuilder{client: suite.client}).MustNew(reqCtx, t)
 	user1Setting, err := user1.Setting(reqCtx)
-	require.NoError(t, err)
+	assert.NilError(t, err)
 
 	// create another user to make sure we don't get their settings back
 	_ = (&UserBuilder{client: suite.client}).MustNew(reqCtx, t)
@@ -106,28 +100,26 @@ func (suite *GraphTestSuite) TestQueryUserSettings() {
 	t.Run("Get User Settings", func(t *testing.T) {
 		resp, err := suite.client.api.GetAllUserSettings(reqCtx)
 
-		require.NoError(t, err)
-		require.NotNil(t, resp)
-		require.NotNil(t, resp.UserSettings.Edges)
+		assert.NilError(t, err)
+		assert.Assert(t, resp != nil)
+		assert.Assert(t, resp.UserSettings.Edges != nil)
 
 		// make sure only the current user settings are returned
-		assert.Equal(t, len(resp.UserSettings.Edges), 1)
+		assert.Check(t, is.Equal(len(resp.UserSettings.Edges), 1))
 
 		// setup valid user context
 		reqCtx := auth.NewTestContextWithValidUser(user1.ID)
 
 		resp, err = suite.client.api.GetAllUserSettings(reqCtx)
 
-		require.NoError(t, err)
-		require.NotNil(t, resp)
-		require.NotNil(t, resp.UserSettings.Edges)
-		require.Equal(t, user1Setting.ID, resp.UserSettings.Edges[0].Node.ID)
+		assert.NilError(t, err)
+		assert.Assert(t, resp != nil)
+		assert.Assert(t, resp.UserSettings.Edges != nil)
+		assert.Equal(t, user1Setting.ID, resp.UserSettings.Edges[0].Node.ID)
 	})
 }
 
-func (suite *GraphTestSuite) TestMutationUpdateUserSetting() {
-	t := suite.T()
-
+func TestMutationUpdateUserSetting(t *testing.T) {
 	org := (&OrganizationBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	om := (&OrgMemberBuilder{client: suite.client, UserID: viewOnlyUser.ID}).MustNew(testUser1.UserCtx, t)
@@ -140,7 +132,7 @@ func (suite *GraphTestSuite) TestMutationUpdateUserSetting() {
 		name          string
 		userSettingID string
 		updateInput   openlaneclient.UpdateUserSettingInput
-		client        *openlaneclient.OpenlaneClient
+		client        openlaneclient.OpenlaneClient
 		ctx           context.Context
 		expectedRes   openlaneclient.UpdateUserSetting_UpdateUserSetting_UserSetting
 		errorMsg      string
@@ -179,16 +171,16 @@ func (suite *GraphTestSuite) TestMutationUpdateUserSetting() {
 				},
 			},
 		},
-		{
-			name:          "update default org to org without access",
-			userSettingID: testUser1.UserInfo.Edges.Setting.ID,
-			updateInput: openlaneclient.UpdateUserSettingInput{
-				DefaultOrgID: &org2.ID,
-			},
-			client:   suite.client.api,
-			ctx:      testUser1.UserCtx,
-			errorMsg: "Organization with the specified ID was not found",
-		},
+		// {
+		// 	name:          "update default org to org without access",
+		// 	userSettingID: testUser1.UserInfo.Edges.Setting.ID,
+		// 	updateInput: openlaneclient.UpdateUserSettingInput{
+		// 		DefaultOrgID: &org2.ID,
+		// 	},
+		// 	client:   suite.client.api,
+		// 	ctx:      testUser1.UserCtx,
+		// 	errorMsg: "Organization with the specified ID was not found",
+		// },
 		{
 			name:          "update status to invalid",
 			userSettingID: testUser1.UserInfo.Edges.Setting.ID,
@@ -220,24 +212,27 @@ func (suite *GraphTestSuite) TestMutationUpdateUserSetting() {
 			resp, err := tc.client.UpdateUserSetting(tc.ctx, tc.userSettingID, tc.updateInput)
 
 			if tc.errorMsg != "" {
-				require.Error(t, err)
+
 				assert.ErrorContains(t, err, tc.errorMsg)
-				assert.Nil(t, resp)
+				assert.Check(t, is.Nil(resp))
 
 				return
 			}
 
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.NotNil(t, resp.UpdateUserSetting.UserSetting)
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
 
 			// Make sure provided values match
-			assert.Equal(t, tc.expectedRes.Status, resp.UpdateUserSetting.UserSetting.Status)
-			assert.ElementsMatch(t, tc.expectedRes.Tags, resp.UpdateUserSetting.UserSetting.Tags)
+			assert.Check(t, is.Equal(tc.expectedRes.Status, resp.UpdateUserSetting.UserSetting.Status))
+			assert.DeepEqual(t, tc.expectedRes.Tags, resp.UpdateUserSetting.UserSetting.Tags)
 
 			if tc.updateInput.DefaultOrgID != nil {
-				assert.Equal(t, tc.expectedRes.DefaultOrg.ID, resp.UpdateUserSetting.UserSetting.DefaultOrg.ID)
+				assert.Check(t, is.Equal(tc.expectedRes.DefaultOrg.ID, resp.UpdateUserSetting.UserSetting.DefaultOrg.ID))
 			}
 		})
 	}
+
+	// cleanup created organizations
+	(&Cleanup[*generated.OrganizationDeleteOne]{client: suite.client.db.Organization, ID: org.ID}).MustDelete(testUser1.UserCtx, t)
+	(&Cleanup[*generated.OrganizationDeleteOne]{client: suite.client.db.Organization, ID: org2.ID}).MustDelete(testUser2.UserCtx, t)
 }

--- a/internal/graphapi/webauthn_test.go
+++ b/internal/graphapi/webauthn_test.go
@@ -51,7 +51,6 @@ func TestQueryPasskeys(t *testing.T) {
 			resp, err := tc.client.GetAllWebauthns(tc.ctx)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 
@@ -69,7 +68,6 @@ func TestQueryPasskeys(t *testing.T) {
 }
 
 func TestMutationDeletePasskeys(t *testing.T) {
-
 	passkey := (&WebauthnBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	secondPasskey := (&WebauthnBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
@@ -111,7 +109,6 @@ func TestMutationDeletePasskeys(t *testing.T) {
 			resp, err := tc.client.DeleteWebauthn(tc.ctx, tc.passkeyID)
 
 			if tc.errorMsg != "" {
-
 				assert.ErrorContains(t, err, tc.errorMsg)
 				assert.Check(t, is.Nil(resp))
 

--- a/internal/graphapi/webauthn_test.go
+++ b/internal/graphapi/webauthn_test.go
@@ -16,7 +16,7 @@ func TestQueryPasskeys(t *testing.T) {
 	testCases := []struct {
 		name          string
 		userID        string
-		client        openlaneclient.OpenlaneClient
+		client        *openlaneclient.OpenlaneClient
 		ctx           context.Context
 		errorMsg      string
 		expectedCount int
@@ -74,7 +74,7 @@ func TestMutationDeletePasskeys(t *testing.T) {
 	testCases := []struct {
 		name          string
 		userID        string
-		client        openlaneclient.OpenlaneClient
+		client        *openlaneclient.OpenlaneClient
 		ctx           context.Context
 		errorMsg      string
 		passkeyID     string

--- a/pkg/openlaneclient/graphclient.go
+++ b/pkg/openlaneclient/graphclient.go
@@ -141,6 +141,7 @@ type OpenlaneGraphClient interface {
 	DeleteGroup(ctx context.Context, deleteGroupID string, interceptors ...clientv2.RequestInterceptor) (*DeleteGroup, error)
 	GetAllGroups(ctx context.Context, interceptors ...clientv2.RequestInterceptor) (*GetAllGroups, error)
 	GetGroupByID(ctx context.Context, groupID string, interceptors ...clientv2.RequestInterceptor) (*GetGroupByID, error)
+	GetGroupInfo(ctx context.Context, where *GroupWhereInput, interceptors ...clientv2.RequestInterceptor) (*GetGroupInfo, error)
 	GetGroups(ctx context.Context, where *GroupWhereInput, interceptors ...clientv2.RequestInterceptor) (*GetGroups, error)
 	UpdateGroup(ctx context.Context, updateGroupID string, input UpdateGroupInput, interceptors ...clientv2.RequestInterceptor) (*UpdateGroup, error)
 	GetAllGroupHistories(ctx context.Context, interceptors ...clientv2.RequestInterceptor) (*GetAllGroupHistories, error)
@@ -17530,9 +17531,16 @@ func (t *CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_Notes) GetEdges() []*C
 }
 
 type CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_EntityType struct {
+	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
+func (t *CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_EntityType) GetID() string {
+	if t == nil {
+		t = &CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_EntityType{}
+	}
+	return t.ID
+}
 func (t *CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_EntityType) GetName() string {
 	if t == nil {
 		t = &CreateBulkCSVEntity_CreateBulkCSVEntity_Entities_EntityType{}
@@ -17701,9 +17709,16 @@ func (t *CreateBulkEntity_CreateBulkEntity_Entities_Notes) GetEdges() []*CreateB
 }
 
 type CreateBulkEntity_CreateBulkEntity_Entities_EntityType struct {
+	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
+func (t *CreateBulkEntity_CreateBulkEntity_Entities_EntityType) GetID() string {
+	if t == nil {
+		t = &CreateBulkEntity_CreateBulkEntity_Entities_EntityType{}
+	}
+	return t.ID
+}
 func (t *CreateBulkEntity_CreateBulkEntity_Entities_EntityType) GetName() string {
 	if t == nil {
 		t = &CreateBulkEntity_CreateBulkEntity_Entities_EntityType{}
@@ -17872,9 +17887,16 @@ func (t *CreateEntity_CreateEntity_Entity_Notes) GetEdges() []*CreateEntity_Crea
 }
 
 type CreateEntity_CreateEntity_Entity_EntityType struct {
+	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
+func (t *CreateEntity_CreateEntity_Entity_EntityType) GetID() string {
+	if t == nil {
+		t = &CreateEntity_CreateEntity_Entity_EntityType{}
+	}
+	return t.ID
+}
 func (t *CreateEntity_CreateEntity_Entity_EntityType) GetName() string {
 	if t == nil {
 		t = &CreateEntity_CreateEntity_Entity_EntityType{}
@@ -18054,9 +18076,16 @@ func (t *GetAllEntities_Entities_Edges_Node_Notes) GetEdges() []*GetAllEntities_
 }
 
 type GetAllEntities_Entities_Edges_Node_EntityType struct {
+	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
+func (t *GetAllEntities_Entities_Edges_Node_EntityType) GetID() string {
+	if t == nil {
+		t = &GetAllEntities_Entities_Edges_Node_EntityType{}
+	}
+	return t.ID
+}
 func (t *GetAllEntities_Entities_Edges_Node_EntityType) GetName() string {
 	if t == nil {
 		t = &GetAllEntities_Entities_Edges_Node_EntityType{}
@@ -18236,9 +18265,16 @@ func (t *GetEntities_Entities_Edges_Node_Notes) GetEdges() []*GetEntities_Entiti
 }
 
 type GetEntities_Entities_Edges_Node_EntityType struct {
+	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
+func (t *GetEntities_Entities_Edges_Node_EntityType) GetID() string {
+	if t == nil {
+		t = &GetEntities_Entities_Edges_Node_EntityType{}
+	}
+	return t.ID
+}
 func (t *GetEntities_Entities_Edges_Node_EntityType) GetName() string {
 	if t == nil {
 		t = &GetEntities_Entities_Edges_Node_EntityType{}
@@ -18418,9 +18454,16 @@ func (t *GetEntityByID_Entity_Notes) GetEdges() []*GetEntityByID_Entity_Notes_Ed
 }
 
 type GetEntityByID_Entity_EntityType struct {
+	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
+func (t *GetEntityByID_Entity_EntityType) GetID() string {
+	if t == nil {
+		t = &GetEntityByID_Entity_EntityType{}
+	}
+	return t.ID
+}
 func (t *GetEntityByID_Entity_EntityType) GetName() string {
 	if t == nil {
 		t = &GetEntityByID_Entity_EntityType{}
@@ -18660,9 +18703,16 @@ func (t *UpdateEntity_UpdateEntity_Entity_Notes) GetEdges() []*UpdateEntity_Upda
 }
 
 type UpdateEntity_UpdateEntity_Entity_EntityType struct {
+	ID   string "json:\"id\" graphql:\"id\""
 	Name string "json:\"name\" graphql:\"name\""
 }
 
+func (t *UpdateEntity_UpdateEntity_Entity_EntityType) GetID() string {
+	if t == nil {
+		t = &UpdateEntity_UpdateEntity_Entity_EntityType{}
+	}
+	return t.ID
+}
 func (t *UpdateEntity_UpdateEntity_Entity_EntityType) GetName() string {
 	if t == nil {
 		t = &UpdateEntity_UpdateEntity_Entity_EntityType{}
@@ -26681,6 +26731,183 @@ func (t *GetGroupByID_Group) GetUpdatedBy() *string {
 		t = &GetGroupByID_Group{}
 	}
 	return t.UpdatedBy
+}
+
+type GetGroupInfo_Groups_Edges_Node_Setting struct {
+	CreatedAt    *time.Time       "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy    *string          "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	ID           string           "json:\"id\" graphql:\"id\""
+	JoinPolicy   enums.JoinPolicy "json:\"joinPolicy\" graphql:\"joinPolicy\""
+	SyncToGithub *bool            "json:\"syncToGithub,omitempty\" graphql:\"syncToGithub\""
+	SyncToSlack  *bool            "json:\"syncToSlack,omitempty\" graphql:\"syncToSlack\""
+	UpdatedAt    *time.Time       "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy    *string          "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Visibility   enums.Visibility "json:\"visibility\" graphql:\"visibility\""
+}
+
+func (t *GetGroupInfo_Groups_Edges_Node_Setting) GetCreatedAt() *time.Time {
+	if t == nil {
+		t = &GetGroupInfo_Groups_Edges_Node_Setting{}
+	}
+	return t.CreatedAt
+}
+func (t *GetGroupInfo_Groups_Edges_Node_Setting) GetCreatedBy() *string {
+	if t == nil {
+		t = &GetGroupInfo_Groups_Edges_Node_Setting{}
+	}
+	return t.CreatedBy
+}
+func (t *GetGroupInfo_Groups_Edges_Node_Setting) GetID() string {
+	if t == nil {
+		t = &GetGroupInfo_Groups_Edges_Node_Setting{}
+	}
+	return t.ID
+}
+func (t *GetGroupInfo_Groups_Edges_Node_Setting) GetJoinPolicy() *enums.JoinPolicy {
+	if t == nil {
+		t = &GetGroupInfo_Groups_Edges_Node_Setting{}
+	}
+	return &t.JoinPolicy
+}
+func (t *GetGroupInfo_Groups_Edges_Node_Setting) GetSyncToGithub() *bool {
+	if t == nil {
+		t = &GetGroupInfo_Groups_Edges_Node_Setting{}
+	}
+	return t.SyncToGithub
+}
+func (t *GetGroupInfo_Groups_Edges_Node_Setting) GetSyncToSlack() *bool {
+	if t == nil {
+		t = &GetGroupInfo_Groups_Edges_Node_Setting{}
+	}
+	return t.SyncToSlack
+}
+func (t *GetGroupInfo_Groups_Edges_Node_Setting) GetUpdatedAt() *time.Time {
+	if t == nil {
+		t = &GetGroupInfo_Groups_Edges_Node_Setting{}
+	}
+	return t.UpdatedAt
+}
+func (t *GetGroupInfo_Groups_Edges_Node_Setting) GetUpdatedBy() *string {
+	if t == nil {
+		t = &GetGroupInfo_Groups_Edges_Node_Setting{}
+	}
+	return t.UpdatedBy
+}
+func (t *GetGroupInfo_Groups_Edges_Node_Setting) GetVisibility() *enums.Visibility {
+	if t == nil {
+		t = &GetGroupInfo_Groups_Edges_Node_Setting{}
+	}
+	return &t.Visibility
+}
+
+type GetGroupInfo_Groups_Edges_Node struct {
+	CreatedAt   *time.Time                              "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy   *string                                 "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	Description *string                                 "json:\"description,omitempty\" graphql:\"description\""
+	DisplayName string                                  "json:\"displayName\" graphql:\"displayName\""
+	ID          string                                  "json:\"id\" graphql:\"id\""
+	IsManaged   *bool                                   "json:\"isManaged,omitempty\" graphql:\"isManaged\""
+	LogoURL     *string                                 "json:\"logoURL,omitempty\" graphql:\"logoURL\""
+	Name        string                                  "json:\"name\" graphql:\"name\""
+	Setting     *GetGroupInfo_Groups_Edges_Node_Setting "json:\"setting,omitempty\" graphql:\"setting\""
+	Tags        []string                                "json:\"tags,omitempty\" graphql:\"tags\""
+	UpdatedAt   *time.Time                              "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy   *string                                 "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+}
+
+func (t *GetGroupInfo_Groups_Edges_Node) GetCreatedAt() *time.Time {
+	if t == nil {
+		t = &GetGroupInfo_Groups_Edges_Node{}
+	}
+	return t.CreatedAt
+}
+func (t *GetGroupInfo_Groups_Edges_Node) GetCreatedBy() *string {
+	if t == nil {
+		t = &GetGroupInfo_Groups_Edges_Node{}
+	}
+	return t.CreatedBy
+}
+func (t *GetGroupInfo_Groups_Edges_Node) GetDescription() *string {
+	if t == nil {
+		t = &GetGroupInfo_Groups_Edges_Node{}
+	}
+	return t.Description
+}
+func (t *GetGroupInfo_Groups_Edges_Node) GetDisplayName() string {
+	if t == nil {
+		t = &GetGroupInfo_Groups_Edges_Node{}
+	}
+	return t.DisplayName
+}
+func (t *GetGroupInfo_Groups_Edges_Node) GetID() string {
+	if t == nil {
+		t = &GetGroupInfo_Groups_Edges_Node{}
+	}
+	return t.ID
+}
+func (t *GetGroupInfo_Groups_Edges_Node) GetIsManaged() *bool {
+	if t == nil {
+		t = &GetGroupInfo_Groups_Edges_Node{}
+	}
+	return t.IsManaged
+}
+func (t *GetGroupInfo_Groups_Edges_Node) GetLogoURL() *string {
+	if t == nil {
+		t = &GetGroupInfo_Groups_Edges_Node{}
+	}
+	return t.LogoURL
+}
+func (t *GetGroupInfo_Groups_Edges_Node) GetName() string {
+	if t == nil {
+		t = &GetGroupInfo_Groups_Edges_Node{}
+	}
+	return t.Name
+}
+func (t *GetGroupInfo_Groups_Edges_Node) GetSetting() *GetGroupInfo_Groups_Edges_Node_Setting {
+	if t == nil {
+		t = &GetGroupInfo_Groups_Edges_Node{}
+	}
+	return t.Setting
+}
+func (t *GetGroupInfo_Groups_Edges_Node) GetTags() []string {
+	if t == nil {
+		t = &GetGroupInfo_Groups_Edges_Node{}
+	}
+	return t.Tags
+}
+func (t *GetGroupInfo_Groups_Edges_Node) GetUpdatedAt() *time.Time {
+	if t == nil {
+		t = &GetGroupInfo_Groups_Edges_Node{}
+	}
+	return t.UpdatedAt
+}
+func (t *GetGroupInfo_Groups_Edges_Node) GetUpdatedBy() *string {
+	if t == nil {
+		t = &GetGroupInfo_Groups_Edges_Node{}
+	}
+	return t.UpdatedBy
+}
+
+type GetGroupInfo_Groups_Edges struct {
+	Node *GetGroupInfo_Groups_Edges_Node "json:\"node,omitempty\" graphql:\"node\""
+}
+
+func (t *GetGroupInfo_Groups_Edges) GetNode() *GetGroupInfo_Groups_Edges_Node {
+	if t == nil {
+		t = &GetGroupInfo_Groups_Edges{}
+	}
+	return t.Node
+}
+
+type GetGroupInfo_Groups struct {
+	Edges []*GetGroupInfo_Groups_Edges "json:\"edges,omitempty\" graphql:\"edges\""
+}
+
+func (t *GetGroupInfo_Groups) GetEdges() []*GetGroupInfo_Groups_Edges {
+	if t == nil {
+		t = &GetGroupInfo_Groups{}
+	}
+	return t.Edges
 }
 
 type GetGroups_Groups_Edges_Node_Owner struct {
@@ -70365,6 +70592,17 @@ func (t *GetGroupByID) GetGroup() *GetGroupByID_Group {
 	return &t.Group
 }
 
+type GetGroupInfo struct {
+	Groups GetGroupInfo_Groups "json:\"groups\" graphql:\"groups\""
+}
+
+func (t *GetGroupInfo) GetGroups() *GetGroupInfo_Groups {
+	if t == nil {
+		t = &GetGroupInfo{}
+	}
+	return &t.Groups
+}
+
 type GetGroups struct {
 	Groups GetGroups_Groups "json:\"groups\" graphql:\"groups\""
 }
@@ -77275,6 +77513,7 @@ const CreateBulkCSVEntityDocument = `mutation CreateBulkCSVEntity ($input: Uploa
 				}
 			}
 			entityType {
+				id
 				name
 			}
 			id
@@ -77324,6 +77563,7 @@ const CreateBulkEntityDocument = `mutation CreateBulkEntity ($input: [CreateEnti
 				}
 			}
 			entityType {
+				id
 				name
 			}
 			id
@@ -77373,6 +77613,7 @@ const CreateEntityDocument = `mutation CreateEntity ($input: CreateEntityInput!)
 				}
 			}
 			entityType {
+				id
 				name
 			}
 			id
@@ -77447,6 +77688,7 @@ const GetAllEntitiesDocument = `query GetAllEntities {
 					}
 				}
 				entityType {
+					id
 					name
 				}
 				id
@@ -77496,6 +77738,7 @@ const GetEntitiesDocument = `query GetEntities ($where: EntityWhereInput) {
 					}
 				}
 				entityType {
+					id
 					name
 				}
 				id
@@ -77545,6 +77788,7 @@ const GetEntityByIDDocument = `query GetEntityByID ($entityId: ID!) {
 			}
 		}
 		entityType {
+			id
 			name
 		}
 		id
@@ -77606,6 +77850,7 @@ const UpdateEntityDocument = `mutation UpdateEntity ($updateEntityId: ID!, $inpu
 				}
 			}
 			entityType {
+				id
 				name
 			}
 			id
@@ -79850,6 +80095,55 @@ func (c *Client) GetGroupByID(ctx context.Context, groupID string, interceptors 
 
 	var res GetGroupByID
 	if err := c.Client.Post(ctx, "GetGroupByID", GetGroupByIDDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const GetGroupInfoDocument = `query GetGroupInfo ($where: GroupWhereInput) {
+	groups(where: $where) {
+		edges {
+			node {
+				description
+				displayName
+				id
+				logoURL
+				name
+				tags
+				isManaged
+				setting {
+					createdAt
+					createdBy
+					id
+					joinPolicy
+					syncToGithub
+					syncToSlack
+					updatedAt
+					updatedBy
+					visibility
+				}
+				createdAt
+				createdBy
+				updatedAt
+				updatedBy
+			}
+		}
+	}
+}
+`
+
+func (c *Client) GetGroupInfo(ctx context.Context, where *GroupWhereInput, interceptors ...clientv2.RequestInterceptor) (*GetGroupInfo, error) {
+	vars := map[string]any{
+		"where": where,
+	}
+
+	var res GetGroupInfo
+	if err := c.Client.Post(ctx, "GetGroupInfo", GetGroupInfoDocument, &res, vars, interceptors...); err != nil {
 		if c.Client.ParseDataWhenErrors {
 			return &res, err
 		}
@@ -91767,6 +92061,7 @@ var DocumentOperationNames = map[string]string{
 	DeleteGroupDocument:                          "DeleteGroup",
 	GetAllGroupsDocument:                         "GetAllGroups",
 	GetGroupByIDDocument:                         "GetGroupByID",
+	GetGroupInfoDocument:                         "GetGroupInfo",
 	GetGroupsDocument:                            "GetGroups",
 	UpdateGroupDocument:                          "UpdateGroup",
 	GetAllGroupHistoriesDocument:                 "GetAllGroupHistories",

--- a/pkg/openlaneclient/graphclient.go
+++ b/pkg/openlaneclient/graphclient.go
@@ -66035,11 +66035,18 @@ func (t *GetTFASetting_TfaSetting_Owner) GetID() string {
 }
 
 type GetTFASetting_TfaSetting struct {
+	ID          string                          "json:\"id\" graphql:\"id\""
 	Owner       *GetTFASetting_TfaSetting_Owner "json:\"owner,omitempty\" graphql:\"owner\""
 	TotpAllowed *bool                           "json:\"totpAllowed,omitempty\" graphql:\"totpAllowed\""
 	Verified    bool                            "json:\"verified\" graphql:\"verified\""
 }
 
+func (t *GetTFASetting_TfaSetting) GetID() string {
+	if t == nil {
+		t = &GetTFASetting_TfaSetting{}
+	}
+	return t.ID
+}
 func (t *GetTFASetting_TfaSetting) GetOwner() *GetTFASetting_TfaSetting_Owner {
 	if t == nil {
 		t = &GetTFASetting_TfaSetting{}
@@ -91037,6 +91044,7 @@ func (c *Client) GetAllTFASettings(ctx context.Context, interceptors ...clientv2
 
 const GetTFASettingDocument = `query GetTFASetting {
 	tfaSetting {
+		id
 		totpAllowed
 		verified
 		owner {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,3 +13,4 @@ sonar.test.exclusions=**/vendor/**
 
 sonar.sourceEncoding=UTF-8
 sonar.go.coverage.reportPaths=coverage.out
+sonar.junit.reportPaths=junit.xml

--- a/tools.go
+++ b/tools.go
@@ -11,4 +11,5 @@ import (
 	_ "github.com/oNaiPs/go-generate-fast"
 	_ "github.com/openfga/go-sdk"
 	_ "github.com/vektra/mockery/v3"
+	_ "gotest.tools/gotestsum"
 )


### PR DESCRIPTION
- moves away from testify suite for the longest test package (graphapi)
- uses `gotestsum` which gives better output, auto retries, and integrates with buildkite test analytics
- moves to https://github.com/gotestyourself/gotest.tools from testify assert + require as it works well with gotestsum and is a simpler package
- adding `coverage` loses the caching in buildkite, but its not big difference anymore