### PR TITLE
fix: set trialExpiresAt for `trialing` status

### DIFF
--- a/cmd/cli/cmd/orgsubscription/root.go
+++ b/cmd/cli/cmd/orgsubscription/root.go
@@ -91,6 +91,8 @@ func tableOutput(out []openlaneclient.OrgSubscription) {
 		exp := ""
 		if i.ExpiresAt != nil {
 			exp = i.ExpiresAt.String()
+		} else if i.TrialExpiresAt != nil {
+			exp = i.TrialExpiresAt.String()
 		}
 
 		price := ""

--- a/docker/all-in-one/Dockerfile.all-in-one
+++ b/docker/all-in-one/Dockerfile.all-in-one
@@ -21,7 +21,7 @@ COPY --from=ghcr.io/theopenlane/dbx:145-c77867be /bin/dbx /bin/dbx
 COPY --from=ghcr.io/theopenlane/riverboat:amd64-86-3eaa899d /bin/riverboat /bin/riverboat
 
 # Copy redis binary
-COPY --from=redis:8.0.1 /usr/local/bin/redis-server /bin/redis-server
+COPY --from=redis:7.4.3 /usr/local/bin/redis-server /bin/redis-server
 
 # Copy FGA binary
 COPY --from=openfga/openfga:v1.8.12 /openfga /bin/openfga

--- a/docker/docker-compose-redis.yml
+++ b/docker/docker-compose-redis.yml
@@ -1,6 +1,6 @@
 services:
   redis:
-    image: redis:8.0.1-alpine
+    image: redis:7.4.3-alpine
     restart: always
     ports:
       - '6379:6379'

--- a/internal/ent/hooks/event.go
+++ b/internal/ent/hooks/event.go
@@ -338,10 +338,13 @@ func updateCustomerOrgSub(ctx context.Context, customer *entitlements.Organizati
 	// update the expiration date based on the subscription status
 	// if the subscription is trialing, set the expiration date to the trial end date
 	// otherwise, set the expiration date to the end date if it exists
-	expiresAt := time.Unix(0, 0)
+	trialExpiresAt := time.Unix(0, 0)
 	if customer.Status == string(stripe.SubscriptionStatusTrialing) {
-		expiresAt = time.Unix(customer.TrialEnd, 0)
-	} else if customer.EndDate > 0 {
+		trialExpiresAt = time.Unix(customer.TrialEnd, 0)
+	}
+
+	expiresAt := time.Unix(0, 0)
+	if customer.EndDate > 0 {
 		expiresAt = time.Unix(customer.EndDate, 0)
 	}
 
@@ -362,7 +365,7 @@ func updateCustomerOrgSub(ctx context.Context, customer *entitlements.Organizati
 	// if the subscription is trialing, set the expiration date to the trial end date
 	// otherwise, set the expiration date to the end date
 	if customer.Status == string(stripe.SubscriptionStatusTrialing) {
-		update.SetTrialExpiresAt(expiresAt)
+		update.SetTrialExpiresAt(trialExpiresAt)
 	} else {
 		update.SetExpiresAt(expiresAt)
 	}

--- a/internal/ent/hooks/event.go
+++ b/internal/ent/hooks/event.go
@@ -335,16 +335,19 @@ func updateCustomerOrgSub(ctx context.Context, customer *entitlements.Organizati
 		}
 	}
 
+	// update the expiration date based on the subscription status
+	// if the subscription is trialing, set the expiration date to the trial end date
+	// otherwise, set the expiration date to the end date if it exists
 	expiresAt := time.Unix(0, 0)
-	if customer.EndDate > 0 {
-		expiresAt = time.Unix(customer.EndDate, 0)
-	} else if customer.Status == string(stripe.SubscriptionStatusTrialing) {
+	if customer.Status == string(stripe.SubscriptionStatusTrialing) {
 		expiresAt = time.Unix(customer.TrialEnd, 0)
+	} else if customer.EndDate > 0 {
+		expiresAt = time.Unix(customer.EndDate, 0)
 	}
 
 	active := customer.Status == string(stripe.SubscriptionStatusActive) || customer.Status == string(stripe.SubscriptionStatusTrialing)
 
-	return client.(*entgen.Client).OrgSubscription.UpdateOneID(customer.OrganizationSubscriptionID).
+	update := client.(*entgen.Client).OrgSubscription.UpdateOneID(customer.OrganizationSubscriptionID).
 		SetStripeSubscriptionID(customer.StripeSubscriptionID).
 		SetStripeCustomerID(customer.StripeCustomerID).
 		SetStripeSubscriptionStatus(customer.Subscription.Status).
@@ -353,8 +356,18 @@ func updateCustomerOrgSub(ctx context.Context, customer *entitlements.Organizati
 		SetFeatures(customer.FeatureNames).
 		SetFeatureLookupKeys(customer.Features).
 		SetStripeProductTierID(customer.Subscription.ProductID).
-		SetProductPrice(productPrice).
-		SetExpiresAt(expiresAt).Exec(ctx)
+		SetProductPrice(productPrice)
+
+	// ensure the correct expiration date is set based on the subscription status
+	// if the subscription is trialing, set the expiration date to the trial end date
+	// otherwise, set the expiration date to the end date
+	if customer.Status == string(stripe.SubscriptionStatusTrialing) {
+		update.SetTrialExpiresAt(expiresAt)
+	} else {
+		update.SetExpiresAt(expiresAt)
+	}
+
+	return update.Exec(ctx)
 }
 
 // updateOrgCustomerWithSubscription updates the organization customer with the subscription data


### PR DESCRIPTION
We had updated previously to use the `trialExpiresAt` field when `trialing`, but on the original creation we were setting `expiresAt` instead. This caused some confusion with what the UI should render.

Now it should have:
`trialExpiresAt` when `trialing` and `expiresAt` only is used after a subscription is moved out of a trial

Also updated the cli to return `trialExpiresAt` if `expiresAt` is not set

Before change the first three records, second three after:

```
       expires_at       |    trial_expires_at    |             id             | stripe_subscription_status | active 
------------------------+------------------------+----------------------------+----------------------------+--------
 2025-06-20 19:04:06+00 |                        | 01JVT3PFC7TAD5R02KEW2X8DZZ | trialing                   | t
 2025-06-20 19:10:28+00 |                        | 01JVT42578Y51ZYAGX9TRMHEV7 | trialing                   | t
 2025-06-20 19:16:22+00 |                        | 01JVT4CYRSDB9R963HJKHSCGGG | trialing                   | t
                        | 2025-06-20 19:29:29+00 | 01JVT54Z00GXN08QMJBFRWT2EB | trialing                   | t
                        | 2025-06-20 19:33:03+00 | 01JVT5BFFQEND81AK4ETJ60YRX | trialing                   | t
                        | 2025-06-20 19:41:35+00 | 01JVT5V4D6DF3AJ746ETMYW3C2 | trialing                   | t

```

This PR also reverts the redis 8 change, I had to roll this back in prod, and seeing some weird issues locally so wanted it consistent until we test it fully. 