### PR TITLE
Cascade delete controls

### DIFF
--- a/docker/docker-compose-fga.yml
+++ b/docker/docker-compose-fga.yml
@@ -28,6 +28,7 @@ services:
       - OPENFGA_LIST_OBJECTS_MAX_RESULTS=1000
       - OPENFGA_MAX_CHECKS_PER_BATCH_CHECK=500
       - OPENFGA_LIST_OBJECTS_DEADLINE=5s
+      - OPENFGA_MAX_CHECKS_PER_BATCH_CHECK=100
     command:
       - run
       - --check-query-cache-enabled

--- a/docker/docker-compose-fga.yml
+++ b/docker/docker-compose-fga.yml
@@ -28,7 +28,6 @@ services:
       - OPENFGA_LIST_OBJECTS_MAX_RESULTS=1000
       - OPENFGA_MAX_CHECKS_PER_BATCH_CHECK=500
       - OPENFGA_LIST_OBJECTS_DEADLINE=5s
-      - OPENFGA_MAX_CHECKS_PER_BATCH_CHECK=100
     command:
       - run
       - --check-query-cache-enabled

--- a/fga/model/model.fga
+++ b/fga/model/model.fga
@@ -202,8 +202,8 @@ type program
 type control
   relations
     define can_view: [user, service] or can_edit or (viewer but not blocked)
-    define can_edit: [user, service] or owner or delegate or (editor but not blocked)
-    define can_delete: [user, service] or owner or (editor but not blocked)
+    define can_edit: [user, service] or owner or delegate or system_admin from system or (editor but not blocked) 
+    define can_delete: [user, service] or owner or (editor but not blocked) or system_admin from system
     define audit_log_viewer: ([user, service] or audit_log_viewer from parent) and can_view
     define parent: [user, service, organization, program, standard]
     # do not include group#member here as controls automatically inherit access from the parent organization
@@ -216,6 +216,7 @@ type control
     define owner: [group#member]
     # delegate is a group of users that are given temporary access to the control, they will have edit but not delete access
     define delegate: [group#member]
+    define system: [system]
 # subcontrols are associated with an organization but do not inherit access from the organization
 # subcontrols inherit access from the their parent control(s)
 type subcontrol

--- a/internal/ent/generated/runtime/runtime.go
+++ b/internal/ent/generated/runtime/runtime.go
@@ -5090,6 +5090,8 @@ func init() {
 	standard.Hooks[6] = standardHooks[0]
 
 	standard.Hooks[7] = standardHooks[1]
+
+	standard.Hooks[8] = standardHooks[2]
 	standardMixinInters1 := standardMixin[1].Interceptors()
 	standardMixinInters6 := standardMixin[6].Interceptors()
 	standardInters := schema.Standard{}.Interceptors()

--- a/internal/ent/generated/standard/standard.go
+++ b/internal/ent/generated/standard/standard.go
@@ -130,7 +130,7 @@ func ValidColumn(column string) bool {
 //
 //	import _ "github.com/theopenlane/core/internal/ent/generated/runtime"
 var (
-	Hooks        [8]ent.Hook
+	Hooks        [9]ent.Hook
 	Interceptors [3]ent.Interceptor
 	Policy       ent.Policy
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.

--- a/internal/ent/hooks/standard.go
+++ b/internal/ent/hooks/standard.go
@@ -18,7 +18,7 @@ import (
 var (
 	// ErrPublicStandardCannotBeDeleted defines an error that denotes a public standard cannot be
 	// deleted once made public
-	ErrPublicStandardCannotBeDeleted = errors.New("public standard not allowed to be deleted.")
+	ErrPublicStandardCannotBeDeleted = errors.New("public standard not allowed to be deleted")
 )
 
 // HookStandardDelete cascades the deletion of all controls that have a standard linked/connected

--- a/internal/ent/schema/control.go
+++ b/internal/ent/schema/control.go
@@ -162,8 +162,8 @@ func (Control) Hooks() []ent.Hook {
 func (Control) Policy() ent.Policy {
 	return policy.NewPolicy(
 		policy.WithMutationRules(
-			// when an admin deletes a standard, we cascade
-			// delete controls that might belong to an org
+			// when an admin deletes a standard, we updated
+			// controls to unlink the standard that might belong to an organization
 			rule.AllowMutationIfSystemAdmin(),
 			rule.AllowIfContextAllowRule(),
 			rule.CanCreateObjectsUnderParent[*generated.ControlMutation](rule.ProgramParent), // if mutation contains program_id, check access

--- a/internal/ent/schema/control.go
+++ b/internal/ent/schema/control.go
@@ -162,6 +162,9 @@ func (Control) Hooks() []ent.Hook {
 func (Control) Policy() ent.Policy {
 	return policy.NewPolicy(
 		policy.WithMutationRules(
+			// when an admin deletes a standard, we cascade
+			// delete controls that might belong to an org
+			rule.AllowMutationIfSystemAdmin(),
 			rule.AllowIfContextAllowRule(),
 			rule.CanCreateObjectsUnderParent[*generated.ControlMutation](rule.ProgramParent), // if mutation contains program_id, check access
 			policy.CheckCreateAccess(),

--- a/internal/ent/schema/standard.go
+++ b/internal/ent/schema/standard.go
@@ -149,6 +149,7 @@ func (Standard) Hooks() []ent.Hook {
 	return []ent.Hook{
 		hooks.HookStandardPublicAccessTuples(),
 		hooks.HookStandardCreate(),
+		hooks.HookStandardDelete(),
 	}
 }
 

--- a/internal/graphapi/control_test.go
+++ b/internal/graphapi/control_test.go
@@ -1010,9 +1010,7 @@ func TestMutationCreateControlsByClone(t *testing.T) {
 	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: controlIDsToDelete}).MustDelete(testUser1.UserCtx, t)
 	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, IDs: []string{publicStandard.ID, publicStandard2.ID}}).MustDelete(systemAdminUser.UserCtx, t)
 	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: orgStandard.ID}).MustDelete(testUser1.UserCtx, t)
-	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: controlIDs}).MustDelete(systemAdminUser.UserCtx, t)
 	(&Cleanup[*generated.SubcontrolDeleteOne]{client: suite.client.db.Subcontrol, IDs: subcontrolIDs}).MustDelete(systemAdminUser.UserCtx, t)
-	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: controlID2s}).MustDelete(systemAdminUser.UserCtx, t)
 	(&Cleanup[*generated.SubcontrolDeleteOne]{client: suite.client.db.Subcontrol, IDs: subcontrolID2s}).MustDelete(systemAdminUser.UserCtx, t)
 	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, ID: program.ID}).MustDelete(testUser1.UserCtx, t)
 }

--- a/internal/graphapi/control_test.go
+++ b/internal/graphapi/control_test.go
@@ -1009,6 +1009,10 @@ func TestMutationCreateControlsByClone(t *testing.T) {
 	(&Cleanup[*generated.SubcontrolDeleteOne]{client: suite.client.db.Subcontrol, IDs: subcontrolIDsToDelete}).MustDelete(testUser1.UserCtx, t)
 	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: controlIDsToDelete}).MustDelete(testUser1.UserCtx, t)
 	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: orgStandard.ID}).MustDelete(testUser1.UserCtx, t)
+
+	// now we can delete it and the controls under it will be deleted
+	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, IDs: []string{publicStandard.ID, publicStandard2.ID}}).MustDelete(systemAdminUser.UserCtx, t)
+
 	(&Cleanup[*generated.SubcontrolDeleteOne]{client: suite.client.db.Subcontrol, IDs: subcontrolIDs}).MustDelete(systemAdminUser.UserCtx, t)
 	(&Cleanup[*generated.SubcontrolDeleteOne]{client: suite.client.db.Subcontrol, IDs: subcontrolID2s}).MustDelete(systemAdminUser.UserCtx, t)
 	(&Cleanup[*generated.ProgramDeleteOne]{client: suite.client.db.Program, ID: program.ID}).MustDelete(testUser1.UserCtx, t)
@@ -1450,6 +1454,11 @@ func TestQueryControlCategories(t *testing.T) {
 	(&Cleanup[*generated.SubcontrolDeleteOne]{client: suite.client.db.Subcontrol, ID: subcontrol.ID}).MustDelete(newUser.UserCtx, t)
 }
 
+// TestQueryControlSubcategories tests the query for control subcategories
+// Note: this test will pull all categories, even if the controls weren't created in this test, or in this organization (E.g. public standards)
+// will affect the results of this test
+// never try to run this in parallel with other tests that create controls
+// or standards, or that have controls linked to them
 func TestQueryControlSubcategories(t *testing.T) {
 	// create controls with categories and subcategories
 	control1 := (&ControlBuilder{client: suite.client, AllFields: true}).MustNew(testUser1.UserCtx, t)
@@ -1517,6 +1526,11 @@ func TestQueryControlSubcategories(t *testing.T) {
 	(&Cleanup[*generated.SubcontrolDeleteOne]{client: suite.client.db.Subcontrol, ID: subcontrol.ID}).MustDelete(testUser1.UserCtx, t)
 }
 
+// TestQueryControlCategoriesByFramework tests the query for control subcategories by framework
+// Note: this test will pull all categories, even if the controls weren't created in this test, or in this organization (E.g. public standards)
+// will affect the results of this test
+// never try to run this in parallel with other tests that create controls
+// or standards, or that have controls linked to them
 func TestQueryControlCategoriesByFramework(t *testing.T) {
 	customFramework := "Custom"
 
@@ -1877,6 +1891,6 @@ func TestQueryControlGroupsByCategory(t *testing.T) {
 	}
 
 	// cleanup created controls
-	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: []string{control1.ID, control2.ID, control3.ID, control4.ID, control5.ID, control6.ID, control7.ID}}).MustDelete(user1.UserCtx, t)
 	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: standard.ID}).MustDelete(user1.UserCtx, t)
+	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: []string{control1.ID, control2.ID, control3.ID, control4.ID, control5.ID, control6.ID, control7.ID}}).MustDelete(user1.UserCtx, t)
 }

--- a/internal/graphapi/internalpolicy_test.go
+++ b/internal/graphapi/internalpolicy_test.go
@@ -484,7 +484,6 @@ func TestMutationCreateInternalPolicy(t *testing.T) {
 
 	// cleanup the system standard and control
 	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, IDs: []string{systemStandard.ID}}).MustDelete(systemAdminUser.UserCtx, t)
-	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: []string{systemControl.ID}}).MustDelete(systemAdminUser.UserCtx, t)
 }
 
 func TestMutationUpdateInternalPolicy(t *testing.T) {

--- a/internal/graphapi/programextended_test.go
+++ b/internal/graphapi/programextended_test.go
@@ -116,7 +116,7 @@ func TestMutationCreateProgramWithMembers(t *testing.T) {
 	}
 
 	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: adminControlIDs}).MustDelete(systemAdminUser.UserCtx, t)
-	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: publicStandard.ID}).MustDelete(systemAdminUser.UserCtx, t)
+	// (&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: publicStandard.ID}).MustDelete(systemAdminUser.UserCtx, t)
 }
 
 func TestMutationCreateFullProgram(t *testing.T) {
@@ -287,5 +287,4 @@ func TestMutationCreateFullProgram(t *testing.T) {
 	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: controlIDs}).MustDelete(user.UserCtx, t)
 	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: adminControlIDs}).MustDelete(systemAdminUser.UserCtx, t)
 	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: orgStandard.ID}).MustDelete(user.UserCtx, t)
-	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: publicStandard.ID}).MustDelete(systemAdminUser.UserCtx, t)
 }

--- a/internal/graphapi/programextended_test.go
+++ b/internal/graphapi/programextended_test.go
@@ -116,7 +116,7 @@ func TestMutationCreateProgramWithMembers(t *testing.T) {
 	}
 
 	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: adminControlIDs}).MustDelete(systemAdminUser.UserCtx, t)
-	// (&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: publicStandard.ID}).MustDelete(systemAdminUser.UserCtx, t)
+	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: publicStandard.ID}).MustDelete(systemAdminUser.UserCtx, t)
 }
 
 func TestMutationCreateFullProgram(t *testing.T) {
@@ -285,6 +285,6 @@ func TestMutationCreateFullProgram(t *testing.T) {
 
 	// cleanup seeded input
 	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: controlIDs}).MustDelete(user.UserCtx, t)
-	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: adminControlIDs}).MustDelete(systemAdminUser.UserCtx, t)
 	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: orgStandard.ID}).MustDelete(user.UserCtx, t)
+	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: publicStandard.ID}).MustDelete(systemAdminUser.UserCtx, t)
 }

--- a/internal/graphapi/standard_test.go
+++ b/internal/graphapi/standard_test.go
@@ -518,9 +518,6 @@ func TestMutationCreateStandard(t *testing.T) {
 			(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: resp.CreateStandard.Standard.ID}).MustDelete(ctx, t)
 		})
 	}
-
-	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: controlIDs}).MustDelete(testUser1.UserCtx, t)
-	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: adminControlIDs}).MustDelete(systemAdminUser.UserCtx, t)
 }
 
 func TestMutationUpdateStandard(t *testing.T) {


### PR DESCRIPTION
If an admin deletes a standard, it should cascade delete all controls under it.

org owned controls linked to the standard do not get deleted, they just get unlinked from the standard
