### PR TITLE
Evidence: creation date cannot be in the future

### DIFF
--- a/internal/ent/hooks/errors.go
+++ b/internal/ent/hooks/errors.go
@@ -66,6 +66,11 @@ var (
 	ErrCadenceOrCronRequired = errors.New("either cadence or cron must be specified")
 	// ErrEitherCadenceOrCron is returned when both a cadence and cron is specified
 	ErrEitherCadenceOrCron = errors.New("only one of cadence or cron must be specified")
+	// ErrZeroTimeNotAllowed is returned when you try to set a non usable time value
+	ErrZeroTimeNotAllowed = errors.New("time cannot be empty. Provide a valid time/date")
+	// ErrFutureTimeNotAllowed is returned when you try to set a time into the future.
+	// future being any second/minute past the current time of validation
+	ErrFutureTimeNotAllowed = errors.New("time cannot be in the future")
 )
 
 // IsUniqueConstraintError reports if the error resulted from a DB uniqueness constraint violation.

--- a/internal/ent/hooks/evidence.go
+++ b/internal/ent/hooks/evidence.go
@@ -26,10 +26,8 @@ func HookEvidenceFiles() ent.Hook {
 					return nil, ErrZeroTimeNotAllowed
 				}
 
-				if ok || op == ent.OpCreate {
-					if creationDate.After(time.Now()) {
-						return nil, ErrFutureTimeNotAllowed
-					}
+				if ok && creationDate.After(time.Now()) {
+					return nil, ErrFutureTimeNotAllowed
 				}
 			}
 

--- a/internal/graphapi/evidence_test.go
+++ b/internal/graphapi/evidence_test.go
@@ -338,6 +338,16 @@ func TestMutationCreateEvidence(t *testing.T) {
 			ctx:         testUser1.UserCtx,
 			expectedErr: "invalid or unparsable field",
 		},
+		{
+			name: "creation date in the future",
+			request: openlaneclient.CreateEvidenceInput{
+				Name:         "Test Evidence",
+				CreationDate: lo.ToPtr(time.Now().Add(time.Hour)),
+			},
+			client:      suite.client.api,
+			ctx:         testUser1.UserCtx,
+			expectedErr: "time cannot be in the future",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -510,6 +520,15 @@ func TestMutationUpdateEvidence(t *testing.T) {
 			client:      suite.client.api,
 			ctx:         testUser2.UserCtx,
 			expectedErr: notFoundErrorMsg,
+		},
+		{
+			name: "update not allowed, creation date is in the future",
+			request: openlaneclient.UpdateEvidenceInput{
+				CreationDate: lo.ToPtr(time.Now().Add(time.Minute)),
+			},
+			client:      suite.client.api,
+			ctx:         adminUser.UserCtx,
+			expectedErr: "time cannot be in the future",
 		},
 	}
 

--- a/internal/graphapi/models_test.go
+++ b/internal/graphapi/models_test.go
@@ -1101,6 +1101,7 @@ func (c *EvidenceBuilder) MustNew(ctx context.Context, t *testing.T) *ent.Eviden
 	}
 
 	mutation := c.client.db.Evidence.Create().
+		SetCreationDate(time.Now().Add(-time.Minute)).
 		SetName(c.Name)
 
 	if c.ProgramID != "" {


### PR DESCRIPTION
- made sure the `creation_date` cannot be in the future
- validate if present only for updates but hard requirement on new creations
- updated tests
