### PR TITLE
ensure orgID is set in JWT for verify path

### DIFF
--- a/internal/httpserve/authmanager/authmanager.go
+++ b/internal/httpserve/authmanager/authmanager.go
@@ -224,10 +224,6 @@ func (a *Client) generateOauthUserSession(ctx context.Context, w http.ResponseWr
 // if the user does not have access to the target organization, the user's default org is used (or falls back)
 // to their personal org
 func (a *Client) authCheck(ctx context.Context, user *generated.User, orgID string) (string, error) {
-	if skip := skipOrgValidation(ctx); skip {
-		return orgID, nil
-	}
-
 	if orgID == "" {
 		// get the default org for the user to check access
 		var err error
@@ -236,6 +232,10 @@ func (a *Client) authCheck(ctx context.Context, user *generated.User, orgID stri
 		if err != nil {
 			return "", err
 		}
+	}
+
+	if skip := skipOrgValidation(ctx); skip {
+		return orgID, nil
 	}
 
 	au, err := auth.GetAuthenticatedUserFromContext(ctx)

--- a/internal/httpserve/handlers/verify_test.go
+++ b/internal/httpserve/handlers/verify_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/brianvoe/gofakeit/v7"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -153,6 +154,17 @@ func (suite *HandlerTestSuite) TestVerifyHandler() {
 
 			if tc.expectedStatus >= http.StatusOK && tc.expectedStatus <= http.StatusCreated {
 				assert.Contains(t, out.Message, tc.expectedMessage)
+
+				if tc.userConfirmed {
+					// check the claims to ensure the the claims are set correctly
+					token, _, err := new(jwt.Parser).ParseUnverified(out.AccessToken, jwt.MapClaims{})
+					require.NoError(t, err)
+
+					claims, ok := token.Claims.(jwt.MapClaims)
+					require.True(t, ok)
+
+					assert.NotEmpty(t, claims["org"])
+				}
 			} else {
 				assert.Contains(t, out.Error, tc.expectedMessage)
 			}


### PR DESCRIPTION
ensures we use the `defaultOrg` in the verification path