### PR TITLE
Hook to clean up files from object store on deletion

### DIFF
--- a/internal/ent/generated/file/file.go
+++ b/internal/ent/generated/file/file.go
@@ -257,7 +257,7 @@ func ValidColumn(column string) bool {
 //
 //	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
-	Hooks        [3]ent.Hook
+	Hooks        [4]ent.Hook
 	Interceptors [3]ent.Interceptor
 	Policy       ent.Policy
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.

--- a/internal/ent/generated/runtime/runtime.go
+++ b/internal/ent/generated/runtime/runtime.go
@@ -1776,10 +1776,13 @@ func init() {
 	}
 	fileMixinHooks0 := fileMixin[0].Hooks()
 	fileMixinHooks1 := fileMixin[1].Hooks()
+	fileHooks := schema.File{}.Hooks()
 
 	file.Hooks[1] = fileMixinHooks0[0]
 
 	file.Hooks[2] = fileMixinHooks1[0]
+
+	file.Hooks[3] = fileHooks[0]
 	fileMixinInters1 := fileMixin[1].Interceptors()
 	fileMixinInters5 := fileMixin[5].Interceptors()
 	fileInters := schema.File{}.Interceptors()

--- a/internal/ent/hooks/file.go
+++ b/internal/ent/hooks/file.go
@@ -1,0 +1,52 @@
+package hooks
+
+import (
+	"context"
+	"errors"
+
+	"entgo.io/ent"
+	"github.com/theopenlane/core/internal/ent/generated"
+	"github.com/theopenlane/core/internal/ent/generated/hook"
+)
+
+var (
+	errInvalidStoragePath = errors.New("invalid path when deleting file from object storage")
+)
+
+// HookFileDelete makes sure to clean up the file from external storage once deleted
+func HookFileDelete() ent.Hook {
+	return hook.On(func(next ent.Mutator) ent.Mutator {
+		return hook.FileFunc(
+			func(ctx context.Context, m *generated.FileMutation) (generated.Value, error) {
+
+				var storagePath string
+				if m.ObjectManager != nil && isDeleteOp(ctx, m) {
+
+					id, ok := m.ID()
+					if !ok {
+						return nil, errInvalidStoragePath
+					}
+
+					file, err := m.Client().File.Get(ctx, id)
+					if err != nil {
+						return nil, err
+					}
+
+					storagePath = file.StoragePath
+				}
+
+				v, err := next.Mutate(ctx, m)
+				if err != nil {
+					return nil, err
+				}
+
+				if storagePath != "" {
+					if err := m.ObjectManager.Storage.Delete(ctx, storagePath); err != nil {
+						return nil, err
+					}
+				}
+
+				return v, err
+			})
+	}, ent.OpDelete|ent.OpDeleteOne|ent.OpUpdate|ent.OpUpdateOne)
+}

--- a/internal/ent/schema/file.go
+++ b/internal/ent/schema/file.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
+	"github.com/theopenlane/core/internal/ent/hooks"
 	"github.com/theopenlane/core/internal/ent/interceptors"
 	"github.com/theopenlane/core/internal/ent/privacy/policy"
 )
@@ -149,4 +150,11 @@ func (File) Policy() ent.Policy {
 			privacy.AlwaysAllowRule(),
 		),
 	)
+}
+
+// Hooks of the File
+func (File) Hooks() []ent.Hook {
+	return []ent.Hook{
+		hooks.HookFileDelete(),
+	}
 }


### PR DESCRIPTION
While the logic to delete from storage exists, it exists only in the resolver so if you deleted the file from another hook
or a db operation. the s3 or external store would never get cleaned up