### PR TITLE
bug-fix slack templates

### DIFF
--- a/cmd/cli/Taskfile.yaml
+++ b/cmd/cli/Taskfile.yaml
@@ -74,7 +74,7 @@ tasks:
       - go run main.go pat create -n development -o {{.ORG_ID}}
     vars:
       ORG_ID:
-        sh: go run main.go org get  -z json  | jq -r '.organizations.edges.[0].node.id'
+        sh: go run main.go org get -z json  | jq -r '.organizations.edges.[0].node.id'
 
   program:create:
     desc: creates an program against a running local instance of the server

--- a/internal/ent/hooks/event.go
+++ b/internal/ent/hooks/event.go
@@ -313,7 +313,7 @@ func handleSubscriberCreate(event soiree.Event) error {
 			return err
 		}
 	} else {
-		t, err = template.New("slack").ParseFS(slacktemplates.Templates, slacktemplates.SubscriberTemplateName)
+		t, err = template.ParseFS(slacktemplates.Templates, slacktemplates.SubscriberTemplateName)
 		if err != nil {
 			zerolog.Ctx(event.Context()).Debug().Msg("failed to parse embedded slack template")
 
@@ -368,7 +368,7 @@ func handleUserCreate(event soiree.Event) error {
 			return err
 		}
 	} else {
-		t, err = template.New("slack").ParseFS(slacktemplates.Templates, slacktemplates.UserTemplateName)
+		t, err = template.ParseFS(slacktemplates.Templates, slacktemplates.UserTemplateName)
 		if err != nil {
 			zerolog.Ctx(event.Context()).Debug().Msg("failed to parse embedded slack template")
 


### PR DESCRIPTION
Need to use parseFS correctly when falling back to the `embed` file system 