### PR TITLE
org members should view other user's avatars in the same org

### DIFF
--- a/fga/model/model.fga
+++ b/fga/model/model.fga
@@ -143,7 +143,7 @@ type group
 # files have their permissions defined by the parent object (like a control or a procedure), users with access to the parent object will have access to the file
 type file
   relations
-    define can_view: [user, service] or parent_viewer
+    define can_view: [user, service, organization#member] or parent_viewer
     define can_edit: [user, service] or parent_editor
     define can_delete: [user, service] or parent_deleter
 

--- a/fga/tests/tests.yaml
+++ b/fga/tests/tests.yaml
@@ -407,6 +407,73 @@ tests:
           can_view: true
           can_edit: true
           can_delete: true
+      # test user-owned file access
+      - user: user:ulid-file-owner # the file owner should have full access
+        object: file:file-user-owned
+        assertions:
+          can_view: true
+          can_edit: true
+          can_delete: true
+      - user: user:ulid-org-member-viewer # org member should be able to view user-owned file
+        object: file:file-user-owned
+        context:
+          email_domain: "theopenlane.io"
+        assertions:
+          can_view: true
+          can_edit: false
+          can_delete: false
+      - user: user:ulid-of-member # existing org member should be able to view user-owned file
+        object: file:file-user-owned
+        context:
+          email_domain: "theopenlane.io"
+        assertions:
+          can_view: true
+          can_edit: false
+          can_delete: false
+      - user: user:ulid-other-org-user # user from a different org should NOT be able to view file
+        object: file:file-user-owned
+        context:
+          email_domain: "example.com"
+        assertions:
+          can_view: false
+          can_edit: false
+          can_delete: false
+    list_objects:
+      - user: user:ulid-file-owner
+        type: file
+        assertions:
+          can_view:
+            - file:file-user-owned
+          can_edit:
+            - file:file-user-owned
+          can_delete:
+            - file:file-user-owned
+      - user: user:ulid-org-member-viewer
+        type: file
+        context:
+          email_domain: "theopenlane.io"
+        assertions:
+          can_view:
+            - file:file-user-owned
+          can_edit:
+          can_delete:
+      - user: user:ulid-of-member
+        type: file
+        context:
+          email_domain: "theopenlane.io"
+        assertions:
+          can_view:
+            - file:file-user-owned
+          can_edit:
+          can_delete:
+      - user: user:ulid-other-org-user
+        type: file
+        context:
+          email_domain: "example.com"
+        assertions:
+          can_view:
+          can_edit:
+          can_delete:
   - name: tasks
     description: tasks can be associated to many objects and users can access tasks based on their permissions
     tuple_file: tuples/tasks.yaml

--- a/fga/tests/tuples/files.yaml
+++ b/fga/tests/tuples/files.yaml
@@ -41,3 +41,39 @@
 - user: organization:contact-org
   relation: parent
   object: contact:contact-1
+
+# user-owned files with organization member access
+- user: user:ulid-file-owner
+  relation: _self
+  object: user:ulid-file-owner
+- user: user:ulid-file-owner
+  relation: member
+  object: organization:openlane
+- user: user:ulid-file-owner
+  relation: parent
+  object: file:file-user-owned
+- user: organization:openlane#member
+  relation: can_view
+  object: file:file-user-owned
+- user: user:ulid-org-member-viewer
+  relation: _self
+  object: user:ulid-org-member-viewer
+- user: user:ulid-org-member-viewer
+  relation: member
+  object: organization:openlane
+- user: user:ulid-other-org-user
+  relation: _self
+  object: user:ulid-other-org-user
+- user: user:ulid-other-org-user
+  relation: member
+  object: organization:other-org
+- user: organization:other-org#member
+  relation: access
+  object: organization:other-org
+  condition:
+    name: email_domains_allowed
+    context:
+      allowed_domains: []
+- user: user:ulid-other-org-owner
+  relation: owner
+  object: organization:other-org


### PR DESCRIPTION
- [x] added fga tests 
- [x] updated models
- [x] updated permissions 