### PR TITLE
bug: fix ability to update permissions on managed group to other objects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -599,7 +599,7 @@ require (
 	go.uber.org/goleak v1.3.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
-	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6
+	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 // indirect
 	golang.org/x/mod v0.24.0
 	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/sync v0.14.0

--- a/go.mod
+++ b/go.mod
@@ -599,7 +599,7 @@ require (
 	go.uber.org/goleak v1.3.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
-	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 // indirect
+	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6
 	golang.org/x/mod v0.24.0
 	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/sync v0.14.0

--- a/internal/ent/hooks/group.go
+++ b/internal/ent/hooks/group.go
@@ -3,6 +3,7 @@ package hooks
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"entgo.io/ent"
@@ -12,7 +13,6 @@ import (
 	"github.com/theopenlane/iam/fgax"
 	"github.com/theopenlane/utils/contextx"
 	"github.com/theopenlane/utils/gravatar"
-	"golang.org/x/exp/slices"
 
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/hook"

--- a/internal/ent/hooks/group.go
+++ b/internal/ent/hooks/group.go
@@ -12,6 +12,7 @@ import (
 	"github.com/theopenlane/iam/fgax"
 	"github.com/theopenlane/utils/contextx"
 	"github.com/theopenlane/utils/gravatar"
+	"golang.org/x/exp/slices"
 
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/hook"
@@ -79,13 +80,79 @@ func HookManagedGroups() ent.Hook {
 			_, allowCtx := privacy.DecisionFromContext(ctx)
 			_, allowManagedCtx := contextx.From[ManagedContextKey](ctx)
 
+			// before returning the error, we need to allow for edges to be updated
+			// if they are permissions edges
 			if group.IsManaged && (!allowManagedCtx && !allowCtx) {
-				return nil, ErrManagedGroup
+				if err := checkOnlyDefaultFields(m); err != nil {
+					return nil, ErrManagedGroup
+				}
+
+				if err := checkOnlyPermissionEdges(m); err != nil {
+					return nil, err
+				}
 			}
+
+			// if we got here, the only that that was updated was edges for permissions (Editor, Viewer, BlockedGroups)
+			// and we can continue
 
 			return next.Mutate(ctx, m)
 		})
 	}, ent.OpUpdate|ent.OpUpdateOne|ent.OpDelete|ent.OpDeleteOne)
+}
+
+// checkOnlyDefaultFields checks if the added or cleared fields are only default fields
+// and returns an error if they are not
+func checkOnlyDefaultFields(m *generated.GroupMutation) error {
+	fields := m.Fields()
+	numericFields := m.AddedFields()
+	clearedFields := m.ClearedFields()
+
+	// if nothing changed, return no error
+	if len(fields) == 0 && len(numericFields) == 0 && len(clearedFields) == 0 {
+		return nil
+	}
+
+	// default fields are updatedAt, updatedBy
+	defaultFields := []string{
+		"updated_at",
+		"updated_by",
+		// TODO: see why this is sent in the mutation, added a test to confirm it doesn't actually change
+		"display_id",
+	}
+
+	// check if any of the fields are not default fields
+	for _, field := range fields {
+		if !slices.Contains(defaultFields, field) {
+			return ErrManagedGroup
+		}
+	}
+
+	return nil
+}
+
+// checkOnlyPermissionEdges checks if the added or cleared edges are only permission edges
+// and returns an error if they are not
+func checkOnlyPermissionEdges(m *generated.GroupMutation) error {
+	addedEdges := m.AddedEdges()
+	clearedEdges := m.ClearedEdges()
+
+	if len(addedEdges) > 0 || len(clearedEdges) > 0 {
+		for _, edge := range addedEdges {
+			_, _, isPermissionEdge := isPermissionsEdge(edge)
+			if !isPermissionEdge {
+				return ErrManagedGroup
+			}
+		}
+
+		for _, edge := range clearedEdges {
+			_, _, isPermissionEdge := isPermissionsEdge(edge)
+			if !isPermissionEdge {
+				return ErrManagedGroup
+			}
+		}
+	}
+
+	return nil
 }
 
 // HookGroupAuthz runs on group mutations to setup or remove relationship tuples

--- a/internal/graphapi/query/group.graphql
+++ b/internal/graphapi/query/group.graphql
@@ -338,6 +338,7 @@ mutation UpdateGroup($updateGroupId: ID!, $input: UpdateGroupInput!) {
       description
       displayName
       id
+      displayID
       logoURL
       name
       tags

--- a/pkg/openlaneclient/graphclient.go
+++ b/pkg/openlaneclient/graphclient.go
@@ -27582,6 +27582,7 @@ func (t *UpdateGroup_UpdateGroup_Group_Members) GetUser() *UpdateGroup_UpdateGro
 
 type UpdateGroup_UpdateGroup_Group struct {
 	Description *string                                      "json:\"description,omitempty\" graphql:\"description\""
+	DisplayID   string                                       "json:\"displayID\" graphql:\"displayID\""
 	DisplayName string                                       "json:\"displayName\" graphql:\"displayName\""
 	ID          string                                       "json:\"id\" graphql:\"id\""
 	LogoURL     *string                                      "json:\"logoURL,omitempty\" graphql:\"logoURL\""
@@ -27598,6 +27599,12 @@ func (t *UpdateGroup_UpdateGroup_Group) GetDescription() *string {
 		t = &UpdateGroup_UpdateGroup_Group{}
 	}
 	return t.Description
+}
+func (t *UpdateGroup_UpdateGroup_Group) GetDisplayID() string {
+	if t == nil {
+		t = &UpdateGroup_UpdateGroup_Group{}
+	}
+	return t.DisplayID
 }
 func (t *UpdateGroup_UpdateGroup_Group) GetDisplayName() string {
 	if t == nil {
@@ -82854,6 +82861,7 @@ const UpdateGroupDocument = `mutation UpdateGroup ($updateGroupId: ID!, $input: 
 			description
 			displayName
 			id
+			displayID
 			logoURL
 			name
 			tags


### PR DESCRIPTION
You could previously add a group to an object (e.g. on a program, set a group to have edit permissions) but you couldn't do the opposite - edit a managed group to add a permission to a program. This fixes it to allow it from either object. 

I added tests as well as tested this from the UI