### PR TITLE
bug: keep cookies, send header via gqlgen interceptor

### DIFF
--- a/cmd/cli/cmd/client.go
+++ b/cmd/cli/cmd/client.go
@@ -91,47 +91,7 @@ func SetupClientWithAuth(ctx context.Context) (*openlaneclient.OpenlaneClient, e
 		return nil, err
 	}
 
-	return clientWithCSRFToken(ctx, client, opts...)
-}
-
-// cloneClientWithCookies creates a new OpenlaneClient instance
-// with with the same config and cookies from the original client.
-func cloneClientWithCookies(client *openlaneclient.OpenlaneClient, opts ...openlaneclient.ClientOption) (*openlaneclient.OpenlaneClient, error) {
-	// grab the original client's configuration
-	config := client.Config()
-
-	// Create a new client with the same configuration and options
-	newClient, err := openlaneclient.New(*config, opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	// Copy cookies from the original client to the new one
-	cookies, err := client.Cookies()
-	if err != nil {
-		return nil, err
-	}
-
-	u := newClient.Config().BaseURL.ResolveReference(&url.URL{Path: "/"})
-	newClient.HTTPSlingRequester().CookieJar().SetCookies(u, cookies)
-
-	return newClient, nil
-}
-
-// clientWithCSRFToken initializes a new OpenlaneClient with a CSRF token
-// for subsequent requests. It first fetches the CSRF token and then
-// clones the client to ensure cookies are preserved and sets
-// the CSRF token in the options for future requests in the header
-func clientWithCSRFToken(ctx context.Context, client *openlaneclient.OpenlaneClient, opts ...openlaneclient.ClientOption) (*openlaneclient.OpenlaneClient, error) {
-	// initialize csrf token for subsequent requests
-	csrfToken, err := client.InitCSRF(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	opts = append(opts, openlaneclient.WithCSRFToken(csrfToken))
-
-	return cloneClientWithCookies(client, opts...)
+	return client.ClientWithCSRFToken(ctx, opts...)
 }
 
 // SetupClient will setup the client without the Authorization header
@@ -147,7 +107,7 @@ func SetupClient(ctx context.Context) (*openlaneclient.OpenlaneClient, error) {
 		return nil, err
 	}
 
-	return clientWithCSRFToken(ctx, client, opts...)
+	return client.ClientWithCSRFToken(ctx, opts...)
 }
 
 // configureDefaultOpts will setup the default options for the client

--- a/pkg/openlaneclient/client.go
+++ b/pkg/openlaneclient/client.go
@@ -68,13 +68,13 @@ func New(config Config, opts ...ClientOption) (*OpenlaneClient, error) {
 // APIv1 implements the Client interface and provides methods to interact with the API
 type APIv1 struct {
 	// Config is the configuration for the APIv1 client
-	Config Config
+	Config *Config
 	// Requester is the HTTP client for the APIv1 client
 	Requester *httpsling.Requester
 }
 
 // Config is the configuration for the APIv1 client
-func (c *OpenlaneClient) Config() Config {
+func (c *OpenlaneClient) Config() *Config {
 	api := c.OpenlaneRestClient.(*APIv1)
 
 	return api.Config

--- a/pkg/openlaneclient/config.go
+++ b/pkg/openlaneclient/config.go
@@ -21,7 +21,7 @@ type Config struct {
 }
 
 // graphRequestPath returns the full URL path for the GraphQL endpoint
-func graphRequestPath(config Config) string {
+func graphRequestPath(config *Config) string {
 	baseurl := config.BaseURL.String()
 
 	return baseurl + config.GraphQLPath

--- a/pkg/openlaneclient/csrf.go
+++ b/pkg/openlaneclient/csrf.go
@@ -57,7 +57,9 @@ func (c *OpenlaneClient) FetchCSRFToken(ctx context.Context) (string, error) {
 		}
 	}
 
-	return "", ErrCSRFCookieNotFound
+	// do not return an error, if CSRF protection is not enabled
+	// there may not be a CSRF cookie set
+	return "", nil
 }
 
 // SetCSRFToken sets the CSRF header on the client for all subsequent requests.

--- a/pkg/openlaneclient/interceptor.go
+++ b/pkg/openlaneclient/interceptor.go
@@ -27,6 +27,8 @@ func (a Authorization) WithAuthorization() clientv2.RequestInterceptor {
 	}
 }
 
+// WithCSRFTokenInterceptor adds a CSRF token interceptor to the client request
+// in the header
 func WithCSRFTokenInterceptor(token string) clientv2.RequestInterceptor {
 	return func(
 		ctx context.Context,

--- a/pkg/openlaneclient/interceptor.go
+++ b/pkg/openlaneclient/interceptor.go
@@ -27,6 +27,23 @@ func (a Authorization) WithAuthorization() clientv2.RequestInterceptor {
 	}
 }
 
+func WithCSRFTokenInterceptor(token string) clientv2.RequestInterceptor {
+	return func(
+		ctx context.Context,
+		req *http.Request,
+		gqlInfo *clientv2.GQLRequestInfo,
+		res interface{},
+		next clientv2.RequestInterceptorFunc,
+	) error {
+		// set the CSRF token in the request header if it is not empty
+		if token != "" {
+			req.Header.Set(csrfHeader, token)
+		}
+
+		return next(ctx, req, gqlInfo, res)
+	}
+}
+
 // WithLoggingInterceptor adds a http debug logging interceptor
 func WithLoggingInterceptor() clientv2.RequestInterceptor {
 	return func(ctx context.Context, req *http.Request, gqlInfo *clientv2.GQLRequestInfo, res interface{}, next clientv2.RequestInterceptorFunc) error {

--- a/pkg/openlaneclient/options.go
+++ b/pkg/openlaneclient/options.go
@@ -77,16 +77,9 @@ func WithTransport(transport http.RoundTripper) ClientOption {
 // WithCSRFToken sets the CSRF token header on the client for all requests
 func WithCSRFToken(token string) ClientOption {
 	return func(c *APIv1) error {
-		if token == "" {
-			return nil
-		}
+		c.Config.Interceptors = append(c.Config.Interceptors, WithCSRFTokenInterceptor(token))
 
-		if c.Requester.Header == nil {
-			c.Requester.Header = make(http.Header)
-		}
-
-		c.Requester.Header.Set(csrfHeader, token)
-
-		return nil
+		// set the CSRF token header on the HTTPSling client for REST requests
+		return c.Requester.Apply(httpsling.Header(csrfHeader, token))
 	}
 }

--- a/pkg/openlaneclient/options.go
+++ b/pkg/openlaneclient/options.go
@@ -77,6 +77,11 @@ func WithTransport(transport http.RoundTripper) ClientOption {
 // WithCSRFToken sets the CSRF token header on the client for all requests
 func WithCSRFToken(token string) ClientOption {
 	return func(c *APIv1) error {
+		if token == "" {
+			// If the token is empty, we do not set the interceptor
+			return nil
+		}
+
 		c.Config.Interceptors = append(c.Config.Interceptors, WithCSRFTokenInterceptor(token))
 
 		// set the CSRF token header on the HTTPSling client for REST requests

--- a/pkg/openlaneclient/restclient.go
+++ b/pkg/openlaneclient/restclient.go
@@ -34,7 +34,7 @@ type OpenlaneRestClient interface {
 // New creates a new API v1 client that implements the Openlane Client interface
 func NewRestClient(config Config, opts ...ClientOption) (_ OpenlaneRestClient, err error) {
 	c := &APIv1{
-		Config: config,
+		Config: &config,
 	}
 
 	// create the HTTP sling requester if it is not set with the default client


### PR DESCRIPTION
Confirmed everything works with the following CSRF config:

```
  csrfProtection:
    enabled: true
    header: X-CSRF-Token
    cookie: csrf_token
    secure: false 
    sameSite: Lax
```

```
(⎈ |default:default)➜  core git:(bug-fix-csrf-off) task cli:user:all:another
task: [cli:user:verify] curl http://localhost:17608/v1/verify?token=x66nUl1JxpQ-CXWGPChpRV6KjwBYveQLUWkagcFQirs
{"success":true,"user_id":"01JXBWB2TWT1TV3V9XRD3SZFWC","email":"funk1@example.com","message":"success","access_token":"eyJhbGciOiJSUzI1NiIsImtpZCI6IjAyR0dCUzY4QU0xMjE3OE0wUkVXM0NFQUdHIiwidHlwIjoiSldUIn0.eyJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjE3NjA4Iiwic3ViIjoiMDFKWEJXQjJUV1QxVFYzVjlYUkQzU1pGV0MiLCJhdWQiOlsiaHR0cDovL2xvY2FsaG9zdDoxNzYwOCJdLCJleHAiOjE3NDk1Mjc4NTMsIm5iZiI6MTc0OTUyNDI1MywiaWF0IjoxNzQ5NTI0MjUzLCJqdGkiOiIwMWp4YndiMzE2bnRnYXA3YWJydmV4djczOSIsInVzZXJfaWQiOiIwMUpYQldCMlRXVDFUVjNWOVhSRDNTWkZXQyJ9.bofKkVV2tN1wC3AI1EeTAm_5uhZalYSPHMqHcma4PbsXF5CWZDPWTbe1MxDloEU4nWKbJ4DEOL2-atGFd_arSd8vPSOLWIROAGbVmMLvPLyZEjxTO1O91xn4LQMN9VbepQ1Rg4WLL91_JyUi3UC01HCIxs81_CO-dVFvqa9NktifkYMFVHgAx277xPnBrLaIJ5toXyjqVAvve2vTf-NCrci9e--mryD3MCrBWu1HN_orjHY1Ard7CFUieg2rH_skVqg4wVinAtA87kp1cZLgfuZwPLD7PxmUploc9eXZnhWkBc_iZgO-UsY-5UurVbj3ZVbYr1H98C1f7JK4GqmxCg","refresh_token":"eyJhbGciOiJSUzI1NiIsImtpZCI6IjAyR0dCUzY4QU0xMjE3OE0wUkVXM0NFQUdHIiwidHlwIjoiSldUIn0.eyJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjE3NjA4Iiwic3ViIjoiMDFKWEJXQjJUV1QxVFYzVjlYUkQzU1pGV0MiLCJhdWQiOlsiaHR0cDovL2xvY2FsaG9zdDoxNzYwOCIsImh0dHA6Ly9sb2NhbGhvc3Q6MTc2MDgvdjEvcmVmcmVzaCJdLCJleHAiOjE3NDk1MzE0NTMsIm5iZiI6MTc0OTUyNjk1MywiaWF0IjoxNzQ5NTI0MjUzLCJqdGkiOiIwMWp4YndiMzE2bnRnYXA3YWJydmV4djczOSJ9.BL2HsRDq3BqSt627x4igKMt3fRsY0MSqM3YvdkNE8y9HGXJ-Tpw4TshSNBFVeaNPY8FB54Ah1TE6WeyHBn-KlS75WFk771X4i2SqCkvXb-vtwVe9XvyGi9klQmFWHwN9Gu5UBoKUzJdHVs0w7624IHTej7MfhUkphMizOGSqfTJ56ZaDEPaN1rkVhKSf27LfJ_gxX90YXxGSrHeAgC8dmFyT_9eFPMTCqsj4q8g7PF4Kite4ShDHKkkVbmyWaabcDBzjYygfCejcjW2CQB_lN0rogojVwoFIacrBMCkdQE-OoB53mcPjzoe4kfuCiuoTzCCxoh3XuMFXGICvs1thrg","session":"MTc0OTUyNDI1M3xBVS1JR2Q0YTl0WVQxNDhiUFFyOURYMWtCN1BSRUFzbktxejVLRjMzTEtFQnVRcDJCb09Rb0N1MGlxdndXUVo5Tlg4YXRORElBNllrb090djgwYlBCTUlFcWpZLXlRbUsteXpPcHNvV2x6M0pGa3l6bnkzWWpoMjhmUHFvMzNJZ3BXODZwTDZFTFRscGVmNGhIbnFrS0pOY2VaMC1xUUVuVEY4RnxNypdVfSN3ifY-7Y7Q8NSYOie4HAjUim1EEwVmIzXl6g==","token_type":"Bearer"}
task: [cli:login:creds] go run main.go login -u funk1@example.com

Authentication Successful!
auth tokens successfully stored in keychain
(⎈ |default:default)➜  core git:(bug-fix-csrf-off) ✗ task cli:login:another   
task: [cli:login:creds] go run main.go login -u funk1@example.com

Authentication Successful!
auth tokens successfully stored in keychain
(⎈ |default:default)➜  core git:(bug-fix-csrf-off) ✗ go run cmd/cli/main.go org get -p
┌────────────────────────────┬────────────────┬───────────────────────────────────────┬──────────────┬──────────┬─────────┐
│ ID                         │ NAME           │ DESCRIPTION                           │ PERSONAL ORG │ CHILDREN │ MEMBERS │
├────────────────────────────┼────────────────┼───────────────────────────────────────┼──────────────┼──────────┼─────────┤
│ 01JXBWB2XJSAH8A1WMRD3HSYTJ │ Proud Foxhound │ Personal Organization - Matt Anderson │ true         │ 0        │ 1       │
└────────────────────────────┴────────────────┴───────────────────────────────────────┴──────────────┴──────────┴─────────┘

(⎈ |default:default)➜  core git:(bug-fix-csrf-off) ✗ go run cmd/cli/main.go org create -n meow
┌────────────────────────────┬──────┬─────────────┬──────────────┬──────────┬─────────┐
│ ID                         │ NAME │ DESCRIPTION │ PERSONAL ORG │ CHILDREN │ MEMBERS │
├────────────────────────────┼──────┼─────────────┼──────────────┼──────────┼─────────┤
│ 01JXBWBNZQKEN45XCH07NG9ZNJ │ meow │             │ false        │ 0        │ 0       │
└────────────────────────────┴──────┴─────────────┴──────────────┴──────────┴─────────┘

(⎈ |default:default)➜  core git:(bug-fix-csrf-off) ✗ go run cmd/cli/main.go org get -p        
┌────────────────────────────┬────────────────┬───────────────────────────────────────┬──────────────┬──────────┬─────────┐
│ ID                         │ NAME           │ DESCRIPTION                           │ PERSONAL ORG │ CHILDREN │ MEMBERS │
├────────────────────────────┼────────────────┼───────────────────────────────────────┼──────────────┼──────────┼─────────┤
│ 01JXBWBNZQKEN45XCH07NG9ZNJ │ meow           │                                       │ false        │ 0        │ 1       │
├────────────────────────────┼────────────────┼───────────────────────────────────────┼──────────────┼──────────┼─────────┤
│ 01JXBWB2XJSAH8A1WMRD3HSYTJ │ Proud Foxhound │ Personal Organization - Matt Anderson │ true         │ 0        │ 1       │
└────────────────────────────┴────────────────┴───────────────────────────────────────┴──────────────┴──────────┴─────────┘
```

as well as with:
```
  csrfProtection:
    enabled: false
```

```
(⎈ |default:default)➜  core git:(bug-fix-csrf-off) ✗ task cli:login:another           
task: [cli:login:creds] go run main.go login -u funk@example.com

Authentication Successful!
auth tokens successfully stored in keychain
(⎈ |default:default)➜  core git:(bug-fix-csrf-off) go run cmd/cli/main.go org get -p
┌────────────────────────────┬────────────────┬───────────────────────────────────────┬──────────────┬──────────┬─────────┐
│ ID                         │ NAME           │ DESCRIPTION                           │ PERSONAL ORG │ CHILDREN │ MEMBERS │
├────────────────────────────┼────────────────┼───────────────────────────────────────┼──────────────┼──────────┼─────────┤
│ 01JXBMG5A7YVN9BD3MBD0MM4H7 │ Choice Jawfish │ Personal Organization - Matt Anderson │ true         │ 0        │ 1       │
└────────────────────────────┴────────────────┴───────────────────────────────────────┴──────────────┴──────────┴─────────┘
```