### PR TITLE
Feat : add standard cloning to other program endpoints

### DIFF
--- a/internal/graphapi/clientschema/schema.graphql
+++ b/internal/graphapi/clientschema/schema.graphql
@@ -7375,6 +7375,7 @@ input CreateProgramMembershipInput {
 input CreateProgramWithMembersInput {
 	program: CreateProgramInput!
 	members: [CreateMemberWithProgramInput!]
+	standardID: ID!
 }
 """
 CreateRiskInput is used for create Risk object.

--- a/internal/graphapi/clientschema/schema.graphql
+++ b/internal/graphapi/clientschema/schema.graphql
@@ -6731,7 +6731,7 @@ input CreateFullProgramInput {
 	internalPolicies: [CreateInternalPolicyInput!]
 	procedures: [CreateProcedureInput!]
 	members: [CreateMemberWithProgramInput!]
-	standardID: ID!
+	standardID: ID
 }
 """
 CreateGroupInput is used for create Group object.
@@ -7375,7 +7375,7 @@ input CreateProgramMembershipInput {
 input CreateProgramWithMembersInput {
 	program: CreateProgramInput!
 	members: [CreateMemberWithProgramInput!]
-	standardID: ID!
+	standardID: ID
 }
 """
 CreateRiskInput is used for create Risk object.

--- a/internal/graphapi/control_clone.go
+++ b/internal/graphapi/control_clone.go
@@ -25,7 +25,6 @@ func getStandardID[T createProgramRequest](value T) string {
 }
 
 func (r *mutationResolver) cloneControlsFromStandard(ctx context.Context, standardID string) ([]*generated.Control, error) {
-
 	standardRes, err := withTransactionalMutation(ctx).Standard.Get(ctx, standardID)
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionGet, object: "standard"})

--- a/internal/graphapi/control_clone.go
+++ b/internal/graphapi/control_clone.go
@@ -16,12 +16,16 @@ type createProgramRequest interface {
 func getStandardID[T createProgramRequest](value T) string {
 	switch input := any(value).(type) {
 	case model.CreateProgramWithMembersInput:
-		return input.StandardID
+		if input.StandardID != nil {
+			return *input.StandardID
+		}
 	case model.CreateFullProgramInput:
-		return input.StandardID
-	default:
-		return ""
+		if input.StandardID != nil {
+			return *input.StandardID
+		}
 	}
+
+	return ""
 }
 
 func (r *mutationResolver) cloneControlsFromStandard(ctx context.Context, standardID string) ([]*generated.Control, error) {

--- a/internal/graphapi/generated/programextended.generated.go
+++ b/internal/graphapi/generated/programextended.generated.go
@@ -119,7 +119,7 @@ func (ec *executionContext) unmarshalInputCreateFullProgramInput(ctx context.Con
 			it.Members = data
 		case "standardID":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("standardID"))
-			data, err := ec.unmarshalNID2string(ctx, v)
+			data, err := ec.unmarshalOID2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -194,7 +194,7 @@ func (ec *executionContext) unmarshalInputCreateProgramWithMembersInput(ctx cont
 			it.Members = data
 		case "standardID":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("standardID"))
-			data, err := ec.unmarshalNID2string(ctx, v)
+			data, err := ec.unmarshalOID2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/internal/graphapi/generated/programextended.generated.go
+++ b/internal/graphapi/generated/programextended.generated.go
@@ -171,7 +171,7 @@ func (ec *executionContext) unmarshalInputCreateProgramWithMembersInput(ctx cont
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"program", "members"}
+	fieldsInOrder := [...]string{"program", "members", "standardID"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -192,6 +192,13 @@ func (ec *executionContext) unmarshalInputCreateProgramWithMembersInput(ctx cont
 				return it, err
 			}
 			it.Members = data
+		case "standardID":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("standardID"))
+			data, err := ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.StandardID = data
 		}
 	}
 

--- a/internal/graphapi/generated/root_.generated.go
+++ b/internal/graphapi/generated/root_.generated.go
@@ -71285,6 +71285,7 @@ input CreateFullProgramInput{
 input CreateProgramWithMembersInput{
   program: CreateProgramInput!
   members: [CreateMemberWithProgramInput!]
+  standardID: ID!
 }
 
 input CreateMemberWithProgramInput {

--- a/internal/graphapi/generated/root_.generated.go
+++ b/internal/graphapi/generated/root_.generated.go
@@ -71279,13 +71279,13 @@ input CreateFullProgramInput{
   internalPolicies: [CreateInternalPolicyInput!]
   procedures: [CreateProcedureInput!]
   members: [CreateMemberWithProgramInput!]
-  standardID: ID!
+  standardID: ID
 }
 
 input CreateProgramWithMembersInput{
   program: CreateProgramInput!
   members: [CreateMemberWithProgramInput!]
-  standardID: ID!
+  standardID: ID
 }
 
 input CreateMemberWithProgramInput {

--- a/internal/graphapi/model/gen_models.go
+++ b/internal/graphapi/model/gen_models.go
@@ -221,8 +221,9 @@ type CreateMemberWithProgramInput struct {
 }
 
 type CreateProgramWithMembersInput struct {
-	Program *generated.CreateProgramInput   `json:"program"`
-	Members []*CreateMemberWithProgramInput `json:"members,omitempty"`
+	Program    *generated.CreateProgramInput   `json:"program"`
+	Members    []*CreateMemberWithProgramInput `json:"members,omitempty"`
+	StandardID string                          `json:"standardID"`
 }
 
 // Return response for createBulkCustomDomain mutation

--- a/internal/graphapi/model/gen_models.go
+++ b/internal/graphapi/model/gen_models.go
@@ -212,7 +212,7 @@ type CreateFullProgramInput struct {
 	InternalPolicies []*generated.CreateInternalPolicyInput `json:"internalPolicies,omitempty"`
 	Procedures       []*generated.CreateProcedureInput      `json:"procedures,omitempty"`
 	Members          []*CreateMemberWithProgramInput        `json:"members,omitempty"`
-	StandardID       string                                 `json:"standardID"`
+	StandardID       *string                                `json:"standardID,omitempty"`
 }
 
 type CreateMemberWithProgramInput struct {
@@ -223,7 +223,7 @@ type CreateMemberWithProgramInput struct {
 type CreateProgramWithMembersInput struct {
 	Program    *generated.CreateProgramInput   `json:"program"`
 	Members    []*CreateMemberWithProgramInput `json:"members,omitempty"`
-	StandardID string                          `json:"standardID"`
+	StandardID *string                         `json:"standardID,omitempty"`
 }
 
 // Return response for createBulkCustomDomain mutation

--- a/internal/graphapi/schema/programextended.graphql
+++ b/internal/graphapi/schema/programextended.graphql
@@ -26,6 +26,7 @@ input CreateFullProgramInput{
 input CreateProgramWithMembersInput{
   program: CreateProgramInput!
   members: [CreateMemberWithProgramInput!]
+  standardID: ID!
 }
 
 input CreateMemberWithProgramInput {

--- a/internal/graphapi/schema/programextended.graphql
+++ b/internal/graphapi/schema/programextended.graphql
@@ -20,13 +20,13 @@ input CreateFullProgramInput{
   internalPolicies: [CreateInternalPolicyInput!]
   procedures: [CreateProcedureInput!]
   members: [CreateMemberWithProgramInput!]
-  standardID: ID!
+  standardID: ID
 }
 
 input CreateProgramWithMembersInput{
   program: CreateProgramInput!
   members: [CreateMemberWithProgramInput!]
-  standardID: ID!
+  standardID: ID
 }
 
 input CreateMemberWithProgramInput {

--- a/pkg/openlaneclient/models.go
+++ b/pkg/openlaneclient/models.go
@@ -4677,8 +4677,9 @@ type CreateProgramMembershipInput struct {
 }
 
 type CreateProgramWithMembersInput struct {
-	Program *CreateProgramInput             `json:"program"`
-	Members []*CreateMemberWithProgramInput `json:"members,omitempty"`
+	Program    *CreateProgramInput             `json:"program"`
+	Members    []*CreateMemberWithProgramInput `json:"members,omitempty"`
+	StandardID string                          `json:"standardID"`
 }
 
 // CreateRiskInput is used for create Risk object.

--- a/pkg/openlaneclient/models.go
+++ b/pkg/openlaneclient/models.go
@@ -4236,7 +4236,7 @@ type CreateFullProgramInput struct {
 	InternalPolicies []*CreateInternalPolicyInput         `json:"internalPolicies,omitempty"`
 	Procedures       []*CreateProcedureInput              `json:"procedures,omitempty"`
 	Members          []*CreateMemberWithProgramInput      `json:"members,omitempty"`
-	StandardID       string                               `json:"standardID"`
+	StandardID       *string                              `json:"standardID,omitempty"`
 }
 
 // CreateGroupInput is used for create Group object.
@@ -4679,7 +4679,7 @@ type CreateProgramMembershipInput struct {
 type CreateProgramWithMembersInput struct {
 	Program    *CreateProgramInput             `json:"program"`
 	Members    []*CreateMemberWithProgramInput `json:"members,omitempty"`
-	StandardID string                          `json:"standardID"`
+	StandardID *string                         `json:"standardID,omitempty"`
 }
 
 // CreateRiskInput is used for create Risk object.


### PR DESCRIPTION
Wanted to simplify the UI. While we added this to `CreateFullProgram` in #714 , the frontend 
uses `CreateProgramWithMembers`. I do not want to complicate on the frontend to have way too many 
switches bacause of a `standardID`.

I have also made `standardID` be more graphql like by making it optional from the schema level