### PR TITLE
Graceful Shutdown of DB Clients, Redis Clients, Event Pools

### DIFF
--- a/internal/entdb/client.go
+++ b/internal/entdb/client.go
@@ -231,7 +231,7 @@ func (c *client) runGooseMigrations() error {
 func (c *client) runAtlasMigrations(ctx context.Context) error {
 	// Run the automatic migration tool to create all schema resources.
 	if err := c.pc.Schema.Create(ctx,
-		EnablePostgresOption(c.pc.DB())); err != nil {
+		EnablePostgresOption(SQLDB(c.pc))); err != nil {
 		log.Error().Err(err).Msg("failed creating schema resources")
 
 		return err

--- a/internal/entdb/client.go
+++ b/internal/entdb/client.go
@@ -109,6 +109,11 @@ func New(ctx context.Context, c entx.Config, jobOpts []riverqueue.Option, opts .
 		}
 	}
 
+	drvPrimary = blockDriver(drvPrimary)
+	if drvSecondary != nil {
+		drvSecondary = blockDriver(drvSecondary)
+	}
+
 	// add the option to the client for the drivers
 	if drvSecondary != nil {
 		cOpts = []ent.Option{ent.Driver(&entx.MultiWriteDriver{Wp: drvPrimary, Ws: drvSecondary})}
@@ -144,6 +149,7 @@ func New(ctx context.Context, c entx.Config, jobOpts []riverqueue.Option, opts .
 	}
 
 	db.Intercept(interceptors.QueryLogger())
+	db.Intercept(BlockInterceptor())
 
 	// add event emission for mutations
 	eventer := hooks.NewEventerPool(db)
@@ -154,6 +160,7 @@ func New(ctx context.Context, c entx.Config, jobOpts []riverqueue.Option, opts .
 	}
 
 	db.Use(hooks.MetricsHook())
+	db.Use(BlockHook())
 
 	return db, nil
 }

--- a/internal/entdb/errors.go
+++ b/internal/entdb/errors.go
@@ -1,0 +1,12 @@
+package entdb
+
+import (
+	"errors"
+)
+
+var (
+	// ErrDriverLackingBeginTx is returned when the driver does not support BeginTx
+	ErrDriverLackingBeginTx = errors.New("driver does not support BeginTx")
+	// ErrShuttingDown is returned when operations are attempted during shutdown
+	ErrShuttingDown = errors.New("database shutting down")
+)

--- a/internal/entdb/redis_shutdown_test.go
+++ b/internal/entdb/redis_shutdown_test.go
@@ -1,0 +1,40 @@
+package entdb
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	coreutils "github.com/theopenlane/core/pkg/testutils"
+)
+
+// TestRedisClientClose verifies that the redis client is closed when the context is cancelled.
+func TestRedisClientClose(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	client := coreutils.NewRedisClient()
+	defer client.Close()
+
+	closed := make(chan struct{})
+	go func() {
+		<-ctx.Done()
+		_ = client.Close()
+		close(closed)
+	}()
+
+	// ensure client works before cancellation
+	require.NoError(t, client.Ping(ctx).Err())
+
+	cancel()
+
+	select {
+	case <-closed:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("redis close not triggered")
+	}
+
+	err := client.Ping(context.Background()).Err()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "closed")
+}

--- a/internal/entdb/shutdown.go
+++ b/internal/entdb/shutdown.go
@@ -2,98 +2,174 @@ package entdb
 
 import (
 	"context"
-	"database/sql"
+	stdsql "database/sql"
 	"errors"
+	"fmt"
 	"sync/atomic"
 	"time"
 
+	"ariga.io/entcache"
 	"entgo.io/ent/dialect"
+	entsql "entgo.io/ent/dialect/sql"
 
 	ent "github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/intercept"
 )
 
-var (
-	// ErrShuttingDown is returned when operations are attempted during shutdown
-	ErrShuttingDown = errors.New("database shutting down")
-	// ErrDriverSupportBeginTx is returned when the driver does not support BeginTx
-	ErrDriverSupportBeginTx = errors.New("driver does not support BeginTx")
-	// shuttingDown is set to true when GracefulClose is called
-	shuttingDown atomic.Bool
-)
+// ShutdownFlag tracks whether a shutdown is in progress
+type ShutdownFlag struct {
+	// flag is an atomic boolean that indicates if a shutdown is in progress
+	// atomic.Bool is used to ensure thread-safe access to the flag
+	// without the need for explicit locks
+	// this is important in a concurrent environment where multiple goroutines
+	// may be checking or setting the flag at the same time
+	flag atomic.Bool
+}
 
-// BeginShutdown marks the system as shutting down. It is safe to call multiple times.
+// Begin sets the shutdown flag to true, indicating that a shutdown is in progress
+func (s *ShutdownFlag) Begin() {
+	s.flag.Store(true)
+}
+
+// Reset clears the shutdown flag, indicating that a shutdown is no longer in progress
+func (s *ShutdownFlag) Reset() {
+	s.flag.Store(false)
+}
+
+// IsSet checks if the shutdown flag is set to true
+func (s *ShutdownFlag) IsSet() bool {
+	return s.flag.Load()
+}
+
+// newShutdownFlag creates a new instance of ShutdownFlag
+func newShutdownFlag() *ShutdownFlag {
+	return &ShutdownFlag{}
+}
+
+// / defaultShutdown is the default shutdown flag used throughout the package
+var defaultShutdown = newShutdownFlag()
+
+// BeginShutdown marks the system as shutting down. It is safe to call multiple times
 func BeginShutdown() {
-	markShuttingDown()
+	defaultShutdown.Begin()
 }
 
-// ResetShutdown clears the shutdown flag. It is intended for tests.
+// ResetShutdown clears the shutdown flag. It is intended for tests
 func ResetShutdown() {
-	shuttingDown.Store(false)
-}
-
-func markShuttingDown() {
-	shuttingDown.Store(true)
+	defaultShutdown.Reset()
 }
 
 // IsShuttingDown reports whether GracefulClose was invoked
 func IsShuttingDown() bool {
-	return shuttingDown.Load()
+	return defaultShutdown.IsSet()
+}
+
+// SQLDB unwraps the ent driver and returns the underlying *sql.DB
+func SQLDB(c *ent.Client) *stdsql.DB {
+	if c == nil {
+		return nil
+	}
+
+	return extractSQLDB(c.Driver())
+}
+
+// extractSQLDB is a utility designed to retrieve the underlying *sql.DB
+// (aliased here as *stdsql.DB) from a potentially wrapped Ent database driver
+func extractSQLDB(d dialect.Driver) *stdsql.DB {
+	switch drv := d.(type) {
+	case *entsql.Driver:
+		return drv.DB()
+	case *entcache.Driver:
+		return extractSQLDB(drv.Driver)
+	case *dialect.DebugDriver:
+		return extractSQLDB(drv.Driver)
+	case *blockingDriver:
+		return extractSQLDB(drv.Driver)
+	default:
+		panic(fmt.Sprintf("entdb: unknown driver type %T", d))
+	}
 }
 
 // blockDriver wraps a dialect.Driver and returns ErrShuttingDown when new
 // operations are attempted after shutdown started
 func blockDriver(d dialect.Driver) dialect.Driver {
-	return &blockingDriver{Driver: d}
+	return blockDriverWithFlag(d, defaultShutdown)
 }
 
+// blockDriverWithFlag returns a new instance of blockingDriver, which embeds the
+// original driver and holds a reference to the shutdown flag
+func blockDriverWithFlag(d dialect.Driver, f *ShutdownFlag) dialect.Driver {
+	return &blockingDriver{Driver: d, flag: f}
+}
+
+// blockingDriver is a wrapper around a dialect.Driver that checks a shutdown flag
 type blockingDriver struct {
 	dialect.Driver
+	flag *ShutdownFlag
 }
 
+// Exec wraps the Exec method of the underlying driver but with an atomic flag
+// check for shutdown processes
 func (d *blockingDriver) Exec(ctx context.Context, query string, args, v any) error {
-	if shuttingDown.Load() {
+	if d.flag.IsSet() {
 		return ErrShuttingDown
 	}
 
 	return d.Driver.Exec(ctx, query, args, v)
 }
 
+// Query wraps the Query method of the underlying driver but with an atomic flag
+// check for shutdown processes
 func (d *blockingDriver) Query(ctx context.Context, query string, args, v any) error {
-	if shuttingDown.Load() {
+	if d.flag.IsSet() {
 		return ErrShuttingDown
 	}
 
 	return d.Driver.Query(ctx, query, args, v)
 }
 
+// Tx wraps the Tx method of the underlying driver but with an atomic flag
+// check for shutdown processes
 func (d *blockingDriver) Tx(ctx context.Context) (dialect.Tx, error) {
-	if shuttingDown.Load() {
+	if d.flag.IsSet() {
 		return nil, ErrShuttingDown
 	}
 
 	return d.Driver.Tx(ctx)
 }
 
-func (d *blockingDriver) BeginTx(ctx context.Context, opts *sql.TxOptions) (dialect.Tx, error) {
-	if shuttingDown.Load() {
+// BeginTx wraps the BeginTx method of the underlying driver but with an atomic
+// flag check for shutdown processes
+func (d *blockingDriver) BeginTx(ctx context.Context, opts *stdsql.TxOptions) (dialect.Tx, error) {
+	if d.flag.IsSet() {
 		return nil, ErrShuttingDown
 	}
 
 	if drv, ok := d.Driver.(interface {
-		BeginTx(context.Context, *sql.TxOptions) (dialect.Tx, error)
+		BeginTx(context.Context, *stdsql.TxOptions) (dialect.Tx, error)
 	}); ok {
 		return drv.BeginTx(ctx, opts)
 	}
 
-	return nil, ErrDriverSupportBeginTx
+	return nil, errors.New("driver does not support BeginTx")
 }
 
 // BlockHook returns an ent.Hook that prevents mutations after shutdown begins
 func BlockHook() ent.Hook {
+	return BlockHookWithFlag(defaultShutdown)
+}
+
+// BlockHookWithFlag returns an ent.Hook tied to the provided shutdown flag
+// it's added as a global hook to the ent.Client, so it's attached to all mutations
+// the hook wraps the next mutator in the chain; before allowing the mutation to proceed,
+// it checks the shutdown flag, and returns an error and blocks the mutation
+// if the flag is NOT set, it just calls the next mutator in the chain
+// This function is intended to ensure data consistency and avoid partial writes or race conditions
+// as the application is shutting down
+func BlockHookWithFlag(f *ShutdownFlag) ent.Hook {
 	return func(next ent.Mutator) ent.Mutator {
 		return ent.MutateFunc(func(ctx context.Context, m ent.Mutation) (ent.Value, error) {
-			if shuttingDown.Load() {
+			if f.IsSet() {
 				return nil, ErrShuttingDown
 			}
 
@@ -104,8 +180,18 @@ func BlockHook() ent.Hook {
 
 // BlockInterceptor returns an ent.Interceptor that prevents queries once shutdown starts
 func BlockInterceptor() ent.Interceptor {
-	return intercept.Func(func(_ context.Context, _ intercept.Query) error {
-		if shuttingDown.Load() {
+	return BlockInterceptorWithFlag(defaultShutdown)
+}
+
+// BlockInterceptorWithFlag returns an interceptor tied to the provided shutdown flag
+// it works similarly to BlockHook, but is used for intercepting queries
+// it checks the shutdown flag before allowing the query to proceed
+// if the flag is set, it returns ErrShuttingDown and blocks the query
+// if the flag is NOT set, it allows the query to proceed
+// this is useful for preventing new queries from being executed while the system is shutting down
+func BlockInterceptorWithFlag(f *ShutdownFlag) ent.Interceptor {
+	return intercept.Func(func(ctx context.Context, _ intercept.Query) error {
+		if f.IsSet() {
 			return ErrShuttingDown
 		}
 
@@ -115,24 +201,40 @@ func BlockInterceptor() ent.Interceptor {
 
 // GracefulClose waits for in-flight queries to finish before closing the database connections
 func GracefulClose(ctx context.Context, c *ent.Client, interval time.Duration) error {
+	return GracefulCloseWithFlag(ctx, c, interval, defaultShutdown)
+}
+
+// GracefulCloseWithFlag behaves like GracefulClose but uses the provided shutdown flag
+func GracefulCloseWithFlag(ctx context.Context, c *ent.Client, interval time.Duration, f *ShutdownFlag) error {
 	if c == nil {
 		return nil
 	}
 
-	markShuttingDown()
-
-	db := c.DB()
-	if interval <= 0 {
-		interval = 100 * time.Millisecond // nolint: mnd
+	if f != nil {
+		f.Begin()
 	}
+
+	// fetch the underlying SQL DB connection
+	db := SQLDB(c)
+
+	// determines how frequently we re-check connection pool for active queries
+	// you can pass interval, but if not set or non-positive, default to 100ms
+	if interval <= 0 {
+		interval = 100 * time.Millisecond
+	}
+
 	ticker := time.NewTicker(interval)
+
 	defer ticker.Stop()
 
+	// enter db connection pool stats check loop
+	// it waits until there are no active connections indicating all queries have returned
 	for {
 		stats := db.Stats()
 		if stats.InUse == 0 {
 			break
 		}
+
 		select {
 		case <-ctx.Done():
 			// context canceled before all queries completed
@@ -142,6 +244,7 @@ func GracefulClose(ctx context.Context, c *ent.Client, interval time.Duration) e
 		}
 	}
 
+	// check if client has Job component and attempt to gracefully close it
 	if c.Job != nil {
 		if err := c.Job.Close(); err != nil {
 			return err
@@ -150,3 +253,8 @@ func GracefulClose(ctx context.Context, c *ent.Client, interval time.Duration) e
 
 	return c.Close()
 }
+
+var (
+	// ErrShuttingDown is returned when operations are attempted during shutdown
+	ErrShuttingDown = errors.New("database shutting down")
+)

--- a/internal/entdb/shutdown.go
+++ b/internal/entdb/shutdown.go
@@ -1,0 +1,152 @@
+package entdb
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"sync/atomic"
+	"time"
+
+	"entgo.io/ent/dialect"
+
+	ent "github.com/theopenlane/core/internal/ent/generated"
+	"github.com/theopenlane/core/internal/ent/generated/intercept"
+)
+
+var (
+	// ErrShuttingDown is returned when operations are attempted during shutdown
+	ErrShuttingDown = errors.New("database shutting down")
+	// ErrDriverSupportBeginTx is returned when the driver does not support BeginTx
+	ErrDriverSupportBeginTx = errors.New("driver does not support BeginTx")
+	// shuttingDown is set to true when GracefulClose is called
+	shuttingDown atomic.Bool
+)
+
+// BeginShutdown marks the system as shutting down. It is safe to call multiple times.
+func BeginShutdown() {
+	markShuttingDown()
+}
+
+// ResetShutdown clears the shutdown flag. It is intended for tests.
+func ResetShutdown() {
+	shuttingDown.Store(false)
+}
+
+func markShuttingDown() {
+	shuttingDown.Store(true)
+}
+
+// IsShuttingDown reports whether GracefulClose was invoked
+func IsShuttingDown() bool {
+	return shuttingDown.Load()
+}
+
+// blockDriver wraps a dialect.Driver and returns ErrShuttingDown when new
+// operations are attempted after shutdown started
+func blockDriver(d dialect.Driver) dialect.Driver {
+	return &blockingDriver{Driver: d}
+}
+
+type blockingDriver struct {
+	dialect.Driver
+}
+
+func (d *blockingDriver) Exec(ctx context.Context, query string, args, v any) error {
+	if shuttingDown.Load() {
+		return ErrShuttingDown
+	}
+
+	return d.Driver.Exec(ctx, query, args, v)
+}
+
+func (d *blockingDriver) Query(ctx context.Context, query string, args, v any) error {
+	if shuttingDown.Load() {
+		return ErrShuttingDown
+	}
+
+	return d.Driver.Query(ctx, query, args, v)
+}
+
+func (d *blockingDriver) Tx(ctx context.Context) (dialect.Tx, error) {
+	if shuttingDown.Load() {
+		return nil, ErrShuttingDown
+	}
+
+	return d.Driver.Tx(ctx)
+}
+
+func (d *blockingDriver) BeginTx(ctx context.Context, opts *sql.TxOptions) (dialect.Tx, error) {
+	if shuttingDown.Load() {
+		return nil, ErrShuttingDown
+	}
+
+	if drv, ok := d.Driver.(interface {
+		BeginTx(context.Context, *sql.TxOptions) (dialect.Tx, error)
+	}); ok {
+		return drv.BeginTx(ctx, opts)
+	}
+
+	return nil, ErrDriverSupportBeginTx
+}
+
+// BlockHook returns an ent.Hook that prevents mutations after shutdown begins
+func BlockHook() ent.Hook {
+	return func(next ent.Mutator) ent.Mutator {
+		return ent.MutateFunc(func(ctx context.Context, m ent.Mutation) (ent.Value, error) {
+			if shuttingDown.Load() {
+				return nil, ErrShuttingDown
+			}
+
+			return next.Mutate(ctx, m)
+		})
+	}
+}
+
+// BlockInterceptor returns an ent.Interceptor that prevents queries once shutdown starts
+func BlockInterceptor() ent.Interceptor {
+	return intercept.Func(func(_ context.Context, _ intercept.Query) error {
+		if shuttingDown.Load() {
+			return ErrShuttingDown
+		}
+
+		return nil
+	})
+}
+
+// GracefulClose waits for in-flight queries to finish before closing the database connections
+func GracefulClose(ctx context.Context, c *ent.Client, interval time.Duration) error {
+	if c == nil {
+		return nil
+	}
+
+	markShuttingDown()
+
+	db := c.DB()
+	if interval <= 0 {
+		interval = 100 * time.Millisecond // nolint: mnd
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		stats := db.Stats()
+		if stats.InUse == 0 {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			// context canceled before all queries completed
+			// proceed to close the connection
+			break
+		case <-ticker.C:
+		}
+	}
+
+	if c.Job != nil {
+		if err := c.Job.Close(); err != nil {
+			return err
+		}
+	}
+
+	return c.Close()
+}

--- a/internal/entdb/shutdown_test.go
+++ b/internal/entdb/shutdown_test.go
@@ -1,0 +1,104 @@
+package entdb
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"entgo.io/ent/dialect"
+	entsql "entgo.io/ent/dialect/sql"
+	"github.com/stretchr/testify/require"
+	"github.com/theopenlane/utils/testutils"
+
+	ent "github.com/theopenlane/core/internal/ent/generated"
+	"github.com/theopenlane/core/internal/ent/generated/enttest"
+)
+
+// TestGracefulCloseWaits verifies that GracefulClose waits for in-flight
+// queries before closing the database connection.
+func TestGracefulCloseWaits(t *testing.T) {
+	shuttingDown.Store(false)
+	tf := NewTestFixture()
+	defer testutils.TeardownFixture(tf)
+
+	db, err := sql.Open("postgres", tf.URI)
+	require.NoError(t, err)
+	defer db.Close()
+
+	client := enttest.Open(t, dialect.Postgres, tf.URI,
+		enttest.WithMigrateOptions(EnablePostgresOption(db)))
+	defer func() {
+		require.NoError(t, client.Close())
+	}()
+
+	ctx := context.Background()
+
+	// start a transaction that holds the connection for a short time
+	txCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		tx, err := client.Tx(txCtx)
+		require.NoError(t, err)
+		// hold the connection for 300ms
+		time.Sleep(300 * time.Millisecond)
+		// rollback to release connection
+		_ = tx.Rollback()
+		close(done)
+	}()
+
+	// give the goroutine time to start and obtain connection
+	time.Sleep(50 * time.Millisecond)
+
+	start := time.Now()
+	// GracefulClose should wait until the tx completes
+	require.NoError(t, GracefulClose(ctx, client, 10*time.Millisecond))
+	elapsed := time.Since(start)
+
+	// ensure goroutine finished
+	select {
+	case <-done:
+	default:
+		t.Fatal("transaction did not finish")
+	}
+
+	// should wait at least ~250ms
+	if elapsed < 250*time.Millisecond {
+		t.Fatalf("GracefulClose returned too early: %v", elapsed)
+	}
+}
+
+// TestBlockNewQueries verifies that new operations are rejected after shutdown begins
+func TestBlockNewQueries(t *testing.T) {
+	shuttingDown.Store(false)
+	tf := NewTestFixture()
+	defer testutils.TeardownFixture(tf)
+
+	db, err := sql.Open("postgres", tf.URI)
+	require.NoError(t, err)
+	defer db.Close()
+
+	drv := blockDriver(entsql.OpenDB(dialect.Postgres, db))
+	client := enttest.NewClient(t,
+		enttest.WithOptions(ent.Driver(drv)),
+		enttest.WithMigrateOptions(EnablePostgresOption(db)))
+	defer func() {
+		require.NoError(t, client.Close())
+	}()
+
+	client.Intercept(BlockInterceptor())
+	client.Use(BlockHook())
+
+	ctx := context.Background()
+
+	// verify query succeeds before shutdown
+	_, err = client.Tx(ctx)
+	require.NoError(t, err)
+
+	markShuttingDown()
+
+	_, err = client.Tx(ctx)
+	require.ErrorIs(t, err, ErrShuttingDown)
+}

--- a/internal/graphapi/metrics.go
+++ b/internal/graphapi/metrics.go
@@ -1,0 +1,41 @@
+package graphapi
+
+import (
+	"context"
+	"time"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/99designs/gqlgen/graphql/handler"
+
+	"github.com/theopenlane/core/pkg/metrics"
+)
+
+// WithMetrics adds Prometheus instrumentation around GraphQL operations.
+func WithMetrics(h *handler.Server) {
+	h.AroundOperations(func(ctx context.Context, next graphql.OperationHandler) graphql.ResponseHandler {
+		opCtx := graphql.GetOperationContext(ctx)
+		opName := "unknown"
+		if opCtx != nil {
+			opName = opCtx.OperationName
+			if opName == "" && opCtx.Operation != nil {
+				opName = string(opCtx.Operation.Operation)
+			}
+		}
+
+		start := time.Now()
+
+		return func(ctx context.Context) *graphql.Response {
+			resp := next(ctx)(ctx)
+
+			success := "true"
+			if resp != nil && len(resp.Errors) > 0 {
+				success = "false"
+			}
+
+			metrics.GraphQLOperationTotal.WithLabelValues(opName, success).Inc()
+			metrics.GraphQLOperationDuration.WithLabelValues(opName).Observe(time.Since(start).Seconds())
+
+			return resp
+		}
+	})
+}

--- a/internal/graphapi/resolver.go
+++ b/internal/graphapi/resolver.go
@@ -164,6 +164,8 @@ func (r *Resolver) Handler(withPlayground bool) *Handler {
 	// add max result limits to fields in requests
 	WithResultLimit(srv, r.maxResultLimit)
 
+	WithMetrics(srv)
+
 	srv.Use(otelgqlgen.Middleware())
 
 	h := &Handler{

--- a/internal/httpserve/handlers/oauth_login.go
+++ b/internal/httpserve/handlers/oauth_login.go
@@ -21,6 +21,7 @@ import (
 	ent "github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/privacy/token"
 	"github.com/theopenlane/core/pkg/enums"
+	"github.com/theopenlane/core/pkg/metrics"
 	"github.com/theopenlane/core/pkg/models"
 )
 
@@ -138,6 +139,7 @@ func (h *Handler) issueGoogleSession() http.Handler {
 			return
 		}
 
+		metrics.Logins.WithLabelValues("true").Inc()
 		// remove cookie
 		sessions.RemoveCookie(w, "redirect_to", *h.SessionConfig.CookieConfig)
 
@@ -204,6 +206,8 @@ func (h *Handler) issueGitHubSession() http.Handler {
 
 			return
 		}
+
+		metrics.Logins.WithLabelValues("true").Inc()
 
 		// remove cookie now that its in the context
 		sessions.RemoveCookie(w, "redirect_to", *h.SessionConfig.CookieConfig)

--- a/internal/httpserve/handlers/readiness.go
+++ b/internal/httpserve/handlers/readiness.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/theopenlane/core/internal/entdb"
 	echo "github.com/theopenlane/echox"
 )
 
@@ -33,6 +34,10 @@ func (h *Handler) AddReadinessCheck(name string, f CheckFunc) {
 }
 
 func (c *Checks) ReadyHandler(ctx echo.Context) error {
+	if entdb.IsShuttingDown() {
+		return ctx.JSON(http.StatusServiceUnavailable, echo.Map{"status": "shutting down"})
+	}
+
 	failed := false
 	status := map[string]string{}
 

--- a/internal/httpserve/route/base.go
+++ b/internal/httpserve/route/base.go
@@ -3,6 +3,7 @@ package route
 import (
 	"net/http"
 
+	"github.com/theopenlane/core/internal/entdb"
 	echo "github.com/theopenlane/echox"
 )
 
@@ -17,6 +18,10 @@ func registerLivenessHandler(router *Router) (err error) {
 		Path:        path,
 		Middlewares: mw,
 		Handler: func(c echo.Context) error {
+			if entdb.IsShuttingDown() {
+				return c.JSON(http.StatusServiceUnavailable, echo.Map{"status": "shutting down"})
+			}
+
 			return c.JSON(http.StatusOK, echo.Map{
 				"status": "UP",
 			})

--- a/internal/httpserve/route/health_test.go
+++ b/internal/httpserve/route/health_test.go
@@ -1,0 +1,49 @@
+package route
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/theopenlane/core/internal/entdb"
+	"github.com/theopenlane/core/internal/httpserve/handlers"
+)
+
+// TestHealthEndpointsShutdown verifies liveness and readiness handlers return ServiceUnavailable during shutdown
+func TestHealthEndpointsShutdown(t *testing.T) {
+	entdb.ResetShutdown()
+	r := newTestRouter()
+	r.Handler = &handlers.Handler{}
+
+	require.NoError(t, registerLivenessHandler(r))
+	require.NoError(t, registerReadinessHandler(r))
+
+	ts := httptest.NewServer(r.Echo)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/livez")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+
+	resp, err = http.Get(ts.URL + "/ready")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+
+	entdb.BeginShutdown()
+
+	resp, err = http.Get(ts.URL + "/livez")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	resp.Body.Close()
+
+	resp, err = http.Get(ts.URL + "/ready")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	resp.Body.Close()
+
+	entdb.ResetShutdown()
+}

--- a/internal/httpserve/server/server.go
+++ b/internal/httpserve/server/server.go
@@ -150,6 +150,11 @@ func (s *Server) StartEchoServer(ctx context.Context) error {
 	}
 
 	newMetrics := metrics.New(s.config.Settings.Server.MetricsPort)
+
+	if err := newMetrics.Register(metrics.APIMetrics); err != nil {
+		log.Error().Err(err).Msg("failed to register metrics")
+	}
+
 	go func() {
 		if err := newMetrics.Start(ctx); err != nil {
 			log.Error().Err(err).Msg("metrics server failed to start")

--- a/pkg/events/soiree/eventpool.go
+++ b/pkg/events/soiree/eventpool.go
@@ -43,6 +43,8 @@ func NewEventPool(opts ...EventPoolOption) *EventPool {
 		opt(m)
 	}
 
+	register(m)
+
 	return m
 }
 
@@ -233,6 +235,8 @@ func (m *EventPool) Close() error {
 	if m.pool != nil {
 		m.pool.Release()
 	}
+
+	deregister(m)
 
 	return nil
 }

--- a/pkg/events/soiree/registry.go
+++ b/pkg/events/soiree/registry.go
@@ -1,0 +1,38 @@
+package soiree
+
+import "sync"
+
+var (
+	registry sync.Map
+)
+
+// register adds an event pool to the global registry
+func register(pool *EventPool) {
+	if pool != nil {
+		registry.Store(pool, struct{}{})
+	}
+}
+
+// deregister removes an event pool from the global registry
+func deregister(pool *EventPool) {
+	registry.Delete(pool)
+}
+
+// ShutdownAll gracefully closes all registered event pools
+func ShutdownAll() error {
+	var err error
+
+	registry.Range(func(key, _ any) bool {
+		pool := key.(*EventPool)
+
+		if closeErr := pool.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+
+		registry.Delete(key)
+
+		return true
+	})
+
+	return err
+}

--- a/pkg/events/soiree/registry_test.go
+++ b/pkg/events/soiree/registry_test.go
@@ -1,0 +1,33 @@
+package soiree
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestShutdownAll verifies that ShutdownAll closes all registered event pools.
+func TestShutdownAll(t *testing.T) {
+	p1 := NewEventPool()
+	p2 := NewEventPool()
+
+	// ensure pools accept events before shutdown
+	errChan := p1.Emit("a", nil)
+	for err := range errChan {
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, ShutdownAll())
+
+	// both pools should be closed
+	ch1 := p1.Emit("a", nil)
+	err1 := <-ch1
+	require.ErrorIs(t, err1, ErrEmitterClosed)
+
+	ch2 := p2.Emit("a", nil)
+	err2 := <-ch2
+	require.ErrorIs(t, err2, ErrEmitterClosed)
+
+	// calling ShutdownAll again should be a no-op
+	require.NoError(t, ShutdownAll())
+}

--- a/pkg/metrics/vars.go
+++ b/pkg/metrics/vars.go
@@ -45,6 +45,17 @@ var (
 		Help: "The length of time taken for a task to be processed in seconds",
 	}, []string{"task"})
 
+	GraphQLOperationTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "graphql_operations_total",
+		Help: "The number of GraphQL operations processed",
+	}, []string{"operation", "success"})
+
+	GraphQLOperationDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "graphql_operation_duration_seconds",
+		Help:    "Duration of GraphQL operations in seconds",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"operation"})
+
 	APIMetrics = []prometheus.Collector{
 		WorkerExecutions,
 		WorkerExecutionErrors,
@@ -52,6 +63,8 @@ var (
 		Registrations,
 		QueueTasksPushed,
 		QueueTasksPushFailures,
+		GraphQLOperationTotal,
+		GraphQLOperationDuration,
 	}
 
 	QueueConsumerMetrics = []prometheus.Collector{


### PR DESCRIPTION
During testing and validation of running Openlane on Kubernetes, I noticed strange behavior with how pods were being treated during rolling updates and node evictions. After some testing, it was evident that liveness and readiness endpoints always returned a 200 even if a shutdown was in progress. Event pools were created independently across the codebase with no centralized mechanism for closing them. The database drivers also seemingly did not block new queries once shutdown began and the shutdown helper could only break out of the `select` statement potentially looping forever. This PR attempts to address those concerns with the following changes:

- `Execute()` now creates a context using `signal.NotifyContext` and logs when the context finishes, enabling graceful SIGTERM handling
- the server closes the redis client, database client, and all registered event pools when the context is cancelled
- New blocking drivers, hooks, and interceptors prevent new queries once the shutdown process starts, and `GracefulCloseWithFlag` waits for in-flight operations before closing connections with a labeled loop
- Liveness and Readiness routes now return `503` if shutdown is underway
- Event pools (in soiree) are registered globally so `ShutDownAll` can close them together during shutdown
- the metrics server starts with a custom http.Server that shuts down on context cancellation and logs shutdown errors

With these updates, when Kubernetes sends SIGTERM, the service logs “shutting down gracefully…”, stops accepting new database queries, waits for running queries to finish, closes event pools, the metrics server, Redis and database connections, and reports non‑ready status via /livez and /ready. The system therefore terminates cleanly without disrupting in‑flight work.

The behavior prior this PR / on current main was easily witnessed when running the service locally, and hitting `ctrl + c` :
```
^Ctask: Signal received: "interrupt"
signal: interrupt
task: Failed to run task "run-dev": exit status 1
```

AFTER:

```
^C10:29AM INF cmd/root.go:42 | shutting down gracefully...
task: Signal received: "interrupt"
10:29AM ERR cmd/serve.go:196 | failed to run server error=http: Server closed
task: Failed to run task "run-dev": exit status 1
```

When the server receives `SIGTERM` the context created in `cmd/root.go` is cancelled, which signals the HTTP server to stop. `StartEchoServer` then returns `http.ErrServerClosed`, indicating a graceful shutdown.

```
if err := srv.StartEchoServer(ctx); err != nil {
        log.Error().Err(err).Msg("failed to run server")
}
```
Any graceful shutdown should have resulted in the log line `... failed to run server error=http: Server closed`. It occurs because `Start` returns `http.ErrServerClosed` after `Shutdown` completes, so the _lack_ of this error today means effectively that we were not actually gracefully shutting the server down as we may have thought. 

