### PR TITLE
fix: fix nil pointer panic

### DIFF
--- a/pkg/testutils/client.go
+++ b/pkg/testutils/client.go
@@ -138,6 +138,9 @@ func testGraphServer(c *ent.Client, u *objects.Objects) *handler.Server {
 
 	graphapi.WithTransactions(srv, c)
 
+	// add metrics middleware to the server
+	graphapi.WithMetrics(srv)
+
 	// add the file uploader middleware to the server
 	if u != nil {
 		graphapi.WithFileUploader(srv, u)


### PR DESCRIPTION
- adds metrics middleware to tests to catch errors
- removes `AroundOperations`, we can just use `AroundResponses` and use the already tracked start time


Not sure if this is correct, but when debugging I noticed `.Operation` was just `mutation` whereas `.Name` was the actual `CreateOrganization` etc. 

```
- opName = string(opCtx.Operation.Operation)
+ opName = opCtx.Operation.Name
```