### PR TITLE
Inherit cron schedule from parent job where possible

### DIFF
--- a/db/migrations-goose-postgres/20250721124113_drop_script_and_cadence.sql
+++ b/db/migrations-goose-postgres/20250721124113_drop_script_and_cadence.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- modify "scheduled_job_history" table
+ALTER TABLE "scheduled_job_history" DROP COLUMN "script", DROP COLUMN "cadence";
+-- modify "scheduled_jobs" table
+ALTER TABLE "scheduled_jobs" DROP COLUMN "script", DROP COLUMN "cadence";
+
+-- +goose Down
+-- reverse: modify "scheduled_jobs" table
+ALTER TABLE "scheduled_jobs" ADD COLUMN "cadence" jsonb NULL, ADD COLUMN "script" character varying NULL;
+-- reverse: modify "scheduled_job_history" table
+ALTER TABLE "scheduled_job_history" ADD COLUMN "cadence" jsonb NULL, ADD COLUMN "script" character varying NULL;

--- a/db/migrations-goose-postgres/atlas.sum
+++ b/db/migrations-goose-postgres/atlas.sum
@@ -1,4 +1,4 @@
-h1:vUZ2dcBCtNG8lsKDmDX2bwPE7yfy35wx8a6TwIFLnR8=
+h1:/nL3QaPiq3jjF/tRMBijmftm2AtUHaZjKJiNIb1LFmQ=
 20250414203515_init.sql h1:BeTEtWy9s9mO1t9vLhKE/W3Z/NZS7kklzlmvffjgMys=
 20250418204251_control_objective.sql h1:2zhXUjbVshiTwzY0qh87de8Wh8j2tLDO6KRbn6oohx4=
 20250421141007_aauid_not_unique_per_machine.sql h1:bMzfq+NBG4IFyOf/YintEKVhmQ6ttnQymzRV8/RiuPo=
@@ -38,3 +38,4 @@ h1:vUZ2dcBCtNG8lsKDmDX2bwPE7yfy35wx8a6TwIFLnR8=
 20250714185720_windmill.sql h1:WN5mnXUgU0Kc8F6u2N8okKW9S/u1wBdiAF+8tGNU+aw=
 20250715165030_invite_groups.sql h1:7BPjWqLx8+6qVnZo7EVC1xafBp0Xlkoe9+eGBtY2WcY=
 20250716122257_exportfilters_and_drop_jobtype.sql h1:/4Cw8FOt8e38YkJV0UsincBKhch3hVxFSgubJUqNmZo=
+20250721124113_drop_script_and_cadence.sql h1:IFPIl+S6LUddc9gP0XVy1isMf4JIRZzIs92Jrpl+g1E=

--- a/db/migrations/20250721124105_drop_script_and_cadence.sql
+++ b/db/migrations/20250721124105_drop_script_and_cadence.sql
@@ -1,0 +1,4 @@
+-- Modify "scheduled_job_history" table
+ALTER TABLE "scheduled_job_history" DROP COLUMN "script", DROP COLUMN "cadence";
+-- Modify "scheduled_jobs" table
+ALTER TABLE "scheduled_jobs" DROP COLUMN "script", DROP COLUMN "cadence";

--- a/db/migrations/atlas.sum
+++ b/db/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:zIM/J1Wb3DUxqImRU2dtoda+P6CKOG9CdJty7vKox4I=
+h1:qX5CXEpNWQPjNgUVaYyzCj1G4DKbM/avaxAMrMdCOgA=
 20250414203514_init.sql h1:NmCV8ML7NQDnzWVgI8QwOPofl3cp1WGzZWzPQhilEbY=
 20250418204249_control_objective.sql h1:NVX8qKq77/54YdYSQZMyI+HS5RXNahqyyDtNHf9oMnQ=
 20250421141003_aauid_not_unique_per_machine.sql h1:/ZFOjmdeEiPZl23+/MIjK1sxFWSi8PrMvV3kJ4iqbW4=
@@ -38,3 +38,4 @@ h1:zIM/J1Wb3DUxqImRU2dtoda+P6CKOG9CdJty7vKox4I=
 20250714185712_windmill.sql h1:6oJeQNp85g2bd4wWS98YAnQVT5WhfJR+i/4GKsEFi7w=
 20250715165021_invite_groups.sql h1:FC6zUmoznhT92e5kiehT/qlzGtAT0+6GZ7Ib01b7LOg=
 20250716122250_exportfilters_and_drop_jobtype.sql h1:Qn3DQC5ChuAHVd0R3xEzxOKp1jk4vU7XU1F0itOdeaE=
+20250721124105_drop_script_and_cadence.sql h1:N1tgnGvOc4kdSmk5mciUGKvGIQCaGC3VjPACvKNqniY=

--- a/internal/ent/generated/auditing.go
+++ b/internal/ent/generated/auditing.go
@@ -2688,9 +2688,6 @@ func (sjh *ScheduledJobHistory) changes(new *ScheduledJobHistory) []Change {
 	if !reflect.DeepEqual(sjh.Platform, new.Platform) {
 		changes = append(changes, NewChange(scheduledjobhistory.FieldPlatform, sjh.Platform, new.Platform))
 	}
-	if !reflect.DeepEqual(sjh.Script, new.Script) {
-		changes = append(changes, NewChange(scheduledjobhistory.FieldScript, sjh.Script, new.Script))
-	}
 	if !reflect.DeepEqual(sjh.WindmillPath, new.WindmillPath) {
 		changes = append(changes, NewChange(scheduledjobhistory.FieldWindmillPath, sjh.WindmillPath, new.WindmillPath))
 	}
@@ -2699,9 +2696,6 @@ func (sjh *ScheduledJobHistory) changes(new *ScheduledJobHistory) []Change {
 	}
 	if !reflect.DeepEqual(sjh.Configuration, new.Configuration) {
 		changes = append(changes, NewChange(scheduledjobhistory.FieldConfiguration, sjh.Configuration, new.Configuration))
-	}
-	if !reflect.DeepEqual(sjh.Cadence, new.Cadence) {
-		changes = append(changes, NewChange(scheduledjobhistory.FieldCadence, sjh.Cadence, new.Cadence))
 	}
 	if !reflect.DeepEqual(sjh.Cron, new.Cron) {
 		changes = append(changes, NewChange(scheduledjobhistory.FieldCron, sjh.Cron, new.Cron))

--- a/internal/ent/generated/entql.go
+++ b/internal/ent/generated/entql.go
@@ -2523,11 +2523,9 @@ var schemaGraph = func() *sqlgraph.Schema {
 			scheduledjob.FieldTitle:         {Type: field.TypeString, Column: scheduledjob.FieldTitle},
 			scheduledjob.FieldDescription:   {Type: field.TypeString, Column: scheduledjob.FieldDescription},
 			scheduledjob.FieldPlatform:      {Type: field.TypeEnum, Column: scheduledjob.FieldPlatform},
-			scheduledjob.FieldScript:        {Type: field.TypeString, Column: scheduledjob.FieldScript},
 			scheduledjob.FieldWindmillPath:  {Type: field.TypeString, Column: scheduledjob.FieldWindmillPath},
 			scheduledjob.FieldDownloadURL:   {Type: field.TypeString, Column: scheduledjob.FieldDownloadURL},
 			scheduledjob.FieldConfiguration: {Type: field.TypeJSON, Column: scheduledjob.FieldConfiguration},
-			scheduledjob.FieldCadence:       {Type: field.TypeJSON, Column: scheduledjob.FieldCadence},
 			scheduledjob.FieldCron:          {Type: field.TypeString, Column: scheduledjob.FieldCron},
 		},
 	}
@@ -2558,11 +2556,9 @@ var schemaGraph = func() *sqlgraph.Schema {
 			scheduledjobhistory.FieldTitle:         {Type: field.TypeString, Column: scheduledjobhistory.FieldTitle},
 			scheduledjobhistory.FieldDescription:   {Type: field.TypeString, Column: scheduledjobhistory.FieldDescription},
 			scheduledjobhistory.FieldPlatform:      {Type: field.TypeEnum, Column: scheduledjobhistory.FieldPlatform},
-			scheduledjobhistory.FieldScript:        {Type: field.TypeString, Column: scheduledjobhistory.FieldScript},
 			scheduledjobhistory.FieldWindmillPath:  {Type: field.TypeString, Column: scheduledjobhistory.FieldWindmillPath},
 			scheduledjobhistory.FieldDownloadURL:   {Type: field.TypeString, Column: scheduledjobhistory.FieldDownloadURL},
 			scheduledjobhistory.FieldConfiguration: {Type: field.TypeJSON, Column: scheduledjobhistory.FieldConfiguration},
-			scheduledjobhistory.FieldCadence:       {Type: field.TypeJSON, Column: scheduledjobhistory.FieldCadence},
 			scheduledjobhistory.FieldCron:          {Type: field.TypeString, Column: scheduledjobhistory.FieldCron},
 		},
 	}
@@ -23671,11 +23667,6 @@ func (f *ScheduledJobFilter) WherePlatform(p entql.StringP) {
 	f.Where(p.Field(scheduledjob.FieldPlatform))
 }
 
-// WhereScript applies the entql string predicate on the script field.
-func (f *ScheduledJobFilter) WhereScript(p entql.StringP) {
-	f.Where(p.Field(scheduledjob.FieldScript))
-}
-
 // WhereWindmillPath applies the entql string predicate on the windmill_path field.
 func (f *ScheduledJobFilter) WhereWindmillPath(p entql.StringP) {
 	f.Where(p.Field(scheduledjob.FieldWindmillPath))
@@ -23689,11 +23680,6 @@ func (f *ScheduledJobFilter) WhereDownloadURL(p entql.StringP) {
 // WhereConfiguration applies the entql json.RawMessage predicate on the configuration field.
 func (f *ScheduledJobFilter) WhereConfiguration(p entql.BytesP) {
 	f.Where(p.Field(scheduledjob.FieldConfiguration))
-}
-
-// WhereCadence applies the entql json.RawMessage predicate on the cadence field.
-func (f *ScheduledJobFilter) WhereCadence(p entql.BytesP) {
-	f.Where(p.Field(scheduledjob.FieldCadence))
 }
 
 // WhereCron applies the entql string predicate on the cron field.
@@ -23835,11 +23821,6 @@ func (f *ScheduledJobHistoryFilter) WherePlatform(p entql.StringP) {
 	f.Where(p.Field(scheduledjobhistory.FieldPlatform))
 }
 
-// WhereScript applies the entql string predicate on the script field.
-func (f *ScheduledJobHistoryFilter) WhereScript(p entql.StringP) {
-	f.Where(p.Field(scheduledjobhistory.FieldScript))
-}
-
 // WhereWindmillPath applies the entql string predicate on the windmill_path field.
 func (f *ScheduledJobHistoryFilter) WhereWindmillPath(p entql.StringP) {
 	f.Where(p.Field(scheduledjobhistory.FieldWindmillPath))
@@ -23853,11 +23834,6 @@ func (f *ScheduledJobHistoryFilter) WhereDownloadURL(p entql.StringP) {
 // WhereConfiguration applies the entql json.RawMessage predicate on the configuration field.
 func (f *ScheduledJobHistoryFilter) WhereConfiguration(p entql.BytesP) {
 	f.Where(p.Field(scheduledjobhistory.FieldConfiguration))
-}
-
-// WhereCadence applies the entql json.RawMessage predicate on the cadence field.
-func (f *ScheduledJobHistoryFilter) WhereCadence(p entql.BytesP) {
-	f.Where(p.Field(scheduledjobhistory.FieldCadence))
 }
 
 // WhereCron applies the entql string predicate on the cron field.

--- a/internal/ent/generated/gql_collection.go
+++ b/internal/ent/generated/gql_collection.go
@@ -37087,11 +37087,6 @@ func (sj *ScheduledJobQuery) collectField(ctx context.Context, oneNode bool, opC
 				selectedFields = append(selectedFields, scheduledjob.FieldPlatform)
 				fieldSeen[scheduledjob.FieldPlatform] = struct{}{}
 			}
-		case "script":
-			if _, ok := fieldSeen[scheduledjob.FieldScript]; !ok {
-				selectedFields = append(selectedFields, scheduledjob.FieldScript)
-				fieldSeen[scheduledjob.FieldScript] = struct{}{}
-			}
 		case "windmillPath":
 			if _, ok := fieldSeen[scheduledjob.FieldWindmillPath]; !ok {
 				selectedFields = append(selectedFields, scheduledjob.FieldWindmillPath)
@@ -37106,11 +37101,6 @@ func (sj *ScheduledJobQuery) collectField(ctx context.Context, oneNode bool, opC
 			if _, ok := fieldSeen[scheduledjob.FieldConfiguration]; !ok {
 				selectedFields = append(selectedFields, scheduledjob.FieldConfiguration)
 				fieldSeen[scheduledjob.FieldConfiguration] = struct{}{}
-			}
-		case "cadence":
-			if _, ok := fieldSeen[scheduledjob.FieldCadence]; !ok {
-				selectedFields = append(selectedFields, scheduledjob.FieldCadence)
-				fieldSeen[scheduledjob.FieldCadence] = struct{}{}
 			}
 		case "cron":
 			if _, ok := fieldSeen[scheduledjob.FieldCron]; !ok {
@@ -37277,11 +37267,6 @@ func (sjh *ScheduledJobHistoryQuery) collectField(ctx context.Context, oneNode b
 				selectedFields = append(selectedFields, scheduledjobhistory.FieldPlatform)
 				fieldSeen[scheduledjobhistory.FieldPlatform] = struct{}{}
 			}
-		case "script":
-			if _, ok := fieldSeen[scheduledjobhistory.FieldScript]; !ok {
-				selectedFields = append(selectedFields, scheduledjobhistory.FieldScript)
-				fieldSeen[scheduledjobhistory.FieldScript] = struct{}{}
-			}
 		case "windmillPath":
 			if _, ok := fieldSeen[scheduledjobhistory.FieldWindmillPath]; !ok {
 				selectedFields = append(selectedFields, scheduledjobhistory.FieldWindmillPath)
@@ -37296,11 +37281,6 @@ func (sjh *ScheduledJobHistoryQuery) collectField(ctx context.Context, oneNode b
 			if _, ok := fieldSeen[scheduledjobhistory.FieldConfiguration]; !ok {
 				selectedFields = append(selectedFields, scheduledjobhistory.FieldConfiguration)
 				fieldSeen[scheduledjobhistory.FieldConfiguration] = struct{}{}
-			}
-		case "cadence":
-			if _, ok := fieldSeen[scheduledjobhistory.FieldCadence]; !ok {
-				selectedFields = append(selectedFields, scheduledjobhistory.FieldCadence)
-				fieldSeen[scheduledjobhistory.FieldCadence] = struct{}{}
 			}
 		case "cron":
 			if _, ok := fieldSeen[scheduledjobhistory.FieldCron]; !ok {

--- a/internal/ent/generated/gql_mutation_input.go
+++ b/internal/ent/generated/gql_mutation_input.go
@@ -9433,10 +9433,8 @@ type CreateScheduledJobInput struct {
 	Title         string
 	Description   *string
 	Platform      enums.JobPlatformType
-	Script        *string
 	DownloadURL   string
 	Configuration models.JobConfiguration
-	Cadence       *models.JobCadence
 	Cron          *models.Cron
 	OwnerID       *string
 }
@@ -9451,15 +9449,9 @@ func (i *CreateScheduledJobInput) Mutate(m *ScheduledJobMutation) {
 		m.SetDescription(*v)
 	}
 	m.SetPlatform(i.Platform)
-	if v := i.Script; v != nil {
-		m.SetScript(*v)
-	}
 	m.SetDownloadURL(i.DownloadURL)
 	if v := i.Configuration; v != nil {
 		m.SetConfiguration(v)
-	}
-	if v := i.Cadence; v != nil {
-		m.SetCadence(*v)
 	}
 	if v := i.Cron; v != nil {
 		m.SetCron(*v)
@@ -9483,14 +9475,10 @@ type UpdateScheduledJobInput struct {
 	Title               *string
 	ClearDescription    bool
 	Description         *string
-	ClearScript         bool
-	Script              *string
 	DownloadURL         *string
 	ClearConfiguration  bool
 	Configuration       models.JobConfiguration
 	AppendConfiguration models.JobConfiguration
-	ClearCadence        bool
-	Cadence             *models.JobCadence
 	ClearCron           bool
 	Cron                *models.Cron
 	ClearOwner          bool
@@ -9517,12 +9505,6 @@ func (i *UpdateScheduledJobInput) Mutate(m *ScheduledJobMutation) {
 	if v := i.Description; v != nil {
 		m.SetDescription(*v)
 	}
-	if i.ClearScript {
-		m.ClearScript()
-	}
-	if v := i.Script; v != nil {
-		m.SetScript(*v)
-	}
 	if v := i.DownloadURL; v != nil {
 		m.SetDownloadURL(*v)
 	}
@@ -9534,12 +9516,6 @@ func (i *UpdateScheduledJobInput) Mutate(m *ScheduledJobMutation) {
 	}
 	if i.AppendConfiguration != nil {
 		m.AppendConfiguration(i.Configuration)
-	}
-	if i.ClearCadence {
-		m.ClearCadence()
-	}
-	if v := i.Cadence; v != nil {
-		m.SetCadence(*v)
 	}
 	if i.ClearCron {
 		m.ClearCron()

--- a/internal/ent/generated/history_from_mutation.go
+++ b/internal/ent/generated/history_from_mutation.go
@@ -8709,10 +8709,6 @@ func (m *ScheduledJobMutation) CreateHistoryFromCreate(ctx context.Context) erro
 		create = create.SetPlatform(platform)
 	}
 
-	if script, exists := m.Script(); exists {
-		create = create.SetScript(script)
-	}
-
 	if windmillPath, exists := m.WindmillPath(); exists {
 		create = create.SetWindmillPath(windmillPath)
 	}
@@ -8723,10 +8719,6 @@ func (m *ScheduledJobMutation) CreateHistoryFromCreate(ctx context.Context) erro
 
 	if configuration, exists := m.Configuration(); exists {
 		create = create.SetConfiguration(configuration)
-	}
-
-	if cadence, exists := m.Cadence(); exists {
-		create = create.SetCadence(cadence)
 	}
 
 	if cron, exists := m.Cron(); exists {
@@ -8842,12 +8834,6 @@ func (m *ScheduledJobMutation) CreateHistoryFromUpdate(ctx context.Context) erro
 			create = create.SetPlatform(scheduledjob.Platform)
 		}
 
-		if script, exists := m.Script(); exists {
-			create = create.SetScript(script)
-		} else {
-			create = create.SetScript(scheduledjob.Script)
-		}
-
 		if windmillPath, exists := m.WindmillPath(); exists {
 			create = create.SetWindmillPath(windmillPath)
 		} else {
@@ -8864,12 +8850,6 @@ func (m *ScheduledJobMutation) CreateHistoryFromUpdate(ctx context.Context) erro
 			create = create.SetConfiguration(configuration)
 		} else {
 			create = create.SetConfiguration(scheduledjob.Configuration)
-		}
-
-		if cadence, exists := m.Cadence(); exists {
-			create = create.SetCadence(cadence)
-		} else {
-			create = create.SetCadence(scheduledjob.Cadence)
 		}
 
 		if cron, exists := m.Cron(); exists {
@@ -8926,11 +8906,9 @@ func (m *ScheduledJobMutation) CreateHistoryFromDelete(ctx context.Context) erro
 			SetTitle(scheduledjob.Title).
 			SetDescription(scheduledjob.Description).
 			SetPlatform(scheduledjob.Platform).
-			SetScript(scheduledjob.Script).
 			SetWindmillPath(scheduledjob.WindmillPath).
 			SetDownloadURL(scheduledjob.DownloadURL).
 			SetConfiguration(scheduledjob.Configuration).
-			SetCadence(scheduledjob.Cadence).
 			SetNillableCron(scheduledjob.Cron).
 			Save(ctx)
 		if err != nil {

--- a/internal/ent/generated/migrate/schema.go
+++ b/internal/ent/generated/migrate/schema.go
@@ -3797,11 +3797,9 @@ var (
 		{Name: "title", Type: field.TypeString},
 		{Name: "description", Type: field.TypeString, Nullable: true},
 		{Name: "platform", Type: field.TypeEnum, Enums: []string{"GO", "TS"}},
-		{Name: "script", Type: field.TypeString, Nullable: true},
 		{Name: "windmill_path", Type: field.TypeString},
 		{Name: "download_url", Type: field.TypeString},
 		{Name: "configuration", Type: field.TypeJSON, Nullable: true},
-		{Name: "cadence", Type: field.TypeJSON, Nullable: true},
 		{Name: "cron", Type: field.TypeString, Nullable: true},
 		{Name: "owner_id", Type: field.TypeString, Nullable: true},
 	}
@@ -3813,7 +3811,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "scheduled_jobs_organizations_jobs",
-				Columns:    []*schema.Column{ScheduledJobsColumns[19]},
+				Columns:    []*schema.Column{ScheduledJobsColumns[17]},
 				RefColumns: []*schema.Column{OrganizationsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -3822,12 +3820,12 @@ var (
 			{
 				Name:    "scheduledjob_display_id_owner_id",
 				Unique:  true,
-				Columns: []*schema.Column{ScheduledJobsColumns[7], ScheduledJobsColumns[19]},
+				Columns: []*schema.Column{ScheduledJobsColumns[7], ScheduledJobsColumns[17]},
 			},
 			{
 				Name:    "scheduledjob_owner_id",
 				Unique:  false,
-				Columns: []*schema.Column{ScheduledJobsColumns[19]},
+				Columns: []*schema.Column{ScheduledJobsColumns[17]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "deleted_at is NULL",
 				},
@@ -3853,11 +3851,9 @@ var (
 		{Name: "title", Type: field.TypeString},
 		{Name: "description", Type: field.TypeString, Nullable: true},
 		{Name: "platform", Type: field.TypeEnum, Enums: []string{"GO", "TS"}},
-		{Name: "script", Type: field.TypeString, Nullable: true},
 		{Name: "windmill_path", Type: field.TypeString},
 		{Name: "download_url", Type: field.TypeString},
 		{Name: "configuration", Type: field.TypeJSON, Nullable: true},
-		{Name: "cadence", Type: field.TypeJSON, Nullable: true},
 		{Name: "cron", Type: field.TypeString, Nullable: true},
 	}
 	// ScheduledJobHistoryTable holds the schema information for the "scheduled_job_history" table.

--- a/internal/ent/generated/scheduledjob.go
+++ b/internal/ent/generated/scheduledjob.go
@@ -47,16 +47,12 @@ type ScheduledJob struct {
 	Description string `json:"description,omitempty"`
 	// the platform to use to execute this job
 	Platform enums.JobPlatformType `json:"platform,omitempty"`
-	// the script to run
-	Script string `json:"script,omitempty"`
 	// Windmill path
 	WindmillPath string `json:"windmill_path,omitempty"`
 	// the url from where to download the script from
 	DownloadURL string `json:"download_url,omitempty"`
 	// the configuration to run this job
 	Configuration models.JobConfiguration `json:"configuration,omitempty"`
-	// the schedule to run this job
-	Cadence models.JobCadence `json:"cadence,omitempty"`
 	// cron syntax
 	Cron *models.Cron `json:"cron,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
@@ -94,11 +90,11 @@ func (*ScheduledJob) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case scheduledjob.FieldCron:
 			values[i] = &sql.NullScanner{S: new(models.Cron)}
-		case scheduledjob.FieldTags, scheduledjob.FieldConfiguration, scheduledjob.FieldCadence:
+		case scheduledjob.FieldTags, scheduledjob.FieldConfiguration:
 			values[i] = new([]byte)
 		case scheduledjob.FieldSystemOwned:
 			values[i] = new(sql.NullBool)
-		case scheduledjob.FieldID, scheduledjob.FieldCreatedBy, scheduledjob.FieldUpdatedBy, scheduledjob.FieldDeletedBy, scheduledjob.FieldDisplayID, scheduledjob.FieldOwnerID, scheduledjob.FieldTitle, scheduledjob.FieldDescription, scheduledjob.FieldPlatform, scheduledjob.FieldScript, scheduledjob.FieldWindmillPath, scheduledjob.FieldDownloadURL:
+		case scheduledjob.FieldID, scheduledjob.FieldCreatedBy, scheduledjob.FieldUpdatedBy, scheduledjob.FieldDeletedBy, scheduledjob.FieldDisplayID, scheduledjob.FieldOwnerID, scheduledjob.FieldTitle, scheduledjob.FieldDescription, scheduledjob.FieldPlatform, scheduledjob.FieldWindmillPath, scheduledjob.FieldDownloadURL:
 			values[i] = new(sql.NullString)
 		case scheduledjob.FieldCreatedAt, scheduledjob.FieldUpdatedAt, scheduledjob.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
@@ -203,12 +199,6 @@ func (sj *ScheduledJob) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				sj.Platform = enums.JobPlatformType(value.String)
 			}
-		case scheduledjob.FieldScript:
-			if value, ok := values[i].(*sql.NullString); !ok {
-				return fmt.Errorf("unexpected type %T for field script", values[i])
-			} else if value.Valid {
-				sj.Script = value.String
-			}
 		case scheduledjob.FieldWindmillPath:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field windmill_path", values[i])
@@ -227,14 +217,6 @@ func (sj *ScheduledJob) assignValues(columns []string, values []any) error {
 			} else if value != nil && len(*value) > 0 {
 				if err := json.Unmarshal(*value, &sj.Configuration); err != nil {
 					return fmt.Errorf("unmarshal field configuration: %w", err)
-				}
-			}
-		case scheduledjob.FieldCadence:
-			if value, ok := values[i].(*[]byte); !ok {
-				return fmt.Errorf("unexpected type %T for field cadence", values[i])
-			} else if value != nil && len(*value) > 0 {
-				if err := json.Unmarshal(*value, &sj.Cadence); err != nil {
-					return fmt.Errorf("unmarshal field cadence: %w", err)
 				}
 			}
 		case scheduledjob.FieldCron:
@@ -324,9 +306,6 @@ func (sj *ScheduledJob) String() string {
 	builder.WriteString("platform=")
 	builder.WriteString(fmt.Sprintf("%v", sj.Platform))
 	builder.WriteString(", ")
-	builder.WriteString("script=")
-	builder.WriteString(sj.Script)
-	builder.WriteString(", ")
 	builder.WriteString("windmill_path=")
 	builder.WriteString(sj.WindmillPath)
 	builder.WriteString(", ")
@@ -335,9 +314,6 @@ func (sj *ScheduledJob) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("configuration=")
 	builder.WriteString(fmt.Sprintf("%v", sj.Configuration))
-	builder.WriteString(", ")
-	builder.WriteString("cadence=")
-	builder.WriteString(fmt.Sprintf("%v", sj.Cadence))
 	builder.WriteString(", ")
 	if v := sj.Cron; v != nil {
 		builder.WriteString("cron=")

--- a/internal/ent/generated/scheduledjob/scheduledjob.go
+++ b/internal/ent/generated/scheduledjob/scheduledjob.go
@@ -44,16 +44,12 @@ const (
 	FieldDescription = "description"
 	// FieldPlatform holds the string denoting the platform field in the database.
 	FieldPlatform = "platform"
-	// FieldScript holds the string denoting the script field in the database.
-	FieldScript = "script"
 	// FieldWindmillPath holds the string denoting the windmill_path field in the database.
 	FieldWindmillPath = "windmill_path"
 	// FieldDownloadURL holds the string denoting the download_url field in the database.
 	FieldDownloadURL = "download_url"
 	// FieldConfiguration holds the string denoting the configuration field in the database.
 	FieldConfiguration = "configuration"
-	// FieldCadence holds the string denoting the cadence field in the database.
-	FieldCadence = "cadence"
 	// FieldCron holds the string denoting the cron field in the database.
 	FieldCron = "cron"
 	// EdgeOwner holds the string denoting the owner edge name in mutations.
@@ -85,11 +81,9 @@ var Columns = []string{
 	FieldTitle,
 	FieldDescription,
 	FieldPlatform,
-	FieldScript,
 	FieldWindmillPath,
 	FieldDownloadURL,
 	FieldConfiguration,
-	FieldCadence,
 	FieldCron,
 }
 
@@ -206,11 +200,6 @@ func ByDescription(opts ...sql.OrderTermOption) OrderOption {
 // ByPlatform orders the results by the platform field.
 func ByPlatform(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldPlatform, opts...).ToFunc()
-}
-
-// ByScript orders the results by the script field.
-func ByScript(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldScript, opts...).ToFunc()
 }
 
 // ByWindmillPath orders the results by the windmill_path field.

--- a/internal/ent/generated/scheduledjob/where.go
+++ b/internal/ent/generated/scheduledjob/where.go
@@ -124,11 +124,6 @@ func Description(v string) predicate.ScheduledJob {
 	return predicate.ScheduledJob(sql.FieldEQ(FieldDescription, v))
 }
 
-// Script applies equality check predicate on the "script" field. It's identical to ScriptEQ.
-func Script(v string) predicate.ScheduledJob {
-	return predicate.ScheduledJob(sql.FieldEQ(FieldScript, v))
-}
-
 // WindmillPath applies equality check predicate on the "windmill_path" field. It's identical to WindmillPathEQ.
 func WindmillPath(v string) predicate.ScheduledJob {
 	return predicate.ScheduledJob(sql.FieldEQ(FieldWindmillPath, v))
@@ -859,81 +854,6 @@ func PlatformNotIn(vs ...enums.JobPlatformType) predicate.ScheduledJob {
 	return predicate.ScheduledJob(sql.FieldNotIn(FieldPlatform, v...))
 }
 
-// ScriptEQ applies the EQ predicate on the "script" field.
-func ScriptEQ(v string) predicate.ScheduledJob {
-	return predicate.ScheduledJob(sql.FieldEQ(FieldScript, v))
-}
-
-// ScriptNEQ applies the NEQ predicate on the "script" field.
-func ScriptNEQ(v string) predicate.ScheduledJob {
-	return predicate.ScheduledJob(sql.FieldNEQ(FieldScript, v))
-}
-
-// ScriptIn applies the In predicate on the "script" field.
-func ScriptIn(vs ...string) predicate.ScheduledJob {
-	return predicate.ScheduledJob(sql.FieldIn(FieldScript, vs...))
-}
-
-// ScriptNotIn applies the NotIn predicate on the "script" field.
-func ScriptNotIn(vs ...string) predicate.ScheduledJob {
-	return predicate.ScheduledJob(sql.FieldNotIn(FieldScript, vs...))
-}
-
-// ScriptGT applies the GT predicate on the "script" field.
-func ScriptGT(v string) predicate.ScheduledJob {
-	return predicate.ScheduledJob(sql.FieldGT(FieldScript, v))
-}
-
-// ScriptGTE applies the GTE predicate on the "script" field.
-func ScriptGTE(v string) predicate.ScheduledJob {
-	return predicate.ScheduledJob(sql.FieldGTE(FieldScript, v))
-}
-
-// ScriptLT applies the LT predicate on the "script" field.
-func ScriptLT(v string) predicate.ScheduledJob {
-	return predicate.ScheduledJob(sql.FieldLT(FieldScript, v))
-}
-
-// ScriptLTE applies the LTE predicate on the "script" field.
-func ScriptLTE(v string) predicate.ScheduledJob {
-	return predicate.ScheduledJob(sql.FieldLTE(FieldScript, v))
-}
-
-// ScriptContains applies the Contains predicate on the "script" field.
-func ScriptContains(v string) predicate.ScheduledJob {
-	return predicate.ScheduledJob(sql.FieldContains(FieldScript, v))
-}
-
-// ScriptHasPrefix applies the HasPrefix predicate on the "script" field.
-func ScriptHasPrefix(v string) predicate.ScheduledJob {
-	return predicate.ScheduledJob(sql.FieldHasPrefix(FieldScript, v))
-}
-
-// ScriptHasSuffix applies the HasSuffix predicate on the "script" field.
-func ScriptHasSuffix(v string) predicate.ScheduledJob {
-	return predicate.ScheduledJob(sql.FieldHasSuffix(FieldScript, v))
-}
-
-// ScriptIsNil applies the IsNil predicate on the "script" field.
-func ScriptIsNil() predicate.ScheduledJob {
-	return predicate.ScheduledJob(sql.FieldIsNull(FieldScript))
-}
-
-// ScriptNotNil applies the NotNil predicate on the "script" field.
-func ScriptNotNil() predicate.ScheduledJob {
-	return predicate.ScheduledJob(sql.FieldNotNull(FieldScript))
-}
-
-// ScriptEqualFold applies the EqualFold predicate on the "script" field.
-func ScriptEqualFold(v string) predicate.ScheduledJob {
-	return predicate.ScheduledJob(sql.FieldEqualFold(FieldScript, v))
-}
-
-// ScriptContainsFold applies the ContainsFold predicate on the "script" field.
-func ScriptContainsFold(v string) predicate.ScheduledJob {
-	return predicate.ScheduledJob(sql.FieldContainsFold(FieldScript, v))
-}
-
 // WindmillPathEQ applies the EQ predicate on the "windmill_path" field.
 func WindmillPathEQ(v string) predicate.ScheduledJob {
 	return predicate.ScheduledJob(sql.FieldEQ(FieldWindmillPath, v))
@@ -1072,16 +992,6 @@ func ConfigurationIsNil() predicate.ScheduledJob {
 // ConfigurationNotNil applies the NotNil predicate on the "configuration" field.
 func ConfigurationNotNil() predicate.ScheduledJob {
 	return predicate.ScheduledJob(sql.FieldNotNull(FieldConfiguration))
-}
-
-// CadenceIsNil applies the IsNil predicate on the "cadence" field.
-func CadenceIsNil() predicate.ScheduledJob {
-	return predicate.ScheduledJob(sql.FieldIsNull(FieldCadence))
-}
-
-// CadenceNotNil applies the NotNil predicate on the "cadence" field.
-func CadenceNotNil() predicate.ScheduledJob {
-	return predicate.ScheduledJob(sql.FieldNotNull(FieldCadence))
 }
 
 // CronEQ applies the EQ predicate on the "cron" field.

--- a/internal/ent/generated/scheduledjob_create.go
+++ b/internal/ent/generated/scheduledjob_create.go
@@ -173,20 +173,6 @@ func (sjc *ScheduledJobCreate) SetPlatform(ept enums.JobPlatformType) *Scheduled
 	return sjc
 }
 
-// SetScript sets the "script" field.
-func (sjc *ScheduledJobCreate) SetScript(s string) *ScheduledJobCreate {
-	sjc.mutation.SetScript(s)
-	return sjc
-}
-
-// SetNillableScript sets the "script" field if the given value is not nil.
-func (sjc *ScheduledJobCreate) SetNillableScript(s *string) *ScheduledJobCreate {
-	if s != nil {
-		sjc.SetScript(*s)
-	}
-	return sjc
-}
-
 // SetWindmillPath sets the "windmill_path" field.
 func (sjc *ScheduledJobCreate) SetWindmillPath(s string) *ScheduledJobCreate {
 	sjc.mutation.SetWindmillPath(s)
@@ -202,20 +188,6 @@ func (sjc *ScheduledJobCreate) SetDownloadURL(s string) *ScheduledJobCreate {
 // SetConfiguration sets the "configuration" field.
 func (sjc *ScheduledJobCreate) SetConfiguration(mc models.JobConfiguration) *ScheduledJobCreate {
 	sjc.mutation.SetConfiguration(mc)
-	return sjc
-}
-
-// SetCadence sets the "cadence" field.
-func (sjc *ScheduledJobCreate) SetCadence(mc models.JobCadence) *ScheduledJobCreate {
-	sjc.mutation.SetCadence(mc)
-	return sjc
-}
-
-// SetNillableCadence sets the "cadence" field if the given value is not nil.
-func (sjc *ScheduledJobCreate) SetNillableCadence(mc *models.JobCadence) *ScheduledJobCreate {
-	if mc != nil {
-		sjc.SetCadence(*mc)
-	}
 	return sjc
 }
 
@@ -353,11 +325,6 @@ func (sjc *ScheduledJobCreate) check() error {
 	if _, ok := sjc.mutation.DownloadURL(); !ok {
 		return &ValidationError{Name: "download_url", err: errors.New(`generated: missing required field "ScheduledJob.download_url"`)}
 	}
-	if v, ok := sjc.mutation.Cadence(); ok {
-		if err := v.Validate(); err != nil {
-			return &ValidationError{Name: "cadence", err: fmt.Errorf(`generated: validator failed for field "ScheduledJob.cadence": %w`, err)}
-		}
-	}
 	if v, ok := sjc.mutation.Cron(); ok {
 		if err := v.Validate(); err != nil {
 			return &ValidationError{Name: "cron", err: fmt.Errorf(`generated: validator failed for field "ScheduledJob.cron": %w`, err)}
@@ -447,10 +414,6 @@ func (sjc *ScheduledJobCreate) createSpec() (*ScheduledJob, *sqlgraph.CreateSpec
 		_spec.SetField(scheduledjob.FieldPlatform, field.TypeEnum, value)
 		_node.Platform = value
 	}
-	if value, ok := sjc.mutation.Script(); ok {
-		_spec.SetField(scheduledjob.FieldScript, field.TypeString, value)
-		_node.Script = value
-	}
 	if value, ok := sjc.mutation.WindmillPath(); ok {
 		_spec.SetField(scheduledjob.FieldWindmillPath, field.TypeString, value)
 		_node.WindmillPath = value
@@ -462,10 +425,6 @@ func (sjc *ScheduledJobCreate) createSpec() (*ScheduledJob, *sqlgraph.CreateSpec
 	if value, ok := sjc.mutation.Configuration(); ok {
 		_spec.SetField(scheduledjob.FieldConfiguration, field.TypeJSON, value)
 		_node.Configuration = value
-	}
-	if value, ok := sjc.mutation.Cadence(); ok {
-		_spec.SetField(scheduledjob.FieldCadence, field.TypeJSON, value)
-		_node.Cadence = value
 	}
 	if value, ok := sjc.mutation.Cron(); ok {
 		_spec.SetField(scheduledjob.FieldCron, field.TypeString, value)

--- a/internal/ent/generated/scheduledjob_update.go
+++ b/internal/ent/generated/scheduledjob_update.go
@@ -178,26 +178,6 @@ func (sju *ScheduledJobUpdate) ClearDescription() *ScheduledJobUpdate {
 	return sju
 }
 
-// SetScript sets the "script" field.
-func (sju *ScheduledJobUpdate) SetScript(s string) *ScheduledJobUpdate {
-	sju.mutation.SetScript(s)
-	return sju
-}
-
-// SetNillableScript sets the "script" field if the given value is not nil.
-func (sju *ScheduledJobUpdate) SetNillableScript(s *string) *ScheduledJobUpdate {
-	if s != nil {
-		sju.SetScript(*s)
-	}
-	return sju
-}
-
-// ClearScript clears the value of the "script" field.
-func (sju *ScheduledJobUpdate) ClearScript() *ScheduledJobUpdate {
-	sju.mutation.ClearScript()
-	return sju
-}
-
 // SetWindmillPath sets the "windmill_path" field.
 func (sju *ScheduledJobUpdate) SetWindmillPath(s string) *ScheduledJobUpdate {
 	sju.mutation.SetWindmillPath(s)
@@ -241,26 +221,6 @@ func (sju *ScheduledJobUpdate) AppendConfiguration(mc models.JobConfiguration) *
 // ClearConfiguration clears the value of the "configuration" field.
 func (sju *ScheduledJobUpdate) ClearConfiguration() *ScheduledJobUpdate {
 	sju.mutation.ClearConfiguration()
-	return sju
-}
-
-// SetCadence sets the "cadence" field.
-func (sju *ScheduledJobUpdate) SetCadence(mc models.JobCadence) *ScheduledJobUpdate {
-	sju.mutation.SetCadence(mc)
-	return sju
-}
-
-// SetNillableCadence sets the "cadence" field if the given value is not nil.
-func (sju *ScheduledJobUpdate) SetNillableCadence(mc *models.JobCadence) *ScheduledJobUpdate {
-	if mc != nil {
-		sju.SetCadence(*mc)
-	}
-	return sju
-}
-
-// ClearCadence clears the value of the "cadence" field.
-func (sju *ScheduledJobUpdate) ClearCadence() *ScheduledJobUpdate {
-	sju.mutation.ClearCadence()
 	return sju
 }
 
@@ -349,11 +309,6 @@ func (sju *ScheduledJobUpdate) check() error {
 			return &ValidationError{Name: "title", err: fmt.Errorf(`generated: validator failed for field "ScheduledJob.title": %w`, err)}
 		}
 	}
-	if v, ok := sju.mutation.Cadence(); ok {
-		if err := v.Validate(); err != nil {
-			return &ValidationError{Name: "cadence", err: fmt.Errorf(`generated: validator failed for field "ScheduledJob.cadence": %w`, err)}
-		}
-	}
 	if v, ok := sju.mutation.Cron(); ok {
 		if err := v.Validate(); err != nil {
 			return &ValidationError{Name: "cron", err: fmt.Errorf(`generated: validator failed for field "ScheduledJob.cron": %w`, err)}
@@ -433,12 +388,6 @@ func (sju *ScheduledJobUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	if sju.mutation.DescriptionCleared() {
 		_spec.ClearField(scheduledjob.FieldDescription, field.TypeString)
 	}
-	if value, ok := sju.mutation.Script(); ok {
-		_spec.SetField(scheduledjob.FieldScript, field.TypeString, value)
-	}
-	if sju.mutation.ScriptCleared() {
-		_spec.ClearField(scheduledjob.FieldScript, field.TypeString)
-	}
 	if value, ok := sju.mutation.WindmillPath(); ok {
 		_spec.SetField(scheduledjob.FieldWindmillPath, field.TypeString, value)
 	}
@@ -455,12 +404,6 @@ func (sju *ScheduledJobUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if sju.mutation.ConfigurationCleared() {
 		_spec.ClearField(scheduledjob.FieldConfiguration, field.TypeJSON)
-	}
-	if value, ok := sju.mutation.Cadence(); ok {
-		_spec.SetField(scheduledjob.FieldCadence, field.TypeJSON, value)
-	}
-	if sju.mutation.CadenceCleared() {
-		_spec.ClearField(scheduledjob.FieldCadence, field.TypeJSON)
 	}
 	if value, ok := sju.mutation.Cron(); ok {
 		_spec.SetField(scheduledjob.FieldCron, field.TypeString, value)
@@ -667,26 +610,6 @@ func (sjuo *ScheduledJobUpdateOne) ClearDescription() *ScheduledJobUpdateOne {
 	return sjuo
 }
 
-// SetScript sets the "script" field.
-func (sjuo *ScheduledJobUpdateOne) SetScript(s string) *ScheduledJobUpdateOne {
-	sjuo.mutation.SetScript(s)
-	return sjuo
-}
-
-// SetNillableScript sets the "script" field if the given value is not nil.
-func (sjuo *ScheduledJobUpdateOne) SetNillableScript(s *string) *ScheduledJobUpdateOne {
-	if s != nil {
-		sjuo.SetScript(*s)
-	}
-	return sjuo
-}
-
-// ClearScript clears the value of the "script" field.
-func (sjuo *ScheduledJobUpdateOne) ClearScript() *ScheduledJobUpdateOne {
-	sjuo.mutation.ClearScript()
-	return sjuo
-}
-
 // SetWindmillPath sets the "windmill_path" field.
 func (sjuo *ScheduledJobUpdateOne) SetWindmillPath(s string) *ScheduledJobUpdateOne {
 	sjuo.mutation.SetWindmillPath(s)
@@ -730,26 +653,6 @@ func (sjuo *ScheduledJobUpdateOne) AppendConfiguration(mc models.JobConfiguratio
 // ClearConfiguration clears the value of the "configuration" field.
 func (sjuo *ScheduledJobUpdateOne) ClearConfiguration() *ScheduledJobUpdateOne {
 	sjuo.mutation.ClearConfiguration()
-	return sjuo
-}
-
-// SetCadence sets the "cadence" field.
-func (sjuo *ScheduledJobUpdateOne) SetCadence(mc models.JobCadence) *ScheduledJobUpdateOne {
-	sjuo.mutation.SetCadence(mc)
-	return sjuo
-}
-
-// SetNillableCadence sets the "cadence" field if the given value is not nil.
-func (sjuo *ScheduledJobUpdateOne) SetNillableCadence(mc *models.JobCadence) *ScheduledJobUpdateOne {
-	if mc != nil {
-		sjuo.SetCadence(*mc)
-	}
-	return sjuo
-}
-
-// ClearCadence clears the value of the "cadence" field.
-func (sjuo *ScheduledJobUpdateOne) ClearCadence() *ScheduledJobUpdateOne {
-	sjuo.mutation.ClearCadence()
 	return sjuo
 }
 
@@ -851,11 +754,6 @@ func (sjuo *ScheduledJobUpdateOne) check() error {
 			return &ValidationError{Name: "title", err: fmt.Errorf(`generated: validator failed for field "ScheduledJob.title": %w`, err)}
 		}
 	}
-	if v, ok := sjuo.mutation.Cadence(); ok {
-		if err := v.Validate(); err != nil {
-			return &ValidationError{Name: "cadence", err: fmt.Errorf(`generated: validator failed for field "ScheduledJob.cadence": %w`, err)}
-		}
-	}
 	if v, ok := sjuo.mutation.Cron(); ok {
 		if err := v.Validate(); err != nil {
 			return &ValidationError{Name: "cron", err: fmt.Errorf(`generated: validator failed for field "ScheduledJob.cron": %w`, err)}
@@ -952,12 +850,6 @@ func (sjuo *ScheduledJobUpdateOne) sqlSave(ctx context.Context) (_node *Schedule
 	if sjuo.mutation.DescriptionCleared() {
 		_spec.ClearField(scheduledjob.FieldDescription, field.TypeString)
 	}
-	if value, ok := sjuo.mutation.Script(); ok {
-		_spec.SetField(scheduledjob.FieldScript, field.TypeString, value)
-	}
-	if sjuo.mutation.ScriptCleared() {
-		_spec.ClearField(scheduledjob.FieldScript, field.TypeString)
-	}
 	if value, ok := sjuo.mutation.WindmillPath(); ok {
 		_spec.SetField(scheduledjob.FieldWindmillPath, field.TypeString, value)
 	}
@@ -974,12 +866,6 @@ func (sjuo *ScheduledJobUpdateOne) sqlSave(ctx context.Context) (_node *Schedule
 	}
 	if sjuo.mutation.ConfigurationCleared() {
 		_spec.ClearField(scheduledjob.FieldConfiguration, field.TypeJSON)
-	}
-	if value, ok := sjuo.mutation.Cadence(); ok {
-		_spec.SetField(scheduledjob.FieldCadence, field.TypeJSON, value)
-	}
-	if sjuo.mutation.CadenceCleared() {
-		_spec.ClearField(scheduledjob.FieldCadence, field.TypeJSON)
 	}
 	if value, ok := sjuo.mutation.Cron(); ok {
 		_spec.SetField(scheduledjob.FieldCron, field.TypeString, value)

--- a/internal/ent/generated/scheduledjobhistory.go
+++ b/internal/ent/generated/scheduledjobhistory.go
@@ -53,16 +53,12 @@ type ScheduledJobHistory struct {
 	Description string `json:"description,omitempty"`
 	// the platform to use to execute this job
 	Platform enums.JobPlatformType `json:"platform,omitempty"`
-	// the script to run
-	Script string `json:"script,omitempty"`
 	// Windmill path
 	WindmillPath string `json:"windmill_path,omitempty"`
 	// the url from where to download the script from
 	DownloadURL string `json:"download_url,omitempty"`
 	// the configuration to run this job
 	Configuration models.JobConfiguration `json:"configuration,omitempty"`
-	// the schedule to run this job
-	Cadence models.JobCadence `json:"cadence,omitempty"`
 	// cron syntax
 	Cron         *models.Cron `json:"cron,omitempty"`
 	selectValues sql.SelectValues
@@ -75,13 +71,13 @@ func (*ScheduledJobHistory) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case scheduledjobhistory.FieldCron:
 			values[i] = &sql.NullScanner{S: new(models.Cron)}
-		case scheduledjobhistory.FieldTags, scheduledjobhistory.FieldConfiguration, scheduledjobhistory.FieldCadence:
+		case scheduledjobhistory.FieldTags, scheduledjobhistory.FieldConfiguration:
 			values[i] = new([]byte)
 		case scheduledjobhistory.FieldOperation:
 			values[i] = new(history.OpType)
 		case scheduledjobhistory.FieldSystemOwned:
 			values[i] = new(sql.NullBool)
-		case scheduledjobhistory.FieldID, scheduledjobhistory.FieldRef, scheduledjobhistory.FieldCreatedBy, scheduledjobhistory.FieldUpdatedBy, scheduledjobhistory.FieldDeletedBy, scheduledjobhistory.FieldDisplayID, scheduledjobhistory.FieldOwnerID, scheduledjobhistory.FieldTitle, scheduledjobhistory.FieldDescription, scheduledjobhistory.FieldPlatform, scheduledjobhistory.FieldScript, scheduledjobhistory.FieldWindmillPath, scheduledjobhistory.FieldDownloadURL:
+		case scheduledjobhistory.FieldID, scheduledjobhistory.FieldRef, scheduledjobhistory.FieldCreatedBy, scheduledjobhistory.FieldUpdatedBy, scheduledjobhistory.FieldDeletedBy, scheduledjobhistory.FieldDisplayID, scheduledjobhistory.FieldOwnerID, scheduledjobhistory.FieldTitle, scheduledjobhistory.FieldDescription, scheduledjobhistory.FieldPlatform, scheduledjobhistory.FieldWindmillPath, scheduledjobhistory.FieldDownloadURL:
 			values[i] = new(sql.NullString)
 		case scheduledjobhistory.FieldHistoryTime, scheduledjobhistory.FieldCreatedAt, scheduledjobhistory.FieldUpdatedAt, scheduledjobhistory.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
@@ -204,12 +200,6 @@ func (sjh *ScheduledJobHistory) assignValues(columns []string, values []any) err
 			} else if value.Valid {
 				sjh.Platform = enums.JobPlatformType(value.String)
 			}
-		case scheduledjobhistory.FieldScript:
-			if value, ok := values[i].(*sql.NullString); !ok {
-				return fmt.Errorf("unexpected type %T for field script", values[i])
-			} else if value.Valid {
-				sjh.Script = value.String
-			}
 		case scheduledjobhistory.FieldWindmillPath:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field windmill_path", values[i])
@@ -228,14 +218,6 @@ func (sjh *ScheduledJobHistory) assignValues(columns []string, values []any) err
 			} else if value != nil && len(*value) > 0 {
 				if err := json.Unmarshal(*value, &sjh.Configuration); err != nil {
 					return fmt.Errorf("unmarshal field configuration: %w", err)
-				}
-			}
-		case scheduledjobhistory.FieldCadence:
-			if value, ok := values[i].(*[]byte); !ok {
-				return fmt.Errorf("unexpected type %T for field cadence", values[i])
-			} else if value != nil && len(*value) > 0 {
-				if err := json.Unmarshal(*value, &sjh.Cadence); err != nil {
-					return fmt.Errorf("unmarshal field cadence: %w", err)
 				}
 			}
 		case scheduledjobhistory.FieldCron:
@@ -329,9 +311,6 @@ func (sjh *ScheduledJobHistory) String() string {
 	builder.WriteString("platform=")
 	builder.WriteString(fmt.Sprintf("%v", sjh.Platform))
 	builder.WriteString(", ")
-	builder.WriteString("script=")
-	builder.WriteString(sjh.Script)
-	builder.WriteString(", ")
 	builder.WriteString("windmill_path=")
 	builder.WriteString(sjh.WindmillPath)
 	builder.WriteString(", ")
@@ -340,9 +319,6 @@ func (sjh *ScheduledJobHistory) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("configuration=")
 	builder.WriteString(fmt.Sprintf("%v", sjh.Configuration))
-	builder.WriteString(", ")
-	builder.WriteString("cadence=")
-	builder.WriteString(fmt.Sprintf("%v", sjh.Cadence))
 	builder.WriteString(", ")
 	if v := sjh.Cron; v != nil {
 		builder.WriteString("cron=")

--- a/internal/ent/generated/scheduledjobhistory/scheduledjobhistory.go
+++ b/internal/ent/generated/scheduledjobhistory/scheduledjobhistory.go
@@ -50,16 +50,12 @@ const (
 	FieldDescription = "description"
 	// FieldPlatform holds the string denoting the platform field in the database.
 	FieldPlatform = "platform"
-	// FieldScript holds the string denoting the script field in the database.
-	FieldScript = "script"
 	// FieldWindmillPath holds the string denoting the windmill_path field in the database.
 	FieldWindmillPath = "windmill_path"
 	// FieldDownloadURL holds the string denoting the download_url field in the database.
 	FieldDownloadURL = "download_url"
 	// FieldConfiguration holds the string denoting the configuration field in the database.
 	FieldConfiguration = "configuration"
-	// FieldCadence holds the string denoting the cadence field in the database.
-	FieldCadence = "cadence"
 	// FieldCron holds the string denoting the cron field in the database.
 	FieldCron = "cron"
 	// Table holds the table name of the scheduledjobhistory in the database.
@@ -85,11 +81,9 @@ var Columns = []string{
 	FieldTitle,
 	FieldDescription,
 	FieldPlatform,
-	FieldScript,
 	FieldWindmillPath,
 	FieldDownloadURL,
 	FieldConfiguration,
-	FieldCadence,
 	FieldCron,
 }
 
@@ -229,11 +223,6 @@ func ByDescription(opts ...sql.OrderTermOption) OrderOption {
 // ByPlatform orders the results by the platform field.
 func ByPlatform(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldPlatform, opts...).ToFunc()
-}
-
-// ByScript orders the results by the script field.
-func ByScript(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldScript, opts...).ToFunc()
 }
 
 // ByWindmillPath orders the results by the windmill_path field.

--- a/internal/ent/generated/scheduledjobhistory/where.go
+++ b/internal/ent/generated/scheduledjobhistory/where.go
@@ -132,11 +132,6 @@ func Description(v string) predicate.ScheduledJobHistory {
 	return predicate.ScheduledJobHistory(sql.FieldEQ(FieldDescription, v))
 }
 
-// Script applies equality check predicate on the "script" field. It's identical to ScriptEQ.
-func Script(v string) predicate.ScheduledJobHistory {
-	return predicate.ScheduledJobHistory(sql.FieldEQ(FieldScript, v))
-}
-
 // WindmillPath applies equality check predicate on the "windmill_path" field. It's identical to WindmillPathEQ.
 func WindmillPath(v string) predicate.ScheduledJobHistory {
 	return predicate.ScheduledJobHistory(sql.FieldEQ(FieldWindmillPath, v))
@@ -1002,81 +997,6 @@ func PlatformNotIn(vs ...enums.JobPlatformType) predicate.ScheduledJobHistory {
 	return predicate.ScheduledJobHistory(sql.FieldNotIn(FieldPlatform, v...))
 }
 
-// ScriptEQ applies the EQ predicate on the "script" field.
-func ScriptEQ(v string) predicate.ScheduledJobHistory {
-	return predicate.ScheduledJobHistory(sql.FieldEQ(FieldScript, v))
-}
-
-// ScriptNEQ applies the NEQ predicate on the "script" field.
-func ScriptNEQ(v string) predicate.ScheduledJobHistory {
-	return predicate.ScheduledJobHistory(sql.FieldNEQ(FieldScript, v))
-}
-
-// ScriptIn applies the In predicate on the "script" field.
-func ScriptIn(vs ...string) predicate.ScheduledJobHistory {
-	return predicate.ScheduledJobHistory(sql.FieldIn(FieldScript, vs...))
-}
-
-// ScriptNotIn applies the NotIn predicate on the "script" field.
-func ScriptNotIn(vs ...string) predicate.ScheduledJobHistory {
-	return predicate.ScheduledJobHistory(sql.FieldNotIn(FieldScript, vs...))
-}
-
-// ScriptGT applies the GT predicate on the "script" field.
-func ScriptGT(v string) predicate.ScheduledJobHistory {
-	return predicate.ScheduledJobHistory(sql.FieldGT(FieldScript, v))
-}
-
-// ScriptGTE applies the GTE predicate on the "script" field.
-func ScriptGTE(v string) predicate.ScheduledJobHistory {
-	return predicate.ScheduledJobHistory(sql.FieldGTE(FieldScript, v))
-}
-
-// ScriptLT applies the LT predicate on the "script" field.
-func ScriptLT(v string) predicate.ScheduledJobHistory {
-	return predicate.ScheduledJobHistory(sql.FieldLT(FieldScript, v))
-}
-
-// ScriptLTE applies the LTE predicate on the "script" field.
-func ScriptLTE(v string) predicate.ScheduledJobHistory {
-	return predicate.ScheduledJobHistory(sql.FieldLTE(FieldScript, v))
-}
-
-// ScriptContains applies the Contains predicate on the "script" field.
-func ScriptContains(v string) predicate.ScheduledJobHistory {
-	return predicate.ScheduledJobHistory(sql.FieldContains(FieldScript, v))
-}
-
-// ScriptHasPrefix applies the HasPrefix predicate on the "script" field.
-func ScriptHasPrefix(v string) predicate.ScheduledJobHistory {
-	return predicate.ScheduledJobHistory(sql.FieldHasPrefix(FieldScript, v))
-}
-
-// ScriptHasSuffix applies the HasSuffix predicate on the "script" field.
-func ScriptHasSuffix(v string) predicate.ScheduledJobHistory {
-	return predicate.ScheduledJobHistory(sql.FieldHasSuffix(FieldScript, v))
-}
-
-// ScriptIsNil applies the IsNil predicate on the "script" field.
-func ScriptIsNil() predicate.ScheduledJobHistory {
-	return predicate.ScheduledJobHistory(sql.FieldIsNull(FieldScript))
-}
-
-// ScriptNotNil applies the NotNil predicate on the "script" field.
-func ScriptNotNil() predicate.ScheduledJobHistory {
-	return predicate.ScheduledJobHistory(sql.FieldNotNull(FieldScript))
-}
-
-// ScriptEqualFold applies the EqualFold predicate on the "script" field.
-func ScriptEqualFold(v string) predicate.ScheduledJobHistory {
-	return predicate.ScheduledJobHistory(sql.FieldEqualFold(FieldScript, v))
-}
-
-// ScriptContainsFold applies the ContainsFold predicate on the "script" field.
-func ScriptContainsFold(v string) predicate.ScheduledJobHistory {
-	return predicate.ScheduledJobHistory(sql.FieldContainsFold(FieldScript, v))
-}
-
 // WindmillPathEQ applies the EQ predicate on the "windmill_path" field.
 func WindmillPathEQ(v string) predicate.ScheduledJobHistory {
 	return predicate.ScheduledJobHistory(sql.FieldEQ(FieldWindmillPath, v))
@@ -1215,16 +1135,6 @@ func ConfigurationIsNil() predicate.ScheduledJobHistory {
 // ConfigurationNotNil applies the NotNil predicate on the "configuration" field.
 func ConfigurationNotNil() predicate.ScheduledJobHistory {
 	return predicate.ScheduledJobHistory(sql.FieldNotNull(FieldConfiguration))
-}
-
-// CadenceIsNil applies the IsNil predicate on the "cadence" field.
-func CadenceIsNil() predicate.ScheduledJobHistory {
-	return predicate.ScheduledJobHistory(sql.FieldIsNull(FieldCadence))
-}
-
-// CadenceNotNil applies the NotNil predicate on the "cadence" field.
-func CadenceNotNil() predicate.ScheduledJobHistory {
-	return predicate.ScheduledJobHistory(sql.FieldNotNull(FieldCadence))
 }
 
 // CronEQ applies the EQ predicate on the "cron" field.

--- a/internal/ent/generated/scheduledjobhistory_create.go
+++ b/internal/ent/generated/scheduledjobhistory_create.go
@@ -207,20 +207,6 @@ func (sjhc *ScheduledJobHistoryCreate) SetPlatform(ept enums.JobPlatformType) *S
 	return sjhc
 }
 
-// SetScript sets the "script" field.
-func (sjhc *ScheduledJobHistoryCreate) SetScript(s string) *ScheduledJobHistoryCreate {
-	sjhc.mutation.SetScript(s)
-	return sjhc
-}
-
-// SetNillableScript sets the "script" field if the given value is not nil.
-func (sjhc *ScheduledJobHistoryCreate) SetNillableScript(s *string) *ScheduledJobHistoryCreate {
-	if s != nil {
-		sjhc.SetScript(*s)
-	}
-	return sjhc
-}
-
 // SetWindmillPath sets the "windmill_path" field.
 func (sjhc *ScheduledJobHistoryCreate) SetWindmillPath(s string) *ScheduledJobHistoryCreate {
 	sjhc.mutation.SetWindmillPath(s)
@@ -236,20 +222,6 @@ func (sjhc *ScheduledJobHistoryCreate) SetDownloadURL(s string) *ScheduledJobHis
 // SetConfiguration sets the "configuration" field.
 func (sjhc *ScheduledJobHistoryCreate) SetConfiguration(mc models.JobConfiguration) *ScheduledJobHistoryCreate {
 	sjhc.mutation.SetConfiguration(mc)
-	return sjhc
-}
-
-// SetCadence sets the "cadence" field.
-func (sjhc *ScheduledJobHistoryCreate) SetCadence(mc models.JobCadence) *ScheduledJobHistoryCreate {
-	sjhc.mutation.SetCadence(mc)
-	return sjhc
-}
-
-// SetNillableCadence sets the "cadence" field if the given value is not nil.
-func (sjhc *ScheduledJobHistoryCreate) SetNillableCadence(mc *models.JobCadence) *ScheduledJobHistoryCreate {
-	if mc != nil {
-		sjhc.SetCadence(*mc)
-	}
 	return sjhc
 }
 
@@ -390,11 +362,6 @@ func (sjhc *ScheduledJobHistoryCreate) check() error {
 	if _, ok := sjhc.mutation.DownloadURL(); !ok {
 		return &ValidationError{Name: "download_url", err: errors.New(`generated: missing required field "ScheduledJobHistory.download_url"`)}
 	}
-	if v, ok := sjhc.mutation.Cadence(); ok {
-		if err := v.Validate(); err != nil {
-			return &ValidationError{Name: "cadence", err: fmt.Errorf(`generated: validator failed for field "ScheduledJobHistory.cadence": %w`, err)}
-		}
-	}
 	if v, ok := sjhc.mutation.Cron(); ok {
 		if err := v.Validate(); err != nil {
 			return &ValidationError{Name: "cron", err: fmt.Errorf(`generated: validator failed for field "ScheduledJobHistory.cron": %w`, err)}
@@ -500,10 +467,6 @@ func (sjhc *ScheduledJobHistoryCreate) createSpec() (*ScheduledJobHistory, *sqlg
 		_spec.SetField(scheduledjobhistory.FieldPlatform, field.TypeEnum, value)
 		_node.Platform = value
 	}
-	if value, ok := sjhc.mutation.Script(); ok {
-		_spec.SetField(scheduledjobhistory.FieldScript, field.TypeString, value)
-		_node.Script = value
-	}
 	if value, ok := sjhc.mutation.WindmillPath(); ok {
 		_spec.SetField(scheduledjobhistory.FieldWindmillPath, field.TypeString, value)
 		_node.WindmillPath = value
@@ -515,10 +478,6 @@ func (sjhc *ScheduledJobHistoryCreate) createSpec() (*ScheduledJobHistory, *sqlg
 	if value, ok := sjhc.mutation.Configuration(); ok {
 		_spec.SetField(scheduledjobhistory.FieldConfiguration, field.TypeJSON, value)
 		_node.Configuration = value
-	}
-	if value, ok := sjhc.mutation.Cadence(); ok {
-		_spec.SetField(scheduledjobhistory.FieldCadence, field.TypeJSON, value)
-		_node.Cadence = value
 	}
 	if value, ok := sjhc.mutation.Cron(); ok {
 		_spec.SetField(scheduledjobhistory.FieldCron, field.TypeString, value)

--- a/internal/ent/generated/scheduledjobhistory_update.go
+++ b/internal/ent/generated/scheduledjobhistory_update.go
@@ -177,26 +177,6 @@ func (sjhu *ScheduledJobHistoryUpdate) ClearDescription() *ScheduledJobHistoryUp
 	return sjhu
 }
 
-// SetScript sets the "script" field.
-func (sjhu *ScheduledJobHistoryUpdate) SetScript(s string) *ScheduledJobHistoryUpdate {
-	sjhu.mutation.SetScript(s)
-	return sjhu
-}
-
-// SetNillableScript sets the "script" field if the given value is not nil.
-func (sjhu *ScheduledJobHistoryUpdate) SetNillableScript(s *string) *ScheduledJobHistoryUpdate {
-	if s != nil {
-		sjhu.SetScript(*s)
-	}
-	return sjhu
-}
-
-// ClearScript clears the value of the "script" field.
-func (sjhu *ScheduledJobHistoryUpdate) ClearScript() *ScheduledJobHistoryUpdate {
-	sjhu.mutation.ClearScript()
-	return sjhu
-}
-
 // SetWindmillPath sets the "windmill_path" field.
 func (sjhu *ScheduledJobHistoryUpdate) SetWindmillPath(s string) *ScheduledJobHistoryUpdate {
 	sjhu.mutation.SetWindmillPath(s)
@@ -240,26 +220,6 @@ func (sjhu *ScheduledJobHistoryUpdate) AppendConfiguration(mc models.JobConfigur
 // ClearConfiguration clears the value of the "configuration" field.
 func (sjhu *ScheduledJobHistoryUpdate) ClearConfiguration() *ScheduledJobHistoryUpdate {
 	sjhu.mutation.ClearConfiguration()
-	return sjhu
-}
-
-// SetCadence sets the "cadence" field.
-func (sjhu *ScheduledJobHistoryUpdate) SetCadence(mc models.JobCadence) *ScheduledJobHistoryUpdate {
-	sjhu.mutation.SetCadence(mc)
-	return sjhu
-}
-
-// SetNillableCadence sets the "cadence" field if the given value is not nil.
-func (sjhu *ScheduledJobHistoryUpdate) SetNillableCadence(mc *models.JobCadence) *ScheduledJobHistoryUpdate {
-	if mc != nil {
-		sjhu.SetCadence(*mc)
-	}
-	return sjhu
-}
-
-// ClearCadence clears the value of the "cadence" field.
-func (sjhu *ScheduledJobHistoryUpdate) ClearCadence() *ScheduledJobHistoryUpdate {
-	sjhu.mutation.ClearCadence()
 	return sjhu
 }
 
@@ -407,12 +367,6 @@ func (sjhu *ScheduledJobHistoryUpdate) sqlSave(ctx context.Context) (n int, err 
 	if sjhu.mutation.DescriptionCleared() {
 		_spec.ClearField(scheduledjobhistory.FieldDescription, field.TypeString)
 	}
-	if value, ok := sjhu.mutation.Script(); ok {
-		_spec.SetField(scheduledjobhistory.FieldScript, field.TypeString, value)
-	}
-	if sjhu.mutation.ScriptCleared() {
-		_spec.ClearField(scheduledjobhistory.FieldScript, field.TypeString)
-	}
 	if value, ok := sjhu.mutation.WindmillPath(); ok {
 		_spec.SetField(scheduledjobhistory.FieldWindmillPath, field.TypeString, value)
 	}
@@ -429,12 +383,6 @@ func (sjhu *ScheduledJobHistoryUpdate) sqlSave(ctx context.Context) (n int, err 
 	}
 	if sjhu.mutation.ConfigurationCleared() {
 		_spec.ClearField(scheduledjobhistory.FieldConfiguration, field.TypeJSON)
-	}
-	if value, ok := sjhu.mutation.Cadence(); ok {
-		_spec.SetField(scheduledjobhistory.FieldCadence, field.TypeJSON, value)
-	}
-	if sjhu.mutation.CadenceCleared() {
-		_spec.ClearField(scheduledjobhistory.FieldCadence, field.TypeJSON)
 	}
 	if value, ok := sjhu.mutation.Cron(); ok {
 		_spec.SetField(scheduledjobhistory.FieldCron, field.TypeString, value)
@@ -610,26 +558,6 @@ func (sjhuo *ScheduledJobHistoryUpdateOne) ClearDescription() *ScheduledJobHisto
 	return sjhuo
 }
 
-// SetScript sets the "script" field.
-func (sjhuo *ScheduledJobHistoryUpdateOne) SetScript(s string) *ScheduledJobHistoryUpdateOne {
-	sjhuo.mutation.SetScript(s)
-	return sjhuo
-}
-
-// SetNillableScript sets the "script" field if the given value is not nil.
-func (sjhuo *ScheduledJobHistoryUpdateOne) SetNillableScript(s *string) *ScheduledJobHistoryUpdateOne {
-	if s != nil {
-		sjhuo.SetScript(*s)
-	}
-	return sjhuo
-}
-
-// ClearScript clears the value of the "script" field.
-func (sjhuo *ScheduledJobHistoryUpdateOne) ClearScript() *ScheduledJobHistoryUpdateOne {
-	sjhuo.mutation.ClearScript()
-	return sjhuo
-}
-
 // SetWindmillPath sets the "windmill_path" field.
 func (sjhuo *ScheduledJobHistoryUpdateOne) SetWindmillPath(s string) *ScheduledJobHistoryUpdateOne {
 	sjhuo.mutation.SetWindmillPath(s)
@@ -673,26 +601,6 @@ func (sjhuo *ScheduledJobHistoryUpdateOne) AppendConfiguration(mc models.JobConf
 // ClearConfiguration clears the value of the "configuration" field.
 func (sjhuo *ScheduledJobHistoryUpdateOne) ClearConfiguration() *ScheduledJobHistoryUpdateOne {
 	sjhuo.mutation.ClearConfiguration()
-	return sjhuo
-}
-
-// SetCadence sets the "cadence" field.
-func (sjhuo *ScheduledJobHistoryUpdateOne) SetCadence(mc models.JobCadence) *ScheduledJobHistoryUpdateOne {
-	sjhuo.mutation.SetCadence(mc)
-	return sjhuo
-}
-
-// SetNillableCadence sets the "cadence" field if the given value is not nil.
-func (sjhuo *ScheduledJobHistoryUpdateOne) SetNillableCadence(mc *models.JobCadence) *ScheduledJobHistoryUpdateOne {
-	if mc != nil {
-		sjhuo.SetCadence(*mc)
-	}
-	return sjhuo
-}
-
-// ClearCadence clears the value of the "cadence" field.
-func (sjhuo *ScheduledJobHistoryUpdateOne) ClearCadence() *ScheduledJobHistoryUpdateOne {
-	sjhuo.mutation.ClearCadence()
 	return sjhuo
 }
 
@@ -870,12 +778,6 @@ func (sjhuo *ScheduledJobHistoryUpdateOne) sqlSave(ctx context.Context) (_node *
 	if sjhuo.mutation.DescriptionCleared() {
 		_spec.ClearField(scheduledjobhistory.FieldDescription, field.TypeString)
 	}
-	if value, ok := sjhuo.mutation.Script(); ok {
-		_spec.SetField(scheduledjobhistory.FieldScript, field.TypeString, value)
-	}
-	if sjhuo.mutation.ScriptCleared() {
-		_spec.ClearField(scheduledjobhistory.FieldScript, field.TypeString)
-	}
 	if value, ok := sjhuo.mutation.WindmillPath(); ok {
 		_spec.SetField(scheduledjobhistory.FieldWindmillPath, field.TypeString, value)
 	}
@@ -892,12 +794,6 @@ func (sjhuo *ScheduledJobHistoryUpdateOne) sqlSave(ctx context.Context) (_node *
 	}
 	if sjhuo.mutation.ConfigurationCleared() {
 		_spec.ClearField(scheduledjobhistory.FieldConfiguration, field.TypeJSON)
-	}
-	if value, ok := sjhuo.mutation.Cadence(); ok {
-		_spec.SetField(scheduledjobhistory.FieldCadence, field.TypeJSON, value)
-	}
-	if sjhuo.mutation.CadenceCleared() {
-		_spec.ClearField(scheduledjobhistory.FieldCadence, field.TypeJSON)
 	}
 	if value, ok := sjhuo.mutation.Cron(); ok {
 		_spec.SetField(scheduledjobhistory.FieldCron, field.TypeString, value)

--- a/internal/ent/schema/scheduled_job.go
+++ b/internal/ent/schema/scheduled_job.go
@@ -62,16 +62,6 @@ func (ScheduledJob) Fields() []ent.Field {
 			).
 			Comment("the platform to use to execute this job"),
 
-		field.String("script").
-			Annotations(
-				entgql.Skip(
-					entgql.SkipOrderField |
-						entgql.SkipWhereInput,
-				),
-			).
-			Optional().
-			Comment("the script to run"),
-
 		field.String("windmill_path").
 			Annotations(
 				entgql.Skip(
@@ -95,10 +85,6 @@ func (ScheduledJob) Fields() []ent.Field {
 		field.JSON("configuration", models.JobConfiguration{}).
 			Optional().
 			Comment("the configuration to run this job"),
-
-		field.JSON("cadence", models.JobCadence{}).
-			Comment("the schedule to run this job").
-			Optional(),
 
 		field.String("cron").
 			GoType(models.Cron("")).

--- a/internal/graphapi/clientschema/schema.graphql
+++ b/internal/graphapi/clientschema/schema.graphql
@@ -9529,10 +9529,6 @@ input CreateScheduledJobInput {
 	"""
 	platform: ScheduledJobJobPlatformType!
 	"""
-	the script to run
-	"""
-	script: String
-	"""
 	the url from where to download the script from
 	"""
 	downloadURL: String!
@@ -9540,10 +9536,6 @@ input CreateScheduledJobInput {
 	the configuration to run this job
 	"""
 	configuration: JobConfiguration
-	"""
-	the schedule to run this job
-	"""
-	cadence: JobCadence
 	"""
 	cron syntax
 	"""
@@ -46612,10 +46604,6 @@ type ScheduledJob implements Node {
 	"""
 	platform: ScheduledJobJobPlatformType!
 	"""
-	the script to run
-	"""
-	script: String
-	"""
 	Windmill path
 	"""
 	windmillPath: String!
@@ -46627,10 +46615,6 @@ type ScheduledJob implements Node {
 	the configuration to run this job
 	"""
 	configuration: JobConfiguration
-	"""
-	the schedule to run this job
-	"""
-	cadence: JobCadence
 	"""
 	cron syntax
 	"""
@@ -46732,10 +46716,6 @@ type ScheduledJobHistory implements Node {
 	"""
 	platform: ScheduledJobHistoryJobPlatformType!
 	"""
-	the script to run
-	"""
-	script: String
-	"""
 	Windmill path
 	"""
 	windmillPath: String!
@@ -46747,10 +46727,6 @@ type ScheduledJobHistory implements Node {
 	the configuration to run this job
 	"""
 	configuration: JobConfiguration
-	"""
-	the schedule to run this job
-	"""
-	cadence: JobCadence
 	"""
 	cron syntax
 	"""
@@ -58032,11 +58008,6 @@ input UpdateScheduledJobInput {
 	description: String
 	clearDescription: Boolean
 	"""
-	the script to run
-	"""
-	script: String
-	clearScript: Boolean
-	"""
 	the url from where to download the script from
 	"""
 	downloadURL: String
@@ -58046,11 +58017,6 @@ input UpdateScheduledJobInput {
 	configuration: JobConfiguration
 	appendConfiguration: JobConfiguration
 	clearConfiguration: Boolean
-	"""
-	the schedule to run this job
-	"""
-	cadence: JobCadence
-	clearCadence: Boolean
 	"""
 	cron syntax
 	"""

--- a/internal/graphapi/generated/root_.generated.go
+++ b/internal/graphapi/generated/root_.generated.go
@@ -3832,7 +3832,6 @@ type ComplexityRoot struct {
 	}
 
 	ScheduledJob struct {
-		Cadence       func(childComplexity int) int
 		Configuration func(childComplexity int) int
 		CreatedAt     func(childComplexity int) int
 		CreatedBy     func(childComplexity int) int
@@ -3844,7 +3843,6 @@ type ComplexityRoot struct {
 		Owner         func(childComplexity int) int
 		OwnerID       func(childComplexity int) int
 		Platform      func(childComplexity int) int
-		Script        func(childComplexity int) int
 		SystemOwned   func(childComplexity int) int
 		Tags          func(childComplexity int) int
 		Title         func(childComplexity int) int
@@ -3877,7 +3875,6 @@ type ComplexityRoot struct {
 	}
 
 	ScheduledJobHistory struct {
-		Cadence       func(childComplexity int) int
 		Configuration func(childComplexity int) int
 		CreatedAt     func(childComplexity int) int
 		CreatedBy     func(childComplexity int) int
@@ -3891,7 +3888,6 @@ type ComplexityRoot struct {
 		OwnerID       func(childComplexity int) int
 		Platform      func(childComplexity int) int
 		Ref           func(childComplexity int) int
-		Script        func(childComplexity int) int
 		SystemOwned   func(childComplexity int) int
 		Tags          func(childComplexity int) int
 		Title         func(childComplexity int) int
@@ -26975,13 +26971,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.ScanUpdatePayload.Scan(childComplexity), true
 
-	case "ScheduledJob.cadence":
-		if e.complexity.ScheduledJob.Cadence == nil {
-			break
-		}
-
-		return e.complexity.ScheduledJob.Cadence(childComplexity), true
-
 	case "ScheduledJob.configuration":
 		if e.complexity.ScheduledJob.Configuration == nil {
 			break
@@ -27058,13 +27047,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.ScheduledJob.Platform(childComplexity), true
-
-	case "ScheduledJob.script":
-		if e.complexity.ScheduledJob.Script == nil {
-			break
-		}
-
-		return e.complexity.ScheduledJob.Script(childComplexity), true
 
 	case "ScheduledJob.systemOwned":
 		if e.complexity.ScheduledJob.SystemOwned == nil {
@@ -27164,13 +27146,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.ScheduledJobEdge.Node(childComplexity), true
 
-	case "ScheduledJobHistory.cadence":
-		if e.complexity.ScheduledJobHistory.Cadence == nil {
-			break
-		}
-
-		return e.complexity.ScheduledJobHistory.Cadence(childComplexity), true
-
 	case "ScheduledJobHistory.configuration":
 		if e.complexity.ScheduledJobHistory.Configuration == nil {
 			break
@@ -27261,13 +27236,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.ScheduledJobHistory.Ref(childComplexity), true
-
-	case "ScheduledJobHistory.script":
-		if e.complexity.ScheduledJobHistory.Script == nil {
-			break
-		}
-
-		return e.complexity.ScheduledJobHistory.Script(childComplexity), true
 
 	case "ScheduledJobHistory.systemOwned":
 		if e.complexity.ScheduledJobHistory.SystemOwned == nil {
@@ -44559,10 +44527,6 @@ input CreateScheduledJobInput {
   """
   platform: ScheduledJobJobPlatformType!
   """
-  the script to run
-  """
-  script: String
-  """
   the url from where to download the script from
   """
   downloadURL: String!
@@ -44570,10 +44534,6 @@ input CreateScheduledJobInput {
   the configuration to run this job
   """
   configuration: JobConfiguration
-  """
-  the schedule to run this job
-  """
-  cadence: JobCadence
   """
   cron syntax
   """
@@ -74567,10 +74527,6 @@ type ScheduledJob implements Node {
   """
   platform: ScheduledJobJobPlatformType!
   """
-  the script to run
-  """
-  script: String
-  """
   Windmill path
   """
   windmillPath: String!
@@ -74582,10 +74538,6 @@ type ScheduledJob implements Node {
   the configuration to run this job
   """
   configuration: JobConfiguration
-  """
-  the schedule to run this job
-  """
-  cadence: JobCadence
   """
   cron syntax
   """
@@ -74660,10 +74612,6 @@ type ScheduledJobHistory implements Node {
   """
   platform: ScheduledJobHistoryJobPlatformType!
   """
-  the script to run
-  """
-  script: String
-  """
   Windmill path
   """
   windmillPath: String!
@@ -74675,10 +74623,6 @@ type ScheduledJobHistory implements Node {
   the configuration to run this job
   """
   configuration: JobConfiguration
-  """
-  the schedule to run this job
-  """
-  cadence: JobCadence
   """
   cron syntax
   """
@@ -85504,11 +85448,6 @@ input UpdateScheduledJobInput {
   description: String
   clearDescription: Boolean
   """
-  the script to run
-  """
-  script: String
-  clearScript: Boolean
-  """
   the url from where to download the script from
   """
   downloadURL: String
@@ -85518,11 +85457,6 @@ input UpdateScheduledJobInput {
   configuration: JobConfiguration
   appendConfiguration: JobConfiguration
   clearConfiguration: Boolean
-  """
-  the schedule to run this job
-  """
-  cadence: JobCadence
-  clearCadence: Boolean
   """
   cron syntax
   """

--- a/internal/graphapi/generated/scalars.generated.go
+++ b/internal/graphapi/generated/scalars.generated.go
@@ -428,32 +428,6 @@ func (ec *executionContext) marshalOImplementationGuidance2ᚕgithubᚗcomᚋthe
 	return ret
 }
 
-func (ec *executionContext) unmarshalOJobCadence2githubᚗcomᚋtheopenlaneᚋcoreᚋpkgᚋmodelsᚐJobCadence(ctx context.Context, v any) (models.JobCadence, error) {
-	var res models.JobCadence
-	err := res.UnmarshalGQL(v)
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalOJobCadence2githubᚗcomᚋtheopenlaneᚋcoreᚋpkgᚋmodelsᚐJobCadence(ctx context.Context, sel ast.SelectionSet, v models.JobCadence) graphql.Marshaler {
-	return v
-}
-
-func (ec *executionContext) unmarshalOJobCadence2ᚖgithubᚗcomᚋtheopenlaneᚋcoreᚋpkgᚋmodelsᚐJobCadence(ctx context.Context, v any) (*models.JobCadence, error) {
-	if v == nil {
-		return nil, nil
-	}
-	var res = new(models.JobCadence)
-	err := res.UnmarshalGQL(v)
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalOJobCadence2ᚖgithubᚗcomᚋtheopenlaneᚋcoreᚋpkgᚋmodelsᚐJobCadence(ctx context.Context, sel ast.SelectionSet, v *models.JobCadence) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return v
-}
-
 func (ec *executionContext) unmarshalOJobConfiguration2githubᚗcomᚋtheopenlaneᚋcoreᚋpkgᚋmodelsᚐJobConfiguration(ctx context.Context, v any) (models.JobConfiguration, error) {
 	if v == nil {
 		return nil, nil

--- a/internal/graphapi/generated/scheduledjob.generated.go
+++ b/internal/graphapi/generated/scheduledjob.generated.go
@@ -89,16 +89,12 @@ func (ec *executionContext) fieldContext_ScheduledJobBulkCreatePayload_scheduled
 				return ec.fieldContext_ScheduledJob_description(ctx, field)
 			case "platform":
 				return ec.fieldContext_ScheduledJob_platform(ctx, field)
-			case "script":
-				return ec.fieldContext_ScheduledJob_script(ctx, field)
 			case "windmillPath":
 				return ec.fieldContext_ScheduledJob_windmillPath(ctx, field)
 			case "downloadURL":
 				return ec.fieldContext_ScheduledJob_downloadURL(ctx, field)
 			case "configuration":
 				return ec.fieldContext_ScheduledJob_configuration(ctx, field)
-			case "cadence":
-				return ec.fieldContext_ScheduledJob_cadence(ctx, field)
 			case "cron":
 				return ec.fieldContext_ScheduledJob_cron(ctx, field)
 			case "owner":
@@ -173,16 +169,12 @@ func (ec *executionContext) fieldContext_ScheduledJobCreatePayload_scheduledJob(
 				return ec.fieldContext_ScheduledJob_description(ctx, field)
 			case "platform":
 				return ec.fieldContext_ScheduledJob_platform(ctx, field)
-			case "script":
-				return ec.fieldContext_ScheduledJob_script(ctx, field)
 			case "windmillPath":
 				return ec.fieldContext_ScheduledJob_windmillPath(ctx, field)
 			case "downloadURL":
 				return ec.fieldContext_ScheduledJob_downloadURL(ctx, field)
 			case "configuration":
 				return ec.fieldContext_ScheduledJob_configuration(ctx, field)
-			case "cadence":
-				return ec.fieldContext_ScheduledJob_cadence(ctx, field)
 			case "cron":
 				return ec.fieldContext_ScheduledJob_cron(ctx, field)
 			case "owner":
@@ -301,16 +293,12 @@ func (ec *executionContext) fieldContext_ScheduledJobUpdatePayload_scheduledJob(
 				return ec.fieldContext_ScheduledJob_description(ctx, field)
 			case "platform":
 				return ec.fieldContext_ScheduledJob_platform(ctx, field)
-			case "script":
-				return ec.fieldContext_ScheduledJob_script(ctx, field)
 			case "windmillPath":
 				return ec.fieldContext_ScheduledJob_windmillPath(ctx, field)
 			case "downloadURL":
 				return ec.fieldContext_ScheduledJob_downloadURL(ctx, field)
 			case "configuration":
 				return ec.fieldContext_ScheduledJob_configuration(ctx, field)
-			case "cadence":
-				return ec.fieldContext_ScheduledJob_cadence(ctx, field)
 			case "cron":
 				return ec.fieldContext_ScheduledJob_cron(ctx, field)
 			case "owner":

--- a/internal/graphapi/models_test.go
+++ b/internal/graphapi/models_test.go
@@ -1547,16 +1547,10 @@ func (w *ScheduledJobBuilder) MustNew(ctx context.Context, t *testing.T) *ent.Sc
 	ctx = setContext(ctx, w.client.db)
 	wn, err := w.client.db.ScheduledJob.Create().
 		SetTitle("SSL checks").
+		SetCron("0 22 * * 1-5").
 		SetDescription("Check and verify a tls certificate is valid").
 		SetPlatform(enums.JobPlatformTypeGo).
-		SetScript(`
-echo | openssl s_client -servername {{ .URL }} -connect {{ .URL }}:443 2>/dev/null | openssl x509 -noout -dates -issuer -subject
-		`).
 		SetWindmillPath("u/admin/gifted_script").
-		SetCadence(models.JobCadence{
-			Frequency: enums.JobCadenceFrequencyDaily,
-			Time:      "15:09",
-		}).
 		SetDownloadURL(testScriptURL).
 		Save(ctx)
 	assert.NilError(t, err)

--- a/internal/graphapi/query/adminsearch.graphql
+++ b/internal/graphapi/query/adminsearch.graphql
@@ -731,7 +731,6 @@ query AdminSearch($query: String!) {
           title
           description
           configuration
-          cadence
         }
       }
     }

--- a/internal/graphapi/query/scheduledjob.graphql
+++ b/internal/graphapi/query/scheduledjob.graphql
@@ -2,7 +2,6 @@
 mutation CreateBulkCSVScheduledJob($input: Upload!) {
   createBulkCSVScheduledJob(input: $input) {
     scheduledJobs {
-      cadence
       configuration
       createdAt
       createdBy
@@ -11,7 +10,6 @@ mutation CreateBulkCSVScheduledJob($input: Upload!) {
       displayID
       id
       ownerID
-      script
       systemOwned
       tags
       title
@@ -24,7 +22,6 @@ mutation CreateBulkCSVScheduledJob($input: Upload!) {
 mutation CreateBulkScheduledJob($input: [CreateScheduledJobInput!]) {
   createBulkScheduledJob(input: $input) {
     scheduledJobs {
-      cadence
       configuration
       createdAt
       createdBy
@@ -33,7 +30,6 @@ mutation CreateBulkScheduledJob($input: [CreateScheduledJobInput!]) {
       displayID
       id
       ownerID
-      script
       systemOwned
       tags
       title
@@ -46,7 +42,6 @@ mutation CreateBulkScheduledJob($input: [CreateScheduledJobInput!]) {
 mutation CreateScheduledJob($input: CreateScheduledJobInput!) {
   createScheduledJob(input: $input) {
     scheduledJob {
-      cadence
       configuration
       createdAt
       createdBy
@@ -55,7 +50,6 @@ mutation CreateScheduledJob($input: CreateScheduledJobInput!) {
       displayID
       id
       ownerID
-      script
       systemOwned
       tags
       title
@@ -82,7 +76,6 @@ query GetAllScheduledJobs {
     }
     edges {
       node {
-        cadence
         configuration
         createdAt
         createdBy
@@ -91,7 +84,6 @@ query GetAllScheduledJobs {
         displayID
         id
         ownerID
-        script
         systemOwned
         tags
         title
@@ -103,7 +95,6 @@ query GetAllScheduledJobs {
 }
 query GetScheduledJobByID($scheduledJobId: ID!) {
   scheduledJob(id: $scheduledJobId) {
-    cadence
     configuration
     createdAt
     createdBy
@@ -112,7 +103,6 @@ query GetScheduledJobByID($scheduledJobId: ID!) {
     displayID
     id
     ownerID
-    script
     systemOwned
     tags
     title
@@ -132,7 +122,6 @@ query GetScheduledJobs($first: Int, $last: Int, $where: ScheduledJobWhereInput) 
     }
     edges {
       node {
-        cadence
         configuration
         createdAt
         createdBy
@@ -141,7 +130,6 @@ query GetScheduledJobs($first: Int, $last: Int, $where: ScheduledJobWhereInput) 
         displayID
         id
         ownerID
-        script
         systemOwned
         tags
         title
@@ -154,7 +142,6 @@ query GetScheduledJobs($first: Int, $last: Int, $where: ScheduledJobWhereInput) 
 mutation UpdateScheduledJob($updateScheduledJobId: ID!, $input: UpdateScheduledJobInput!) {
   updateScheduledJob(id: $updateScheduledJobId, input: $input) {
     scheduledJob {
-      cadence
       configuration
       createdAt
       createdBy
@@ -163,7 +150,6 @@ mutation UpdateScheduledJob($updateScheduledJobId: ID!, $input: UpdateScheduledJ
       displayID
       id
       ownerID
-      script
       systemOwned
       tags
       title

--- a/internal/graphapi/query/scheduledjobhistory.graphql
+++ b/internal/graphapi/query/scheduledjobhistory.graphql
@@ -11,7 +11,6 @@ query GetAllScheduledJobHistories {
     }
     edges {
       node {
-        cadence
         configuration
         createdAt
         createdBy
@@ -23,7 +22,6 @@ query GetAllScheduledJobHistories {
         operation
         ownerID
         ref
-        script
         systemOwned
         tags
         title
@@ -45,7 +43,6 @@ query GetScheduledJobHistories($first: Int, $last: Int, $where: ScheduledJobHist
     }
     edges {
       node {
-        cadence
         configuration
         createdAt
         createdBy
@@ -57,7 +54,6 @@ query GetScheduledJobHistories($first: Int, $last: Int, $where: ScheduledJobHist
         operation
         ownerID
         ref
-        script
         systemOwned
         tags
         title

--- a/internal/graphapi/schema/ent.graphql
+++ b/internal/graphapi/schema/ent.graphql
@@ -9019,10 +9019,6 @@ input CreateScheduledJobInput {
   """
   platform: ScheduledJobJobPlatformType!
   """
-  the script to run
-  """
-  script: String
-  """
   the url from where to download the script from
   """
   downloadURL: String!
@@ -9030,10 +9026,6 @@ input CreateScheduledJobInput {
   the configuration to run this job
   """
   configuration: JobConfiguration
-  """
-  the schedule to run this job
-  """
-  cadence: JobCadence
   """
   cron syntax
   """
@@ -39027,10 +39019,6 @@ type ScheduledJob implements Node {
   """
   platform: ScheduledJobJobPlatformType!
   """
-  the script to run
-  """
-  script: String
-  """
   Windmill path
   """
   windmillPath: String!
@@ -39042,10 +39030,6 @@ type ScheduledJob implements Node {
   the configuration to run this job
   """
   configuration: JobConfiguration
-  """
-  the schedule to run this job
-  """
-  cadence: JobCadence
   """
   cron syntax
   """
@@ -39120,10 +39104,6 @@ type ScheduledJobHistory implements Node {
   """
   platform: ScheduledJobHistoryJobPlatformType!
   """
-  the script to run
-  """
-  script: String
-  """
   Windmill path
   """
   windmillPath: String!
@@ -39135,10 +39115,6 @@ type ScheduledJobHistory implements Node {
   the configuration to run this job
   """
   configuration: JobConfiguration
-  """
-  the schedule to run this job
-  """
-  cadence: JobCadence
   """
   cron syntax
   """
@@ -49964,11 +49940,6 @@ input UpdateScheduledJobInput {
   description: String
   clearDescription: Boolean
   """
-  the script to run
-  """
-  script: String
-  clearScript: Boolean
-  """
   the url from where to download the script from
   """
   downloadURL: String
@@ -49978,11 +49949,6 @@ input UpdateScheduledJobInput {
   configuration: JobConfiguration
   appendConfiguration: JobConfiguration
   clearConfiguration: Boolean
-  """
-  the schedule to run this job
-  """
-  cadence: JobCadence
-  clearCadence: Boolean
   """
   cron syntax
   """

--- a/internal/graphapi/search.go
+++ b/internal/graphapi/search.go
@@ -1537,10 +1537,6 @@ func adminSearchScheduledJobs(ctx context.Context, query string, after *entgql.C
 					likeQuery := "%" + query + "%"
 					s.Where(sql.ExprP("(configuration)::text LIKE $7", likeQuery)) // search by Configuration
 				},
-				func(s *sql.Selector) {
-					likeQuery := "%" + query + "%"
-					s.Where(sql.ExprP("(cadence)::text LIKE $8", likeQuery)) // search by Cadence
-				},
 			),
 		)
 

--- a/internal/httpserve/handlers/csv/sample_scheduledjob.csv
+++ b/internal/httpserve/handlers/csv/sample_scheduledjob.csv
@@ -1,2 +1,2 @@
-Tags,Title,Description,Platform,Script,DownloadUrl,Configuration,Cadence,Cron,OwnerId
-example_tags,example_title,example_description,example_platform,example_script,example_downloadurl,example_configuration,example_cadence,example_cron,example_ownerid
+Tags,Title,Description,Platform,DownloadUrl,Configuration,Cron,OwnerId
+example_tags,example_title,example_description,example_platform,example_downloadurl,example_configuration,example_cron,example_ownerid

--- a/pkg/openlaneclient/graphclient.go
+++ b/pkg/openlaneclient/graphclient.go
@@ -6208,7 +6208,6 @@ func (t *AdminSearch_AdminSearch_ScheduledJobs_PageInfo) GetStartCursor() *strin
 }
 
 type AdminSearch_AdminSearch_ScheduledJobs_Edges_Node struct {
-	Cadence       *models.JobCadence      "json:\"cadence,omitempty\" graphql:\"cadence\""
 	Configuration models.JobConfiguration "json:\"configuration,omitempty\" graphql:\"configuration\""
 	Description   *string                 "json:\"description,omitempty\" graphql:\"description\""
 	DisplayID     string                  "json:\"displayID\" graphql:\"displayID\""
@@ -6218,12 +6217,6 @@ type AdminSearch_AdminSearch_ScheduledJobs_Edges_Node struct {
 	Title         string                  "json:\"title\" graphql:\"title\""
 }
 
-func (t *AdminSearch_AdminSearch_ScheduledJobs_Edges_Node) GetCadence() *models.JobCadence {
-	if t == nil {
-		t = &AdminSearch_AdminSearch_ScheduledJobs_Edges_Node{}
-	}
-	return t.Cadence
-}
 func (t *AdminSearch_AdminSearch_ScheduledJobs_Edges_Node) GetConfiguration() *models.JobConfiguration {
 	if t == nil {
 		t = &AdminSearch_AdminSearch_ScheduledJobs_Edges_Node{}
@@ -64408,7 +64401,6 @@ func (t *GetScanHistories_ScanHistories) GetTotalCount() int64 {
 }
 
 type CreateBulkCSVScheduledJob_CreateBulkCSVScheduledJob_ScheduledJobs struct {
-	Cadence       *models.JobCadence      "json:\"cadence,omitempty\" graphql:\"cadence\""
 	Configuration models.JobConfiguration "json:\"configuration,omitempty\" graphql:\"configuration\""
 	CreatedAt     *time.Time              "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy     *string                 "json:\"createdBy,omitempty\" graphql:\"createdBy\""
@@ -64417,7 +64409,6 @@ type CreateBulkCSVScheduledJob_CreateBulkCSVScheduledJob_ScheduledJobs struct {
 	DisplayID     string                  "json:\"displayID\" graphql:\"displayID\""
 	ID            string                  "json:\"id\" graphql:\"id\""
 	OwnerID       *string                 "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Script        *string                 "json:\"script,omitempty\" graphql:\"script\""
 	SystemOwned   *bool                   "json:\"systemOwned,omitempty\" graphql:\"systemOwned\""
 	Tags          []string                "json:\"tags,omitempty\" graphql:\"tags\""
 	Title         string                  "json:\"title\" graphql:\"title\""
@@ -64425,12 +64416,6 @@ type CreateBulkCSVScheduledJob_CreateBulkCSVScheduledJob_ScheduledJobs struct {
 	UpdatedBy     *string                 "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *CreateBulkCSVScheduledJob_CreateBulkCSVScheduledJob_ScheduledJobs) GetCadence() *models.JobCadence {
-	if t == nil {
-		t = &CreateBulkCSVScheduledJob_CreateBulkCSVScheduledJob_ScheduledJobs{}
-	}
-	return t.Cadence
-}
 func (t *CreateBulkCSVScheduledJob_CreateBulkCSVScheduledJob_ScheduledJobs) GetConfiguration() *models.JobConfiguration {
 	if t == nil {
 		t = &CreateBulkCSVScheduledJob_CreateBulkCSVScheduledJob_ScheduledJobs{}
@@ -64479,12 +64464,6 @@ func (t *CreateBulkCSVScheduledJob_CreateBulkCSVScheduledJob_ScheduledJobs) GetO
 	}
 	return t.OwnerID
 }
-func (t *CreateBulkCSVScheduledJob_CreateBulkCSVScheduledJob_ScheduledJobs) GetScript() *string {
-	if t == nil {
-		t = &CreateBulkCSVScheduledJob_CreateBulkCSVScheduledJob_ScheduledJobs{}
-	}
-	return t.Script
-}
 func (t *CreateBulkCSVScheduledJob_CreateBulkCSVScheduledJob_ScheduledJobs) GetSystemOwned() *bool {
 	if t == nil {
 		t = &CreateBulkCSVScheduledJob_CreateBulkCSVScheduledJob_ScheduledJobs{}
@@ -64528,7 +64507,6 @@ func (t *CreateBulkCSVScheduledJob_CreateBulkCSVScheduledJob) GetScheduledJobs()
 }
 
 type CreateBulkScheduledJob_CreateBulkScheduledJob_ScheduledJobs struct {
-	Cadence       *models.JobCadence      "json:\"cadence,omitempty\" graphql:\"cadence\""
 	Configuration models.JobConfiguration "json:\"configuration,omitempty\" graphql:\"configuration\""
 	CreatedAt     *time.Time              "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy     *string                 "json:\"createdBy,omitempty\" graphql:\"createdBy\""
@@ -64537,7 +64515,6 @@ type CreateBulkScheduledJob_CreateBulkScheduledJob_ScheduledJobs struct {
 	DisplayID     string                  "json:\"displayID\" graphql:\"displayID\""
 	ID            string                  "json:\"id\" graphql:\"id\""
 	OwnerID       *string                 "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Script        *string                 "json:\"script,omitempty\" graphql:\"script\""
 	SystemOwned   *bool                   "json:\"systemOwned,omitempty\" graphql:\"systemOwned\""
 	Tags          []string                "json:\"tags,omitempty\" graphql:\"tags\""
 	Title         string                  "json:\"title\" graphql:\"title\""
@@ -64545,12 +64522,6 @@ type CreateBulkScheduledJob_CreateBulkScheduledJob_ScheduledJobs struct {
 	UpdatedBy     *string                 "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *CreateBulkScheduledJob_CreateBulkScheduledJob_ScheduledJobs) GetCadence() *models.JobCadence {
-	if t == nil {
-		t = &CreateBulkScheduledJob_CreateBulkScheduledJob_ScheduledJobs{}
-	}
-	return t.Cadence
-}
 func (t *CreateBulkScheduledJob_CreateBulkScheduledJob_ScheduledJobs) GetConfiguration() *models.JobConfiguration {
 	if t == nil {
 		t = &CreateBulkScheduledJob_CreateBulkScheduledJob_ScheduledJobs{}
@@ -64599,12 +64570,6 @@ func (t *CreateBulkScheduledJob_CreateBulkScheduledJob_ScheduledJobs) GetOwnerID
 	}
 	return t.OwnerID
 }
-func (t *CreateBulkScheduledJob_CreateBulkScheduledJob_ScheduledJobs) GetScript() *string {
-	if t == nil {
-		t = &CreateBulkScheduledJob_CreateBulkScheduledJob_ScheduledJobs{}
-	}
-	return t.Script
-}
 func (t *CreateBulkScheduledJob_CreateBulkScheduledJob_ScheduledJobs) GetSystemOwned() *bool {
 	if t == nil {
 		t = &CreateBulkScheduledJob_CreateBulkScheduledJob_ScheduledJobs{}
@@ -64648,7 +64613,6 @@ func (t *CreateBulkScheduledJob_CreateBulkScheduledJob) GetScheduledJobs() []*Cr
 }
 
 type CreateScheduledJob_CreateScheduledJob_ScheduledJob struct {
-	Cadence       *models.JobCadence      "json:\"cadence,omitempty\" graphql:\"cadence\""
 	Configuration models.JobConfiguration "json:\"configuration,omitempty\" graphql:\"configuration\""
 	CreatedAt     *time.Time              "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy     *string                 "json:\"createdBy,omitempty\" graphql:\"createdBy\""
@@ -64657,7 +64621,6 @@ type CreateScheduledJob_CreateScheduledJob_ScheduledJob struct {
 	DisplayID     string                  "json:\"displayID\" graphql:\"displayID\""
 	ID            string                  "json:\"id\" graphql:\"id\""
 	OwnerID       *string                 "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Script        *string                 "json:\"script,omitempty\" graphql:\"script\""
 	SystemOwned   *bool                   "json:\"systemOwned,omitempty\" graphql:\"systemOwned\""
 	Tags          []string                "json:\"tags,omitempty\" graphql:\"tags\""
 	Title         string                  "json:\"title\" graphql:\"title\""
@@ -64665,12 +64628,6 @@ type CreateScheduledJob_CreateScheduledJob_ScheduledJob struct {
 	UpdatedBy     *string                 "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *CreateScheduledJob_CreateScheduledJob_ScheduledJob) GetCadence() *models.JobCadence {
-	if t == nil {
-		t = &CreateScheduledJob_CreateScheduledJob_ScheduledJob{}
-	}
-	return t.Cadence
-}
 func (t *CreateScheduledJob_CreateScheduledJob_ScheduledJob) GetConfiguration() *models.JobConfiguration {
 	if t == nil {
 		t = &CreateScheduledJob_CreateScheduledJob_ScheduledJob{}
@@ -64718,12 +64675,6 @@ func (t *CreateScheduledJob_CreateScheduledJob_ScheduledJob) GetOwnerID() *strin
 		t = &CreateScheduledJob_CreateScheduledJob_ScheduledJob{}
 	}
 	return t.OwnerID
-}
-func (t *CreateScheduledJob_CreateScheduledJob_ScheduledJob) GetScript() *string {
-	if t == nil {
-		t = &CreateScheduledJob_CreateScheduledJob_ScheduledJob{}
-	}
-	return t.Script
 }
 func (t *CreateScheduledJob_CreateScheduledJob_ScheduledJob) GetSystemOwned() *bool {
 	if t == nil {
@@ -64811,7 +64762,6 @@ func (t *GetAllScheduledJobs_ScheduledJobs_PageInfo) GetStartCursor() *string {
 }
 
 type GetAllScheduledJobs_ScheduledJobs_Edges_Node struct {
-	Cadence       *models.JobCadence      "json:\"cadence,omitempty\" graphql:\"cadence\""
 	Configuration models.JobConfiguration "json:\"configuration,omitempty\" graphql:\"configuration\""
 	CreatedAt     *time.Time              "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy     *string                 "json:\"createdBy,omitempty\" graphql:\"createdBy\""
@@ -64820,7 +64770,6 @@ type GetAllScheduledJobs_ScheduledJobs_Edges_Node struct {
 	DisplayID     string                  "json:\"displayID\" graphql:\"displayID\""
 	ID            string                  "json:\"id\" graphql:\"id\""
 	OwnerID       *string                 "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Script        *string                 "json:\"script,omitempty\" graphql:\"script\""
 	SystemOwned   *bool                   "json:\"systemOwned,omitempty\" graphql:\"systemOwned\""
 	Tags          []string                "json:\"tags,omitempty\" graphql:\"tags\""
 	Title         string                  "json:\"title\" graphql:\"title\""
@@ -64828,12 +64777,6 @@ type GetAllScheduledJobs_ScheduledJobs_Edges_Node struct {
 	UpdatedBy     *string                 "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *GetAllScheduledJobs_ScheduledJobs_Edges_Node) GetCadence() *models.JobCadence {
-	if t == nil {
-		t = &GetAllScheduledJobs_ScheduledJobs_Edges_Node{}
-	}
-	return t.Cadence
-}
 func (t *GetAllScheduledJobs_ScheduledJobs_Edges_Node) GetConfiguration() *models.JobConfiguration {
 	if t == nil {
 		t = &GetAllScheduledJobs_ScheduledJobs_Edges_Node{}
@@ -64881,12 +64824,6 @@ func (t *GetAllScheduledJobs_ScheduledJobs_Edges_Node) GetOwnerID() *string {
 		t = &GetAllScheduledJobs_ScheduledJobs_Edges_Node{}
 	}
 	return t.OwnerID
-}
-func (t *GetAllScheduledJobs_ScheduledJobs_Edges_Node) GetScript() *string {
-	if t == nil {
-		t = &GetAllScheduledJobs_ScheduledJobs_Edges_Node{}
-	}
-	return t.Script
 }
 func (t *GetAllScheduledJobs_ScheduledJobs_Edges_Node) GetSystemOwned() *bool {
 	if t == nil {
@@ -64956,7 +64893,6 @@ func (t *GetAllScheduledJobs_ScheduledJobs) GetTotalCount() int64 {
 }
 
 type GetScheduledJobByID_ScheduledJob struct {
-	Cadence       *models.JobCadence      "json:\"cadence,omitempty\" graphql:\"cadence\""
 	Configuration models.JobConfiguration "json:\"configuration,omitempty\" graphql:\"configuration\""
 	CreatedAt     *time.Time              "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy     *string                 "json:\"createdBy,omitempty\" graphql:\"createdBy\""
@@ -64965,7 +64901,6 @@ type GetScheduledJobByID_ScheduledJob struct {
 	DisplayID     string                  "json:\"displayID\" graphql:\"displayID\""
 	ID            string                  "json:\"id\" graphql:\"id\""
 	OwnerID       *string                 "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Script        *string                 "json:\"script,omitempty\" graphql:\"script\""
 	SystemOwned   *bool                   "json:\"systemOwned,omitempty\" graphql:\"systemOwned\""
 	Tags          []string                "json:\"tags,omitempty\" graphql:\"tags\""
 	Title         string                  "json:\"title\" graphql:\"title\""
@@ -64973,12 +64908,6 @@ type GetScheduledJobByID_ScheduledJob struct {
 	UpdatedBy     *string                 "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *GetScheduledJobByID_ScheduledJob) GetCadence() *models.JobCadence {
-	if t == nil {
-		t = &GetScheduledJobByID_ScheduledJob{}
-	}
-	return t.Cadence
-}
 func (t *GetScheduledJobByID_ScheduledJob) GetConfiguration() *models.JobConfiguration {
 	if t == nil {
 		t = &GetScheduledJobByID_ScheduledJob{}
@@ -65026,12 +64955,6 @@ func (t *GetScheduledJobByID_ScheduledJob) GetOwnerID() *string {
 		t = &GetScheduledJobByID_ScheduledJob{}
 	}
 	return t.OwnerID
-}
-func (t *GetScheduledJobByID_ScheduledJob) GetScript() *string {
-	if t == nil {
-		t = &GetScheduledJobByID_ScheduledJob{}
-	}
-	return t.Script
 }
 func (t *GetScheduledJobByID_ScheduledJob) GetSystemOwned() *bool {
 	if t == nil {
@@ -65097,7 +65020,6 @@ func (t *GetScheduledJobs_ScheduledJobs_PageInfo) GetStartCursor() *string {
 }
 
 type GetScheduledJobs_ScheduledJobs_Edges_Node struct {
-	Cadence       *models.JobCadence      "json:\"cadence,omitempty\" graphql:\"cadence\""
 	Configuration models.JobConfiguration "json:\"configuration,omitempty\" graphql:\"configuration\""
 	CreatedAt     *time.Time              "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy     *string                 "json:\"createdBy,omitempty\" graphql:\"createdBy\""
@@ -65106,7 +65028,6 @@ type GetScheduledJobs_ScheduledJobs_Edges_Node struct {
 	DisplayID     string                  "json:\"displayID\" graphql:\"displayID\""
 	ID            string                  "json:\"id\" graphql:\"id\""
 	OwnerID       *string                 "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Script        *string                 "json:\"script,omitempty\" graphql:\"script\""
 	SystemOwned   *bool                   "json:\"systemOwned,omitempty\" graphql:\"systemOwned\""
 	Tags          []string                "json:\"tags,omitempty\" graphql:\"tags\""
 	Title         string                  "json:\"title\" graphql:\"title\""
@@ -65114,12 +65035,6 @@ type GetScheduledJobs_ScheduledJobs_Edges_Node struct {
 	UpdatedBy     *string                 "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *GetScheduledJobs_ScheduledJobs_Edges_Node) GetCadence() *models.JobCadence {
-	if t == nil {
-		t = &GetScheduledJobs_ScheduledJobs_Edges_Node{}
-	}
-	return t.Cadence
-}
 func (t *GetScheduledJobs_ScheduledJobs_Edges_Node) GetConfiguration() *models.JobConfiguration {
 	if t == nil {
 		t = &GetScheduledJobs_ScheduledJobs_Edges_Node{}
@@ -65167,12 +65082,6 @@ func (t *GetScheduledJobs_ScheduledJobs_Edges_Node) GetOwnerID() *string {
 		t = &GetScheduledJobs_ScheduledJobs_Edges_Node{}
 	}
 	return t.OwnerID
-}
-func (t *GetScheduledJobs_ScheduledJobs_Edges_Node) GetScript() *string {
-	if t == nil {
-		t = &GetScheduledJobs_ScheduledJobs_Edges_Node{}
-	}
-	return t.Script
 }
 func (t *GetScheduledJobs_ScheduledJobs_Edges_Node) GetSystemOwned() *bool {
 	if t == nil {
@@ -65242,7 +65151,6 @@ func (t *GetScheduledJobs_ScheduledJobs) GetTotalCount() int64 {
 }
 
 type UpdateScheduledJob_UpdateScheduledJob_ScheduledJob struct {
-	Cadence       *models.JobCadence      "json:\"cadence,omitempty\" graphql:\"cadence\""
 	Configuration models.JobConfiguration "json:\"configuration,omitempty\" graphql:\"configuration\""
 	CreatedAt     *time.Time              "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy     *string                 "json:\"createdBy,omitempty\" graphql:\"createdBy\""
@@ -65251,7 +65159,6 @@ type UpdateScheduledJob_UpdateScheduledJob_ScheduledJob struct {
 	DisplayID     string                  "json:\"displayID\" graphql:\"displayID\""
 	ID            string                  "json:\"id\" graphql:\"id\""
 	OwnerID       *string                 "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	Script        *string                 "json:\"script,omitempty\" graphql:\"script\""
 	SystemOwned   *bool                   "json:\"systemOwned,omitempty\" graphql:\"systemOwned\""
 	Tags          []string                "json:\"tags,omitempty\" graphql:\"tags\""
 	Title         string                  "json:\"title\" graphql:\"title\""
@@ -65259,12 +65166,6 @@ type UpdateScheduledJob_UpdateScheduledJob_ScheduledJob struct {
 	UpdatedBy     *string                 "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *UpdateScheduledJob_UpdateScheduledJob_ScheduledJob) GetCadence() *models.JobCadence {
-	if t == nil {
-		t = &UpdateScheduledJob_UpdateScheduledJob_ScheduledJob{}
-	}
-	return t.Cadence
-}
 func (t *UpdateScheduledJob_UpdateScheduledJob_ScheduledJob) GetConfiguration() *models.JobConfiguration {
 	if t == nil {
 		t = &UpdateScheduledJob_UpdateScheduledJob_ScheduledJob{}
@@ -65312,12 +65213,6 @@ func (t *UpdateScheduledJob_UpdateScheduledJob_ScheduledJob) GetOwnerID() *strin
 		t = &UpdateScheduledJob_UpdateScheduledJob_ScheduledJob{}
 	}
 	return t.OwnerID
-}
-func (t *UpdateScheduledJob_UpdateScheduledJob_ScheduledJob) GetScript() *string {
-	if t == nil {
-		t = &UpdateScheduledJob_UpdateScheduledJob_ScheduledJob{}
-	}
-	return t.Script
 }
 func (t *UpdateScheduledJob_UpdateScheduledJob_ScheduledJob) GetSystemOwned() *bool {
 	if t == nil {
@@ -65394,7 +65289,6 @@ func (t *GetAllScheduledJobHistories_ScheduledJobHistories_PageInfo) GetStartCur
 }
 
 type GetAllScheduledJobHistories_ScheduledJobHistories_Edges_Node struct {
-	Cadence       *models.JobCadence      "json:\"cadence,omitempty\" graphql:\"cadence\""
 	Configuration models.JobConfiguration "json:\"configuration,omitempty\" graphql:\"configuration\""
 	CreatedAt     *time.Time              "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy     *string                 "json:\"createdBy,omitempty\" graphql:\"createdBy\""
@@ -65406,7 +65300,6 @@ type GetAllScheduledJobHistories_ScheduledJobHistories_Edges_Node struct {
 	Operation     history.OpType          "json:\"operation\" graphql:\"operation\""
 	OwnerID       *string                 "json:\"ownerID,omitempty\" graphql:\"ownerID\""
 	Ref           *string                 "json:\"ref,omitempty\" graphql:\"ref\""
-	Script        *string                 "json:\"script,omitempty\" graphql:\"script\""
 	SystemOwned   *bool                   "json:\"systemOwned,omitempty\" graphql:\"systemOwned\""
 	Tags          []string                "json:\"tags,omitempty\" graphql:\"tags\""
 	Title         string                  "json:\"title\" graphql:\"title\""
@@ -65414,12 +65307,6 @@ type GetAllScheduledJobHistories_ScheduledJobHistories_Edges_Node struct {
 	UpdatedBy     *string                 "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *GetAllScheduledJobHistories_ScheduledJobHistories_Edges_Node) GetCadence() *models.JobCadence {
-	if t == nil {
-		t = &GetAllScheduledJobHistories_ScheduledJobHistories_Edges_Node{}
-	}
-	return t.Cadence
-}
 func (t *GetAllScheduledJobHistories_ScheduledJobHistories_Edges_Node) GetConfiguration() *models.JobConfiguration {
 	if t == nil {
 		t = &GetAllScheduledJobHistories_ScheduledJobHistories_Edges_Node{}
@@ -65485,12 +65372,6 @@ func (t *GetAllScheduledJobHistories_ScheduledJobHistories_Edges_Node) GetRef() 
 		t = &GetAllScheduledJobHistories_ScheduledJobHistories_Edges_Node{}
 	}
 	return t.Ref
-}
-func (t *GetAllScheduledJobHistories_ScheduledJobHistories_Edges_Node) GetScript() *string {
-	if t == nil {
-		t = &GetAllScheduledJobHistories_ScheduledJobHistories_Edges_Node{}
-	}
-	return t.Script
 }
 func (t *GetAllScheduledJobHistories_ScheduledJobHistories_Edges_Node) GetSystemOwned() *bool {
 	if t == nil {
@@ -65592,7 +65473,6 @@ func (t *GetScheduledJobHistories_ScheduledJobHistories_PageInfo) GetStartCursor
 }
 
 type GetScheduledJobHistories_ScheduledJobHistories_Edges_Node struct {
-	Cadence       *models.JobCadence      "json:\"cadence,omitempty\" graphql:\"cadence\""
 	Configuration models.JobConfiguration "json:\"configuration,omitempty\" graphql:\"configuration\""
 	CreatedAt     *time.Time              "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy     *string                 "json:\"createdBy,omitempty\" graphql:\"createdBy\""
@@ -65604,7 +65484,6 @@ type GetScheduledJobHistories_ScheduledJobHistories_Edges_Node struct {
 	Operation     history.OpType          "json:\"operation\" graphql:\"operation\""
 	OwnerID       *string                 "json:\"ownerID,omitempty\" graphql:\"ownerID\""
 	Ref           *string                 "json:\"ref,omitempty\" graphql:\"ref\""
-	Script        *string                 "json:\"script,omitempty\" graphql:\"script\""
 	SystemOwned   *bool                   "json:\"systemOwned,omitempty\" graphql:\"systemOwned\""
 	Tags          []string                "json:\"tags,omitempty\" graphql:\"tags\""
 	Title         string                  "json:\"title\" graphql:\"title\""
@@ -65612,12 +65491,6 @@ type GetScheduledJobHistories_ScheduledJobHistories_Edges_Node struct {
 	UpdatedBy     *string                 "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
-func (t *GetScheduledJobHistories_ScheduledJobHistories_Edges_Node) GetCadence() *models.JobCadence {
-	if t == nil {
-		t = &GetScheduledJobHistories_ScheduledJobHistories_Edges_Node{}
-	}
-	return t.Cadence
-}
 func (t *GetScheduledJobHistories_ScheduledJobHistories_Edges_Node) GetConfiguration() *models.JobConfiguration {
 	if t == nil {
 		t = &GetScheduledJobHistories_ScheduledJobHistories_Edges_Node{}
@@ -65683,12 +65556,6 @@ func (t *GetScheduledJobHistories_ScheduledJobHistories_Edges_Node) GetRef() *st
 		t = &GetScheduledJobHistories_ScheduledJobHistories_Edges_Node{}
 	}
 	return t.Ref
-}
-func (t *GetScheduledJobHistories_ScheduledJobHistories_Edges_Node) GetScript() *string {
-	if t == nil {
-		t = &GetScheduledJobHistories_ScheduledJobHistories_Edges_Node{}
-	}
-	return t.Script
 }
 func (t *GetScheduledJobHistories_ScheduledJobHistories_Edges_Node) GetSystemOwned() *bool {
 	if t == nil {
@@ -94469,7 +94336,6 @@ const AdminSearchDocument = `query AdminSearch ($query: String!) {
 					title
 					description
 					configuration
-					cadence
 				}
 			}
 		}
@@ -111429,7 +111295,6 @@ func (c *Client) GetScanHistories(ctx context.Context, first *int64, last *int64
 const CreateBulkCSVScheduledJobDocument = `mutation CreateBulkCSVScheduledJob ($input: Upload!) {
 	createBulkCSVScheduledJob(input: $input) {
 		scheduledJobs {
-			cadence
 			configuration
 			createdAt
 			createdBy
@@ -111438,7 +111303,6 @@ const CreateBulkCSVScheduledJobDocument = `mutation CreateBulkCSVScheduledJob ($
 			displayID
 			id
 			ownerID
-			script
 			systemOwned
 			tags
 			title
@@ -111469,7 +111333,6 @@ func (c *Client) CreateBulkCSVScheduledJob(ctx context.Context, input graphql.Up
 const CreateBulkScheduledJobDocument = `mutation CreateBulkScheduledJob ($input: [CreateScheduledJobInput!]) {
 	createBulkScheduledJob(input: $input) {
 		scheduledJobs {
-			cadence
 			configuration
 			createdAt
 			createdBy
@@ -111478,7 +111341,6 @@ const CreateBulkScheduledJobDocument = `mutation CreateBulkScheduledJob ($input:
 			displayID
 			id
 			ownerID
-			script
 			systemOwned
 			tags
 			title
@@ -111509,7 +111371,6 @@ func (c *Client) CreateBulkScheduledJob(ctx context.Context, input []*CreateSche
 const CreateScheduledJobDocument = `mutation CreateScheduledJob ($input: CreateScheduledJobInput!) {
 	createScheduledJob(input: $input) {
 		scheduledJob {
-			cadence
 			configuration
 			createdAt
 			createdBy
@@ -111518,7 +111379,6 @@ const CreateScheduledJobDocument = `mutation CreateScheduledJob ($input: CreateS
 			displayID
 			id
 			ownerID
-			script
 			systemOwned
 			tags
 			title
@@ -111581,7 +111441,6 @@ const GetAllScheduledJobsDocument = `query GetAllScheduledJobs {
 		}
 		edges {
 			node {
-				cadence
 				configuration
 				createdAt
 				createdBy
@@ -111590,7 +111449,6 @@ const GetAllScheduledJobsDocument = `query GetAllScheduledJobs {
 				displayID
 				id
 				ownerID
-				script
 				systemOwned
 				tags
 				title
@@ -111619,7 +111477,6 @@ func (c *Client) GetAllScheduledJobs(ctx context.Context, interceptors ...client
 
 const GetScheduledJobByIDDocument = `query GetScheduledJobByID ($scheduledJobId: ID!) {
 	scheduledJob(id: $scheduledJobId) {
-		cadence
 		configuration
 		createdAt
 		createdBy
@@ -111628,7 +111485,6 @@ const GetScheduledJobByIDDocument = `query GetScheduledJobByID ($scheduledJobId:
 		displayID
 		id
 		ownerID
-		script
 		systemOwned
 		tags
 		title
@@ -111666,7 +111522,6 @@ const GetScheduledJobsDocument = `query GetScheduledJobs ($first: Int, $last: In
 		}
 		edges {
 			node {
-				cadence
 				configuration
 				createdAt
 				createdBy
@@ -111675,7 +111530,6 @@ const GetScheduledJobsDocument = `query GetScheduledJobs ($first: Int, $last: In
 				displayID
 				id
 				ownerID
-				script
 				systemOwned
 				tags
 				title
@@ -111709,7 +111563,6 @@ func (c *Client) GetScheduledJobs(ctx context.Context, first *int64, last *int64
 const UpdateScheduledJobDocument = `mutation UpdateScheduledJob ($updateScheduledJobId: ID!, $input: UpdateScheduledJobInput!) {
 	updateScheduledJob(id: $updateScheduledJobId, input: $input) {
 		scheduledJob {
-			cadence
 			configuration
 			createdAt
 			createdBy
@@ -111718,7 +111571,6 @@ const UpdateScheduledJobDocument = `mutation UpdateScheduledJob ($updateSchedule
 			displayID
 			id
 			ownerID
-			script
 			systemOwned
 			tags
 			title
@@ -111758,7 +111610,6 @@ const GetAllScheduledJobHistoriesDocument = `query GetAllScheduledJobHistories {
 		}
 		edges {
 			node {
-				cadence
 				configuration
 				createdAt
 				createdBy
@@ -111770,7 +111621,6 @@ const GetAllScheduledJobHistoriesDocument = `query GetAllScheduledJobHistories {
 				operation
 				ownerID
 				ref
-				script
 				systemOwned
 				tags
 				title
@@ -111808,7 +111658,6 @@ const GetScheduledJobHistoriesDocument = `query GetScheduledJobHistories ($first
 		}
 		edges {
 			node {
-				cadence
 				configuration
 				createdAt
 				createdBy
@@ -111820,7 +111669,6 @@ const GetScheduledJobHistoriesDocument = `query GetScheduledJobHistories ($first
 				operation
 				ownerID
 				ref
-				script
 				systemOwned
 				tags
 				title

--- a/pkg/windmill/client.go
+++ b/pkg/windmill/client.go
@@ -244,6 +244,7 @@ func (c *Client) CreateScheduledJob(ctx context.Context, req CreateScheduledJobR
 	url := fmt.Sprintf("%s/api/w/%s/schedules/create", c.baseURL, c.workspace)
 
 	apiReq := struct {
+		IsFlow     bool   `json:"is_flow"`
 		Path       string `json:"path"`
 		Schedule   string `json:"schedule"`
 		ScriptPath string `json:"script_path"`
@@ -265,6 +266,7 @@ func (c *Client) CreateScheduledJob(ctx context.Context, req CreateScheduledJobR
 		ScriptPath: req.FlowPath,
 		Enabled:    true,
 		Timezone:   c.timezone,
+		IsFlow:     true,
 	}
 
 	if c.onFailureScript != "" {


### PR DESCRIPTION
When adding a control to a job, if you don't provide a cron schedule, It should inherit that of the parent
