### PR TITLE
fix: align api spec models with bind values

### DIFF
--- a/internal/httpserve/handlers/job_runner_register.go
+++ b/internal/httpserve/handlers/job_runner_register.go
@@ -21,8 +21,8 @@ func (h *Handler) BindRegisterRunnerNode() *openapi3.Operation {
 	registerJobRunner.OperationID = "RegisterRunnerNode"
 	registerJobRunner.Security = &openapi3.SecurityRequirements{}
 
-	h.AddRequestBody("RegisterRunner", models.ExampleJobRunnerRegistrationRequest, registerJobRunner)
-	h.AddResponse("RegisterRunnerReply", "success", models.ExampleJobRunnerRegistrationResponse, registerJobRunner, http.StatusOK)
+	h.AddRequestBody("JobRunnerRegistrationRequest", models.ExampleJobRunnerRegistrationRequest, registerJobRunner)
+	h.AddResponse("JobRunnerRegistrationReply", "success", models.ExampleJobRunnerRegistrationResponse, registerJobRunner, http.StatusOK)
 	registerJobRunner.AddResponse(http.StatusBadRequest, badRequest())
 	registerJobRunner.AddResponse(http.StatusBadRequest, invalidInput())
 
@@ -74,7 +74,7 @@ func (h *Handler) RegisterJobRunner(ctx echo.Context) error {
 		return h.InternalServerError(ctx, ErrUnableToRegisterJobRunner)
 	}
 
-	out := &models.JobRunnerRegistrationResponse{
+	out := &models.JobRunnerRegistrationReply{
 		Reply: rout.Reply{
 			Success: true,
 		},

--- a/internal/httpserve/handlers/job_runner_register_test.go
+++ b/internal/httpserve/handlers/job_runner_register_test.go
@@ -85,7 +85,7 @@ func (suite *HandlerTestSuite) TestRegisterJobRunner() {
 			res := recorder.Result()
 			defer res.Body.Close()
 
-			var resp *models.JobRunnerRegistrationResponse
+			var resp *models.JobRunnerRegistrationReply
 
 			// parse response body
 			err = json.NewDecoder(res.Body).Decode(&resp)
@@ -161,7 +161,7 @@ func (suite *HandlerTestSuite) TestRegisterJobRunner_ExpiredToken() {
 			res := recorder.Result()
 			defer res.Body.Close()
 
-			var resp *models.JobRunnerRegistrationResponse
+			var resp *models.JobRunnerRegistrationReply
 
 			// parse response body
 			err = json.NewDecoder(res.Body).Decode(&resp)

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -946,9 +946,9 @@ func (r *JobRunnerRegistrationRequest) Validate() error {
 	return nil
 }
 
-// JobRunnerRegistrationResponse is the response to begin a webauthn login
+// JobRunnerRegistrationReply is the response to begin a webauthn login
 // this includes the credential creation options and the session token
-type JobRunnerRegistrationResponse struct {
+type JobRunnerRegistrationReply struct {
 	Reply   rout.Reply
 	Message string `json:"message"`
 }
@@ -964,7 +964,7 @@ var ExampleJobRunnerRegistrationRequest = JobRunnerRegistrationRequest{
 
 // ExampleJobRunnerRegistrationResponse is an example of a successful job runner
 // registration response
-var ExampleJobRunnerRegistrationResponse = JobRunnerRegistrationResponse{
+var ExampleJobRunnerRegistrationResponse = JobRunnerRegistrationReply{
 	Reply:   rout.Reply{Success: true},
 	Message: "Job runner node registered",
 }


### PR DESCRIPTION
Should fix this error:

```
Error: [Missing $ref pointer "#/components/schemas/RegisterRunner". Token "RegisterRunner" does not exist.] with footprint [paths,/runners,post,requestBody,content,application/json,schema+/Users/sarahfunkhouser/go/src/github.com/theopenlane/openlane-docs/docs/+EMISSINGPOINTER+Missing $ref pointer "#/components/schemas/RegisterRunner". Token "RegisterRunner" does not exist.]
SyntaxError: "undefined" is not valid JSON
WARNING: the following OpenAPI spec returned undefined: https://api.theopenlane.io/api-docs
```