### PR TITLE
fix: nil pointer when switching to personal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -200,7 +200,7 @@ require (
 	github.com/dnephin/pflag v1.0.7 // indirect
 	github.com/docker/docker v28.1.1+incompatible // indirect
 	github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707 // indirect
-	github.com/ebitengine/purego v0.8.2 // indirect
+	github.com/ebitengine/purego v0.8.3 // indirect
 	github.com/ettle/strcase v0.2.0 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -386,6 +386,8 @@ github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0 h1:a
 github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0/go.mod h1:8AuBTZBRSFqEYBPYULd+NN474/zZBLP+6WeT5S9xlAc=
 github.com/ebitengine/purego v0.8.2 h1:jPPGWs2sZ1UgOSgD2bClL0MJIqu58nOmIcBuXr62z1I=
 github.com/ebitengine/purego v0.8.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/ebitengine/purego v0.8.3 h1:K+0AjQp63JEZTEMZiwsI9g0+hAMNohwUOtY0RPGexmc=
+github.com/ebitengine/purego v0.8.3/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/internal/httpserve/authmanager/authmanager.go
+++ b/internal/httpserve/authmanager/authmanager.go
@@ -383,7 +383,10 @@ func (a *Client) updateDefaultOrgToPersonal(ctx context.Context, user *generated
 
 // getPersonalOrgID returns the personal org ID for the user
 func (a *Client) getPersonalOrgID(ctx context.Context, user *generated.User) (*generated.Organization, error) {
-	return a.db.User.QueryOrganizations(user).Where(organization.PersonalOrg(true)).Only(ctx)
+	// ensure the organization is not filtered by the default interceptor
+	allowCtx := privacy.DecisionContext(ctx, privacy.Allow)
+
+	return a.db.User.QueryOrganizations(user).Where(organization.PersonalOrg(true)).Only(allowCtx)
 }
 
 // skipOrgValidation checks if the org validation should be skipped based on the context


### PR DESCRIPTION
Should fix a nil pointer error when user's default org is no longer valid, it will bypass the filters and give the ability to actually return the personal org 