### PR TITLE
remove extra filter on mutations

### DIFF
--- a/internal/ent/generated/control/control.go
+++ b/internal/ent/generated/control/control.go
@@ -350,7 +350,7 @@ func ValidColumn(column string) bool {
 //
 //	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
-	Hooks        [12]ent.Hook
+	Hooks        [11]ent.Hook
 	Interceptors [3]ent.Interceptor
 	Policy       ent.Policy
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.

--- a/internal/ent/generated/controlimplementation/controlimplementation.go
+++ b/internal/ent/generated/controlimplementation/controlimplementation.go
@@ -144,7 +144,7 @@ func ValidColumn(column string) bool {
 //
 //	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
-	Hooks        [10]ent.Hook
+	Hooks        [9]ent.Hook
 	Interceptors [3]ent.Interceptor
 	Policy       ent.Policy
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.

--- a/internal/ent/generated/controlobjective/controlobjective.go
+++ b/internal/ent/generated/controlobjective/controlobjective.go
@@ -223,7 +223,7 @@ func ValidColumn(column string) bool {
 //
 //	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
-	Hooks        [11]ent.Hook
+	Hooks        [10]ent.Hook
 	Interceptors [3]ent.Interceptor
 	Policy       ent.Policy
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.

--- a/internal/ent/generated/documentdata/documentdata.go
+++ b/internal/ent/generated/documentdata/documentdata.go
@@ -111,7 +111,7 @@ func ValidColumn(column string) bool {
 //
 //	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
-	Hooks        [6]ent.Hook
+	Hooks        [5]ent.Hook
 	Interceptors [3]ent.Interceptor
 	Policy       ent.Policy
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.

--- a/internal/ent/generated/evidence/evidence.go
+++ b/internal/ent/generated/evidence/evidence.go
@@ -169,7 +169,7 @@ func ValidColumn(column string) bool {
 //
 //	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
-	Hooks        [8]ent.Hook
+	Hooks        [7]ent.Hook
 	Interceptors [3]ent.Interceptor
 	Policy       ent.Policy
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.

--- a/internal/ent/generated/narrative/narrative.go
+++ b/internal/ent/generated/narrative/narrative.go
@@ -170,7 +170,7 @@ func ValidColumn(column string) bool {
 //
 //	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
-	Hooks        [10]ent.Hook
+	Hooks        [9]ent.Hook
 	Interceptors [3]ent.Interceptor
 	Policy       ent.Policy
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.

--- a/internal/ent/generated/note/note.go
+++ b/internal/ent/generated/note/note.go
@@ -107,7 +107,7 @@ func ValidColumn(column string) bool {
 //
 //	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
-	Hooks        [8]ent.Hook
+	Hooks        [7]ent.Hook
 	Interceptors [3]ent.Interceptor
 	Policy       ent.Policy
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.

--- a/internal/ent/generated/risk/risk.go
+++ b/internal/ent/generated/risk/risk.go
@@ -274,7 +274,7 @@ func ValidColumn(column string) bool {
 //
 //	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
-	Hooks        [12]ent.Hook
+	Hooks        [11]ent.Hook
 	Interceptors [3]ent.Interceptor
 	Policy       ent.Policy
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.

--- a/internal/ent/generated/runtime/runtime.go
+++ b/internal/ent/generated/runtime/runtime.go
@@ -599,13 +599,11 @@ func init() {
 
 	control.Hooks[7] = controlMixinHooks6[1]
 
-	control.Hooks[8] = controlMixinHooks6[2]
+	control.Hooks[8] = controlMixinHooks7[0]
 
-	control.Hooks[9] = controlMixinHooks7[0]
+	control.Hooks[9] = controlMixinHooks7[1]
 
-	control.Hooks[10] = controlMixinHooks7[1]
-
-	control.Hooks[11] = controlHooks[0]
+	control.Hooks[10] = controlHooks[0]
 	controlMixinInters1 := controlMixin[1].Interceptors()
 	controlMixinInters6 := controlMixin[6].Interceptors()
 	control.Interceptors[0] = controlMixinInters1[0]
@@ -703,15 +701,13 @@ func init() {
 
 	controlimplementation.Hooks[4] = controlimplementationMixinHooks5[1]
 
-	controlimplementation.Hooks[5] = controlimplementationMixinHooks5[2]
+	controlimplementation.Hooks[5] = controlimplementationMixinHooks6[0]
 
-	controlimplementation.Hooks[6] = controlimplementationMixinHooks6[0]
+	controlimplementation.Hooks[6] = controlimplementationMixinHooks6[1]
 
-	controlimplementation.Hooks[7] = controlimplementationMixinHooks6[1]
+	controlimplementation.Hooks[7] = controlimplementationMixinHooks6[2]
 
-	controlimplementation.Hooks[8] = controlimplementationMixinHooks6[2]
-
-	controlimplementation.Hooks[9] = controlimplementationHooks[0]
+	controlimplementation.Hooks[8] = controlimplementationHooks[0]
 	controlimplementationMixinInters1 := controlimplementationMixin[1].Interceptors()
 	controlimplementationMixinInters5 := controlimplementationMixin[5].Interceptors()
 	controlimplementation.Interceptors[0] = controlimplementationMixinInters1[0]
@@ -804,13 +800,11 @@ func init() {
 
 	controlobjective.Hooks[6] = controlobjectiveMixinHooks6[1]
 
-	controlobjective.Hooks[7] = controlobjectiveMixinHooks6[2]
+	controlobjective.Hooks[7] = controlobjectiveMixinHooks7[0]
 
-	controlobjective.Hooks[8] = controlobjectiveMixinHooks7[0]
+	controlobjective.Hooks[8] = controlobjectiveMixinHooks7[1]
 
-	controlobjective.Hooks[9] = controlobjectiveMixinHooks7[1]
-
-	controlobjective.Hooks[10] = controlobjectiveMixinHooks7[2]
+	controlobjective.Hooks[9] = controlobjectiveMixinHooks7[2]
 	controlobjectiveMixinInters1 := controlobjectiveMixin[1].Interceptors()
 	controlobjectiveMixinInters6 := controlobjectiveMixin[6].Interceptors()
 	controlobjective.Interceptors[0] = controlobjectiveMixinInters1[0]
@@ -1237,8 +1231,6 @@ func init() {
 	documentdata.Hooks[3] = documentdataMixinHooks5[0]
 
 	documentdata.Hooks[4] = documentdataMixinHooks5[1]
-
-	documentdata.Hooks[5] = documentdataMixinHooks5[2]
 	documentdataMixinInters1 := documentdataMixin[1].Interceptors()
 	documentdataMixinInters5 := documentdataMixin[5].Interceptors()
 	documentdata.Interceptors[0] = documentdataMixinInters1[0]
@@ -1668,9 +1660,7 @@ func init() {
 
 	evidence.Hooks[5] = evidenceMixinHooks5[1]
 
-	evidence.Hooks[6] = evidenceMixinHooks5[2]
-
-	evidence.Hooks[7] = evidenceHooks[0]
+	evidence.Hooks[6] = evidenceHooks[0]
 	evidenceMixinInters1 := evidenceMixin[1].Interceptors()
 	evidenceMixinInters5 := evidenceMixin[5].Interceptors()
 	evidence.Interceptors[0] = evidenceMixinInters1[0]
@@ -3067,13 +3057,11 @@ func init() {
 
 	narrative.Hooks[5] = narrativeMixinHooks5[1]
 
-	narrative.Hooks[6] = narrativeMixinHooks5[2]
+	narrative.Hooks[6] = narrativeMixinHooks6[0]
 
-	narrative.Hooks[7] = narrativeMixinHooks6[0]
+	narrative.Hooks[7] = narrativeMixinHooks6[1]
 
-	narrative.Hooks[8] = narrativeMixinHooks6[1]
-
-	narrative.Hooks[9] = narrativeMixinHooks6[2]
+	narrative.Hooks[8] = narrativeMixinHooks6[2]
 	narrativeMixinInters1 := narrativeMixin[1].Interceptors()
 	narrativeMixinInters5 := narrativeMixin[5].Interceptors()
 	narrative.Interceptors[0] = narrativeMixinInters1[0]
@@ -3171,9 +3159,7 @@ func init() {
 
 	note.Hooks[5] = noteMixinHooks4[1]
 
-	note.Hooks[6] = noteMixinHooks4[2]
-
-	note.Hooks[7] = noteHooks[0]
+	note.Hooks[6] = noteHooks[0]
 	noteMixinInters1 := noteMixin[1].Interceptors()
 	noteMixinInters4 := noteMixin[4].Interceptors()
 	note.Interceptors[0] = noteMixinInters1[0]
@@ -4399,17 +4385,15 @@ func init() {
 
 	risk.Hooks[5] = riskMixinHooks5[1]
 
-	risk.Hooks[6] = riskMixinHooks5[2]
+	risk.Hooks[6] = riskMixinHooks6[0]
 
-	risk.Hooks[7] = riskMixinHooks6[0]
+	risk.Hooks[7] = riskMixinHooks6[1]
 
-	risk.Hooks[8] = riskMixinHooks6[1]
+	risk.Hooks[8] = riskMixinHooks6[2]
 
-	risk.Hooks[9] = riskMixinHooks6[2]
+	risk.Hooks[9] = riskHooks[0]
 
-	risk.Hooks[10] = riskHooks[0]
-
-	risk.Hooks[11] = riskHooks[1]
+	risk.Hooks[10] = riskHooks[1]
 	riskMixinInters1 := riskMixin[1].Interceptors()
 	riskMixinInters5 := riskMixin[5].Interceptors()
 	risk.Interceptors[0] = riskMixinInters1[0]
@@ -4921,11 +4905,9 @@ func init() {
 
 	subcontrol.Hooks[7] = subcontrolMixinHooks6[1]
 
-	subcontrol.Hooks[8] = subcontrolMixinHooks6[2]
+	subcontrol.Hooks[8] = subcontrolHooks[0]
 
-	subcontrol.Hooks[9] = subcontrolHooks[0]
-
-	subcontrol.Hooks[10] = subcontrolHooks[1]
+	subcontrol.Hooks[9] = subcontrolHooks[1]
 	subcontrolMixinInters1 := subcontrolMixin[1].Interceptors()
 	subcontrolMixinInters6 := subcontrolMixin[6].Interceptors()
 	subcontrol.Interceptors[0] = subcontrolMixinInters1[0]
@@ -5187,11 +5169,9 @@ func init() {
 
 	task.Hooks[5] = taskMixinHooks5[1]
 
-	task.Hooks[6] = taskMixinHooks5[2]
+	task.Hooks[6] = taskHooks[0]
 
-	task.Hooks[7] = taskHooks[0]
-
-	task.Hooks[8] = taskHooks[1]
+	task.Hooks[7] = taskHooks[1]
 	taskMixinInters1 := taskMixin[1].Interceptors()
 	taskMixinInters5 := taskMixin[5].Interceptors()
 	task.Interceptors[0] = taskMixinInters1[0]

--- a/internal/ent/generated/subcontrol/subcontrol.go
+++ b/internal/ent/generated/subcontrol/subcontrol.go
@@ -302,7 +302,7 @@ func ValidColumn(column string) bool {
 //
 //	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
-	Hooks        [11]ent.Hook
+	Hooks        [10]ent.Hook
 	Interceptors [3]ent.Interceptor
 	Policy       ent.Policy
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.

--- a/internal/ent/generated/task/task.go
+++ b/internal/ent/generated/task/task.go
@@ -223,7 +223,7 @@ func ValidColumn(column string) bool {
 //
 //	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
-	Hooks        [9]ent.Hook
+	Hooks        [8]ent.Hook
 	Interceptors [3]ent.Interceptor
 	Policy       ent.Policy
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.

--- a/internal/ent/schema/mixin_objectowned.go
+++ b/internal/ent/schema/mixin_objectowned.go
@@ -14,11 +14,9 @@ import (
 	"entgo.io/ent/schema/mixin"
 
 	"github.com/rs/zerolog/log"
-	"github.com/stoewer/go-strcase"
 
 	"github.com/theopenlane/iam/fgax"
 
-	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/hook"
 	"github.com/theopenlane/core/internal/ent/hooks"
 	"github.com/theopenlane/core/internal/ent/interceptors"
@@ -70,7 +68,7 @@ func newObjectOwnedMixin[V any](schema any, opts ...objectOwnedOption) ObjectOwn
 	// defaults settings
 	o := ObjectOwnedMixin{
 		Ref:       sch.PluralName(),
-		HookFuncs: []HookFunc{defaultObjectHookFunc, defaultTupleUpdateFunc},
+		HookFuncs: []HookFunc{defaultTupleUpdateFunc},
 		InterceptorFuncs: []InterceptorFunc{func(_ ObjectOwnedMixin) ent.Interceptor {
 			return interceptors.FilterQueryResults[V]()
 		}},
@@ -296,48 +294,6 @@ var defaultTupleUpdateFunc HookFunc = func(o ObjectOwnedMixin) ent.Hook {
 		hooks.HookObjectOwnedTuples(o.FieldNames, ownerRelation),
 		ent.OpCreate|ent.OpUpdateOne|ent.OpUpdateOne,
 	)
-}
-
-// defaultObjectHookFunc is the default hook function for the object owned mixin
-var defaultObjectHookFunc HookFunc = func(o ObjectOwnedMixin) ent.Hook {
-	return hook.On(func(next ent.Mutator) ent.Mutator {
-		return ent.MutateFunc(func(ctx context.Context, m ent.Mutation) (ent.Value, error) {
-			// skip the hook if the context has the token type
-			// this is useful for tokens, where the user is not yet authenticated to
-			// a particular organization yet and auth policy allows this
-			if skip := rule.SkipTokenInContext(ctx, o.SkipTokenType); skip {
-				return next.Mutate(ctx, m)
-			}
-
-			skip, err := o.skipOrgHookForAdmins(ctx, m)
-			if err != nil {
-				return nil, err
-			}
-
-			if skip {
-				return next.Mutate(ctx, m)
-			}
-
-			objectIDs, err := interceptors.GetAuthorizedObjectIDs(ctx, strcase.SnakeCase(m.Type()), fgax.CanEdit)
-			if err != nil {
-				return nil, err
-			}
-
-			// filter by object ids on update and delete mutations
-			mx, ok := m.(interface {
-				SetOp(ent.Op)
-				Client() *generated.Client
-				WhereP(...func(*sql.Selector))
-			})
-			if !ok {
-				return nil, ErrUnexpectedMutationType
-			}
-
-			o.P(mx, objectIDs)
-
-			return next.Mutate(ctx, m)
-		})
-	}, ent.OpUpdateOne|ent.OpUpdate|ent.OpDelete|ent.OpDeleteOne)
 }
 
 // skipOrgHookForAdmins checks if the hook should be skipped for the given mutation for system admins


### PR DESCRIPTION
all object owned functions already having existing policies to enforce permissions; this filter is not only not needed; it is an expensive query to be run, especially on objects like controls. 