### PR TITLE
fix: hard delete needs to delete tuples first

### DIFF
--- a/internal/graphapi/groupmembership.resolvers.go
+++ b/internal/graphapi/groupmembership.resolvers.go
@@ -12,6 +12,8 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/groupmembership"
 	"github.com/theopenlane/core/internal/graphapi/model"
+	"github.com/theopenlane/iam/entfga"
+	"github.com/theopenlane/utils/contextx"
 	"github.com/theopenlane/utils/rout"
 )
 
@@ -81,6 +83,9 @@ func (r *mutationResolver) UpdateGroupMembership(ctx context.Context, id string,
 
 // DeleteGroupMembership is the resolver for the deleteGroupMembership field.
 func (r *mutationResolver) DeleteGroupMembership(ctx context.Context, id string) (*model.GroupMembershipDeletePayload, error) {
+	// org memberships are hard deleted, so we need to delete the tuples first
+	ctx = contextx.With(ctx, entfga.DeleteTuplesFirstKey{})
+
 	if err := withTransactionalMutation(ctx).GroupMembership.DeleteOneID(id).Exec(ctx); err != nil {
 		return nil, parseRequestError(err, action{action: ActionDelete, object: "groupmembership"})
 	}

--- a/internal/graphapi/orgmembers_test.go
+++ b/internal/graphapi/orgmembers_test.go
@@ -179,18 +179,22 @@ func TestQueryOrgMembers(t *testing.T) {
 }
 
 func TestMutationCreateOrgMembers(t *testing.T) {
-	org1 := (&OrganizationBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	t.Parallel()
 
-	userCtx := auth.NewTestContextWithOrgID(testUser1.ID, org1.ID)
+	testUser := suite.userBuilder(context.Background(), t)
 
-	user1 := (&UserBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
-	user2 := (&UserBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	org1 := (&OrganizationBuilder{client: suite.client}).MustNew(testUser.UserCtx, t)
 
-	userWithValidDomain := (&UserBuilder{client: suite.client, Email: "matt@anderson.net"}).MustNew(testUser1.UserCtx, t)
-	userWithInvalidDomain := (&UserBuilder{client: suite.client, Email: "mitb@example.com"}).MustNew(testUser1.UserCtx, t)
+	userCtx := auth.NewTestContextWithOrgID(testUser.ID, org1.ID)
 
-	orgWithRestrictions := (&OrganizationBuilder{client: suite.client, AllowedDomains: []string{"anderson.io", "anderson.net"}}).MustNew(testUser1.UserCtx, t)
-	otherOrgCtx := auth.NewTestContextWithOrgID(testUser1.ID, orgWithRestrictions.ID)
+	user1 := (&UserBuilder{client: suite.client}).MustNew(testUser.UserCtx, t)
+	user2 := (&UserBuilder{client: suite.client}).MustNew(testUser.UserCtx, t)
+
+	userWithValidDomain := (&UserBuilder{client: suite.client, Email: "matt@anderson.net"}).MustNew(testUser.UserCtx, t)
+	userWithInvalidDomain := (&UserBuilder{client: suite.client, Email: "mitb@example.com"}).MustNew(testUser.UserCtx, t)
+
+	orgWithRestrictions := (&OrganizationBuilder{client: suite.client, AllowedDomains: []string{"anderson.io", "anderson.net"}}).MustNew(testUser.UserCtx, t)
+	otherOrgCtx := auth.NewTestContextWithOrgID(testUser.ID, orgWithRestrictions.ID)
 
 	testCases := []struct {
 		name   string
@@ -247,7 +251,7 @@ func TestMutationCreateOrgMembers(t *testing.T) {
 		},
 		{
 			name:   "add user to personal org not allowed",
-			orgID:  testUser1.PersonalOrgID,
+			orgID:  testUser.PersonalOrgID,
 			userID: user1.ID,
 			role:   enums.RoleMember,
 			ctx:    userCtx,
@@ -394,19 +398,27 @@ func TestMutationUpdateOrgMembers(t *testing.T) {
 }
 
 func TestMutationDeleteOrgMembers(t *testing.T) {
-	om := (&OrgMemberBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
+	t.Parallel()
 
-	resp, err := suite.client.api.RemoveUserFromOrg(testUser1.UserCtx, om.ID)
+	testUser := suite.userBuilder(context.Background(), t)
+
+	om := (&OrgMemberBuilder{client: suite.client}).MustNew(testUser.UserCtx, t)
+	adminOrgMember := (&OrgMemberBuilder{client: suite.client, Role: string(enums.RoleAdmin)}).MustNew(testUser.UserCtx, t)
+
+	// create admin user context
+	adminUserCtx := auth.NewTestContextWithOrgID(adminOrgMember.UserID, testUser.OrganizationID)
+
+	resp, err := suite.client.api.RemoveUserFromOrg(testUser.UserCtx, om.ID)
 
 	assert.NilError(t, err)
 	assert.Assert(t, resp != nil)
 	assert.Check(t, is.Equal(om.ID, resp.DeleteOrgMembership.DeletedID))
 
 	// make sure the user default org is not set to the deleted org
-	suite.assertDefaultOrgUpdate(testUser1.UserCtx, t, om.UserID, om.OrganizationID, false)
+	suite.assertDefaultOrgUpdate(testUser.UserCtx, t, om.UserID, om.OrganizationID, false)
 
 	// test re-adding the user to the org
-	_, err = suite.client.api.AddUserToOrgWithRole(testUser1.UserCtx, openlaneclient.CreateOrgMembershipInput{
+	_, err = suite.client.api.AddUserToOrgWithRole(testUser.UserCtx, openlaneclient.CreateOrgMembershipInput{
 		OrganizationID: om.OrganizationID,
 		UserID:         om.UserID,
 		Role:           &om.Role,
@@ -415,21 +427,21 @@ func TestMutationDeleteOrgMembers(t *testing.T) {
 	assert.NilError(t, err)
 
 	// cant remove self from org and owners cannot be removed
-	orgMembers, err := suite.client.api.GetOrgMembersByOrgID(testUser1.UserCtx, &openlaneclient.OrgMembershipWhereInput{
-		OrganizationID: &testUser1.OrganizationID,
+	orgMembers, err := suite.client.api.GetOrgMembersByOrgID(testUser.UserCtx, &openlaneclient.OrgMembershipWhereInput{
+		OrganizationID: &testUser.OrganizationID,
 	})
 	assert.NilError(t, err)
 
 	for _, edge := range orgMembers.OrgMemberships.Edges {
 		// cannot delete self
 		if edge.Node.UserID == adminUser.ID {
-			_, err := suite.client.api.RemoveUserFromOrg(adminUser.UserCtx, edge.Node.ID)
+			_, err := suite.client.api.RemoveUserFromOrg(adminUserCtx, edge.Node.ID)
 			assert.ErrorContains(t, err, notAuthorizedErrorMsg)
 		}
 
 		// organization owner cannot be deleted
-		if edge.Node.UserID == testUser1.ID {
-			_, err = suite.client.api.RemoveUserFromOrg(adminUser.UserCtx, edge.Node.ID)
+		if edge.Node.UserID == testUser.ID {
+			_, err = suite.client.api.RemoveUserFromOrg(adminUserCtx, edge.Node.ID)
 			assert.ErrorContains(t, err, notAuthorizedErrorMsg)
 			break
 		}

--- a/internal/graphapi/orgmembership.resolvers.go
+++ b/internal/graphapi/orgmembership.resolvers.go
@@ -12,6 +12,8 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/orgmembership"
 	"github.com/theopenlane/core/internal/graphapi/model"
+	"github.com/theopenlane/iam/entfga"
+	"github.com/theopenlane/utils/contextx"
 	"github.com/theopenlane/utils/rout"
 )
 
@@ -94,6 +96,9 @@ func (r *mutationResolver) DeleteOrgMembership(ctx context.Context, id string) (
 	if err != nil {
 		return nil, parseRequestError(err, action{action: ActionDelete, object: "orgmembership"})
 	}
+
+	// org memberships are hard deleted, so we need to delete the tuples first
+	ctx = contextx.With(ctx, entfga.DeleteTuplesFirstKey{})
 
 	if err := withTransactionalMutation(ctx).OrgMembership.DeleteOneID(id).Exec(ctx); err != nil {
 		return nil, parseRequestError(err, action{action: ActionDelete, object: "orgmembership"})

--- a/internal/graphapi/programmembership.resolvers.go
+++ b/internal/graphapi/programmembership.resolvers.go
@@ -12,6 +12,8 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/programmembership"
 	"github.com/theopenlane/core/internal/graphapi/model"
+	"github.com/theopenlane/iam/entfga"
+	"github.com/theopenlane/utils/contextx"
 	"github.com/theopenlane/utils/rout"
 )
 
@@ -74,6 +76,9 @@ func (r *mutationResolver) UpdateProgramMembership(ctx context.Context, id strin
 
 // DeleteProgramMembership is the resolver for the deleteProgramMembership field.
 func (r *mutationResolver) DeleteProgramMembership(ctx context.Context, id string) (*model.ProgramMembershipDeletePayload, error) {
+	// org memberships are hard deleted, so we need to delete the tuples first
+	ctx = contextx.With(ctx, entfga.DeleteTuplesFirstKey{})
+
 	if err := withTransactionalMutation(ctx).ProgramMembership.DeleteOneID(id).Exec(ctx); err != nil {
 		return nil, parseRequestError(err, action{action: ActionDelete, object: "programmembership"})
 	}


### PR DESCRIPTION
adds the following to the `*_membership` resolvers, so ensure tuples are deleted _before_ a hard delete, otherwise the tuples are not properly deleted. 

```
ctx = contextx.With(ctx, entfga.DeleteTuplesFirstKey{})
```

This needs to happen before any regular hooks, because the authz is a runtime hook and happens first