### PR TITLE
feat: clone controls via standard ID

### DIFF
--- a/internal/graphapi/clientschema/schema.graphql
+++ b/internal/graphapi/clientschema/schema.graphql
@@ -1593,8 +1593,21 @@ CloneControlInput is used to clone controls and their subcontrols
 under an organization (ownerID)
 """
 input CloneControlInput {
+	"""
+	controlIDs are the ids of the control to clone. If standardID is passed, this is ignored
+	"""
 	controlIDs: [ID!]
+	"""
+	standardID to clone all controls from into the organization
+	"""
+	standardID: ID
+	"""
+	organization ID that the controls will be under
+	"""
 	ownerID: ID
+	"""
+	optional program ID to associate to the controls
+	"""
 	programID: ID
 }
 type Contact implements Node {

--- a/internal/graphapi/control_test.go
+++ b/internal/graphapi/control_test.go
@@ -665,6 +665,16 @@ func TestMutationCreateControlsByClone(t *testing.T) {
 		expectedErr        string
 	}{
 		{
+			name: "happy path, all controls under standard using standard id",
+			request: openlaneclient.CloneControlInput{
+				StandardID: &publicStandard.ID,
+			},
+			expectedStandard: lo.ToPtr(publicStandard.ShortName),
+			expectedControls: controls,
+			client:           suite.client.api,
+			ctx:              testUser1.UserCtx,
+		},
+		{
 			name: "happy path, all controls under standard",
 			request: openlaneclient.CloneControlInput{
 				ControlIDs: controlIDs,
@@ -806,7 +816,7 @@ func TestMutationCreateControlsByClone(t *testing.T) {
 			assert.NilError(t, err)
 			assert.Check(t, resp != nil)
 
-			assert.Check(t, is.Len(resp.CreateControlsByClone.Controls, len(tc.request.ControlIDs)))
+			assert.Check(t, is.Len(resp.CreateControlsByClone.Controls, len(tc.expectedControls)))
 
 			// sort controls so they are consistent
 			slices.SortFunc(resp.CreateControlsByClone.Controls, func(a, b *openlaneclient.CreateControlsByClone_CreateControlsByClone_Controls) int {

--- a/internal/graphapi/generated/controlextended.generated.go
+++ b/internal/graphapi/generated/controlextended.generated.go
@@ -34,7 +34,7 @@ func (ec *executionContext) unmarshalInputCloneControlInput(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"controlIDs", "ownerID", "programID"}
+	fieldsInOrder := [...]string{"controlIDs", "standardID", "ownerID", "programID"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -48,6 +48,13 @@ func (ec *executionContext) unmarshalInputCloneControlInput(ctx context.Context,
 				return it, err
 			}
 			it.ControlIDs = data
+		case "standardID":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("standardID"))
+			data, err := ec.unmarshalOID2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.StandardID = data
 		case "ownerID":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("ownerID"))
 			data, err := ec.unmarshalOID2ᚖstring(ctx, v)

--- a/internal/graphapi/generated/root_.generated.go
+++ b/internal/graphapi/generated/root_.generated.go
@@ -29728,8 +29728,21 @@ CloneControlInput is used to clone controls and their subcontrols
 under an organization (ownerID)
 """
 input CloneControlInput {
+    """
+    controlIDs are the ids of the control to clone. If standardID is passed, this is ignored
+    """
     controlIDs: [ID!]
+    """
+    standardID to clone all controls from into the organization
+    """
+    standardID: ID
+    """
+    organization ID that the controls will be under
+    """
     ownerID: ID
+    """
+    optional program ID to associate to the controls
+    """
     programID: ID
 }
 

--- a/internal/graphapi/model/gen_models.go
+++ b/internal/graphapi/model/gen_models.go
@@ -70,9 +70,14 @@ type AddProgramMembershipInput struct {
 // CloneControlInput is used to clone controls and their subcontrols
 // under an organization (ownerID)
 type CloneControlInput struct {
+	// controlIDs are the ids of the control to clone. If standardID is passed, this is ignored
 	ControlIDs []string `json:"controlIDs,omitempty"`
-	OwnerID    *string  `json:"ownerID,omitempty"`
-	ProgramID  *string  `json:"programID,omitempty"`
+	// standardID to clone all controls from into the organization
+	StandardID *string `json:"standardID,omitempty"`
+	// organization ID that the controls will be under
+	OwnerID *string `json:"ownerID,omitempty"`
+	// optional program ID to associate to the controls
+	ProgramID *string `json:"programID,omitempty"`
 }
 
 // Return response for createBulkContact mutation

--- a/internal/graphapi/schema/controlextended.graphql
+++ b/internal/graphapi/schema/controlextended.graphql
@@ -3,8 +3,21 @@ CloneControlInput is used to clone controls and their subcontrols
 under an organization (ownerID)
 """
 input CloneControlInput {
+    """
+    controlIDs are the ids of the control to clone. If standardID is passed, this is ignored
+    """
     controlIDs: [ID!]
+    """
+    standardID to clone all controls from into the organization
+    """
+    standardID: ID
+    """
+    organization ID that the controls will be under
+    """
     ownerID: ID
+    """
+    optional program ID to associate to the controls
+    """
     programID: ID
 }
 

--- a/pkg/openlaneclient/models.go
+++ b/pkg/openlaneclient/models.go
@@ -1048,9 +1048,14 @@ type AuditLogWhereInput struct {
 // CloneControlInput is used to clone controls and their subcontrols
 // under an organization (ownerID)
 type CloneControlInput struct {
+	// controlIDs are the ids of the control to clone. If standardID is passed, this is ignored
 	ControlIDs []string `json:"controlIDs,omitempty"`
-	OwnerID    *string  `json:"ownerID,omitempty"`
-	ProgramID  *string  `json:"programID,omitempty"`
+	// standardID to clone all controls from into the organization
+	StandardID *string `json:"standardID,omitempty"`
+	// organization ID that the controls will be under
+	OwnerID *string `json:"ownerID,omitempty"`
+	// optional program ID to associate to the controls
+	ProgramID *string `json:"programID,omitempty"`
 }
 
 type Contact struct {


### PR DESCRIPTION
allows for the cloning of controls via a standard ID, which will take precedence over the controlIDs. This was already using in the `createFullProgram` resolver, but wasn't an input option on the `cloneControls` resolver. 