### PR TITLE
bug: org owners should have edit access to policies and procedures

### DIFF
--- a/fga/model/model.fga
+++ b/fga/model/model.fga
@@ -295,9 +295,9 @@ type internal_policy
     # the parent of the policy will be the organization, not all permissions will be inherited
     define parent: [organization]
     # allow a user or service to be assigned to add edit permissions
-    define admin: [user,service]
+    define admin: [user,service] or can_delete from parent
     # allow a group to be assigned to add edit permissions for a set of users
-    define editor: [group#member] or can_delete from parent
+    define editor: [group#member]
     # allow for auditors assigned to the program to view the policy
     define viewer: [program#auditor, group#member] or editor or can_view from parent
     # allow users or groups to be blocked from view + edit access
@@ -318,9 +318,9 @@ type procedure
     # the parent of the procedure will be the organization, not all permissions will be inherited
     define parent: [organization]
     # allow a user or service to be assigned to add edit permissions
-    define admin: [user,service]
+    define admin: [user,service] or can_delete from parent
     # allow a group to be assigned to add edit permissions for a set of users
-    define editor: [group#member] or can_delete from parent
+    define editor: [group#member]
       # allow for auditors assigned to the program to view the procedure
     define viewer: [program#auditor, group#member] or editor or can_view from parent
     # allow users or groups to be blocked from view + edit access

--- a/fga/model/model.fga
+++ b/fga/model/model.fga
@@ -288,18 +288,18 @@ type action_plan
 # groups can be used to give edit (or delete) access to users
 type internal_policy
   relations
-    define can_view: ([user, service] and member from parent) or can_edit or ((can_view from parent or viewer) but not blocked)
+    define can_view: ([user, service] and member from parent) or can_edit or (viewer but not blocked)
     define can_edit: ([user, service] and member from parent) or admin or approver or delegate or (editor but not blocked)
-    define can_delete: ([user, service] and member from parent) or admin or approver or ((can_delete from parent or editor) but not blocked)
+    define can_delete: ([user, service] and member from parent) or admin or approver or (editor but not blocked)
     define audit_log_viewer: ([user, service] or audit_log_viewer from parent) and can_view
     # the parent of the policy will be the organization, not all permissions will be inherited
     define parent: [organization]
     # allow a user or service to be assigned to add edit permissions
     define admin: [user,service]
     # allow a group to be assigned to add edit permissions for a set of users
-    define editor: [group#member]
+    define editor: [group#member] or can_delete from parent
     # allow for auditors assigned to the program to view the policy
-    define viewer: [program#auditor] or editor
+    define viewer: [program#auditor, group#member] or editor or can_view from parent
     # allow users or groups to be blocked from view + edit access
     define blocked: [user, group#member]
     # approver is the group of users that are responsible for the approval of changes to the policy, they will have full access to the policy
@@ -311,18 +311,18 @@ type internal_policy
 # groups can be used to give edit (or delete) access to users
 type procedure
   relations
-    define can_view: ([user, service] and member from parent) or can_edit or ((can_view from parent or viewer) but not blocked)
+    define can_view: ([user, service] and member from parent) or can_edit or (viewer but not blocked)
     define can_edit: ([user, service] and member from parent) or admin or approver or delegate or (editor but not blocked)
-    define can_delete: ([user, service] and member from parent) or admin or approver or ((can_delete from parent or editor) but not blocked)
+    define can_delete: ([user, service] and member from parent) or admin or approver or (editor but not blocked)
     define audit_log_viewer: ([user, service] or audit_log_viewer from parent) and can_view
     # the parent of the procedure will be the organization, not all permissions will be inherited
     define parent: [organization]
     # allow a user or service to be assigned to add edit permissions
     define admin: [user,service]
     # allow a group to be assigned to add edit permissions for a set of users
-    define editor: [group#member]
+    define editor: [group#member] or can_delete from parent
       # allow for auditors assigned to the program to view the procedure
-    define viewer: [program#auditor, group#member] or editor
+    define viewer: [program#auditor, group#member] or editor or can_view from parent
     # allow users or groups to be blocked from view + edit access
     define blocked: [user, group#member]
     # approver is the group of users that are responsible for the approval of changes to the procedure, they will have full access to the procedure

--- a/fga/tests/tests.yaml
+++ b/fga/tests/tests.yaml
@@ -500,6 +500,12 @@ tests:
           can_view: true
           can_edit: true
           can_delete: true
+      - user: user:ulid-of-owner # owner of the internal_policy should have all permissions
+        object: procedure:procedure-1
+        assertions:
+          can_view: true
+          can_edit: true
+          can_delete: true
       - user: user:ulid-group-editor # editor of the procedure should have edit permissions
         object: procedure:procedure-1
         assertions:
@@ -535,6 +541,12 @@ tests:
     tuple_file: tuples/policies.yaml
     check:
       - user: user:ulid-admin # admin of the internal_policy should have all permissions
+        object: internal_policy:internal_policy-1
+        assertions:
+          can_view: true
+          can_edit: true
+          can_delete: true
+      - user: user:ulid-of-owner # owner of the internal_policy should have all permissions
         object: internal_policy:internal_policy-1
         assertions:
           can_view: true

--- a/internal/httpserve/handlers/acmesolver_test.go
+++ b/internal/httpserve/handlers/acmesolver_test.go
@@ -42,10 +42,10 @@ func (suite *HandlerTestSuite) TestACMESolverHandler() {
 		SetCloudflareHostnameID(gofakeit.UUID()).
 		SetDNSTxtRecord("_acme-challenge.example.com").
 		SetDNSTxtValue(gofakeit.UUID()).
-		SetDNSVerificationStatus(enums.CustomDomainStatusPending).
+		SetDNSVerificationStatus(enums.DNSVerificationStatusPending).
 		SetAcmeChallengePath(testPath).
 		SetExpectedAcmeChallengeValue(testValue).
-		SetAcmeChallengeStatus(enums.CustomDomainStatusPending).
+		SetAcmeChallengeStatus(enums.SSLVerificationStatusPendingValidation).
 		SetOwnerID(testUser1.OrganizationID).
 		Save(ctx)
 	require.NoError(t, err)
@@ -55,10 +55,10 @@ func (suite *HandlerTestSuite) TestACMESolverHandler() {
 		SetCloudflareHostnameID(gofakeit.UUID()).
 		SetDNSTxtRecord("_acme-challenge.deleted.com").
 		SetDNSTxtValue(gofakeit.UUID()).
-		SetDNSVerificationStatus(enums.CustomDomainStatusPending).
+		SetDNSVerificationStatus(enums.DNSVerificationStatusPending).
 		SetAcmeChallengePath("deleted-path").
 		SetExpectedAcmeChallengeValue("deleted-value").
-		SetAcmeChallengeStatus(enums.CustomDomainStatusPending).
+		SetAcmeChallengeStatus(enums.SSLVerificationStatusPendingValidation).
 		SetOwnerID(testUser1.OrganizationID).
 		SetDeletedAt(time.Now()).
 		SetDeletedBy("test").

--- a/internal/httpserve/handlers/acmesolver_test.go
+++ b/internal/httpserve/handlers/acmesolver_test.go
@@ -45,7 +45,7 @@ func (suite *HandlerTestSuite) TestACMESolverHandler() {
 		SetDNSVerificationStatus(enums.DNSVerificationStatusPending).
 		SetAcmeChallengePath(testPath).
 		SetExpectedAcmeChallengeValue(testValue).
-		SetAcmeChallengeStatus(enums.SSLVerificationStatusPendingValidation).
+		SetAcmeChallengeStatus(enums.SSLVerificationStatusInitializing).
 		SetOwnerID(testUser1.OrganizationID).
 		Save(ctx)
 	require.NoError(t, err)
@@ -58,7 +58,7 @@ func (suite *HandlerTestSuite) TestACMESolverHandler() {
 		SetDNSVerificationStatus(enums.DNSVerificationStatusPending).
 		SetAcmeChallengePath("deleted-path").
 		SetExpectedAcmeChallengeValue("deleted-value").
-		SetAcmeChallengeStatus(enums.SSLVerificationStatusPendingValidation).
+		SetAcmeChallengeStatus(enums.SSLVerificationStatusInitializing).
 		SetOwnerID(testUser1.OrganizationID).
 		SetDeletedAt(time.Now()).
 		SetDeletedBy("test").


### PR DESCRIPTION
- fixes a bug where org owners could delete a policy or procedure but not edit
by default, policies and procedures are viewable to everyone in an organization but not editable. The exception should be made for the org owner to edit and delete these objects. 
- fixes bad merge causing undefined enums in tests