### PR TITLE
feat: add setup for basic user and pat token

### DIFF
--- a/cmd/cli/Taskfile.yaml
+++ b/cmd/cli/Taskfile.yaml
@@ -48,6 +48,21 @@ tasks:
     cmds:
       - go run main.go org create -n {{ .ORG_NAME | default .DEFAULT_ORG_NAME }} -d "Test organization"
 
+  org:get:
+    output: true
+    silent: true
+    desc: a task to get the current organization
+    cmds:
+      - go run main.go org get -c -z json | jq -r '.organization.id'
+
+  user:setup:
+    desc: complete user setup with default privileges
+    cmds:
+      - task: user:register
+      - task: user:login
+      - task: org:create
+      - task: token:create
+
   # === Admin Setup (for Impersonation) ===
   admin:setup:
     desc: complete admin user setup with system admin privileges
@@ -61,17 +76,16 @@ tasks:
       - task: org:create
         vars:
           ORG_NAME: "admin-org"
-      - task: admin:token:create
+      - task: token:create
       - task: admin:grant:fga
 
-  admin:token:create:
+  token:create:
     desc: create PAT for admin user
-    internal: true
     cmds:
-      - go run main.go pat create -n "system-admin-token" -o {{.ORG_ID}}
+      - go run main.go pat create -n "generated-token" -o {{.ORG_ID}}
     vars:
       ORG_ID:
-        sh: go run main.go org get -z json | jq -r '.organizations.edges.[0].node.id'
+        sh: task org:get
 
   admin:grant:fga:
     desc: grant system admin FGA privileges

--- a/cmd/cli/Taskfile.yaml
+++ b/cmd/cli/Taskfile.yaml
@@ -80,7 +80,7 @@ tasks:
       - task: admin:grant:fga
 
   token:create:
-    desc: create PAT for admin user
+    desc: create PAT for the user
     cmds:
       - go run main.go pat create -n "generated-token" -o {{.ORG_ID}}
     vars:


### PR DESCRIPTION
- adds `task cli:user:setup` to setup a basic user with an organization + personal access token
- updates the org get to get the current authorized org, not the first org returned, this causes issues if you have multiple orgs
- makes token:create not internal so it can be used directly, otherwise I get this error:
```
task: Task "cli:token:create" is internal
```