### PR TITLE
updates for version 2 goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,4 @@
+version: '2'
 project_name: openlane
 builds:
   - env:
@@ -32,15 +33,15 @@ builds:
           - CGO_ENABLED=1
     main: ./cmd/cli
 archives:
-  - format: tar.gz # we can use binary, but it seems there's an issue where goreleaser skips the sboms
+  - formats: [tar.gz] # we can use binary, but it seems there's an issue where goreleaser skips the sboms
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
       - goos: windows
-        format: zip
-brews:
-  - homepage: 'https://github.com/theopenlane/core'
+        formats: [zip]
+homebrew_casks:
+  - name: openlane
+    homepage: 'https://github.com/theopenlane/core'
     description: 'openlane is the client CLI for interacting with the openlane server'
-    directory: Formula
     license: 'Apache-2.0'
     commit_author:
       name: theopenlane-bender


### PR DESCRIPTION
Trying to fix these errors: 

>     • DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
>     • DEPRECATED: archives.format_overrides.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
>     • brews is being phased out in favor of homebrew_casks, check https://goreleaser.com/deprecations#brews for more info