### PR TITLE
Minor Job Schemas updates

### DIFF
--- a/db/migrations-goose-postgres/20250804220150_updatejobrunner.sql
+++ b/db/migrations-goose-postgres/20250804220150_updatejobrunner.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- modify "job_results" table
+ALTER TABLE "job_results" ADD COLUMN "log" text NULL;
+-- drop index "job_runners_ip_address_key" from table: "job_runners"
+DROP INDEX "job_runners_ip_address_key";
+-- modify "job_runners" table
+ALTER TABLE "job_runners" ALTER COLUMN "ip_address" DROP NOT NULL, ADD COLUMN "last_seen" timestamptz NULL, ADD COLUMN "version" character varying NULL, ADD COLUMN "os" character varying NULL;
+
+-- +goose Down
+-- reverse: modify "job_runners" table
+ALTER TABLE "job_runners" DROP COLUMN "os", DROP COLUMN "version", DROP COLUMN "last_seen", ALTER COLUMN "ip_address" SET NOT NULL;
+-- reverse: drop index "job_runners_ip_address_key" from table: "job_runners"
+CREATE UNIQUE INDEX "job_runners_ip_address_key" ON "job_runners" ("ip_address");
+-- reverse: modify "job_results" table
+ALTER TABLE "job_results" DROP COLUMN "log";

--- a/db/migrations-goose-postgres/atlas.sum
+++ b/db/migrations-goose-postgres/atlas.sum
@@ -1,4 +1,4 @@
-h1:NAr9CrLW+aqCw6zWDqZwZY22YOQ9m7pftVZazH/+azg=
+h1:WW6EKTVBUcHbeq9M4TVX3sMDuxyM8gkAMOcovavNdv4=
 20250414203515_init.sql h1:BeTEtWy9s9mO1t9vLhKE/W3Z/NZS7kklzlmvffjgMys=
 20250418204251_control_objective.sql h1:2zhXUjbVshiTwzY0qh87de8Wh8j2tLDO6KRbn6oohx4=
 20250421141007_aauid_not_unique_per_machine.sql h1:bMzfq+NBG4IFyOf/YintEKVhmQ6ttnQymzRV8/RiuPo=
@@ -41,3 +41,4 @@ h1:NAr9CrLW+aqCw6zWDqZwZY22YOQ9m7pftVZazH/+azg=
 20250721124113_drop_script_and_cadence.sql h1:IFPIl+S6LUddc9gP0XVy1isMf4JIRZzIs92Jrpl+g1E=
 20250723012543_job_tables_rename.sql h1:dZTTJ5QPXSAg0gUAkjFJyVuejwqEcDqHL/o0oXe0gGs=
 20250804035349_edges.sql h1:ccO0/L6BzNdqGeHTNgcmTHBob0BkAsc/h1gJX4nxfds=
+20250804220150_updatejobrunner.sql h1:DlEOsY19ZkGRxg2EcJWGuMofboqXbm8kDTtF3ZWpxPc=

--- a/db/migrations/20250804220147_updatejobrunner.sql
+++ b/db/migrations/20250804220147_updatejobrunner.sql
@@ -1,0 +1,6 @@
+-- Modify "job_results" table
+ALTER TABLE "job_results" ADD COLUMN "log" text NULL;
+-- Drop index "job_runners_ip_address_key" from table: "job_runners"
+DROP INDEX "job_runners_ip_address_key";
+-- Modify "job_runners" table
+ALTER TABLE "job_runners" ALTER COLUMN "ip_address" DROP NOT NULL, ADD COLUMN "last_seen" timestamptz NULL, ADD COLUMN "version" character varying NULL, ADD COLUMN "os" character varying NULL;

--- a/db/migrations/atlas.sum
+++ b/db/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:RxbXlhr5K3Vwjiuu3i3MCf2bZWWH9SiLGLwPt8W7LIw=
+h1:A1yP8vMy2n1ZMijn1/PcciwQjmWkwARV6i+lHrXGw+0=
 20250414203514_init.sql h1:NmCV8ML7NQDnzWVgI8QwOPofl3cp1WGzZWzPQhilEbY=
 20250418204249_control_objective.sql h1:NVX8qKq77/54YdYSQZMyI+HS5RXNahqyyDtNHf9oMnQ=
 20250421141003_aauid_not_unique_per_machine.sql h1:/ZFOjmdeEiPZl23+/MIjK1sxFWSi8PrMvV3kJ4iqbW4=
@@ -41,3 +41,4 @@ h1:RxbXlhr5K3Vwjiuu3i3MCf2bZWWH9SiLGLwPt8W7LIw=
 20250721124105_drop_script_and_cadence.sql h1:N1tgnGvOc4kdSmk5mciUGKvGIQCaGC3VjPACvKNqniY=
 20250723012540_job_tables_rename.sql h1:Um4IllQTypeqzq+fGQEeR/kzmADnBonI31JLTcIhPaU=
 20250804034858_edges.sql h1:WxeTX0HL1rhKnuMKPywGr9dOZpRTvCYisdSPWOMEtSs=
+20250804220147_updatejobrunner.sql h1:V+yx5tR+5RuvidVlnYYRjpeV27Qk87DACd3dm/S0rP8=

--- a/internal/ent/generated/entql.go
+++ b/internal/ent/generated/entql.go
@@ -1431,6 +1431,7 @@ var schemaGraph = func() *sqlgraph.Schema {
 			jobresult.FieldFinishedAt:     {Type: field.TypeTime, Column: jobresult.FieldFinishedAt},
 			jobresult.FieldStartedAt:      {Type: field.TypeTime, Column: jobresult.FieldStartedAt},
 			jobresult.FieldFileID:         {Type: field.TypeString, Column: jobresult.FieldFileID},
+			jobresult.FieldLog:            {Type: field.TypeString, Column: jobresult.FieldLog},
 		},
 	}
 	graph.Nodes[44] = &sqlgraph.Node{
@@ -1457,6 +1458,9 @@ var schemaGraph = func() *sqlgraph.Schema {
 			jobrunner.FieldName:        {Type: field.TypeString, Column: jobrunner.FieldName},
 			jobrunner.FieldStatus:      {Type: field.TypeEnum, Column: jobrunner.FieldStatus},
 			jobrunner.FieldIPAddress:   {Type: field.TypeString, Column: jobrunner.FieldIPAddress},
+			jobrunner.FieldLastSeen:    {Type: field.TypeTime, Column: jobrunner.FieldLastSeen},
+			jobrunner.FieldVersion:     {Type: field.TypeString, Column: jobrunner.FieldVersion},
+			jobrunner.FieldOs:          {Type: field.TypeString, Column: jobrunner.FieldOs},
 		},
 	}
 	graph.Nodes[45] = &sqlgraph.Node{
@@ -16677,6 +16681,11 @@ func (f *JobResultFilter) WhereFileID(p entql.StringP) {
 	f.Where(p.Field(jobresult.FieldFileID))
 }
 
+// WhereLog applies the entql string predicate on the log field.
+func (f *JobResultFilter) WhereLog(p entql.StringP) {
+	f.Where(p.Field(jobresult.FieldLog))
+}
+
 // WhereHasOwner applies a predicate to check if query has an edge owner.
 func (f *JobResultFilter) WhereHasOwner() {
 	f.Where(entql.HasEdge("owner"))
@@ -16822,6 +16831,21 @@ func (f *JobRunnerFilter) WhereStatus(p entql.StringP) {
 // WhereIPAddress applies the entql string predicate on the ip_address field.
 func (f *JobRunnerFilter) WhereIPAddress(p entql.StringP) {
 	f.Where(p.Field(jobrunner.FieldIPAddress))
+}
+
+// WhereLastSeen applies the entql time.Time predicate on the last_seen field.
+func (f *JobRunnerFilter) WhereLastSeen(p entql.TimeP) {
+	f.Where(p.Field(jobrunner.FieldLastSeen))
+}
+
+// WhereVersion applies the entql string predicate on the version field.
+func (f *JobRunnerFilter) WhereVersion(p entql.StringP) {
+	f.Where(p.Field(jobrunner.FieldVersion))
+}
+
+// WhereOs applies the entql string predicate on the os field.
+func (f *JobRunnerFilter) WhereOs(p entql.StringP) {
+	f.Where(p.Field(jobrunner.FieldOs))
 }
 
 // WhereHasOwner applies a predicate to check if query has an edge owner.

--- a/internal/ent/generated/gql_collection.go
+++ b/internal/ent/generated/gql_collection.go
@@ -19834,6 +19834,11 @@ func (jrq *JobResultQuery) collectField(ctx context.Context, oneNode bool, opCtx
 				selectedFields = append(selectedFields, jobresult.FieldFileID)
 				fieldSeen[jobresult.FieldFileID] = struct{}{}
 			}
+		case "log":
+			if _, ok := fieldSeen[jobresult.FieldLog]; !ok {
+				selectedFields = append(selectedFields, jobresult.FieldLog)
+				fieldSeen[jobresult.FieldLog] = struct{}{}
+			}
 		case "id":
 		case "__typename":
 		default:
@@ -20086,6 +20091,21 @@ func (jrq *JobRunnerQuery) collectField(ctx context.Context, oneNode bool, opCtx
 			if _, ok := fieldSeen[jobrunner.FieldIPAddress]; !ok {
 				selectedFields = append(selectedFields, jobrunner.FieldIPAddress)
 				fieldSeen[jobrunner.FieldIPAddress] = struct{}{}
+			}
+		case "lastSeen":
+			if _, ok := fieldSeen[jobrunner.FieldLastSeen]; !ok {
+				selectedFields = append(selectedFields, jobrunner.FieldLastSeen)
+				fieldSeen[jobrunner.FieldLastSeen] = struct{}{}
+			}
+		case "version":
+			if _, ok := fieldSeen[jobrunner.FieldVersion]; !ok {
+				selectedFields = append(selectedFields, jobrunner.FieldVersion)
+				fieldSeen[jobrunner.FieldVersion] = struct{}{}
+			}
+		case "os":
+			if _, ok := fieldSeen[jobrunner.FieldOs]; !ok {
+				selectedFields = append(selectedFields, jobrunner.FieldOs)
+				fieldSeen[jobrunner.FieldOs] = struct{}{}
 			}
 		case "id":
 		case "__typename":

--- a/internal/ent/generated/gql_mutation_input.go
+++ b/internal/ent/generated/gql_mutation_input.go
@@ -5219,6 +5219,7 @@ type CreateJobResultInput struct {
 	ExitCode       int
 	FinishedAt     *time.Time
 	StartedAt      *time.Time
+	Log            *string
 	OwnerID        *string
 	ScheduledJobID string
 	FileID         string
@@ -5233,6 +5234,9 @@ func (i *CreateJobResultInput) Mutate(m *JobResultMutation) {
 	}
 	if v := i.StartedAt; v != nil {
 		m.SetStartedAt(*v)
+	}
+	if v := i.Log; v != nil {
+		m.SetLog(*v)
 	}
 	if v := i.OwnerID; v != nil {
 		m.SetOwnerID(*v)
@@ -5250,6 +5254,8 @@ func (c *JobResultCreate) SetInput(i CreateJobResultInput) *JobResultCreate {
 // UpdateJobResultInput represents a mutation input for updating jobresults.
 type UpdateJobResultInput struct {
 	Status         *enums.JobExecutionStatus
+	ClearLog       bool
+	Log            *string
 	ClearOwner     bool
 	OwnerID        *string
 	ScheduledJobID *string
@@ -5260,6 +5266,12 @@ type UpdateJobResultInput struct {
 func (i *UpdateJobResultInput) Mutate(m *JobResultMutation) {
 	if v := i.Status; v != nil {
 		m.SetStatus(*v)
+	}
+	if i.ClearLog {
+		m.ClearLog()
+	}
+	if v := i.Log; v != nil {
+		m.SetLog(*v)
 	}
 	if i.ClearOwner {
 		m.ClearOwner()
@@ -5291,7 +5303,10 @@ func (c *JobResultUpdateOne) SetInput(i UpdateJobResultInput) *JobResultUpdateOn
 type CreateJobRunnerInput struct {
 	Tags              []string
 	Name              string
-	IPAddress         string
+	IPAddress         *string
+	LastSeen          *time.Time
+	Version           *string
+	Os                *string
 	OwnerID           *string
 	JobRunnerTokenIDs []string
 }
@@ -5302,7 +5317,18 @@ func (i *CreateJobRunnerInput) Mutate(m *JobRunnerMutation) {
 		m.SetTags(v)
 	}
 	m.SetName(i.Name)
-	m.SetIPAddress(i.IPAddress)
+	if v := i.IPAddress; v != nil {
+		m.SetIPAddress(*v)
+	}
+	if v := i.LastSeen; v != nil {
+		m.SetLastSeen(*v)
+	}
+	if v := i.Version; v != nil {
+		m.SetVersion(*v)
+	}
+	if v := i.Os; v != nil {
+		m.SetOs(*v)
+	}
 	if v := i.OwnerID; v != nil {
 		m.SetOwnerID(*v)
 	}
@@ -5323,6 +5349,14 @@ type UpdateJobRunnerInput struct {
 	Tags                    []string
 	AppendTags              []string
 	Name                    *string
+	ClearIPAddress          bool
+	IPAddress               *string
+	ClearLastSeen           bool
+	LastSeen                *time.Time
+	ClearVersion            bool
+	Version                 *string
+	ClearOs                 bool
+	Os                      *string
 	ClearOwner              bool
 	OwnerID                 *string
 	ClearJobRunnerTokens    bool
@@ -5343,6 +5377,30 @@ func (i *UpdateJobRunnerInput) Mutate(m *JobRunnerMutation) {
 	}
 	if v := i.Name; v != nil {
 		m.SetName(*v)
+	}
+	if i.ClearIPAddress {
+		m.ClearIPAddress()
+	}
+	if v := i.IPAddress; v != nil {
+		m.SetIPAddress(*v)
+	}
+	if i.ClearLastSeen {
+		m.ClearLastSeen()
+	}
+	if v := i.LastSeen; v != nil {
+		m.SetLastSeen(*v)
+	}
+	if i.ClearVersion {
+		m.ClearVersion()
+	}
+	if v := i.Version; v != nil {
+		m.SetVersion(*v)
+	}
+	if i.ClearOs {
+		m.ClearOs()
+	}
+	if v := i.Os; v != nil {
+		m.SetOs(*v)
 	}
 	if i.ClearOwner {
 		m.ClearOwner()

--- a/internal/ent/generated/gql_where_input.go
+++ b/internal/ent/generated/gql_where_input.go
@@ -36087,6 +36087,23 @@ type JobResultWhereInput struct {
 	FileIDEqualFold    *string  `json:"fileIDEqualFold,omitempty"`
 	FileIDContainsFold *string  `json:"fileIDContainsFold,omitempty"`
 
+	// "log" field predicates.
+	Log             *string  `json:"log,omitempty"`
+	LogNEQ          *string  `json:"logNEQ,omitempty"`
+	LogIn           []string `json:"logIn,omitempty"`
+	LogNotIn        []string `json:"logNotIn,omitempty"`
+	LogGT           *string  `json:"logGT,omitempty"`
+	LogGTE          *string  `json:"logGTE,omitempty"`
+	LogLT           *string  `json:"logLT,omitempty"`
+	LogLTE          *string  `json:"logLTE,omitempty"`
+	LogContains     *string  `json:"logContains,omitempty"`
+	LogHasPrefix    *string  `json:"logHasPrefix,omitempty"`
+	LogHasSuffix    *string  `json:"logHasSuffix,omitempty"`
+	LogIsNil        bool     `json:"logIsNil,omitempty"`
+	LogNotNil       bool     `json:"logNotNil,omitempty"`
+	LogEqualFold    *string  `json:"logEqualFold,omitempty"`
+	LogContainsFold *string  `json:"logContainsFold,omitempty"`
+
 	// "owner" edge predicates.
 	HasOwner     *bool                     `json:"hasOwner,omitempty"`
 	HasOwnerWith []*OrganizationWhereInput `json:"hasOwnerWith,omitempty"`
@@ -36558,6 +36575,51 @@ func (i *JobResultWhereInput) P() (predicate.JobResult, error) {
 	if i.FileIDContainsFold != nil {
 		predicates = append(predicates, jobresult.FileIDContainsFold(*i.FileIDContainsFold))
 	}
+	if i.Log != nil {
+		predicates = append(predicates, jobresult.LogEQ(*i.Log))
+	}
+	if i.LogNEQ != nil {
+		predicates = append(predicates, jobresult.LogNEQ(*i.LogNEQ))
+	}
+	if len(i.LogIn) > 0 {
+		predicates = append(predicates, jobresult.LogIn(i.LogIn...))
+	}
+	if len(i.LogNotIn) > 0 {
+		predicates = append(predicates, jobresult.LogNotIn(i.LogNotIn...))
+	}
+	if i.LogGT != nil {
+		predicates = append(predicates, jobresult.LogGT(*i.LogGT))
+	}
+	if i.LogGTE != nil {
+		predicates = append(predicates, jobresult.LogGTE(*i.LogGTE))
+	}
+	if i.LogLT != nil {
+		predicates = append(predicates, jobresult.LogLT(*i.LogLT))
+	}
+	if i.LogLTE != nil {
+		predicates = append(predicates, jobresult.LogLTE(*i.LogLTE))
+	}
+	if i.LogContains != nil {
+		predicates = append(predicates, jobresult.LogContains(*i.LogContains))
+	}
+	if i.LogHasPrefix != nil {
+		predicates = append(predicates, jobresult.LogHasPrefix(*i.LogHasPrefix))
+	}
+	if i.LogHasSuffix != nil {
+		predicates = append(predicates, jobresult.LogHasSuffix(*i.LogHasSuffix))
+	}
+	if i.LogIsNil {
+		predicates = append(predicates, jobresult.LogIsNil())
+	}
+	if i.LogNotNil {
+		predicates = append(predicates, jobresult.LogNotNil())
+	}
+	if i.LogEqualFold != nil {
+		predicates = append(predicates, jobresult.LogEqualFold(*i.LogEqualFold))
+	}
+	if i.LogContainsFold != nil {
+		predicates = append(predicates, jobresult.LogContainsFold(*i.LogContainsFold))
+	}
 
 	if i.HasOwner != nil {
 		p := jobresult.HasOwner()
@@ -36771,8 +36833,56 @@ type JobRunnerWhereInput struct {
 	IPAddressContains     *string  `json:"ipAddressContains,omitempty"`
 	IPAddressHasPrefix    *string  `json:"ipAddressHasPrefix,omitempty"`
 	IPAddressHasSuffix    *string  `json:"ipAddressHasSuffix,omitempty"`
+	IPAddressIsNil        bool     `json:"ipAddressIsNil,omitempty"`
+	IPAddressNotNil       bool     `json:"ipAddressNotNil,omitempty"`
 	IPAddressEqualFold    *string  `json:"ipAddressEqualFold,omitempty"`
 	IPAddressContainsFold *string  `json:"ipAddressContainsFold,omitempty"`
+
+	// "last_seen" field predicates.
+	LastSeen       *time.Time  `json:"lastSeen,omitempty"`
+	LastSeenNEQ    *time.Time  `json:"lastSeenNEQ,omitempty"`
+	LastSeenIn     []time.Time `json:"lastSeenIn,omitempty"`
+	LastSeenNotIn  []time.Time `json:"lastSeenNotIn,omitempty"`
+	LastSeenGT     *time.Time  `json:"lastSeenGT,omitempty"`
+	LastSeenGTE    *time.Time  `json:"lastSeenGTE,omitempty"`
+	LastSeenLT     *time.Time  `json:"lastSeenLT,omitempty"`
+	LastSeenLTE    *time.Time  `json:"lastSeenLTE,omitempty"`
+	LastSeenIsNil  bool        `json:"lastSeenIsNil,omitempty"`
+	LastSeenNotNil bool        `json:"lastSeenNotNil,omitempty"`
+
+	// "version" field predicates.
+	Version             *string  `json:"version,omitempty"`
+	VersionNEQ          *string  `json:"versionNEQ,omitempty"`
+	VersionIn           []string `json:"versionIn,omitempty"`
+	VersionNotIn        []string `json:"versionNotIn,omitempty"`
+	VersionGT           *string  `json:"versionGT,omitempty"`
+	VersionGTE          *string  `json:"versionGTE,omitempty"`
+	VersionLT           *string  `json:"versionLT,omitempty"`
+	VersionLTE          *string  `json:"versionLTE,omitempty"`
+	VersionContains     *string  `json:"versionContains,omitempty"`
+	VersionHasPrefix    *string  `json:"versionHasPrefix,omitempty"`
+	VersionHasSuffix    *string  `json:"versionHasSuffix,omitempty"`
+	VersionIsNil        bool     `json:"versionIsNil,omitempty"`
+	VersionNotNil       bool     `json:"versionNotNil,omitempty"`
+	VersionEqualFold    *string  `json:"versionEqualFold,omitempty"`
+	VersionContainsFold *string  `json:"versionContainsFold,omitempty"`
+
+	// "os" field predicates.
+	Os             *string  `json:"os,omitempty"`
+	OsNEQ          *string  `json:"osNEQ,omitempty"`
+	OsIn           []string `json:"osIn,omitempty"`
+	OsNotIn        []string `json:"osNotIn,omitempty"`
+	OsGT           *string  `json:"osGT,omitempty"`
+	OsGTE          *string  `json:"osGTE,omitempty"`
+	OsLT           *string  `json:"osLT,omitempty"`
+	OsLTE          *string  `json:"osLTE,omitempty"`
+	OsContains     *string  `json:"osContains,omitempty"`
+	OsHasPrefix    *string  `json:"osHasPrefix,omitempty"`
+	OsHasSuffix    *string  `json:"osHasSuffix,omitempty"`
+	OsIsNil        bool     `json:"osIsNil,omitempty"`
+	OsNotNil       bool     `json:"osNotNil,omitempty"`
+	OsEqualFold    *string  `json:"osEqualFold,omitempty"`
+	OsContainsFold *string  `json:"osContainsFold,omitempty"`
 
 	// "owner" edge predicates.
 	HasOwner     *bool                     `json:"hasOwner,omitempty"`
@@ -37214,11 +37324,137 @@ func (i *JobRunnerWhereInput) P() (predicate.JobRunner, error) {
 	if i.IPAddressHasSuffix != nil {
 		predicates = append(predicates, jobrunner.IPAddressHasSuffix(*i.IPAddressHasSuffix))
 	}
+	if i.IPAddressIsNil {
+		predicates = append(predicates, jobrunner.IPAddressIsNil())
+	}
+	if i.IPAddressNotNil {
+		predicates = append(predicates, jobrunner.IPAddressNotNil())
+	}
 	if i.IPAddressEqualFold != nil {
 		predicates = append(predicates, jobrunner.IPAddressEqualFold(*i.IPAddressEqualFold))
 	}
 	if i.IPAddressContainsFold != nil {
 		predicates = append(predicates, jobrunner.IPAddressContainsFold(*i.IPAddressContainsFold))
+	}
+	if i.LastSeen != nil {
+		predicates = append(predicates, jobrunner.LastSeenEQ(*i.LastSeen))
+	}
+	if i.LastSeenNEQ != nil {
+		predicates = append(predicates, jobrunner.LastSeenNEQ(*i.LastSeenNEQ))
+	}
+	if len(i.LastSeenIn) > 0 {
+		predicates = append(predicates, jobrunner.LastSeenIn(i.LastSeenIn...))
+	}
+	if len(i.LastSeenNotIn) > 0 {
+		predicates = append(predicates, jobrunner.LastSeenNotIn(i.LastSeenNotIn...))
+	}
+	if i.LastSeenGT != nil {
+		predicates = append(predicates, jobrunner.LastSeenGT(*i.LastSeenGT))
+	}
+	if i.LastSeenGTE != nil {
+		predicates = append(predicates, jobrunner.LastSeenGTE(*i.LastSeenGTE))
+	}
+	if i.LastSeenLT != nil {
+		predicates = append(predicates, jobrunner.LastSeenLT(*i.LastSeenLT))
+	}
+	if i.LastSeenLTE != nil {
+		predicates = append(predicates, jobrunner.LastSeenLTE(*i.LastSeenLTE))
+	}
+	if i.LastSeenIsNil {
+		predicates = append(predicates, jobrunner.LastSeenIsNil())
+	}
+	if i.LastSeenNotNil {
+		predicates = append(predicates, jobrunner.LastSeenNotNil())
+	}
+	if i.Version != nil {
+		predicates = append(predicates, jobrunner.VersionEQ(*i.Version))
+	}
+	if i.VersionNEQ != nil {
+		predicates = append(predicates, jobrunner.VersionNEQ(*i.VersionNEQ))
+	}
+	if len(i.VersionIn) > 0 {
+		predicates = append(predicates, jobrunner.VersionIn(i.VersionIn...))
+	}
+	if len(i.VersionNotIn) > 0 {
+		predicates = append(predicates, jobrunner.VersionNotIn(i.VersionNotIn...))
+	}
+	if i.VersionGT != nil {
+		predicates = append(predicates, jobrunner.VersionGT(*i.VersionGT))
+	}
+	if i.VersionGTE != nil {
+		predicates = append(predicates, jobrunner.VersionGTE(*i.VersionGTE))
+	}
+	if i.VersionLT != nil {
+		predicates = append(predicates, jobrunner.VersionLT(*i.VersionLT))
+	}
+	if i.VersionLTE != nil {
+		predicates = append(predicates, jobrunner.VersionLTE(*i.VersionLTE))
+	}
+	if i.VersionContains != nil {
+		predicates = append(predicates, jobrunner.VersionContains(*i.VersionContains))
+	}
+	if i.VersionHasPrefix != nil {
+		predicates = append(predicates, jobrunner.VersionHasPrefix(*i.VersionHasPrefix))
+	}
+	if i.VersionHasSuffix != nil {
+		predicates = append(predicates, jobrunner.VersionHasSuffix(*i.VersionHasSuffix))
+	}
+	if i.VersionIsNil {
+		predicates = append(predicates, jobrunner.VersionIsNil())
+	}
+	if i.VersionNotNil {
+		predicates = append(predicates, jobrunner.VersionNotNil())
+	}
+	if i.VersionEqualFold != nil {
+		predicates = append(predicates, jobrunner.VersionEqualFold(*i.VersionEqualFold))
+	}
+	if i.VersionContainsFold != nil {
+		predicates = append(predicates, jobrunner.VersionContainsFold(*i.VersionContainsFold))
+	}
+	if i.Os != nil {
+		predicates = append(predicates, jobrunner.OsEQ(*i.Os))
+	}
+	if i.OsNEQ != nil {
+		predicates = append(predicates, jobrunner.OsNEQ(*i.OsNEQ))
+	}
+	if len(i.OsIn) > 0 {
+		predicates = append(predicates, jobrunner.OsIn(i.OsIn...))
+	}
+	if len(i.OsNotIn) > 0 {
+		predicates = append(predicates, jobrunner.OsNotIn(i.OsNotIn...))
+	}
+	if i.OsGT != nil {
+		predicates = append(predicates, jobrunner.OsGT(*i.OsGT))
+	}
+	if i.OsGTE != nil {
+		predicates = append(predicates, jobrunner.OsGTE(*i.OsGTE))
+	}
+	if i.OsLT != nil {
+		predicates = append(predicates, jobrunner.OsLT(*i.OsLT))
+	}
+	if i.OsLTE != nil {
+		predicates = append(predicates, jobrunner.OsLTE(*i.OsLTE))
+	}
+	if i.OsContains != nil {
+		predicates = append(predicates, jobrunner.OsContains(*i.OsContains))
+	}
+	if i.OsHasPrefix != nil {
+		predicates = append(predicates, jobrunner.OsHasPrefix(*i.OsHasPrefix))
+	}
+	if i.OsHasSuffix != nil {
+		predicates = append(predicates, jobrunner.OsHasSuffix(*i.OsHasSuffix))
+	}
+	if i.OsIsNil {
+		predicates = append(predicates, jobrunner.OsIsNil())
+	}
+	if i.OsNotNil {
+		predicates = append(predicates, jobrunner.OsNotNil())
+	}
+	if i.OsEqualFold != nil {
+		predicates = append(predicates, jobrunner.OsEqualFold(*i.OsEqualFold))
+	}
+	if i.OsContainsFold != nil {
+		predicates = append(predicates, jobrunner.OsContainsFold(*i.OsContainsFold))
 	}
 
 	if i.HasOwner != nil {

--- a/internal/ent/generated/jobresult/jobresult.go
+++ b/internal/ent/generated/jobresult/jobresult.go
@@ -44,6 +44,8 @@ const (
 	FieldStartedAt = "started_at"
 	// FieldFileID holds the string denoting the file_id field in the database.
 	FieldFileID = "file_id"
+	// FieldLog holds the string denoting the log field in the database.
+	FieldLog = "log"
 	// EdgeOwner holds the string denoting the owner edge name in mutations.
 	EdgeOwner = "owner"
 	// EdgeScheduledJob holds the string denoting the scheduled_job edge name in mutations.
@@ -91,6 +93,7 @@ var Columns = []string{
 	FieldFinishedAt,
 	FieldStartedAt,
 	FieldFileID,
+	FieldLog,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -211,6 +214,11 @@ func ByStartedAt(opts ...sql.OrderTermOption) OrderOption {
 // ByFileID orders the results by the file_id field.
 func ByFileID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldFileID, opts...).ToFunc()
+}
+
+// ByLog orders the results by the log field.
+func ByLog(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldLog, opts...).ToFunc()
 }
 
 // ByOwnerField orders the results by owner field.

--- a/internal/ent/generated/jobresult/where.go
+++ b/internal/ent/generated/jobresult/where.go
@@ -128,6 +128,11 @@ func FileID(v string) predicate.JobResult {
 	return predicate.JobResult(sql.FieldEQ(FieldFileID, v))
 }
 
+// Log applies equality check predicate on the "log" field. It's identical to LogEQ.
+func Log(v string) predicate.JobResult {
+	return predicate.JobResult(sql.FieldEQ(FieldLog, v))
+}
+
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
 func CreatedAtEQ(v time.Time) predicate.JobResult {
 	return predicate.JobResult(sql.FieldEQ(FieldCreatedAt, v))
@@ -856,6 +861,81 @@ func FileIDEqualFold(v string) predicate.JobResult {
 // FileIDContainsFold applies the ContainsFold predicate on the "file_id" field.
 func FileIDContainsFold(v string) predicate.JobResult {
 	return predicate.JobResult(sql.FieldContainsFold(FieldFileID, v))
+}
+
+// LogEQ applies the EQ predicate on the "log" field.
+func LogEQ(v string) predicate.JobResult {
+	return predicate.JobResult(sql.FieldEQ(FieldLog, v))
+}
+
+// LogNEQ applies the NEQ predicate on the "log" field.
+func LogNEQ(v string) predicate.JobResult {
+	return predicate.JobResult(sql.FieldNEQ(FieldLog, v))
+}
+
+// LogIn applies the In predicate on the "log" field.
+func LogIn(vs ...string) predicate.JobResult {
+	return predicate.JobResult(sql.FieldIn(FieldLog, vs...))
+}
+
+// LogNotIn applies the NotIn predicate on the "log" field.
+func LogNotIn(vs ...string) predicate.JobResult {
+	return predicate.JobResult(sql.FieldNotIn(FieldLog, vs...))
+}
+
+// LogGT applies the GT predicate on the "log" field.
+func LogGT(v string) predicate.JobResult {
+	return predicate.JobResult(sql.FieldGT(FieldLog, v))
+}
+
+// LogGTE applies the GTE predicate on the "log" field.
+func LogGTE(v string) predicate.JobResult {
+	return predicate.JobResult(sql.FieldGTE(FieldLog, v))
+}
+
+// LogLT applies the LT predicate on the "log" field.
+func LogLT(v string) predicate.JobResult {
+	return predicate.JobResult(sql.FieldLT(FieldLog, v))
+}
+
+// LogLTE applies the LTE predicate on the "log" field.
+func LogLTE(v string) predicate.JobResult {
+	return predicate.JobResult(sql.FieldLTE(FieldLog, v))
+}
+
+// LogContains applies the Contains predicate on the "log" field.
+func LogContains(v string) predicate.JobResult {
+	return predicate.JobResult(sql.FieldContains(FieldLog, v))
+}
+
+// LogHasPrefix applies the HasPrefix predicate on the "log" field.
+func LogHasPrefix(v string) predicate.JobResult {
+	return predicate.JobResult(sql.FieldHasPrefix(FieldLog, v))
+}
+
+// LogHasSuffix applies the HasSuffix predicate on the "log" field.
+func LogHasSuffix(v string) predicate.JobResult {
+	return predicate.JobResult(sql.FieldHasSuffix(FieldLog, v))
+}
+
+// LogIsNil applies the IsNil predicate on the "log" field.
+func LogIsNil() predicate.JobResult {
+	return predicate.JobResult(sql.FieldIsNull(FieldLog))
+}
+
+// LogNotNil applies the NotNil predicate on the "log" field.
+func LogNotNil() predicate.JobResult {
+	return predicate.JobResult(sql.FieldNotNull(FieldLog))
+}
+
+// LogEqualFold applies the EqualFold predicate on the "log" field.
+func LogEqualFold(v string) predicate.JobResult {
+	return predicate.JobResult(sql.FieldEqualFold(FieldLog, v))
+}
+
+// LogContainsFold applies the ContainsFold predicate on the "log" field.
+func LogContainsFold(v string) predicate.JobResult {
+	return predicate.JobResult(sql.FieldContainsFold(FieldLog, v))
 }
 
 // HasOwner applies the HasEdge predicate on the "owner" edge.

--- a/internal/ent/generated/jobresult_create.go
+++ b/internal/ent/generated/jobresult_create.go
@@ -174,6 +174,20 @@ func (jrc *JobResultCreate) SetFileID(s string) *JobResultCreate {
 	return jrc
 }
 
+// SetLog sets the "log" field.
+func (jrc *JobResultCreate) SetLog(s string) *JobResultCreate {
+	jrc.mutation.SetLog(s)
+	return jrc
+}
+
+// SetNillableLog sets the "log" field if the given value is not nil.
+func (jrc *JobResultCreate) SetNillableLog(s *string) *JobResultCreate {
+	if s != nil {
+		jrc.SetLog(*s)
+	}
+	return jrc
+}
+
 // SetID sets the "id" field.
 func (jrc *JobResultCreate) SetID(s string) *JobResultCreate {
 	jrc.mutation.SetID(s)
@@ -394,6 +408,10 @@ func (jrc *JobResultCreate) createSpec() (*JobResult, *sqlgraph.CreateSpec) {
 	if value, ok := jrc.mutation.StartedAt(); ok {
 		_spec.SetField(jobresult.FieldStartedAt, field.TypeTime, value)
 		_node.StartedAt = value
+	}
+	if value, ok := jrc.mutation.Log(); ok {
+		_spec.SetField(jobresult.FieldLog, field.TypeString, value)
+		_node.Log = &value
 	}
 	if nodes := jrc.mutation.OwnerIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/internal/ent/generated/jobresult_update.go
+++ b/internal/ent/generated/jobresult_update.go
@@ -169,6 +169,26 @@ func (jru *JobResultUpdate) SetNillableFileID(s *string) *JobResultUpdate {
 	return jru
 }
 
+// SetLog sets the "log" field.
+func (jru *JobResultUpdate) SetLog(s string) *JobResultUpdate {
+	jru.mutation.SetLog(s)
+	return jru
+}
+
+// SetNillableLog sets the "log" field if the given value is not nil.
+func (jru *JobResultUpdate) SetNillableLog(s *string) *JobResultUpdate {
+	if s != nil {
+		jru.SetLog(*s)
+	}
+	return jru
+}
+
+// ClearLog clears the value of the "log" field.
+func (jru *JobResultUpdate) ClearLog() *JobResultUpdate {
+	jru.mutation.ClearLog()
+	return jru
+}
+
 // SetOwner sets the "owner" edge to the Organization entity.
 func (jru *JobResultUpdate) SetOwner(o *Organization) *JobResultUpdate {
 	return jru.SetOwnerID(o.ID)
@@ -320,6 +340,12 @@ func (jru *JobResultUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := jru.mutation.Status(); ok {
 		_spec.SetField(jobresult.FieldStatus, field.TypeEnum, value)
+	}
+	if value, ok := jru.mutation.Log(); ok {
+		_spec.SetField(jobresult.FieldLog, field.TypeString, value)
+	}
+	if jru.mutation.LogCleared() {
+		_spec.ClearField(jobresult.FieldLog, field.TypeString)
 	}
 	if jru.mutation.OwnerCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -572,6 +598,26 @@ func (jruo *JobResultUpdateOne) SetNillableFileID(s *string) *JobResultUpdateOne
 	return jruo
 }
 
+// SetLog sets the "log" field.
+func (jruo *JobResultUpdateOne) SetLog(s string) *JobResultUpdateOne {
+	jruo.mutation.SetLog(s)
+	return jruo
+}
+
+// SetNillableLog sets the "log" field if the given value is not nil.
+func (jruo *JobResultUpdateOne) SetNillableLog(s *string) *JobResultUpdateOne {
+	if s != nil {
+		jruo.SetLog(*s)
+	}
+	return jruo
+}
+
+// ClearLog clears the value of the "log" field.
+func (jruo *JobResultUpdateOne) ClearLog() *JobResultUpdateOne {
+	jruo.mutation.ClearLog()
+	return jruo
+}
+
 // SetOwner sets the "owner" edge to the Organization entity.
 func (jruo *JobResultUpdateOne) SetOwner(o *Organization) *JobResultUpdateOne {
 	return jruo.SetOwnerID(o.ID)
@@ -753,6 +799,12 @@ func (jruo *JobResultUpdateOne) sqlSave(ctx context.Context) (_node *JobResult, 
 	}
 	if value, ok := jruo.mutation.Status(); ok {
 		_spec.SetField(jobresult.FieldStatus, field.TypeEnum, value)
+	}
+	if value, ok := jruo.mutation.Log(); ok {
+		_spec.SetField(jobresult.FieldLog, field.TypeString, value)
+	}
+	if jruo.mutation.LogCleared() {
+		_spec.ClearField(jobresult.FieldLog, field.TypeString)
 	}
 	if jruo.mutation.OwnerCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/internal/ent/generated/jobrunner/jobrunner.go
+++ b/internal/ent/generated/jobrunner/jobrunner.go
@@ -44,6 +44,12 @@ const (
 	FieldStatus = "status"
 	// FieldIPAddress holds the string denoting the ip_address field in the database.
 	FieldIPAddress = "ip_address"
+	// FieldLastSeen holds the string denoting the last_seen field in the database.
+	FieldLastSeen = "last_seen"
+	// FieldVersion holds the string denoting the version field in the database.
+	FieldVersion = "version"
+	// FieldOs holds the string denoting the os field in the database.
+	FieldOs = "os"
 	// EdgeOwner holds the string denoting the owner edge name in mutations.
 	EdgeOwner = "owner"
 	// EdgeJobRunnerTokens holds the string denoting the job_runner_tokens edge name in mutations.
@@ -80,6 +86,9 @@ var Columns = []string{
 	FieldName,
 	FieldStatus,
 	FieldIPAddress,
+	FieldLastSeen,
+	FieldVersion,
+	FieldOs,
 }
 
 var (
@@ -119,8 +128,6 @@ var (
 	DefaultTags []string
 	// DefaultSystemOwned holds the default value on creation for the "system_owned" field.
 	DefaultSystemOwned bool
-	// IPAddressValidator is a validator for the "ip_address" field. It is called by the builders before save.
-	IPAddressValidator func(string) error
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() string
 )
@@ -203,6 +210,21 @@ func ByStatus(opts ...sql.OrderTermOption) OrderOption {
 // ByIPAddress orders the results by the ip_address field.
 func ByIPAddress(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldIPAddress, opts...).ToFunc()
+}
+
+// ByLastSeen orders the results by the last_seen field.
+func ByLastSeen(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldLastSeen, opts...).ToFunc()
+}
+
+// ByVersion orders the results by the version field.
+func ByVersion(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldVersion, opts...).ToFunc()
+}
+
+// ByOs orders the results by the os field.
+func ByOs(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldOs, opts...).ToFunc()
 }
 
 // ByOwnerField orders the results by owner field.

--- a/internal/ent/generated/jobrunner/where.go
+++ b/internal/ent/generated/jobrunner/where.go
@@ -123,6 +123,21 @@ func IPAddress(v string) predicate.JobRunner {
 	return predicate.JobRunner(sql.FieldEQ(FieldIPAddress, v))
 }
 
+// LastSeen applies equality check predicate on the "last_seen" field. It's identical to LastSeenEQ.
+func LastSeen(v time.Time) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldEQ(FieldLastSeen, v))
+}
+
+// Version applies equality check predicate on the "version" field. It's identical to VersionEQ.
+func Version(v string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldEQ(FieldVersion, v))
+}
+
+// Os applies equality check predicate on the "os" field. It's identical to OsEQ.
+func Os(v string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldEQ(FieldOs, v))
+}
+
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
 func CreatedAtEQ(v time.Time) predicate.JobRunner {
 	return predicate.JobRunner(sql.FieldEQ(FieldCreatedAt, v))
@@ -818,6 +833,16 @@ func IPAddressHasSuffix(v string) predicate.JobRunner {
 	return predicate.JobRunner(sql.FieldHasSuffix(FieldIPAddress, v))
 }
 
+// IPAddressIsNil applies the IsNil predicate on the "ip_address" field.
+func IPAddressIsNil() predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldIsNull(FieldIPAddress))
+}
+
+// IPAddressNotNil applies the NotNil predicate on the "ip_address" field.
+func IPAddressNotNil() predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldNotNull(FieldIPAddress))
+}
+
 // IPAddressEqualFold applies the EqualFold predicate on the "ip_address" field.
 func IPAddressEqualFold(v string) predicate.JobRunner {
 	return predicate.JobRunner(sql.FieldEqualFold(FieldIPAddress, v))
@@ -826,6 +851,206 @@ func IPAddressEqualFold(v string) predicate.JobRunner {
 // IPAddressContainsFold applies the ContainsFold predicate on the "ip_address" field.
 func IPAddressContainsFold(v string) predicate.JobRunner {
 	return predicate.JobRunner(sql.FieldContainsFold(FieldIPAddress, v))
+}
+
+// LastSeenEQ applies the EQ predicate on the "last_seen" field.
+func LastSeenEQ(v time.Time) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldEQ(FieldLastSeen, v))
+}
+
+// LastSeenNEQ applies the NEQ predicate on the "last_seen" field.
+func LastSeenNEQ(v time.Time) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldNEQ(FieldLastSeen, v))
+}
+
+// LastSeenIn applies the In predicate on the "last_seen" field.
+func LastSeenIn(vs ...time.Time) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldIn(FieldLastSeen, vs...))
+}
+
+// LastSeenNotIn applies the NotIn predicate on the "last_seen" field.
+func LastSeenNotIn(vs ...time.Time) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldNotIn(FieldLastSeen, vs...))
+}
+
+// LastSeenGT applies the GT predicate on the "last_seen" field.
+func LastSeenGT(v time.Time) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldGT(FieldLastSeen, v))
+}
+
+// LastSeenGTE applies the GTE predicate on the "last_seen" field.
+func LastSeenGTE(v time.Time) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldGTE(FieldLastSeen, v))
+}
+
+// LastSeenLT applies the LT predicate on the "last_seen" field.
+func LastSeenLT(v time.Time) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldLT(FieldLastSeen, v))
+}
+
+// LastSeenLTE applies the LTE predicate on the "last_seen" field.
+func LastSeenLTE(v time.Time) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldLTE(FieldLastSeen, v))
+}
+
+// LastSeenIsNil applies the IsNil predicate on the "last_seen" field.
+func LastSeenIsNil() predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldIsNull(FieldLastSeen))
+}
+
+// LastSeenNotNil applies the NotNil predicate on the "last_seen" field.
+func LastSeenNotNil() predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldNotNull(FieldLastSeen))
+}
+
+// VersionEQ applies the EQ predicate on the "version" field.
+func VersionEQ(v string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldEQ(FieldVersion, v))
+}
+
+// VersionNEQ applies the NEQ predicate on the "version" field.
+func VersionNEQ(v string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldNEQ(FieldVersion, v))
+}
+
+// VersionIn applies the In predicate on the "version" field.
+func VersionIn(vs ...string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldIn(FieldVersion, vs...))
+}
+
+// VersionNotIn applies the NotIn predicate on the "version" field.
+func VersionNotIn(vs ...string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldNotIn(FieldVersion, vs...))
+}
+
+// VersionGT applies the GT predicate on the "version" field.
+func VersionGT(v string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldGT(FieldVersion, v))
+}
+
+// VersionGTE applies the GTE predicate on the "version" field.
+func VersionGTE(v string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldGTE(FieldVersion, v))
+}
+
+// VersionLT applies the LT predicate on the "version" field.
+func VersionLT(v string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldLT(FieldVersion, v))
+}
+
+// VersionLTE applies the LTE predicate on the "version" field.
+func VersionLTE(v string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldLTE(FieldVersion, v))
+}
+
+// VersionContains applies the Contains predicate on the "version" field.
+func VersionContains(v string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldContains(FieldVersion, v))
+}
+
+// VersionHasPrefix applies the HasPrefix predicate on the "version" field.
+func VersionHasPrefix(v string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldHasPrefix(FieldVersion, v))
+}
+
+// VersionHasSuffix applies the HasSuffix predicate on the "version" field.
+func VersionHasSuffix(v string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldHasSuffix(FieldVersion, v))
+}
+
+// VersionIsNil applies the IsNil predicate on the "version" field.
+func VersionIsNil() predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldIsNull(FieldVersion))
+}
+
+// VersionNotNil applies the NotNil predicate on the "version" field.
+func VersionNotNil() predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldNotNull(FieldVersion))
+}
+
+// VersionEqualFold applies the EqualFold predicate on the "version" field.
+func VersionEqualFold(v string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldEqualFold(FieldVersion, v))
+}
+
+// VersionContainsFold applies the ContainsFold predicate on the "version" field.
+func VersionContainsFold(v string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldContainsFold(FieldVersion, v))
+}
+
+// OsEQ applies the EQ predicate on the "os" field.
+func OsEQ(v string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldEQ(FieldOs, v))
+}
+
+// OsNEQ applies the NEQ predicate on the "os" field.
+func OsNEQ(v string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldNEQ(FieldOs, v))
+}
+
+// OsIn applies the In predicate on the "os" field.
+func OsIn(vs ...string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldIn(FieldOs, vs...))
+}
+
+// OsNotIn applies the NotIn predicate on the "os" field.
+func OsNotIn(vs ...string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldNotIn(FieldOs, vs...))
+}
+
+// OsGT applies the GT predicate on the "os" field.
+func OsGT(v string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldGT(FieldOs, v))
+}
+
+// OsGTE applies the GTE predicate on the "os" field.
+func OsGTE(v string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldGTE(FieldOs, v))
+}
+
+// OsLT applies the LT predicate on the "os" field.
+func OsLT(v string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldLT(FieldOs, v))
+}
+
+// OsLTE applies the LTE predicate on the "os" field.
+func OsLTE(v string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldLTE(FieldOs, v))
+}
+
+// OsContains applies the Contains predicate on the "os" field.
+func OsContains(v string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldContains(FieldOs, v))
+}
+
+// OsHasPrefix applies the HasPrefix predicate on the "os" field.
+func OsHasPrefix(v string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldHasPrefix(FieldOs, v))
+}
+
+// OsHasSuffix applies the HasSuffix predicate on the "os" field.
+func OsHasSuffix(v string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldHasSuffix(FieldOs, v))
+}
+
+// OsIsNil applies the IsNil predicate on the "os" field.
+func OsIsNil() predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldIsNull(FieldOs))
+}
+
+// OsNotNil applies the NotNil predicate on the "os" field.
+func OsNotNil() predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldNotNull(FieldOs))
+}
+
+// OsEqualFold applies the EqualFold predicate on the "os" field.
+func OsEqualFold(v string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldEqualFold(FieldOs, v))
+}
+
+// OsContainsFold applies the ContainsFold predicate on the "os" field.
+func OsContainsFold(v string) predicate.JobRunner {
+	return predicate.JobRunner(sql.FieldContainsFold(FieldOs, v))
 }
 
 // HasOwner applies the HasEdge predicate on the "owner" edge.

--- a/internal/ent/generated/jobrunner_create.go
+++ b/internal/ent/generated/jobrunner_create.go
@@ -173,6 +173,56 @@ func (jrc *JobRunnerCreate) SetIPAddress(s string) *JobRunnerCreate {
 	return jrc
 }
 
+// SetNillableIPAddress sets the "ip_address" field if the given value is not nil.
+func (jrc *JobRunnerCreate) SetNillableIPAddress(s *string) *JobRunnerCreate {
+	if s != nil {
+		jrc.SetIPAddress(*s)
+	}
+	return jrc
+}
+
+// SetLastSeen sets the "last_seen" field.
+func (jrc *JobRunnerCreate) SetLastSeen(t time.Time) *JobRunnerCreate {
+	jrc.mutation.SetLastSeen(t)
+	return jrc
+}
+
+// SetNillableLastSeen sets the "last_seen" field if the given value is not nil.
+func (jrc *JobRunnerCreate) SetNillableLastSeen(t *time.Time) *JobRunnerCreate {
+	if t != nil {
+		jrc.SetLastSeen(*t)
+	}
+	return jrc
+}
+
+// SetVersion sets the "version" field.
+func (jrc *JobRunnerCreate) SetVersion(s string) *JobRunnerCreate {
+	jrc.mutation.SetVersion(s)
+	return jrc
+}
+
+// SetNillableVersion sets the "version" field if the given value is not nil.
+func (jrc *JobRunnerCreate) SetNillableVersion(s *string) *JobRunnerCreate {
+	if s != nil {
+		jrc.SetVersion(*s)
+	}
+	return jrc
+}
+
+// SetOs sets the "os" field.
+func (jrc *JobRunnerCreate) SetOs(s string) *JobRunnerCreate {
+	jrc.mutation.SetOs(s)
+	return jrc
+}
+
+// SetNillableOs sets the "os" field if the given value is not nil.
+func (jrc *JobRunnerCreate) SetNillableOs(s *string) *JobRunnerCreate {
+	if s != nil {
+		jrc.SetOs(*s)
+	}
+	return jrc
+}
+
 // SetID sets the "id" field.
 func (jrc *JobRunnerCreate) SetID(s string) *JobRunnerCreate {
 	jrc.mutation.SetID(s)
@@ -301,14 +351,6 @@ func (jrc *JobRunnerCreate) check() error {
 			return &ValidationError{Name: "status", err: fmt.Errorf(`generated: validator failed for field "JobRunner.status": %w`, err)}
 		}
 	}
-	if _, ok := jrc.mutation.IPAddress(); !ok {
-		return &ValidationError{Name: "ip_address", err: errors.New(`generated: missing required field "JobRunner.ip_address"`)}
-	}
-	if v, ok := jrc.mutation.IPAddress(); ok {
-		if err := jobrunner.IPAddressValidator(v); err != nil {
-			return &ValidationError{Name: "ip_address", err: fmt.Errorf(`generated: validator failed for field "JobRunner.ip_address": %w`, err)}
-		}
-	}
 	return nil
 }
 
@@ -392,6 +434,18 @@ func (jrc *JobRunnerCreate) createSpec() (*JobRunner, *sqlgraph.CreateSpec) {
 	if value, ok := jrc.mutation.IPAddress(); ok {
 		_spec.SetField(jobrunner.FieldIPAddress, field.TypeString, value)
 		_node.IPAddress = value
+	}
+	if value, ok := jrc.mutation.LastSeen(); ok {
+		_spec.SetField(jobrunner.FieldLastSeen, field.TypeTime, value)
+		_node.LastSeen = value
+	}
+	if value, ok := jrc.mutation.Version(); ok {
+		_spec.SetField(jobrunner.FieldVersion, field.TypeString, value)
+		_node.Version = value
+	}
+	if value, ok := jrc.mutation.Os(); ok {
+		_spec.SetField(jobrunner.FieldOs, field.TypeString, value)
+		_node.Os = value
 	}
 	if nodes := jrc.mutation.OwnerIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/internal/ent/generated/jobrunner_update.go
+++ b/internal/ent/generated/jobrunner_update.go
@@ -173,6 +173,86 @@ func (jru *JobRunnerUpdate) SetNillableStatus(ers *enums.JobRunnerStatus) *JobRu
 	return jru
 }
 
+// SetIPAddress sets the "ip_address" field.
+func (jru *JobRunnerUpdate) SetIPAddress(s string) *JobRunnerUpdate {
+	jru.mutation.SetIPAddress(s)
+	return jru
+}
+
+// SetNillableIPAddress sets the "ip_address" field if the given value is not nil.
+func (jru *JobRunnerUpdate) SetNillableIPAddress(s *string) *JobRunnerUpdate {
+	if s != nil {
+		jru.SetIPAddress(*s)
+	}
+	return jru
+}
+
+// ClearIPAddress clears the value of the "ip_address" field.
+func (jru *JobRunnerUpdate) ClearIPAddress() *JobRunnerUpdate {
+	jru.mutation.ClearIPAddress()
+	return jru
+}
+
+// SetLastSeen sets the "last_seen" field.
+func (jru *JobRunnerUpdate) SetLastSeen(t time.Time) *JobRunnerUpdate {
+	jru.mutation.SetLastSeen(t)
+	return jru
+}
+
+// SetNillableLastSeen sets the "last_seen" field if the given value is not nil.
+func (jru *JobRunnerUpdate) SetNillableLastSeen(t *time.Time) *JobRunnerUpdate {
+	if t != nil {
+		jru.SetLastSeen(*t)
+	}
+	return jru
+}
+
+// ClearLastSeen clears the value of the "last_seen" field.
+func (jru *JobRunnerUpdate) ClearLastSeen() *JobRunnerUpdate {
+	jru.mutation.ClearLastSeen()
+	return jru
+}
+
+// SetVersion sets the "version" field.
+func (jru *JobRunnerUpdate) SetVersion(s string) *JobRunnerUpdate {
+	jru.mutation.SetVersion(s)
+	return jru
+}
+
+// SetNillableVersion sets the "version" field if the given value is not nil.
+func (jru *JobRunnerUpdate) SetNillableVersion(s *string) *JobRunnerUpdate {
+	if s != nil {
+		jru.SetVersion(*s)
+	}
+	return jru
+}
+
+// ClearVersion clears the value of the "version" field.
+func (jru *JobRunnerUpdate) ClearVersion() *JobRunnerUpdate {
+	jru.mutation.ClearVersion()
+	return jru
+}
+
+// SetOs sets the "os" field.
+func (jru *JobRunnerUpdate) SetOs(s string) *JobRunnerUpdate {
+	jru.mutation.SetOs(s)
+	return jru
+}
+
+// SetNillableOs sets the "os" field if the given value is not nil.
+func (jru *JobRunnerUpdate) SetNillableOs(s *string) *JobRunnerUpdate {
+	if s != nil {
+		jru.SetOs(*s)
+	}
+	return jru
+}
+
+// ClearOs clears the value of the "os" field.
+func (jru *JobRunnerUpdate) ClearOs() *JobRunnerUpdate {
+	jru.mutation.ClearOs()
+	return jru
+}
+
 // SetOwner sets the "owner" edge to the Organization entity.
 func (jru *JobRunnerUpdate) SetOwner(o *Organization) *JobRunnerUpdate {
 	return jru.SetOwnerID(o.ID)
@@ -344,6 +424,30 @@ func (jru *JobRunnerUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := jru.mutation.Status(); ok {
 		_spec.SetField(jobrunner.FieldStatus, field.TypeEnum, value)
+	}
+	if value, ok := jru.mutation.IPAddress(); ok {
+		_spec.SetField(jobrunner.FieldIPAddress, field.TypeString, value)
+	}
+	if jru.mutation.IPAddressCleared() {
+		_spec.ClearField(jobrunner.FieldIPAddress, field.TypeString)
+	}
+	if value, ok := jru.mutation.LastSeen(); ok {
+		_spec.SetField(jobrunner.FieldLastSeen, field.TypeTime, value)
+	}
+	if jru.mutation.LastSeenCleared() {
+		_spec.ClearField(jobrunner.FieldLastSeen, field.TypeTime)
+	}
+	if value, ok := jru.mutation.Version(); ok {
+		_spec.SetField(jobrunner.FieldVersion, field.TypeString, value)
+	}
+	if jru.mutation.VersionCleared() {
+		_spec.ClearField(jobrunner.FieldVersion, field.TypeString)
+	}
+	if value, ok := jru.mutation.Os(); ok {
+		_spec.SetField(jobrunner.FieldOs, field.TypeString, value)
+	}
+	if jru.mutation.OsCleared() {
+		_spec.ClearField(jobrunner.FieldOs, field.TypeString)
 	}
 	if jru.mutation.OwnerCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -586,6 +690,86 @@ func (jruo *JobRunnerUpdateOne) SetNillableStatus(ers *enums.JobRunnerStatus) *J
 	return jruo
 }
 
+// SetIPAddress sets the "ip_address" field.
+func (jruo *JobRunnerUpdateOne) SetIPAddress(s string) *JobRunnerUpdateOne {
+	jruo.mutation.SetIPAddress(s)
+	return jruo
+}
+
+// SetNillableIPAddress sets the "ip_address" field if the given value is not nil.
+func (jruo *JobRunnerUpdateOne) SetNillableIPAddress(s *string) *JobRunnerUpdateOne {
+	if s != nil {
+		jruo.SetIPAddress(*s)
+	}
+	return jruo
+}
+
+// ClearIPAddress clears the value of the "ip_address" field.
+func (jruo *JobRunnerUpdateOne) ClearIPAddress() *JobRunnerUpdateOne {
+	jruo.mutation.ClearIPAddress()
+	return jruo
+}
+
+// SetLastSeen sets the "last_seen" field.
+func (jruo *JobRunnerUpdateOne) SetLastSeen(t time.Time) *JobRunnerUpdateOne {
+	jruo.mutation.SetLastSeen(t)
+	return jruo
+}
+
+// SetNillableLastSeen sets the "last_seen" field if the given value is not nil.
+func (jruo *JobRunnerUpdateOne) SetNillableLastSeen(t *time.Time) *JobRunnerUpdateOne {
+	if t != nil {
+		jruo.SetLastSeen(*t)
+	}
+	return jruo
+}
+
+// ClearLastSeen clears the value of the "last_seen" field.
+func (jruo *JobRunnerUpdateOne) ClearLastSeen() *JobRunnerUpdateOne {
+	jruo.mutation.ClearLastSeen()
+	return jruo
+}
+
+// SetVersion sets the "version" field.
+func (jruo *JobRunnerUpdateOne) SetVersion(s string) *JobRunnerUpdateOne {
+	jruo.mutation.SetVersion(s)
+	return jruo
+}
+
+// SetNillableVersion sets the "version" field if the given value is not nil.
+func (jruo *JobRunnerUpdateOne) SetNillableVersion(s *string) *JobRunnerUpdateOne {
+	if s != nil {
+		jruo.SetVersion(*s)
+	}
+	return jruo
+}
+
+// ClearVersion clears the value of the "version" field.
+func (jruo *JobRunnerUpdateOne) ClearVersion() *JobRunnerUpdateOne {
+	jruo.mutation.ClearVersion()
+	return jruo
+}
+
+// SetOs sets the "os" field.
+func (jruo *JobRunnerUpdateOne) SetOs(s string) *JobRunnerUpdateOne {
+	jruo.mutation.SetOs(s)
+	return jruo
+}
+
+// SetNillableOs sets the "os" field if the given value is not nil.
+func (jruo *JobRunnerUpdateOne) SetNillableOs(s *string) *JobRunnerUpdateOne {
+	if s != nil {
+		jruo.SetOs(*s)
+	}
+	return jruo
+}
+
+// ClearOs clears the value of the "os" field.
+func (jruo *JobRunnerUpdateOne) ClearOs() *JobRunnerUpdateOne {
+	jruo.mutation.ClearOs()
+	return jruo
+}
+
 // SetOwner sets the "owner" edge to the Organization entity.
 func (jruo *JobRunnerUpdateOne) SetOwner(o *Organization) *JobRunnerUpdateOne {
 	return jruo.SetOwnerID(o.ID)
@@ -787,6 +971,30 @@ func (jruo *JobRunnerUpdateOne) sqlSave(ctx context.Context) (_node *JobRunner, 
 	}
 	if value, ok := jruo.mutation.Status(); ok {
 		_spec.SetField(jobrunner.FieldStatus, field.TypeEnum, value)
+	}
+	if value, ok := jruo.mutation.IPAddress(); ok {
+		_spec.SetField(jobrunner.FieldIPAddress, field.TypeString, value)
+	}
+	if jruo.mutation.IPAddressCleared() {
+		_spec.ClearField(jobrunner.FieldIPAddress, field.TypeString)
+	}
+	if value, ok := jruo.mutation.LastSeen(); ok {
+		_spec.SetField(jobrunner.FieldLastSeen, field.TypeTime, value)
+	}
+	if jruo.mutation.LastSeenCleared() {
+		_spec.ClearField(jobrunner.FieldLastSeen, field.TypeTime)
+	}
+	if value, ok := jruo.mutation.Version(); ok {
+		_spec.SetField(jobrunner.FieldVersion, field.TypeString, value)
+	}
+	if jruo.mutation.VersionCleared() {
+		_spec.ClearField(jobrunner.FieldVersion, field.TypeString)
+	}
+	if value, ok := jruo.mutation.Os(); ok {
+		_spec.SetField(jobrunner.FieldOs, field.TypeString, value)
+	}
+	if jruo.mutation.OsCleared() {
+		_spec.ClearField(jobrunner.FieldOs, field.TypeString)
 	}
 	if jruo.mutation.OwnerCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/internal/ent/generated/migrate/schema.go
+++ b/internal/ent/generated/migrate/schema.go
@@ -2094,6 +2094,7 @@ var (
 		{Name: "exit_code", Type: field.TypeInt},
 		{Name: "finished_at", Type: field.TypeTime},
 		{Name: "started_at", Type: field.TypeTime},
+		{Name: "log", Type: field.TypeString, Nullable: true, Size: 2147483647},
 		{Name: "scheduled_job_id", Type: field.TypeString},
 		{Name: "file_id", Type: field.TypeString},
 		{Name: "owner_id", Type: field.TypeString, Nullable: true},
@@ -2106,19 +2107,19 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "job_results_scheduled_jobs_scheduled_job",
-				Columns:    []*schema.Column{JobResultsColumns[11]},
+				Columns:    []*schema.Column{JobResultsColumns[12]},
 				RefColumns: []*schema.Column{ScheduledJobsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "job_results_files_file",
-				Columns:    []*schema.Column{JobResultsColumns[12]},
+				Columns:    []*schema.Column{JobResultsColumns[13]},
 				RefColumns: []*schema.Column{FilesColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "job_results_organizations_job_results",
-				Columns:    []*schema.Column{JobResultsColumns[13]},
+				Columns:    []*schema.Column{JobResultsColumns[14]},
 				RefColumns: []*schema.Column{OrganizationsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -2127,7 +2128,7 @@ var (
 			{
 				Name:    "jobresult_owner_id",
 				Unique:  false,
-				Columns: []*schema.Column{JobResultsColumns[13]},
+				Columns: []*schema.Column{JobResultsColumns[14]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "deleted_at is NULL",
 				},
@@ -2148,7 +2149,10 @@ var (
 		{Name: "system_owned", Type: field.TypeBool, Nullable: true, Default: false},
 		{Name: "name", Type: field.TypeString},
 		{Name: "status", Type: field.TypeEnum, Enums: []string{"ONLINE", "OFFLINE"}, Default: "OFFLINE"},
-		{Name: "ip_address", Type: field.TypeString, Unique: true},
+		{Name: "ip_address", Type: field.TypeString, Nullable: true},
+		{Name: "last_seen", Type: field.TypeTime, Nullable: true},
+		{Name: "version", Type: field.TypeString, Nullable: true},
+		{Name: "os", Type: field.TypeString, Nullable: true},
 		{Name: "owner_id", Type: field.TypeString, Nullable: true},
 	}
 	// JobRunnersTable holds the schema information for the "job_runners" table.
@@ -2159,7 +2163,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "job_runners_organizations_job_runners",
-				Columns:    []*schema.Column{JobRunnersColumns[13]},
+				Columns:    []*schema.Column{JobRunnersColumns[16]},
 				RefColumns: []*schema.Column{OrganizationsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -2168,12 +2172,12 @@ var (
 			{
 				Name:    "jobrunner_display_id_owner_id",
 				Unique:  true,
-				Columns: []*schema.Column{JobRunnersColumns[7], JobRunnersColumns[13]},
+				Columns: []*schema.Column{JobRunnersColumns[7], JobRunnersColumns[16]},
 			},
 			{
 				Name:    "jobrunner_owner_id",
 				Unique:  false,
-				Columns: []*schema.Column{JobRunnersColumns[13]},
+				Columns: []*schema.Column{JobRunnersColumns[16]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "deleted_at is NULL",
 				},

--- a/internal/ent/generated/runtime/runtime.go
+++ b/internal/ent/generated/runtime/runtime.go
@@ -2992,10 +2992,6 @@ func init() {
 	jobrunnerDescSystemOwned := jobrunnerMixinFields7[0].Descriptor()
 	// jobrunner.DefaultSystemOwned holds the default value on creation for the system_owned field.
 	jobrunner.DefaultSystemOwned = jobrunnerDescSystemOwned.Default.(bool)
-	// jobrunnerDescIPAddress is the schema descriptor for ip_address field.
-	jobrunnerDescIPAddress := jobrunnerFields[2].Descriptor()
-	// jobrunner.IPAddressValidator is a validator for the "ip_address" field. It is called by the builders before save.
-	jobrunner.IPAddressValidator = jobrunnerDescIPAddress.Validators[0].(func(string) error)
 	// jobrunnerDescID is the schema descriptor for id field.
 	jobrunnerDescID := jobrunnerMixinFields3[0].Descriptor()
 	// jobrunner.DefaultID holds the default value on creation for the id field.

--- a/internal/ent/schema/jobresult.go
+++ b/internal/ent/schema/jobresult.go
@@ -88,6 +88,10 @@ func (JobResult) Fields() []ent.Field {
 			Annotations(
 				entgql.Skip(entgql.SkipMutationCreateInput, entgql.SkipMutationUpdateInput),
 			),
+		field.Text("log").
+			Comment("the log output from the job").
+			Optional().
+			Nillable(),
 	}
 }
 

--- a/internal/ent/schema/jobrunner.go
+++ b/internal/ent/schema/jobrunner.go
@@ -14,7 +14,6 @@ import (
 	"github.com/theopenlane/core/internal/ent/privacy/rule"
 	"github.com/theopenlane/core/internal/ent/privacy/token"
 	"github.com/theopenlane/core/pkg/enums"
-	"github.com/theopenlane/core/pkg/models"
 	"github.com/theopenlane/entx"
 	"github.com/theopenlane/entx/history"
 )
@@ -61,10 +60,17 @@ func (JobRunner) Fields() []ent.Field {
 			).
 			Comment("the status of this runner"),
 		field.String("ip_address").
-			Immutable().
-			Unique().
 			Comment("the IP address of this runner").
-			Validate(models.ValidateIP),
+			Optional(),
+		field.Time("last_seen").
+			Comment("the last time this runner was seen").
+			Optional(),
+		field.String("version").
+			Comment("the version of the runner").
+			Optional(),
+		field.String("os").
+			Comment("the operating system of the runner").
+			Optional(),
 	}
 }
 

--- a/internal/graphapi/clientschema/schema.graphql
+++ b/internal/graphapi/clientschema/schema.graphql
@@ -8184,6 +8184,10 @@ input CreateJobResultInput {
 	The time the job started it's execution. This is different from the db insertion time
 	"""
 	startedAt: Time
+	"""
+	the log output from the job
+	"""
+	log: String
 	ownerID: ID
 	scheduledJobID: ID!
 	fileID: ID!
@@ -8204,7 +8208,19 @@ input CreateJobRunnerInput {
 	"""
 	the IP address of this runner
 	"""
-	ipAddress: String!
+	ipAddress: String
+	"""
+	the last time this runner was seen
+	"""
+	lastSeen: Time
+	"""
+	the version of the runner
+	"""
+	version: String
+	"""
+	the operating system of the runner
+	"""
+	os: String
 	ownerID: ID
 	jobRunnerTokenIDs: [ID!]
 }
@@ -22063,6 +22079,10 @@ type JobResult implements Node {
 	"""
 	startedAt: Time!
 	fileID: ID!
+	"""
+	the log output from the job
+	"""
+	log: String
 	owner: Organization
 	scheduledJob: ScheduledJob!
 	file: File!
@@ -22331,6 +22351,24 @@ input JobResultWhereInput {
 	fileIDEqualFold: ID
 	fileIDContainsFold: ID
 	"""
+	log field predicates
+	"""
+	log: String
+	logNEQ: String
+	logIn: [String!]
+	logNotIn: [String!]
+	logGT: String
+	logGTE: String
+	logLT: String
+	logLTE: String
+	logContains: String
+	logHasPrefix: String
+	logHasSuffix: String
+	logIsNil: Boolean
+	logNotNil: Boolean
+	logEqualFold: String
+	logContainsFold: String
+	"""
 	owner edge predicates
 	"""
 	hasOwner: Boolean
@@ -22379,7 +22417,19 @@ type JobRunner implements Node {
 	"""
 	the IP address of this runner
 	"""
-	ipAddress: String!
+	ipAddress: String
+	"""
+	the last time this runner was seen
+	"""
+	lastSeen: Time
+	"""
+	the version of the runner
+	"""
+	version: String
+	"""
+	the operating system of the runner
+	"""
+	os: String
 	owner: Organization
 	jobRunnerTokens(
 		"""
@@ -23249,8 +23299,59 @@ input JobRunnerWhereInput {
 	ipAddressContains: String
 	ipAddressHasPrefix: String
 	ipAddressHasSuffix: String
+	ipAddressIsNil: Boolean
+	ipAddressNotNil: Boolean
 	ipAddressEqualFold: String
 	ipAddressContainsFold: String
+	"""
+	last_seen field predicates
+	"""
+	lastSeen: Time
+	lastSeenNEQ: Time
+	lastSeenIn: [Time!]
+	lastSeenNotIn: [Time!]
+	lastSeenGT: Time
+	lastSeenGTE: Time
+	lastSeenLT: Time
+	lastSeenLTE: Time
+	lastSeenIsNil: Boolean
+	lastSeenNotNil: Boolean
+	"""
+	version field predicates
+	"""
+	version: String
+	versionNEQ: String
+	versionIn: [String!]
+	versionNotIn: [String!]
+	versionGT: String
+	versionGTE: String
+	versionLT: String
+	versionLTE: String
+	versionContains: String
+	versionHasPrefix: String
+	versionHasSuffix: String
+	versionIsNil: Boolean
+	versionNotNil: Boolean
+	versionEqualFold: String
+	versionContainsFold: String
+	"""
+	os field predicates
+	"""
+	os: String
+	osNEQ: String
+	osIn: [String!]
+	osNotIn: [String!]
+	osGT: String
+	osGTE: String
+	osLT: String
+	osLTE: String
+	osContains: String
+	osHasPrefix: String
+	osHasSuffix: String
+	osIsNil: Boolean
+	osNotNil: Boolean
+	osEqualFold: String
+	osContainsFold: String
 	"""
 	owner edge predicates
 	"""
@@ -57419,6 +57520,11 @@ input UpdateJobResultInput {
 	the status of this job. did it fail? did it succeed?
 	"""
 	status: JobResultJobExecutionStatus
+	"""
+	the log output from the job
+	"""
+	log: String
+	clearLog: Boolean
 	ownerID: ID
 	clearOwner: Boolean
 	scheduledJobID: ID
@@ -57439,6 +57545,26 @@ input UpdateJobRunnerInput {
 	the name of the runner
 	"""
 	name: String
+	"""
+	the IP address of this runner
+	"""
+	ipAddress: String
+	clearIPAddress: Boolean
+	"""
+	the last time this runner was seen
+	"""
+	lastSeen: Time
+	clearLastSeen: Boolean
+	"""
+	the version of the runner
+	"""
+	version: String
+	clearVersion: Boolean
+	"""
+	the operating system of the runner
+	"""
+	os: String
+	clearOs: Boolean
 	ownerID: ID
 	clearOwner: Boolean
 	addJobRunnerTokenIDs: [ID!]

--- a/internal/graphapi/generated/jobresult.generated.go
+++ b/internal/graphapi/generated/jobresult.generated.go
@@ -92,6 +92,8 @@ func (ec *executionContext) fieldContext_JobResultCreatePayload_jobResult(_ cont
 				return ec.fieldContext_JobResult_startedAt(ctx, field)
 			case "fileID":
 				return ec.fieldContext_JobResult_fileID(ctx, field)
+			case "log":
+				return ec.fieldContext_JobResult_log(ctx, field)
 			case "owner":
 				return ec.fieldContext_JobResult_owner(ctx, field)
 			case "scheduledJob":
@@ -212,6 +214,8 @@ func (ec *executionContext) fieldContext_JobResultUpdatePayload_jobResult(_ cont
 				return ec.fieldContext_JobResult_startedAt(ctx, field)
 			case "fileID":
 				return ec.fieldContext_JobResult_fileID(ctx, field)
+			case "log":
+				return ec.fieldContext_JobResult_log(ctx, field)
 			case "owner":
 				return ec.fieldContext_JobResult_owner(ctx, field)
 			case "scheduledJob":

--- a/internal/graphapi/generated/jobrunner.generated.go
+++ b/internal/graphapi/generated/jobrunner.generated.go
@@ -92,6 +92,12 @@ func (ec *executionContext) fieldContext_JobRunnerCreatePayload_jobRunner(_ cont
 				return ec.fieldContext_JobRunner_status(ctx, field)
 			case "ipAddress":
 				return ec.fieldContext_JobRunner_ipAddress(ctx, field)
+			case "lastSeen":
+				return ec.fieldContext_JobRunner_lastSeen(ctx, field)
+			case "version":
+				return ec.fieldContext_JobRunner_version(ctx, field)
+			case "os":
+				return ec.fieldContext_JobRunner_os(ctx, field)
 			case "owner":
 				return ec.fieldContext_JobRunner_owner(ctx, field)
 			case "jobRunnerTokens":
@@ -210,6 +216,12 @@ func (ec *executionContext) fieldContext_JobRunnerUpdatePayload_jobRunner(_ cont
 				return ec.fieldContext_JobRunner_status(ctx, field)
 			case "ipAddress":
 				return ec.fieldContext_JobRunner_ipAddress(ctx, field)
+			case "lastSeen":
+				return ec.fieldContext_JobRunner_lastSeen(ctx, field)
+			case "version":
+				return ec.fieldContext_JobRunner_version(ctx, field)
+			case "os":
+				return ec.fieldContext_JobRunner_os(ctx, field)
 			case "owner":
 				return ec.fieldContext_JobRunner_owner(ctx, field)
 			case "jobRunnerTokens":

--- a/internal/graphapi/generated/root_.generated.go
+++ b/internal/graphapi/generated/root_.generated.go
@@ -1951,6 +1951,7 @@ type ComplexityRoot struct {
 		FileID         func(childComplexity int) int
 		FinishedAt     func(childComplexity int) int
 		ID             func(childComplexity int) int
+		Log            func(childComplexity int) int
 		Owner          func(childComplexity int) int
 		OwnerID        func(childComplexity int) int
 		ScheduledJob   func(childComplexity int) int
@@ -1991,7 +1992,9 @@ type ComplexityRoot struct {
 		ID              func(childComplexity int) int
 		IPAddress       func(childComplexity int) int
 		JobRunnerTokens func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.JobRunnerTokenOrder, where *generated.JobRunnerTokenWhereInput) int
+		LastSeen        func(childComplexity int) int
 		Name            func(childComplexity int) int
+		Os              func(childComplexity int) int
 		Owner           func(childComplexity int) int
 		OwnerID         func(childComplexity int) int
 		Status          func(childComplexity int) int
@@ -1999,6 +2002,7 @@ type ComplexityRoot struct {
 		Tags            func(childComplexity int) int
 		UpdatedAt       func(childComplexity int) int
 		UpdatedBy       func(childComplexity int) int
+		Version         func(childComplexity int) int
 	}
 
 	JobRunnerConnection struct {
@@ -14149,6 +14153,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.JobResult.ID(childComplexity), true
 
+	case "JobResult.log":
+		if e.complexity.JobResult.Log == nil {
+			break
+		}
+
+		return e.complexity.JobResult.Log(childComplexity), true
+
 	case "JobResult.owner":
 		if e.complexity.JobResult.Owner == nil {
 			break
@@ -14308,12 +14319,26 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.JobRunner.JobRunnerTokens(childComplexity, args["after"].(*entgql.Cursor[string]), args["first"].(*int), args["before"].(*entgql.Cursor[string]), args["last"].(*int), args["orderBy"].([]*generated.JobRunnerTokenOrder), args["where"].(*generated.JobRunnerTokenWhereInput)), true
 
+	case "JobRunner.lastSeen":
+		if e.complexity.JobRunner.LastSeen == nil {
+			break
+		}
+
+		return e.complexity.JobRunner.LastSeen(childComplexity), true
+
 	case "JobRunner.name":
 		if e.complexity.JobRunner.Name == nil {
 			break
 		}
 
 		return e.complexity.JobRunner.Name(childComplexity), true
+
+	case "JobRunner.os":
+		if e.complexity.JobRunner.Os == nil {
+			break
+		}
+
+		return e.complexity.JobRunner.Os(childComplexity), true
 
 	case "JobRunner.owner":
 		if e.complexity.JobRunner.Owner == nil {
@@ -14363,6 +14388,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.JobRunner.UpdatedBy(childComplexity), true
+
+	case "JobRunner.version":
+		if e.complexity.JobRunner.Version == nil {
+			break
+		}
+
+		return e.complexity.JobRunner.Version(childComplexity), true
 
 	case "JobRunnerConnection.edges":
 		if e.complexity.JobRunnerConnection.Edges == nil {
@@ -43628,6 +43660,10 @@ input CreateJobResultInput {
   The time the job started it's execution. This is different from the db insertion time
   """
   startedAt: Time
+  """
+  the log output from the job
+  """
+  log: String
   ownerID: ID
   scheduledJobID: ID!
   fileID: ID!
@@ -43648,7 +43684,19 @@ input CreateJobRunnerInput {
   """
   the IP address of this runner
   """
-  ipAddress: String!
+  ipAddress: String
+  """
+  the last time this runner was seen
+  """
+  lastSeen: Time
+  """
+  the version of the runner
+  """
+  version: String
+  """
+  the operating system of the runner
+  """
+  os: String
   ownerID: ID
   jobRunnerTokenIDs: [ID!]
 }
@@ -56746,6 +56794,10 @@ type JobResult implements Node {
   """
   startedAt: Time!
   fileID: ID!
+  """
+  the log output from the job
+  """
+  log: String
   owner: Organization
   scheduledJob: ScheduledJob!
   file: File!
@@ -56987,6 +57039,24 @@ input JobResultWhereInput {
   fileIDEqualFold: ID
   fileIDContainsFold: ID
   """
+  log field predicates
+  """
+  log: String
+  logNEQ: String
+  logIn: [String!]
+  logNotIn: [String!]
+  logGT: String
+  logGTE: String
+  logLT: String
+  logLTE: String
+  logContains: String
+  logHasPrefix: String
+  logHasSuffix: String
+  logIsNil: Boolean
+  logNotNil: Boolean
+  logEqualFold: String
+  logContainsFold: String
+  """
   owner edge predicates
   """
   hasOwner: Boolean
@@ -57035,7 +57105,19 @@ type JobRunner implements Node {
   """
   the IP address of this runner
   """
-  ipAddress: String!
+  ipAddress: String
+  """
+  the last time this runner was seen
+  """
+  lastSeen: Time
+  """
+  the version of the runner
+  """
+  version: String
+  """
+  the operating system of the runner
+  """
+  os: String
   owner: Organization
   jobRunnerTokens(
     """
@@ -57824,8 +57906,59 @@ input JobRunnerWhereInput {
   ipAddressContains: String
   ipAddressHasPrefix: String
   ipAddressHasSuffix: String
+  ipAddressIsNil: Boolean
+  ipAddressNotNil: Boolean
   ipAddressEqualFold: String
   ipAddressContainsFold: String
+  """
+  last_seen field predicates
+  """
+  lastSeen: Time
+  lastSeenNEQ: Time
+  lastSeenIn: [Time!]
+  lastSeenNotIn: [Time!]
+  lastSeenGT: Time
+  lastSeenGTE: Time
+  lastSeenLT: Time
+  lastSeenLTE: Time
+  lastSeenIsNil: Boolean
+  lastSeenNotNil: Boolean
+  """
+  version field predicates
+  """
+  version: String
+  versionNEQ: String
+  versionIn: [String!]
+  versionNotIn: [String!]
+  versionGT: String
+  versionGTE: String
+  versionLT: String
+  versionLTE: String
+  versionContains: String
+  versionHasPrefix: String
+  versionHasSuffix: String
+  versionIsNil: Boolean
+  versionNotNil: Boolean
+  versionEqualFold: String
+  versionContainsFold: String
+  """
+  os field predicates
+  """
+  os: String
+  osNEQ: String
+  osIn: [String!]
+  osNotIn: [String!]
+  osGT: String
+  osGTE: String
+  osLT: String
+  osLTE: String
+  osContains: String
+  osHasPrefix: String
+  osHasSuffix: String
+  osIsNil: Boolean
+  osNotNil: Boolean
+  osEqualFold: String
+  osContainsFold: String
   """
   owner edge predicates
   """
@@ -84988,6 +85121,11 @@ input UpdateJobResultInput {
   the status of this job. did it fail? did it succeed?
   """
   status: JobResultJobExecutionStatus
+  """
+  the log output from the job
+  """
+  log: String
+  clearLog: Boolean
   ownerID: ID
   clearOwner: Boolean
   scheduledJobID: ID
@@ -85008,6 +85146,26 @@ input UpdateJobRunnerInput {
   the name of the runner
   """
   name: String
+  """
+  the IP address of this runner
+  """
+  ipAddress: String
+  clearIPAddress: Boolean
+  """
+  the last time this runner was seen
+  """
+  lastSeen: Time
+  clearLastSeen: Boolean
+  """
+  the version of the runner
+  """
+  version: String
+  clearVersion: Boolean
+  """
+  the operating system of the runner
+  """
+  os: String
+  clearOs: Boolean
   ownerID: ID
   clearOwner: Boolean
   addJobRunnerTokenIDs: [ID!]

--- a/internal/graphapi/query/adminsearch.graphql
+++ b/internal/graphapi/query/adminsearch.graphql
@@ -434,6 +434,8 @@ query AdminSearch($query: String!) {
           ownerID
           name
           ipAddress
+          version
+          os
         }
       }
     }

--- a/internal/graphapi/schema/ent.graphql
+++ b/internal/graphapi/schema/ent.graphql
@@ -7681,6 +7681,10 @@ input CreateJobResultInput {
   The time the job started it's execution. This is different from the db insertion time
   """
   startedAt: Time
+  """
+  the log output from the job
+  """
+  log: String
   ownerID: ID
   scheduledJobID: ID!
   fileID: ID!
@@ -7701,7 +7705,19 @@ input CreateJobRunnerInput {
   """
   the IP address of this runner
   """
-  ipAddress: String!
+  ipAddress: String
+  """
+  the last time this runner was seen
+  """
+  lastSeen: Time
+  """
+  the version of the runner
+  """
+  version: String
+  """
+  the operating system of the runner
+  """
+  os: String
   ownerID: ID
   jobRunnerTokenIDs: [ID!]
 }
@@ -20799,6 +20815,10 @@ type JobResult implements Node {
   """
   startedAt: Time!
   fileID: ID!
+  """
+  the log output from the job
+  """
+  log: String
   owner: Organization
   scheduledJob: ScheduledJob!
   file: File!
@@ -21040,6 +21060,24 @@ input JobResultWhereInput {
   fileIDEqualFold: ID
   fileIDContainsFold: ID
   """
+  log field predicates
+  """
+  log: String
+  logNEQ: String
+  logIn: [String!]
+  logNotIn: [String!]
+  logGT: String
+  logGTE: String
+  logLT: String
+  logLTE: String
+  logContains: String
+  logHasPrefix: String
+  logHasSuffix: String
+  logIsNil: Boolean
+  logNotNil: Boolean
+  logEqualFold: String
+  logContainsFold: String
+  """
   owner edge predicates
   """
   hasOwner: Boolean
@@ -21088,7 +21126,19 @@ type JobRunner implements Node {
   """
   the IP address of this runner
   """
-  ipAddress: String!
+  ipAddress: String
+  """
+  the last time this runner was seen
+  """
+  lastSeen: Time
+  """
+  the version of the runner
+  """
+  version: String
+  """
+  the operating system of the runner
+  """
+  os: String
   owner: Organization
   jobRunnerTokens(
     """
@@ -21877,8 +21927,59 @@ input JobRunnerWhereInput {
   ipAddressContains: String
   ipAddressHasPrefix: String
   ipAddressHasSuffix: String
+  ipAddressIsNil: Boolean
+  ipAddressNotNil: Boolean
   ipAddressEqualFold: String
   ipAddressContainsFold: String
+  """
+  last_seen field predicates
+  """
+  lastSeen: Time
+  lastSeenNEQ: Time
+  lastSeenIn: [Time!]
+  lastSeenNotIn: [Time!]
+  lastSeenGT: Time
+  lastSeenGTE: Time
+  lastSeenLT: Time
+  lastSeenLTE: Time
+  lastSeenIsNil: Boolean
+  lastSeenNotNil: Boolean
+  """
+  version field predicates
+  """
+  version: String
+  versionNEQ: String
+  versionIn: [String!]
+  versionNotIn: [String!]
+  versionGT: String
+  versionGTE: String
+  versionLT: String
+  versionLTE: String
+  versionContains: String
+  versionHasPrefix: String
+  versionHasSuffix: String
+  versionIsNil: Boolean
+  versionNotNil: Boolean
+  versionEqualFold: String
+  versionContainsFold: String
+  """
+  os field predicates
+  """
+  os: String
+  osNEQ: String
+  osIn: [String!]
+  osNotIn: [String!]
+  osGT: String
+  osGTE: String
+  osLT: String
+  osLTE: String
+  osContains: String
+  osHasPrefix: String
+  osHasSuffix: String
+  osIsNil: Boolean
+  osNotNil: Boolean
+  osEqualFold: String
+  osContainsFold: String
   """
   owner edge predicates
   """
@@ -49041,6 +49142,11 @@ input UpdateJobResultInput {
   the status of this job. did it fail? did it succeed?
   """
   status: JobResultJobExecutionStatus
+  """
+  the log output from the job
+  """
+  log: String
+  clearLog: Boolean
   ownerID: ID
   clearOwner: Boolean
   scheduledJobID: ID
@@ -49061,6 +49167,26 @@ input UpdateJobRunnerInput {
   the name of the runner
   """
   name: String
+  """
+  the IP address of this runner
+  """
+  ipAddress: String
+  clearIPAddress: Boolean
+  """
+  the last time this runner was seen
+  """
+  lastSeen: Time
+  clearLastSeen: Boolean
+  """
+  the version of the runner
+  """
+  version: String
+  clearVersion: Boolean
+  """
+  the operating system of the runner
+  """
+  os: String
+  clearOs: Boolean
   ownerID: ID
   clearOwner: Boolean
   addJobRunnerTokenIDs: [ID!]

--- a/internal/graphapi/search.go
+++ b/internal/graphapi/search.go
@@ -937,6 +937,8 @@ func adminSearchJobRunners(ctx context.Context, query string, after *entgql.Curs
 				jobrunner.OwnerIDContainsFold(query),   // search by OwnerID
 				jobrunner.NameContainsFold(query),      // search by Name
 				jobrunner.IPAddressContainsFold(query), // search by IPAddress
+				jobrunner.VersionContainsFold(query),   // search by Version
+				jobrunner.OsContainsFold(query),        // search by Os
 			),
 		)
 

--- a/internal/graphapi/testclient/graphclient.go
+++ b/internal/graphapi/testclient/graphclient.go
@@ -228,9 +228,13 @@ type TestGraphClient interface {
 	GetAllInvites(ctx context.Context, interceptors ...clientv2.RequestInterceptor) (*GetAllInvites, error)
 	GetInviteByID(ctx context.Context, inviteID string, interceptors ...clientv2.RequestInterceptor) (*GetInviteByID, error)
 	InvitesByOrgID(ctx context.Context, where *InviteWhereInput, interceptors ...clientv2.RequestInterceptor) (*InvitesByOrgID, error)
+	CreateJobResult(ctx context.Context, input CreateJobResultInput, interceptors ...clientv2.RequestInterceptor) (*CreateJobResult, error)
+	DeleteJobResult(ctx context.Context, deleteJobResultID string, interceptors ...clientv2.RequestInterceptor) (*DeleteJobResult, error)
 	GetAllJobResults(ctx context.Context, interceptors ...clientv2.RequestInterceptor) (*GetAllJobResults, error)
 	GetJobResultByID(ctx context.Context, jobResultID string, interceptors ...clientv2.RequestInterceptor) (*GetJobResultByID, error)
 	GetJobResults(ctx context.Context, first *int64, last *int64, where *JobResultWhereInput, interceptors ...clientv2.RequestInterceptor) (*GetJobResults, error)
+	UpdateJobResult(ctx context.Context, updateJobResultID string, input UpdateJobResultInput, interceptors ...clientv2.RequestInterceptor) (*UpdateJobResult, error)
+	CreateJobRunner(ctx context.Context, input CreateJobRunnerInput, interceptors ...clientv2.RequestInterceptor) (*CreateJobRunner, error)
 	DeleteJobRunner(ctx context.Context, deleteJobRunnerID string, interceptors ...clientv2.RequestInterceptor) (*DeleteJobRunner, error)
 	GetAllJobRunners(ctx context.Context, interceptors ...clientv2.RequestInterceptor) (*GetAllJobRunners, error)
 	GetJobRunnerByID(ctx context.Context, jobRunnerID string, interceptors ...clientv2.RequestInterceptor) (*GetJobRunnerByID, error)
@@ -399,6 +403,9 @@ type TestGraphClient interface {
 	GetAllScheduledJobRuns(ctx context.Context, interceptors ...clientv2.RequestInterceptor) (*GetAllScheduledJobRuns, error)
 	GetScheduledJobRunByID(ctx context.Context, scheduledJobRunID string, interceptors ...clientv2.RequestInterceptor) (*GetScheduledJobRunByID, error)
 	GetScheduledJobRuns(ctx context.Context, first *int64, last *int64, where *ScheduledJobRunWhereInput, interceptors ...clientv2.RequestInterceptor) (*GetScheduledJobRuns, error)
+	CreateScheduledJobRun(ctx context.Context, input CreateScheduledJobRunInput, interceptors ...clientv2.RequestInterceptor) (*CreateScheduledJobRun, error)
+	UpdateScheduledJobRun(ctx context.Context, updateScheduledJobRunID string, input UpdateScheduledJobRunInput, interceptors ...clientv2.RequestInterceptor) (*UpdateScheduledJobRun, error)
+	DeleteScheduledJobRun(ctx context.Context, deleteScheduledJobRunID string, interceptors ...clientv2.RequestInterceptor) (*DeleteScheduledJobRun, error)
 	GlobalSearch(ctx context.Context, query string, interceptors ...clientv2.RequestInterceptor) (*GlobalSearch, error)
 	CreateStandard(ctx context.Context, input CreateStandardInput, interceptors ...clientv2.RequestInterceptor) (*CreateStandard, error)
 	DeleteStandard(ctx context.Context, deleteStandardID string, interceptors ...clientv2.RequestInterceptor) (*DeleteStandard, error)
@@ -4549,10 +4556,12 @@ func (t *AdminSearch_AdminSearch_JobRunners_PageInfo) GetStartCursor() *string {
 type AdminSearch_AdminSearch_JobRunners_Edges_Node struct {
 	DisplayID string   "json:\"displayID\" graphql:\"displayID\""
 	ID        string   "json:\"id\" graphql:\"id\""
-	IPAddress string   "json:\"ipAddress\" graphql:\"ipAddress\""
+	IPAddress *string  "json:\"ipAddress,omitempty\" graphql:\"ipAddress\""
 	Name      string   "json:\"name\" graphql:\"name\""
+	Os        *string  "json:\"os,omitempty\" graphql:\"os\""
 	OwnerID   *string  "json:\"ownerID,omitempty\" graphql:\"ownerID\""
 	Tags      []string "json:\"tags,omitempty\" graphql:\"tags\""
+	Version   *string  "json:\"version,omitempty\" graphql:\"version\""
 }
 
 func (t *AdminSearch_AdminSearch_JobRunners_Edges_Node) GetDisplayID() string {
@@ -4567,7 +4576,7 @@ func (t *AdminSearch_AdminSearch_JobRunners_Edges_Node) GetID() string {
 	}
 	return t.ID
 }
-func (t *AdminSearch_AdminSearch_JobRunners_Edges_Node) GetIPAddress() string {
+func (t *AdminSearch_AdminSearch_JobRunners_Edges_Node) GetIPAddress() *string {
 	if t == nil {
 		t = &AdminSearch_AdminSearch_JobRunners_Edges_Node{}
 	}
@@ -4578,6 +4587,12 @@ func (t *AdminSearch_AdminSearch_JobRunners_Edges_Node) GetName() string {
 		t = &AdminSearch_AdminSearch_JobRunners_Edges_Node{}
 	}
 	return t.Name
+}
+func (t *AdminSearch_AdminSearch_JobRunners_Edges_Node) GetOs() *string {
+	if t == nil {
+		t = &AdminSearch_AdminSearch_JobRunners_Edges_Node{}
+	}
+	return t.Os
 }
 func (t *AdminSearch_AdminSearch_JobRunners_Edges_Node) GetOwnerID() *string {
 	if t == nil {
@@ -4590,6 +4605,12 @@ func (t *AdminSearch_AdminSearch_JobRunners_Edges_Node) GetTags() []string {
 		t = &AdminSearch_AdminSearch_JobRunners_Edges_Node{}
 	}
 	return t.Tags
+}
+func (t *AdminSearch_AdminSearch_JobRunners_Edges_Node) GetVersion() *string {
+	if t == nil {
+		t = &AdminSearch_AdminSearch_JobRunners_Edges_Node{}
+	}
+	return t.Version
 }
 
 type AdminSearch_AdminSearch_JobRunners_Edges struct {
@@ -39114,6 +39135,116 @@ func (t *InvitesByOrgID_Invites) GetEdges() []*InvitesByOrgID_Invites_Edges {
 	return t.Edges
 }
 
+type CreateJobResult_CreateJobResult_JobResult struct {
+	CreatedAt      *time.Time               "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy      *string                  "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	ExitCode       int64                    "json:\"exitCode\" graphql:\"exitCode\""
+	FileID         string                   "json:\"fileID\" graphql:\"fileID\""
+	FinishedAt     time.Time                "json:\"finishedAt\" graphql:\"finishedAt\""
+	ID             string                   "json:\"id\" graphql:\"id\""
+	OwnerID        *string                  "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	ScheduledJobID string                   "json:\"scheduledJobID\" graphql:\"scheduledJobID\""
+	StartedAt      time.Time                "json:\"startedAt\" graphql:\"startedAt\""
+	Status         enums.JobExecutionStatus "json:\"status\" graphql:\"status\""
+	UpdatedAt      *time.Time               "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy      *string                  "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+}
+
+func (t *CreateJobResult_CreateJobResult_JobResult) GetCreatedAt() *time.Time {
+	if t == nil {
+		t = &CreateJobResult_CreateJobResult_JobResult{}
+	}
+	return t.CreatedAt
+}
+func (t *CreateJobResult_CreateJobResult_JobResult) GetCreatedBy() *string {
+	if t == nil {
+		t = &CreateJobResult_CreateJobResult_JobResult{}
+	}
+	return t.CreatedBy
+}
+func (t *CreateJobResult_CreateJobResult_JobResult) GetExitCode() int64 {
+	if t == nil {
+		t = &CreateJobResult_CreateJobResult_JobResult{}
+	}
+	return t.ExitCode
+}
+func (t *CreateJobResult_CreateJobResult_JobResult) GetFileID() string {
+	if t == nil {
+		t = &CreateJobResult_CreateJobResult_JobResult{}
+	}
+	return t.FileID
+}
+func (t *CreateJobResult_CreateJobResult_JobResult) GetFinishedAt() *time.Time {
+	if t == nil {
+		t = &CreateJobResult_CreateJobResult_JobResult{}
+	}
+	return &t.FinishedAt
+}
+func (t *CreateJobResult_CreateJobResult_JobResult) GetID() string {
+	if t == nil {
+		t = &CreateJobResult_CreateJobResult_JobResult{}
+	}
+	return t.ID
+}
+func (t *CreateJobResult_CreateJobResult_JobResult) GetOwnerID() *string {
+	if t == nil {
+		t = &CreateJobResult_CreateJobResult_JobResult{}
+	}
+	return t.OwnerID
+}
+func (t *CreateJobResult_CreateJobResult_JobResult) GetScheduledJobID() string {
+	if t == nil {
+		t = &CreateJobResult_CreateJobResult_JobResult{}
+	}
+	return t.ScheduledJobID
+}
+func (t *CreateJobResult_CreateJobResult_JobResult) GetStartedAt() *time.Time {
+	if t == nil {
+		t = &CreateJobResult_CreateJobResult_JobResult{}
+	}
+	return &t.StartedAt
+}
+func (t *CreateJobResult_CreateJobResult_JobResult) GetStatus() *enums.JobExecutionStatus {
+	if t == nil {
+		t = &CreateJobResult_CreateJobResult_JobResult{}
+	}
+	return &t.Status
+}
+func (t *CreateJobResult_CreateJobResult_JobResult) GetUpdatedAt() *time.Time {
+	if t == nil {
+		t = &CreateJobResult_CreateJobResult_JobResult{}
+	}
+	return t.UpdatedAt
+}
+func (t *CreateJobResult_CreateJobResult_JobResult) GetUpdatedBy() *string {
+	if t == nil {
+		t = &CreateJobResult_CreateJobResult_JobResult{}
+	}
+	return t.UpdatedBy
+}
+
+type CreateJobResult_CreateJobResult struct {
+	JobResult CreateJobResult_CreateJobResult_JobResult "json:\"jobResult\" graphql:\"jobResult\""
+}
+
+func (t *CreateJobResult_CreateJobResult) GetJobResult() *CreateJobResult_CreateJobResult_JobResult {
+	if t == nil {
+		t = &CreateJobResult_CreateJobResult{}
+	}
+	return &t.JobResult
+}
+
+type DeleteJobResult_DeleteJobResult struct {
+	DeletedID string "json:\"deletedID\" graphql:\"deletedID\""
+}
+
+func (t *DeleteJobResult_DeleteJobResult) GetDeletedID() string {
+	if t == nil {
+		t = &DeleteJobResult_DeleteJobResult{}
+	}
+	return t.DeletedID
+}
+
 type GetAllJobResults_JobResults_PageInfo struct {
 	EndCursor       *string "json:\"endCursor,omitempty\" graphql:\"endCursor\""
 	HasNextPage     bool    "json:\"hasNextPage\" graphql:\"hasNextPage\""
@@ -39514,6 +39645,197 @@ func (t *GetJobResults_JobResults) GetTotalCount() int64 {
 	return t.TotalCount
 }
 
+type UpdateJobResult_UpdateJobResult_JobResult struct {
+	CreatedAt      *time.Time               "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy      *string                  "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	ExitCode       int64                    "json:\"exitCode\" graphql:\"exitCode\""
+	FileID         string                   "json:\"fileID\" graphql:\"fileID\""
+	FinishedAt     time.Time                "json:\"finishedAt\" graphql:\"finishedAt\""
+	ID             string                   "json:\"id\" graphql:\"id\""
+	OwnerID        *string                  "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	ScheduledJobID string                   "json:\"scheduledJobID\" graphql:\"scheduledJobID\""
+	StartedAt      time.Time                "json:\"startedAt\" graphql:\"startedAt\""
+	Status         enums.JobExecutionStatus "json:\"status\" graphql:\"status\""
+	UpdatedAt      *time.Time               "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy      *string                  "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+}
+
+func (t *UpdateJobResult_UpdateJobResult_JobResult) GetCreatedAt() *time.Time {
+	if t == nil {
+		t = &UpdateJobResult_UpdateJobResult_JobResult{}
+	}
+	return t.CreatedAt
+}
+func (t *UpdateJobResult_UpdateJobResult_JobResult) GetCreatedBy() *string {
+	if t == nil {
+		t = &UpdateJobResult_UpdateJobResult_JobResult{}
+	}
+	return t.CreatedBy
+}
+func (t *UpdateJobResult_UpdateJobResult_JobResult) GetExitCode() int64 {
+	if t == nil {
+		t = &UpdateJobResult_UpdateJobResult_JobResult{}
+	}
+	return t.ExitCode
+}
+func (t *UpdateJobResult_UpdateJobResult_JobResult) GetFileID() string {
+	if t == nil {
+		t = &UpdateJobResult_UpdateJobResult_JobResult{}
+	}
+	return t.FileID
+}
+func (t *UpdateJobResult_UpdateJobResult_JobResult) GetFinishedAt() *time.Time {
+	if t == nil {
+		t = &UpdateJobResult_UpdateJobResult_JobResult{}
+	}
+	return &t.FinishedAt
+}
+func (t *UpdateJobResult_UpdateJobResult_JobResult) GetID() string {
+	if t == nil {
+		t = &UpdateJobResult_UpdateJobResult_JobResult{}
+	}
+	return t.ID
+}
+func (t *UpdateJobResult_UpdateJobResult_JobResult) GetOwnerID() *string {
+	if t == nil {
+		t = &UpdateJobResult_UpdateJobResult_JobResult{}
+	}
+	return t.OwnerID
+}
+func (t *UpdateJobResult_UpdateJobResult_JobResult) GetScheduledJobID() string {
+	if t == nil {
+		t = &UpdateJobResult_UpdateJobResult_JobResult{}
+	}
+	return t.ScheduledJobID
+}
+func (t *UpdateJobResult_UpdateJobResult_JobResult) GetStartedAt() *time.Time {
+	if t == nil {
+		t = &UpdateJobResult_UpdateJobResult_JobResult{}
+	}
+	return &t.StartedAt
+}
+func (t *UpdateJobResult_UpdateJobResult_JobResult) GetStatus() *enums.JobExecutionStatus {
+	if t == nil {
+		t = &UpdateJobResult_UpdateJobResult_JobResult{}
+	}
+	return &t.Status
+}
+func (t *UpdateJobResult_UpdateJobResult_JobResult) GetUpdatedAt() *time.Time {
+	if t == nil {
+		t = &UpdateJobResult_UpdateJobResult_JobResult{}
+	}
+	return t.UpdatedAt
+}
+func (t *UpdateJobResult_UpdateJobResult_JobResult) GetUpdatedBy() *string {
+	if t == nil {
+		t = &UpdateJobResult_UpdateJobResult_JobResult{}
+	}
+	return t.UpdatedBy
+}
+
+type UpdateJobResult_UpdateJobResult struct {
+	JobResult UpdateJobResult_UpdateJobResult_JobResult "json:\"jobResult\" graphql:\"jobResult\""
+}
+
+func (t *UpdateJobResult_UpdateJobResult) GetJobResult() *UpdateJobResult_UpdateJobResult_JobResult {
+	if t == nil {
+		t = &UpdateJobResult_UpdateJobResult{}
+	}
+	return &t.JobResult
+}
+
+type CreateJobRunner_CreateJobRunner_JobRunner struct {
+	CreatedAt *time.Time            "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy *string               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	DisplayID string                "json:\"displayID\" graphql:\"displayID\""
+	ID        string                "json:\"id\" graphql:\"id\""
+	IPAddress *string               "json:\"ipAddress,omitempty\" graphql:\"ipAddress\""
+	Name      string                "json:\"name\" graphql:\"name\""
+	OwnerID   *string               "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	Status    enums.JobRunnerStatus "json:\"status\" graphql:\"status\""
+	Tags      []string              "json:\"tags,omitempty\" graphql:\"tags\""
+	UpdatedAt *time.Time            "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy *string               "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+}
+
+func (t *CreateJobRunner_CreateJobRunner_JobRunner) GetCreatedAt() *time.Time {
+	if t == nil {
+		t = &CreateJobRunner_CreateJobRunner_JobRunner{}
+	}
+	return t.CreatedAt
+}
+func (t *CreateJobRunner_CreateJobRunner_JobRunner) GetCreatedBy() *string {
+	if t == nil {
+		t = &CreateJobRunner_CreateJobRunner_JobRunner{}
+	}
+	return t.CreatedBy
+}
+func (t *CreateJobRunner_CreateJobRunner_JobRunner) GetDisplayID() string {
+	if t == nil {
+		t = &CreateJobRunner_CreateJobRunner_JobRunner{}
+	}
+	return t.DisplayID
+}
+func (t *CreateJobRunner_CreateJobRunner_JobRunner) GetID() string {
+	if t == nil {
+		t = &CreateJobRunner_CreateJobRunner_JobRunner{}
+	}
+	return t.ID
+}
+func (t *CreateJobRunner_CreateJobRunner_JobRunner) GetIPAddress() *string {
+	if t == nil {
+		t = &CreateJobRunner_CreateJobRunner_JobRunner{}
+	}
+	return t.IPAddress
+}
+func (t *CreateJobRunner_CreateJobRunner_JobRunner) GetName() string {
+	if t == nil {
+		t = &CreateJobRunner_CreateJobRunner_JobRunner{}
+	}
+	return t.Name
+}
+func (t *CreateJobRunner_CreateJobRunner_JobRunner) GetOwnerID() *string {
+	if t == nil {
+		t = &CreateJobRunner_CreateJobRunner_JobRunner{}
+	}
+	return t.OwnerID
+}
+func (t *CreateJobRunner_CreateJobRunner_JobRunner) GetStatus() *enums.JobRunnerStatus {
+	if t == nil {
+		t = &CreateJobRunner_CreateJobRunner_JobRunner{}
+	}
+	return &t.Status
+}
+func (t *CreateJobRunner_CreateJobRunner_JobRunner) GetTags() []string {
+	if t == nil {
+		t = &CreateJobRunner_CreateJobRunner_JobRunner{}
+	}
+	return t.Tags
+}
+func (t *CreateJobRunner_CreateJobRunner_JobRunner) GetUpdatedAt() *time.Time {
+	if t == nil {
+		t = &CreateJobRunner_CreateJobRunner_JobRunner{}
+	}
+	return t.UpdatedAt
+}
+func (t *CreateJobRunner_CreateJobRunner_JobRunner) GetUpdatedBy() *string {
+	if t == nil {
+		t = &CreateJobRunner_CreateJobRunner_JobRunner{}
+	}
+	return t.UpdatedBy
+}
+
+type CreateJobRunner_CreateJobRunner struct {
+	JobRunner CreateJobRunner_CreateJobRunner_JobRunner "json:\"jobRunner\" graphql:\"jobRunner\""
+}
+
+func (t *CreateJobRunner_CreateJobRunner) GetJobRunner() *CreateJobRunner_CreateJobRunner_JobRunner {
+	if t == nil {
+		t = &CreateJobRunner_CreateJobRunner{}
+	}
+	return &t.JobRunner
+}
+
 type DeleteJobRunner_DeleteJobRunner struct {
 	DeletedID string "json:\"deletedID\" graphql:\"deletedID\""
 }
@@ -39562,7 +39884,7 @@ type GetAllJobRunners_JobRunners_Edges_Node struct {
 	CreatedBy *string               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	DisplayID string                "json:\"displayID\" graphql:\"displayID\""
 	ID        string                "json:\"id\" graphql:\"id\""
-	IPAddress string                "json:\"ipAddress\" graphql:\"ipAddress\""
+	IPAddress *string               "json:\"ipAddress,omitempty\" graphql:\"ipAddress\""
 	Name      string                "json:\"name\" graphql:\"name\""
 	OwnerID   *string               "json:\"ownerID,omitempty\" graphql:\"ownerID\""
 	Status    enums.JobRunnerStatus "json:\"status\" graphql:\"status\""
@@ -39595,7 +39917,7 @@ func (t *GetAllJobRunners_JobRunners_Edges_Node) GetID() string {
 	}
 	return t.ID
 }
-func (t *GetAllJobRunners_JobRunners_Edges_Node) GetIPAddress() string {
+func (t *GetAllJobRunners_JobRunners_Edges_Node) GetIPAddress() *string {
 	if t == nil {
 		t = &GetAllJobRunners_JobRunners_Edges_Node{}
 	}
@@ -39679,7 +40001,7 @@ type GetJobRunnerByID_JobRunner struct {
 	CreatedBy *string               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	DisplayID string                "json:\"displayID\" graphql:\"displayID\""
 	ID        string                "json:\"id\" graphql:\"id\""
-	IPAddress string                "json:\"ipAddress\" graphql:\"ipAddress\""
+	IPAddress *string               "json:\"ipAddress,omitempty\" graphql:\"ipAddress\""
 	Name      string                "json:\"name\" graphql:\"name\""
 	OwnerID   *string               "json:\"ownerID,omitempty\" graphql:\"ownerID\""
 	Status    enums.JobRunnerStatus "json:\"status\" graphql:\"status\""
@@ -39712,7 +40034,7 @@ func (t *GetJobRunnerByID_JobRunner) GetID() string {
 	}
 	return t.ID
 }
-func (t *GetJobRunnerByID_JobRunner) GetIPAddress() string {
+func (t *GetJobRunnerByID_JobRunner) GetIPAddress() *string {
 	if t == nil {
 		t = &GetJobRunnerByID_JobRunner{}
 	}
@@ -39792,7 +40114,7 @@ type GetJobRunners_JobRunners_Edges_Node struct {
 	CreatedBy *string               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	DisplayID string                "json:\"displayID\" graphql:\"displayID\""
 	ID        string                "json:\"id\" graphql:\"id\""
-	IPAddress string                "json:\"ipAddress\" graphql:\"ipAddress\""
+	IPAddress *string               "json:\"ipAddress,omitempty\" graphql:\"ipAddress\""
 	Name      string                "json:\"name\" graphql:\"name\""
 	OwnerID   *string               "json:\"ownerID,omitempty\" graphql:\"ownerID\""
 	Status    enums.JobRunnerStatus "json:\"status\" graphql:\"status\""
@@ -39825,7 +40147,7 @@ func (t *GetJobRunners_JobRunners_Edges_Node) GetID() string {
 	}
 	return t.ID
 }
-func (t *GetJobRunners_JobRunners_Edges_Node) GetIPAddress() string {
+func (t *GetJobRunners_JobRunners_Edges_Node) GetIPAddress() *string {
 	if t == nil {
 		t = &GetJobRunners_JobRunners_Edges_Node{}
 	}
@@ -39909,7 +40231,7 @@ type UpdateJobRunner_UpdateJobRunner_JobRunner struct {
 	CreatedBy *string               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	DisplayID string                "json:\"displayID\" graphql:\"displayID\""
 	ID        string                "json:\"id\" graphql:\"id\""
-	IPAddress string                "json:\"ipAddress\" graphql:\"ipAddress\""
+	IPAddress *string               "json:\"ipAddress,omitempty\" graphql:\"ipAddress\""
 	Name      string                "json:\"name\" graphql:\"name\""
 	OwnerID   *string               "json:\"ownerID,omitempty\" graphql:\"ownerID\""
 	Status    enums.JobRunnerStatus "json:\"status\" graphql:\"status\""
@@ -39942,7 +40264,7 @@ func (t *UpdateJobRunner_UpdateJobRunner_JobRunner) GetID() string {
 	}
 	return t.ID
 }
-func (t *UpdateJobRunner_UpdateJobRunner_JobRunner) GetIPAddress() string {
+func (t *UpdateJobRunner_UpdateJobRunner_JobRunner) GetIPAddress() *string {
 	if t == nil {
 		t = &UpdateJobRunner_UpdateJobRunner_JobRunner{}
 	}
@@ -67225,6 +67547,173 @@ func (t *GetScheduledJobRuns_ScheduledJobRuns) GetTotalCount() int64 {
 	return t.TotalCount
 }
 
+type CreateScheduledJobRun_CreateScheduledJobRun_ScheduledJobRun struct {
+	CreatedAt      *time.Time                  "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy      *string                     "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	ID             string                      "json:\"id\" graphql:\"id\""
+	JobRunnerID    string                      "json:\"jobRunnerID\" graphql:\"jobRunnerID\""
+	OwnerID        *string                     "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	ScheduledJobID string                      "json:\"scheduledJobID\" graphql:\"scheduledJobID\""
+	Status         enums.ScheduledJobRunStatus "json:\"status\" graphql:\"status\""
+	UpdatedAt      *time.Time                  "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy      *string                     "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+}
+
+func (t *CreateScheduledJobRun_CreateScheduledJobRun_ScheduledJobRun) GetCreatedAt() *time.Time {
+	if t == nil {
+		t = &CreateScheduledJobRun_CreateScheduledJobRun_ScheduledJobRun{}
+	}
+	return t.CreatedAt
+}
+func (t *CreateScheduledJobRun_CreateScheduledJobRun_ScheduledJobRun) GetCreatedBy() *string {
+	if t == nil {
+		t = &CreateScheduledJobRun_CreateScheduledJobRun_ScheduledJobRun{}
+	}
+	return t.CreatedBy
+}
+func (t *CreateScheduledJobRun_CreateScheduledJobRun_ScheduledJobRun) GetID() string {
+	if t == nil {
+		t = &CreateScheduledJobRun_CreateScheduledJobRun_ScheduledJobRun{}
+	}
+	return t.ID
+}
+func (t *CreateScheduledJobRun_CreateScheduledJobRun_ScheduledJobRun) GetJobRunnerID() string {
+	if t == nil {
+		t = &CreateScheduledJobRun_CreateScheduledJobRun_ScheduledJobRun{}
+	}
+	return t.JobRunnerID
+}
+func (t *CreateScheduledJobRun_CreateScheduledJobRun_ScheduledJobRun) GetOwnerID() *string {
+	if t == nil {
+		t = &CreateScheduledJobRun_CreateScheduledJobRun_ScheduledJobRun{}
+	}
+	return t.OwnerID
+}
+func (t *CreateScheduledJobRun_CreateScheduledJobRun_ScheduledJobRun) GetScheduledJobID() string {
+	if t == nil {
+		t = &CreateScheduledJobRun_CreateScheduledJobRun_ScheduledJobRun{}
+	}
+	return t.ScheduledJobID
+}
+func (t *CreateScheduledJobRun_CreateScheduledJobRun_ScheduledJobRun) GetStatus() *enums.ScheduledJobRunStatus {
+	if t == nil {
+		t = &CreateScheduledJobRun_CreateScheduledJobRun_ScheduledJobRun{}
+	}
+	return &t.Status
+}
+func (t *CreateScheduledJobRun_CreateScheduledJobRun_ScheduledJobRun) GetUpdatedAt() *time.Time {
+	if t == nil {
+		t = &CreateScheduledJobRun_CreateScheduledJobRun_ScheduledJobRun{}
+	}
+	return t.UpdatedAt
+}
+func (t *CreateScheduledJobRun_CreateScheduledJobRun_ScheduledJobRun) GetUpdatedBy() *string {
+	if t == nil {
+		t = &CreateScheduledJobRun_CreateScheduledJobRun_ScheduledJobRun{}
+	}
+	return t.UpdatedBy
+}
+
+type CreateScheduledJobRun_CreateScheduledJobRun struct {
+	ScheduledJobRun CreateScheduledJobRun_CreateScheduledJobRun_ScheduledJobRun "json:\"scheduledJobRun\" graphql:\"scheduledJobRun\""
+}
+
+func (t *CreateScheduledJobRun_CreateScheduledJobRun) GetScheduledJobRun() *CreateScheduledJobRun_CreateScheduledJobRun_ScheduledJobRun {
+	if t == nil {
+		t = &CreateScheduledJobRun_CreateScheduledJobRun{}
+	}
+	return &t.ScheduledJobRun
+}
+
+type UpdateScheduledJobRun_UpdateScheduledJobRun_ScheduledJobRun struct {
+	CreatedAt      *time.Time                  "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy      *string                     "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	ID             string                      "json:\"id\" graphql:\"id\""
+	JobRunnerID    string                      "json:\"jobRunnerID\" graphql:\"jobRunnerID\""
+	OwnerID        *string                     "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	ScheduledJobID string                      "json:\"scheduledJobID\" graphql:\"scheduledJobID\""
+	Status         enums.ScheduledJobRunStatus "json:\"status\" graphql:\"status\""
+	UpdatedAt      *time.Time                  "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy      *string                     "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+}
+
+func (t *UpdateScheduledJobRun_UpdateScheduledJobRun_ScheduledJobRun) GetCreatedAt() *time.Time {
+	if t == nil {
+		t = &UpdateScheduledJobRun_UpdateScheduledJobRun_ScheduledJobRun{}
+	}
+	return t.CreatedAt
+}
+func (t *UpdateScheduledJobRun_UpdateScheduledJobRun_ScheduledJobRun) GetCreatedBy() *string {
+	if t == nil {
+		t = &UpdateScheduledJobRun_UpdateScheduledJobRun_ScheduledJobRun{}
+	}
+	return t.CreatedBy
+}
+func (t *UpdateScheduledJobRun_UpdateScheduledJobRun_ScheduledJobRun) GetID() string {
+	if t == nil {
+		t = &UpdateScheduledJobRun_UpdateScheduledJobRun_ScheduledJobRun{}
+	}
+	return t.ID
+}
+func (t *UpdateScheduledJobRun_UpdateScheduledJobRun_ScheduledJobRun) GetJobRunnerID() string {
+	if t == nil {
+		t = &UpdateScheduledJobRun_UpdateScheduledJobRun_ScheduledJobRun{}
+	}
+	return t.JobRunnerID
+}
+func (t *UpdateScheduledJobRun_UpdateScheduledJobRun_ScheduledJobRun) GetOwnerID() *string {
+	if t == nil {
+		t = &UpdateScheduledJobRun_UpdateScheduledJobRun_ScheduledJobRun{}
+	}
+	return t.OwnerID
+}
+func (t *UpdateScheduledJobRun_UpdateScheduledJobRun_ScheduledJobRun) GetScheduledJobID() string {
+	if t == nil {
+		t = &UpdateScheduledJobRun_UpdateScheduledJobRun_ScheduledJobRun{}
+	}
+	return t.ScheduledJobID
+}
+func (t *UpdateScheduledJobRun_UpdateScheduledJobRun_ScheduledJobRun) GetStatus() *enums.ScheduledJobRunStatus {
+	if t == nil {
+		t = &UpdateScheduledJobRun_UpdateScheduledJobRun_ScheduledJobRun{}
+	}
+	return &t.Status
+}
+func (t *UpdateScheduledJobRun_UpdateScheduledJobRun_ScheduledJobRun) GetUpdatedAt() *time.Time {
+	if t == nil {
+		t = &UpdateScheduledJobRun_UpdateScheduledJobRun_ScheduledJobRun{}
+	}
+	return t.UpdatedAt
+}
+func (t *UpdateScheduledJobRun_UpdateScheduledJobRun_ScheduledJobRun) GetUpdatedBy() *string {
+	if t == nil {
+		t = &UpdateScheduledJobRun_UpdateScheduledJobRun_ScheduledJobRun{}
+	}
+	return t.UpdatedBy
+}
+
+type UpdateScheduledJobRun_UpdateScheduledJobRun struct {
+	ScheduledJobRun UpdateScheduledJobRun_UpdateScheduledJobRun_ScheduledJobRun "json:\"scheduledJobRun\" graphql:\"scheduledJobRun\""
+}
+
+func (t *UpdateScheduledJobRun_UpdateScheduledJobRun) GetScheduledJobRun() *UpdateScheduledJobRun_UpdateScheduledJobRun_ScheduledJobRun {
+	if t == nil {
+		t = &UpdateScheduledJobRun_UpdateScheduledJobRun{}
+	}
+	return &t.ScheduledJobRun
+}
+
+type DeleteScheduledJobRun_DeleteScheduledJobRun struct {
+	DeletedID string "json:\"deletedID\" graphql:\"deletedID\""
+}
+
+func (t *DeleteScheduledJobRun_DeleteScheduledJobRun) GetDeletedID() string {
+	if t == nil {
+		t = &DeleteScheduledJobRun_DeleteScheduledJobRun{}
+	}
+	return t.DeletedID
+}
+
 type GlobalSearch_Search_APITokens_PageInfo struct {
 	EndCursor       *string "json:\"endCursor,omitempty\" graphql:\"endCursor\""
 	HasNextPage     bool    "json:\"hasNextPage\" graphql:\"hasNextPage\""
@@ -91624,6 +92113,28 @@ func (t *InvitesByOrgID) GetInvites() *InvitesByOrgID_Invites {
 	return &t.Invites
 }
 
+type CreateJobResult struct {
+	CreateJobResult CreateJobResult_CreateJobResult "json:\"createJobResult\" graphql:\"createJobResult\""
+}
+
+func (t *CreateJobResult) GetCreateJobResult() *CreateJobResult_CreateJobResult {
+	if t == nil {
+		t = &CreateJobResult{}
+	}
+	return &t.CreateJobResult
+}
+
+type DeleteJobResult struct {
+	DeleteJobResult DeleteJobResult_DeleteJobResult "json:\"deleteJobResult\" graphql:\"deleteJobResult\""
+}
+
+func (t *DeleteJobResult) GetDeleteJobResult() *DeleteJobResult_DeleteJobResult {
+	if t == nil {
+		t = &DeleteJobResult{}
+	}
+	return &t.DeleteJobResult
+}
+
 type GetAllJobResults struct {
 	JobResults GetAllJobResults_JobResults "json:\"jobResults\" graphql:\"jobResults\""
 }
@@ -91655,6 +92166,28 @@ func (t *GetJobResults) GetJobResults() *GetJobResults_JobResults {
 		t = &GetJobResults{}
 	}
 	return &t.JobResults
+}
+
+type UpdateJobResult struct {
+	UpdateJobResult UpdateJobResult_UpdateJobResult "json:\"updateJobResult\" graphql:\"updateJobResult\""
+}
+
+func (t *UpdateJobResult) GetUpdateJobResult() *UpdateJobResult_UpdateJobResult {
+	if t == nil {
+		t = &UpdateJobResult{}
+	}
+	return &t.UpdateJobResult
+}
+
+type CreateJobRunner struct {
+	CreateJobRunner CreateJobRunner_CreateJobRunner "json:\"createJobRunner\" graphql:\"createJobRunner\""
+}
+
+func (t *CreateJobRunner) GetCreateJobRunner() *CreateJobRunner_CreateJobRunner {
+	if t == nil {
+		t = &CreateJobRunner{}
+	}
+	return &t.CreateJobRunner
 }
 
 type DeleteJobRunner struct {
@@ -93503,6 +94036,39 @@ func (t *GetScheduledJobRuns) GetScheduledJobRuns() *GetScheduledJobRuns_Schedul
 		t = &GetScheduledJobRuns{}
 	}
 	return &t.ScheduledJobRuns
+}
+
+type CreateScheduledJobRun struct {
+	CreateScheduledJobRun CreateScheduledJobRun_CreateScheduledJobRun "json:\"createScheduledJobRun\" graphql:\"createScheduledJobRun\""
+}
+
+func (t *CreateScheduledJobRun) GetCreateScheduledJobRun() *CreateScheduledJobRun_CreateScheduledJobRun {
+	if t == nil {
+		t = &CreateScheduledJobRun{}
+	}
+	return &t.CreateScheduledJobRun
+}
+
+type UpdateScheduledJobRun struct {
+	UpdateScheduledJobRun UpdateScheduledJobRun_UpdateScheduledJobRun "json:\"updateScheduledJobRun\" graphql:\"updateScheduledJobRun\""
+}
+
+func (t *UpdateScheduledJobRun) GetUpdateScheduledJobRun() *UpdateScheduledJobRun_UpdateScheduledJobRun {
+	if t == nil {
+		t = &UpdateScheduledJobRun{}
+	}
+	return &t.UpdateScheduledJobRun
+}
+
+type DeleteScheduledJobRun struct {
+	DeleteScheduledJobRun DeleteScheduledJobRun_DeleteScheduledJobRun "json:\"deleteScheduledJobRun\" graphql:\"deleteScheduledJobRun\""
+}
+
+func (t *DeleteScheduledJobRun) GetDeleteScheduledJobRun() *DeleteScheduledJobRun_DeleteScheduledJobRun {
+	if t == nil {
+		t = &DeleteScheduledJobRun{}
+	}
+	return &t.DeleteScheduledJobRun
 }
 
 type GlobalSearch struct {
@@ -95650,6 +96216,8 @@ const AdminSearchDocument = `query AdminSearch ($query: String!) {
 					ownerID
 					name
 					ipAddress
+					version
+					os
 				}
 			}
 		}
@@ -105479,6 +106047,67 @@ func (c *Client) InvitesByOrgID(ctx context.Context, where *InviteWhereInput, in
 	return &res, nil
 }
 
+const CreateJobResultDocument = `mutation CreateJobResult ($input: CreateJobResultInput!) {
+	createJobResult(input: $input) {
+		jobResult {
+			id
+			createdAt
+			createdBy
+			updatedAt
+			updatedBy
+			ownerID
+			scheduledJobID
+			status
+			exitCode
+			startedAt
+			finishedAt
+			fileID
+		}
+	}
+}
+`
+
+func (c *Client) CreateJobResult(ctx context.Context, input CreateJobResultInput, interceptors ...clientv2.RequestInterceptor) (*CreateJobResult, error) {
+	vars := map[string]any{
+		"input": input,
+	}
+
+	var res CreateJobResult
+	if err := c.Client.Post(ctx, "CreateJobResult", CreateJobResultDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const DeleteJobResultDocument = `mutation DeleteJobResult ($deleteJobResultId: ID!) {
+	deleteJobResult(id: $deleteJobResultId) {
+		deletedID
+	}
+}
+`
+
+func (c *Client) DeleteJobResult(ctx context.Context, deleteJobResultID string, interceptors ...clientv2.RequestInterceptor) (*DeleteJobResult, error) {
+	vars := map[string]any{
+		"deleteJobResultId": deleteJobResultID,
+	}
+
+	var res DeleteJobResult
+	if err := c.Client.Post(ctx, "DeleteJobResult", DeleteJobResultDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
 const GetAllJobResultsDocument = `query GetAllJobResults {
 	jobResults {
 		totalCount
@@ -105596,6 +106225,80 @@ func (c *Client) GetJobResults(ctx context.Context, first *int64, last *int64, w
 
 	var res GetJobResults
 	if err := c.Client.Post(ctx, "GetJobResults", GetJobResultsDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const UpdateJobResultDocument = `mutation UpdateJobResult ($updateJobResultId: ID!, $input: UpdateJobResultInput!) {
+	updateJobResult(id: $updateJobResultId, input: $input) {
+		jobResult {
+			id
+			createdAt
+			createdBy
+			updatedAt
+			updatedBy
+			ownerID
+			scheduledJobID
+			status
+			exitCode
+			startedAt
+			finishedAt
+			fileID
+		}
+	}
+}
+`
+
+func (c *Client) UpdateJobResult(ctx context.Context, updateJobResultID string, input UpdateJobResultInput, interceptors ...clientv2.RequestInterceptor) (*UpdateJobResult, error) {
+	vars := map[string]any{
+		"updateJobResultId": updateJobResultID,
+		"input":             input,
+	}
+
+	var res UpdateJobResult
+	if err := c.Client.Post(ctx, "UpdateJobResult", UpdateJobResultDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const CreateJobRunnerDocument = `mutation CreateJobRunner ($input: CreateJobRunnerInput!) {
+	createJobRunner(input: $input) {
+		jobRunner {
+			id
+			createdAt
+			createdBy
+			updatedAt
+			updatedBy
+			ownerID
+			name
+			displayID
+			status
+			ipAddress
+			tags
+		}
+	}
+}
+`
+
+func (c *Client) CreateJobRunner(ctx context.Context, input CreateJobRunnerInput, interceptors ...clientv2.RequestInterceptor) (*CreateJobRunner, error) {
+	vars := map[string]any{
+		"input": input,
+	}
+
+	var res CreateJobRunner
+	if err := c.Client.Post(ctx, "CreateJobRunner", CreateJobRunnerDocument, &res, vars, interceptors...); err != nil {
 		if c.Client.ParseDataWhenErrors {
 			return &res, err
 		}
@@ -113647,6 +114350,99 @@ func (c *Client) GetScheduledJobRuns(ctx context.Context, first *int64, last *in
 	return &res, nil
 }
 
+const CreateScheduledJobRunDocument = `mutation CreateScheduledJobRun ($input: CreateScheduledJobRunInput!) {
+	createScheduledJobRun(input: $input) {
+		scheduledJobRun {
+			id
+			createdAt
+			createdBy
+			updatedAt
+			updatedBy
+			ownerID
+			scheduledJobID
+			jobRunnerID
+			status
+		}
+	}
+}
+`
+
+func (c *Client) CreateScheduledJobRun(ctx context.Context, input CreateScheduledJobRunInput, interceptors ...clientv2.RequestInterceptor) (*CreateScheduledJobRun, error) {
+	vars := map[string]any{
+		"input": input,
+	}
+
+	var res CreateScheduledJobRun
+	if err := c.Client.Post(ctx, "CreateScheduledJobRun", CreateScheduledJobRunDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const UpdateScheduledJobRunDocument = `mutation UpdateScheduledJobRun ($updateScheduledJobRunId: ID!, $input: UpdateScheduledJobRunInput!) {
+	updateScheduledJobRun(id: $updateScheduledJobRunId, input: $input) {
+		scheduledJobRun {
+			id
+			createdAt
+			createdBy
+			updatedAt
+			updatedBy
+			ownerID
+			scheduledJobID
+			jobRunnerID
+			status
+		}
+	}
+}
+`
+
+func (c *Client) UpdateScheduledJobRun(ctx context.Context, updateScheduledJobRunID string, input UpdateScheduledJobRunInput, interceptors ...clientv2.RequestInterceptor) (*UpdateScheduledJobRun, error) {
+	vars := map[string]any{
+		"updateScheduledJobRunId": updateScheduledJobRunID,
+		"input":                   input,
+	}
+
+	var res UpdateScheduledJobRun
+	if err := c.Client.Post(ctx, "UpdateScheduledJobRun", UpdateScheduledJobRunDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const DeleteScheduledJobRunDocument = `mutation DeleteScheduledJobRun ($deleteScheduledJobRunId: ID!) {
+	deleteScheduledJobRun(id: $deleteScheduledJobRunId) {
+		deletedID
+	}
+}
+`
+
+func (c *Client) DeleteScheduledJobRun(ctx context.Context, deleteScheduledJobRunID string, interceptors ...clientv2.RequestInterceptor) (*DeleteScheduledJobRun, error) {
+	vars := map[string]any{
+		"deleteScheduledJobRunId": deleteScheduledJobRunID,
+	}
+
+	var res DeleteScheduledJobRun
+	if err := c.Client.Post(ctx, "DeleteScheduledJobRun", DeleteScheduledJobRunDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
 const GlobalSearchDocument = `query GlobalSearch ($query: String!) {
 	search(query: $query) {
 		totalCount
@@ -119809,9 +120605,13 @@ var DocumentOperationNames = map[string]string{
 	GetAllInvitesDocument:                          "GetAllInvites",
 	GetInviteByIDDocument:                          "GetInviteByID",
 	InvitesByOrgIDDocument:                         "InvitesByOrgID",
+	CreateJobResultDocument:                        "CreateJobResult",
+	DeleteJobResultDocument:                        "DeleteJobResult",
 	GetAllJobResultsDocument:                       "GetAllJobResults",
 	GetJobResultByIDDocument:                       "GetJobResultByID",
 	GetJobResultsDocument:                          "GetJobResults",
+	UpdateJobResultDocument:                        "UpdateJobResult",
+	CreateJobRunnerDocument:                        "CreateJobRunner",
 	DeleteJobRunnerDocument:                        "DeleteJobRunner",
 	GetAllJobRunnersDocument:                       "GetAllJobRunners",
 	GetJobRunnerByIDDocument:                       "GetJobRunnerByID",
@@ -119980,6 +120780,9 @@ var DocumentOperationNames = map[string]string{
 	GetAllScheduledJobRunsDocument:                 "GetAllScheduledJobRuns",
 	GetScheduledJobRunByIDDocument:                 "GetScheduledJobRunByID",
 	GetScheduledJobRunsDocument:                    "GetScheduledJobRuns",
+	CreateScheduledJobRunDocument:                  "CreateScheduledJobRun",
+	UpdateScheduledJobRunDocument:                  "UpdateScheduledJobRun",
+	DeleteScheduledJobRunDocument:                  "DeleteScheduledJobRun",
 	GlobalSearchDocument:                           "GlobalSearch",
 	CreateStandardDocument:                         "CreateStandard",
 	DeleteStandardDocument:                         "DeleteStandard",

--- a/internal/graphapi/testclient/models.go
+++ b/internal/graphapi/testclient/models.go
@@ -4847,10 +4847,12 @@ type CreateJobResultInput struct {
 	// The time the job finished it's execution. This is different from the db insertion time
 	FinishedAt *time.Time `json:"finishedAt,omitempty"`
 	// The time the job started it's execution. This is different from the db insertion time
-	StartedAt      *time.Time `json:"startedAt,omitempty"`
-	OwnerID        *string    `json:"ownerID,omitempty"`
-	ScheduledJobID string     `json:"scheduledJobID"`
-	FileID         string     `json:"fileID"`
+	StartedAt *time.Time `json:"startedAt,omitempty"`
+	// the log output from the job
+	Log            *string `json:"log,omitempty"`
+	OwnerID        *string `json:"ownerID,omitempty"`
+	ScheduledJobID string  `json:"scheduledJobID"`
+	FileID         string  `json:"fileID"`
 }
 
 // CreateJobRunnerInput is used for create JobRunner object.
@@ -4861,7 +4863,13 @@ type CreateJobRunnerInput struct {
 	// the name of the runner
 	Name string `json:"name"`
 	// the IP address of this runner
-	IPAddress         string   `json:"ipAddress"`
+	IPAddress *string `json:"ipAddress,omitempty"`
+	// the last time this runner was seen
+	LastSeen *time.Time `json:"lastSeen,omitempty"`
+	// the version of the runner
+	Version *string `json:"version,omitempty"`
+	// the operating system of the runner
+	Os                *string  `json:"os,omitempty"`
 	OwnerID           *string  `json:"ownerID,omitempty"`
 	JobRunnerTokenIDs []string `json:"jobRunnerTokenIDs,omitempty"`
 }
@@ -12961,8 +12969,10 @@ type JobResult struct {
 	// The time the job finished it's execution. This is different from the db insertion time
 	FinishedAt time.Time `json:"finishedAt"`
 	// The time the job started it's execution. This is different from the db insertion time
-	StartedAt    time.Time     `json:"startedAt"`
-	FileID       string        `json:"fileID"`
+	StartedAt time.Time `json:"startedAt"`
+	FileID    string    `json:"fileID"`
+	// the log output from the job
+	Log          *string       `json:"log,omitempty"`
 	Owner        *Organization `json:"owner,omitempty"`
 	ScheduledJob *ScheduledJob `json:"scheduledJob"`
 	File         *File         `json:"file"`
@@ -12980,6 +12990,18 @@ type JobResultConnection struct {
 	TotalCount int64 `json:"totalCount"`
 }
 
+// Return response for createJobResult mutation
+type JobResultCreatePayload struct {
+	// Created jobResult
+	JobResult *JobResult `json:"jobResult"`
+}
+
+// Return response for deleteJobResult mutation
+type JobResultDeletePayload struct {
+	// Deleted jobResult ID
+	DeletedID string `json:"deletedID"`
+}
+
 // An edge in a connection.
 type JobResultEdge struct {
 	// The item at the end of the edge.
@@ -12994,6 +13016,12 @@ type JobResultOrder struct {
 	Direction OrderDirection `json:"direction"`
 	// The field by which to order JobResults.
 	Field JobResultOrderField `json:"field"`
+}
+
+// Return response for updateJobResult mutation
+type JobResultUpdatePayload struct {
+	// Updated jobResult
+	JobResult *JobResult `json:"jobResult"`
 }
 
 // JobResultWhereInput is used for filtering JobResult objects.
@@ -13143,6 +13171,22 @@ type JobResultWhereInput struct {
 	FileIDHasSuffix    *string  `json:"fileIDHasSuffix,omitempty"`
 	FileIDEqualFold    *string  `json:"fileIDEqualFold,omitempty"`
 	FileIDContainsFold *string  `json:"fileIDContainsFold,omitempty"`
+	// log field predicates
+	Log             *string  `json:"log,omitempty"`
+	LogNeq          *string  `json:"logNEQ,omitempty"`
+	LogIn           []string `json:"logIn,omitempty"`
+	LogNotIn        []string `json:"logNotIn,omitempty"`
+	LogGt           *string  `json:"logGT,omitempty"`
+	LogGte          *string  `json:"logGTE,omitempty"`
+	LogLt           *string  `json:"logLT,omitempty"`
+	LogLte          *string  `json:"logLTE,omitempty"`
+	LogContains     *string  `json:"logContains,omitempty"`
+	LogHasPrefix    *string  `json:"logHasPrefix,omitempty"`
+	LogHasSuffix    *string  `json:"logHasSuffix,omitempty"`
+	LogIsNil        *bool    `json:"logIsNil,omitempty"`
+	LogNotNil       *bool    `json:"logNotNil,omitempty"`
+	LogEqualFold    *string  `json:"logEqualFold,omitempty"`
+	LogContainsFold *string  `json:"logContainsFold,omitempty"`
 	// owner edge predicates
 	HasOwner     *bool                     `json:"hasOwner,omitempty"`
 	HasOwnerWith []*OrganizationWhereInput `json:"hasOwnerWith,omitempty"`
@@ -13173,7 +13217,13 @@ type JobRunner struct {
 	// the status of this runner
 	Status enums.JobRunnerStatus `json:"status"`
 	// the IP address of this runner
-	IPAddress       string                    `json:"ipAddress"`
+	IPAddress *string `json:"ipAddress,omitempty"`
+	// the last time this runner was seen
+	LastSeen *time.Time `json:"lastSeen,omitempty"`
+	// the version of the runner
+	Version *string `json:"version,omitempty"`
+	// the operating system of the runner
+	Os              *string                   `json:"os,omitempty"`
 	Owner           *Organization             `json:"owner,omitempty"`
 	JobRunnerTokens *JobRunnerTokenConnection `json:"jobRunnerTokens"`
 }
@@ -13188,6 +13238,12 @@ type JobRunnerConnection struct {
 	PageInfo *PageInfo `json:"pageInfo"`
 	// Identifies the total count of items in the connection.
 	TotalCount int64 `json:"totalCount"`
+}
+
+// Return response for createJobRunner mutation
+type JobRunnerCreatePayload struct {
+	// Created jobRunner
+	JobRunner *JobRunner `json:"jobRunner"`
 }
 
 // Return response for deleteJobRunner mutation
@@ -13780,8 +13836,53 @@ type JobRunnerWhereInput struct {
 	IPAddressContains     *string  `json:"ipAddressContains,omitempty"`
 	IPAddressHasPrefix    *string  `json:"ipAddressHasPrefix,omitempty"`
 	IPAddressHasSuffix    *string  `json:"ipAddressHasSuffix,omitempty"`
+	IPAddressIsNil        *bool    `json:"ipAddressIsNil,omitempty"`
+	IPAddressNotNil       *bool    `json:"ipAddressNotNil,omitempty"`
 	IPAddressEqualFold    *string  `json:"ipAddressEqualFold,omitempty"`
 	IPAddressContainsFold *string  `json:"ipAddressContainsFold,omitempty"`
+	// last_seen field predicates
+	LastSeen       *time.Time   `json:"lastSeen,omitempty"`
+	LastSeenNeq    *time.Time   `json:"lastSeenNEQ,omitempty"`
+	LastSeenIn     []*time.Time `json:"lastSeenIn,omitempty"`
+	LastSeenNotIn  []*time.Time `json:"lastSeenNotIn,omitempty"`
+	LastSeenGt     *time.Time   `json:"lastSeenGT,omitempty"`
+	LastSeenGte    *time.Time   `json:"lastSeenGTE,omitempty"`
+	LastSeenLt     *time.Time   `json:"lastSeenLT,omitempty"`
+	LastSeenLte    *time.Time   `json:"lastSeenLTE,omitempty"`
+	LastSeenIsNil  *bool        `json:"lastSeenIsNil,omitempty"`
+	LastSeenNotNil *bool        `json:"lastSeenNotNil,omitempty"`
+	// version field predicates
+	Version             *string  `json:"version,omitempty"`
+	VersionNeq          *string  `json:"versionNEQ,omitempty"`
+	VersionIn           []string `json:"versionIn,omitempty"`
+	VersionNotIn        []string `json:"versionNotIn,omitempty"`
+	VersionGt           *string  `json:"versionGT,omitempty"`
+	VersionGte          *string  `json:"versionGTE,omitempty"`
+	VersionLt           *string  `json:"versionLT,omitempty"`
+	VersionLte          *string  `json:"versionLTE,omitempty"`
+	VersionContains     *string  `json:"versionContains,omitempty"`
+	VersionHasPrefix    *string  `json:"versionHasPrefix,omitempty"`
+	VersionHasSuffix    *string  `json:"versionHasSuffix,omitempty"`
+	VersionIsNil        *bool    `json:"versionIsNil,omitempty"`
+	VersionNotNil       *bool    `json:"versionNotNil,omitempty"`
+	VersionEqualFold    *string  `json:"versionEqualFold,omitempty"`
+	VersionContainsFold *string  `json:"versionContainsFold,omitempty"`
+	// os field predicates
+	Os             *string  `json:"os,omitempty"`
+	OsNeq          *string  `json:"osNEQ,omitempty"`
+	OsIn           []string `json:"osIn,omitempty"`
+	OsNotIn        []string `json:"osNotIn,omitempty"`
+	OsGt           *string  `json:"osGT,omitempty"`
+	OsGte          *string  `json:"osGTE,omitempty"`
+	OsLt           *string  `json:"osLT,omitempty"`
+	OsLte          *string  `json:"osLTE,omitempty"`
+	OsContains     *string  `json:"osContains,omitempty"`
+	OsHasPrefix    *string  `json:"osHasPrefix,omitempty"`
+	OsHasSuffix    *string  `json:"osHasSuffix,omitempty"`
+	OsIsNil        *bool    `json:"osIsNil,omitempty"`
+	OsNotNil       *bool    `json:"osNotNil,omitempty"`
+	OsEqualFold    *string  `json:"osEqualFold,omitempty"`
+	OsContainsFold *string  `json:"osContainsFold,omitempty"`
 	// owner edge predicates
 	HasOwner     *bool                     `json:"hasOwner,omitempty"`
 	HasOwnerWith []*OrganizationWhereInput `json:"hasOwnerWith,omitempty"`
@@ -21954,6 +22055,18 @@ type ScheduledJobRunConnection struct {
 	TotalCount int64 `json:"totalCount"`
 }
 
+// Return response for createScheduledJobRun mutation
+type ScheduledJobRunCreatePayload struct {
+	// Created scheduledJobRun
+	ScheduledJobRun *ScheduledJobRun `json:"scheduledJobRun"`
+}
+
+// Return response for deleteScheduledJobRun mutation
+type ScheduledJobRunDeletePayload struct {
+	// Deleted scheduledJobRun ID
+	DeletedID string `json:"deletedID"`
+}
+
 // An edge in a connection.
 type ScheduledJobRunEdge struct {
 	// The item at the end of the edge.
@@ -21968,6 +22081,12 @@ type ScheduledJobRunOrder struct {
 	Direction OrderDirection `json:"direction"`
 	// The field by which to order ScheduledJobRuns.
 	Field ScheduledJobRunOrderField `json:"field"`
+}
+
+// Return response for updateScheduledJobRun mutation
+type ScheduledJobRunUpdatePayload struct {
+	// Updated scheduledJobRun
+	ScheduledJobRun *ScheduledJobRun `json:"scheduledJobRun"`
 }
 
 // ScheduledJobRunWhereInput is used for filtering ScheduledJobRun objects.
@@ -28736,11 +28855,14 @@ type UpdateInviteInput struct {
 // Input was generated by ent.
 type UpdateJobResultInput struct {
 	// the status of this job. did it fail? did it succeed?
-	Status         *enums.JobExecutionStatus `json:"status,omitempty"`
-	OwnerID        *string                   `json:"ownerID,omitempty"`
-	ClearOwner     *bool                     `json:"clearOwner,omitempty"`
-	ScheduledJobID *string                   `json:"scheduledJobID,omitempty"`
-	FileID         *string                   `json:"fileID,omitempty"`
+	Status *enums.JobExecutionStatus `json:"status,omitempty"`
+	// the log output from the job
+	Log            *string `json:"log,omitempty"`
+	ClearLog       *bool   `json:"clearLog,omitempty"`
+	OwnerID        *string `json:"ownerID,omitempty"`
+	ClearOwner     *bool   `json:"clearOwner,omitempty"`
+	ScheduledJobID *string `json:"scheduledJobID,omitempty"`
+	FileID         *string `json:"fileID,omitempty"`
 }
 
 // UpdateJobRunnerInput is used for update JobRunner object.
@@ -28751,7 +28873,19 @@ type UpdateJobRunnerInput struct {
 	AppendTags []string `json:"appendTags,omitempty"`
 	ClearTags  *bool    `json:"clearTags,omitempty"`
 	// the name of the runner
-	Name                    *string  `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
+	// the IP address of this runner
+	IPAddress      *string `json:"ipAddress,omitempty"`
+	ClearIPAddress *bool   `json:"clearIPAddress,omitempty"`
+	// the last time this runner was seen
+	LastSeen      *time.Time `json:"lastSeen,omitempty"`
+	ClearLastSeen *bool      `json:"clearLastSeen,omitempty"`
+	// the version of the runner
+	Version      *string `json:"version,omitempty"`
+	ClearVersion *bool   `json:"clearVersion,omitempty"`
+	// the operating system of the runner
+	Os                      *string  `json:"os,omitempty"`
+	ClearOs                 *bool    `json:"clearOs,omitempty"`
 	OwnerID                 *string  `json:"ownerID,omitempty"`
 	ClearOwner              *bool    `json:"clearOwner,omitempty"`
 	AddJobRunnerTokenIDs    []string `json:"addJobRunnerTokenIDs,omitempty"`

--- a/internal/httpserve/handlers/ent.go
+++ b/internal/httpserve/handlers/ent.go
@@ -564,10 +564,9 @@ func (h *Handler) getOrgByJobRunnerVerificationToken(ctx context.Context, token 
 
 func (h *Handler) createJobRunner(ctx context.Context, token *ent.JobRunnerRegistrationToken, req models.JobRunnerRegistrationRequest) error {
 	input := ent.CreateJobRunnerInput{
-		IPAddress: req.IPAddress,
-		Name:      req.Name,
-		Tags:      req.Tags,
-		OwnerID:   &token.OwnerID,
+		Name:    req.Name,
+		Tags:    req.Tags,
+		OwnerID: &token.OwnerID,
 	}
 
 	err := transaction.FromContext(ctx).JobRunner.Create().

--- a/pkg/openlaneclient/graphclient.go
+++ b/pkg/openlaneclient/graphclient.go
@@ -228,12 +228,12 @@ type OpenlaneGraphClient interface {
 	GetAllInvites(ctx context.Context, interceptors ...clientv2.RequestInterceptor) (*GetAllInvites, error)
 	GetInviteByID(ctx context.Context, inviteID string, interceptors ...clientv2.RequestInterceptor) (*GetInviteByID, error)
 	InvitesByOrgID(ctx context.Context, where *InviteWhereInput, interceptors ...clientv2.RequestInterceptor) (*InvitesByOrgID, error)
+	CreateJobResult(ctx context.Context, input CreateJobResultInput, interceptors ...clientv2.RequestInterceptor) (*CreateJobResult, error)
+	DeleteJobResult(ctx context.Context, deleteJobResultID string, interceptors ...clientv2.RequestInterceptor) (*DeleteJobResult, error)
 	GetAllJobResults(ctx context.Context, interceptors ...clientv2.RequestInterceptor) (*GetAllJobResults, error)
 	GetJobResultByID(ctx context.Context, jobResultID string, interceptors ...clientv2.RequestInterceptor) (*GetJobResultByID, error)
 	GetJobResults(ctx context.Context, first *int64, last *int64, where *JobResultWhereInput, interceptors ...clientv2.RequestInterceptor) (*GetJobResults, error)
-	CreateJobResult(ctx context.Context, input CreateJobResultInput, interceptors ...clientv2.RequestInterceptor) (*CreateJobResult, error)
 	UpdateJobResult(ctx context.Context, updateJobResultID string, input UpdateJobResultInput, interceptors ...clientv2.RequestInterceptor) (*UpdateJobResult, error)
-	DeleteJobResult(ctx context.Context, deleteJobResultID string, interceptors ...clientv2.RequestInterceptor) (*DeleteJobResult, error)
 	CreateJobRunner(ctx context.Context, input CreateJobRunnerInput, interceptors ...clientv2.RequestInterceptor) (*CreateJobRunner, error)
 	DeleteJobRunner(ctx context.Context, deleteJobRunnerID string, interceptors ...clientv2.RequestInterceptor) (*DeleteJobRunner, error)
 	GetAllJobRunners(ctx context.Context, interceptors ...clientv2.RequestInterceptor) (*GetAllJobRunners, error)
@@ -4556,10 +4556,12 @@ func (t *AdminSearch_AdminSearch_JobRunners_PageInfo) GetStartCursor() *string {
 type AdminSearch_AdminSearch_JobRunners_Edges_Node struct {
 	DisplayID string   "json:\"displayID\" graphql:\"displayID\""
 	ID        string   "json:\"id\" graphql:\"id\""
-	IPAddress string   "json:\"ipAddress\" graphql:\"ipAddress\""
+	IPAddress *string  "json:\"ipAddress,omitempty\" graphql:\"ipAddress\""
 	Name      string   "json:\"name\" graphql:\"name\""
+	Os        *string  "json:\"os,omitempty\" graphql:\"os\""
 	OwnerID   *string  "json:\"ownerID,omitempty\" graphql:\"ownerID\""
 	Tags      []string "json:\"tags,omitempty\" graphql:\"tags\""
+	Version   *string  "json:\"version,omitempty\" graphql:\"version\""
 }
 
 func (t *AdminSearch_AdminSearch_JobRunners_Edges_Node) GetDisplayID() string {
@@ -4574,7 +4576,7 @@ func (t *AdminSearch_AdminSearch_JobRunners_Edges_Node) GetID() string {
 	}
 	return t.ID
 }
-func (t *AdminSearch_AdminSearch_JobRunners_Edges_Node) GetIPAddress() string {
+func (t *AdminSearch_AdminSearch_JobRunners_Edges_Node) GetIPAddress() *string {
 	if t == nil {
 		t = &AdminSearch_AdminSearch_JobRunners_Edges_Node{}
 	}
@@ -4585,6 +4587,12 @@ func (t *AdminSearch_AdminSearch_JobRunners_Edges_Node) GetName() string {
 		t = &AdminSearch_AdminSearch_JobRunners_Edges_Node{}
 	}
 	return t.Name
+}
+func (t *AdminSearch_AdminSearch_JobRunners_Edges_Node) GetOs() *string {
+	if t == nil {
+		t = &AdminSearch_AdminSearch_JobRunners_Edges_Node{}
+	}
+	return t.Os
 }
 func (t *AdminSearch_AdminSearch_JobRunners_Edges_Node) GetOwnerID() *string {
 	if t == nil {
@@ -4597,6 +4605,12 @@ func (t *AdminSearch_AdminSearch_JobRunners_Edges_Node) GetTags() []string {
 		t = &AdminSearch_AdminSearch_JobRunners_Edges_Node{}
 	}
 	return t.Tags
+}
+func (t *AdminSearch_AdminSearch_JobRunners_Edges_Node) GetVersion() *string {
+	if t == nil {
+		t = &AdminSearch_AdminSearch_JobRunners_Edges_Node{}
+	}
+	return t.Version
 }
 
 type AdminSearch_AdminSearch_JobRunners_Edges struct {
@@ -39121,6 +39135,116 @@ func (t *InvitesByOrgID_Invites) GetEdges() []*InvitesByOrgID_Invites_Edges {
 	return t.Edges
 }
 
+type CreateJobResult_CreateJobResult_JobResult struct {
+	CreatedAt      *time.Time               "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy      *string                  "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	ExitCode       int64                    "json:\"exitCode\" graphql:\"exitCode\""
+	FileID         string                   "json:\"fileID\" graphql:\"fileID\""
+	FinishedAt     time.Time                "json:\"finishedAt\" graphql:\"finishedAt\""
+	ID             string                   "json:\"id\" graphql:\"id\""
+	OwnerID        *string                  "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	ScheduledJobID string                   "json:\"scheduledJobID\" graphql:\"scheduledJobID\""
+	StartedAt      time.Time                "json:\"startedAt\" graphql:\"startedAt\""
+	Status         enums.JobExecutionStatus "json:\"status\" graphql:\"status\""
+	UpdatedAt      *time.Time               "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy      *string                  "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+}
+
+func (t *CreateJobResult_CreateJobResult_JobResult) GetCreatedAt() *time.Time {
+	if t == nil {
+		t = &CreateJobResult_CreateJobResult_JobResult{}
+	}
+	return t.CreatedAt
+}
+func (t *CreateJobResult_CreateJobResult_JobResult) GetCreatedBy() *string {
+	if t == nil {
+		t = &CreateJobResult_CreateJobResult_JobResult{}
+	}
+	return t.CreatedBy
+}
+func (t *CreateJobResult_CreateJobResult_JobResult) GetExitCode() int64 {
+	if t == nil {
+		t = &CreateJobResult_CreateJobResult_JobResult{}
+	}
+	return t.ExitCode
+}
+func (t *CreateJobResult_CreateJobResult_JobResult) GetFileID() string {
+	if t == nil {
+		t = &CreateJobResult_CreateJobResult_JobResult{}
+	}
+	return t.FileID
+}
+func (t *CreateJobResult_CreateJobResult_JobResult) GetFinishedAt() *time.Time {
+	if t == nil {
+		t = &CreateJobResult_CreateJobResult_JobResult{}
+	}
+	return &t.FinishedAt
+}
+func (t *CreateJobResult_CreateJobResult_JobResult) GetID() string {
+	if t == nil {
+		t = &CreateJobResult_CreateJobResult_JobResult{}
+	}
+	return t.ID
+}
+func (t *CreateJobResult_CreateJobResult_JobResult) GetOwnerID() *string {
+	if t == nil {
+		t = &CreateJobResult_CreateJobResult_JobResult{}
+	}
+	return t.OwnerID
+}
+func (t *CreateJobResult_CreateJobResult_JobResult) GetScheduledJobID() string {
+	if t == nil {
+		t = &CreateJobResult_CreateJobResult_JobResult{}
+	}
+	return t.ScheduledJobID
+}
+func (t *CreateJobResult_CreateJobResult_JobResult) GetStartedAt() *time.Time {
+	if t == nil {
+		t = &CreateJobResult_CreateJobResult_JobResult{}
+	}
+	return &t.StartedAt
+}
+func (t *CreateJobResult_CreateJobResult_JobResult) GetStatus() *enums.JobExecutionStatus {
+	if t == nil {
+		t = &CreateJobResult_CreateJobResult_JobResult{}
+	}
+	return &t.Status
+}
+func (t *CreateJobResult_CreateJobResult_JobResult) GetUpdatedAt() *time.Time {
+	if t == nil {
+		t = &CreateJobResult_CreateJobResult_JobResult{}
+	}
+	return t.UpdatedAt
+}
+func (t *CreateJobResult_CreateJobResult_JobResult) GetUpdatedBy() *string {
+	if t == nil {
+		t = &CreateJobResult_CreateJobResult_JobResult{}
+	}
+	return t.UpdatedBy
+}
+
+type CreateJobResult_CreateJobResult struct {
+	JobResult CreateJobResult_CreateJobResult_JobResult "json:\"jobResult\" graphql:\"jobResult\""
+}
+
+func (t *CreateJobResult_CreateJobResult) GetJobResult() *CreateJobResult_CreateJobResult_JobResult {
+	if t == nil {
+		t = &CreateJobResult_CreateJobResult{}
+	}
+	return &t.JobResult
+}
+
+type DeleteJobResult_DeleteJobResult struct {
+	DeletedID string "json:\"deletedID\" graphql:\"deletedID\""
+}
+
+func (t *DeleteJobResult_DeleteJobResult) GetDeletedID() string {
+	if t == nil {
+		t = &DeleteJobResult_DeleteJobResult{}
+	}
+	return t.DeletedID
+}
+
 type GetAllJobResults_JobResults_PageInfo struct {
 	EndCursor       *string "json:\"endCursor,omitempty\" graphql:\"endCursor\""
 	HasNextPage     bool    "json:\"hasNextPage\" graphql:\"hasNextPage\""
@@ -39521,105 +39645,6 @@ func (t *GetJobResults_JobResults) GetTotalCount() int64 {
 	return t.TotalCount
 }
 
-type CreateJobResult_CreateJobResult_JobResult struct {
-	CreatedAt      *time.Time               "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy      *string                  "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	ExitCode       int64                    "json:\"exitCode\" graphql:\"exitCode\""
-	FileID         string                   "json:\"fileID\" graphql:\"fileID\""
-	FinishedAt     time.Time                "json:\"finishedAt\" graphql:\"finishedAt\""
-	ID             string                   "json:\"id\" graphql:\"id\""
-	OwnerID        *string                  "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	ScheduledJobID string                   "json:\"scheduledJobID\" graphql:\"scheduledJobID\""
-	StartedAt      time.Time                "json:\"startedAt\" graphql:\"startedAt\""
-	Status         enums.JobExecutionStatus "json:\"status\" graphql:\"status\""
-	UpdatedAt      *time.Time               "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy      *string                  "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
-}
-
-func (t *CreateJobResult_CreateJobResult_JobResult) GetCreatedAt() *time.Time {
-	if t == nil {
-		t = &CreateJobResult_CreateJobResult_JobResult{}
-	}
-	return t.CreatedAt
-}
-func (t *CreateJobResult_CreateJobResult_JobResult) GetCreatedBy() *string {
-	if t == nil {
-		t = &CreateJobResult_CreateJobResult_JobResult{}
-	}
-	return t.CreatedBy
-}
-func (t *CreateJobResult_CreateJobResult_JobResult) GetExitCode() int64 {
-	if t == nil {
-		t = &CreateJobResult_CreateJobResult_JobResult{}
-	}
-	return t.ExitCode
-}
-func (t *CreateJobResult_CreateJobResult_JobResult) GetFileID() string {
-	if t == nil {
-		t = &CreateJobResult_CreateJobResult_JobResult{}
-	}
-	return t.FileID
-}
-func (t *CreateJobResult_CreateJobResult_JobResult) GetFinishedAt() *time.Time {
-	if t == nil {
-		t = &CreateJobResult_CreateJobResult_JobResult{}
-	}
-	return &t.FinishedAt
-}
-func (t *CreateJobResult_CreateJobResult_JobResult) GetID() string {
-	if t == nil {
-		t = &CreateJobResult_CreateJobResult_JobResult{}
-	}
-	return t.ID
-}
-func (t *CreateJobResult_CreateJobResult_JobResult) GetOwnerID() *string {
-	if t == nil {
-		t = &CreateJobResult_CreateJobResult_JobResult{}
-	}
-	return t.OwnerID
-}
-func (t *CreateJobResult_CreateJobResult_JobResult) GetScheduledJobID() string {
-	if t == nil {
-		t = &CreateJobResult_CreateJobResult_JobResult{}
-	}
-	return t.ScheduledJobID
-}
-func (t *CreateJobResult_CreateJobResult_JobResult) GetStartedAt() *time.Time {
-	if t == nil {
-		t = &CreateJobResult_CreateJobResult_JobResult{}
-	}
-	return &t.StartedAt
-}
-func (t *CreateJobResult_CreateJobResult_JobResult) GetStatus() *enums.JobExecutionStatus {
-	if t == nil {
-		t = &CreateJobResult_CreateJobResult_JobResult{}
-	}
-	return &t.Status
-}
-func (t *CreateJobResult_CreateJobResult_JobResult) GetUpdatedAt() *time.Time {
-	if t == nil {
-		t = &CreateJobResult_CreateJobResult_JobResult{}
-	}
-	return t.UpdatedAt
-}
-func (t *CreateJobResult_CreateJobResult_JobResult) GetUpdatedBy() *string {
-	if t == nil {
-		t = &CreateJobResult_CreateJobResult_JobResult{}
-	}
-	return t.UpdatedBy
-}
-
-type CreateJobResult_CreateJobResult struct {
-	JobResult CreateJobResult_CreateJobResult_JobResult "json:\"jobResult\" graphql:\"jobResult\""
-}
-
-func (t *CreateJobResult_CreateJobResult) GetJobResult() *CreateJobResult_CreateJobResult_JobResult {
-	if t == nil {
-		t = &CreateJobResult_CreateJobResult{}
-	}
-	return &t.JobResult
-}
-
 type UpdateJobResult_UpdateJobResult_JobResult struct {
 	CreatedAt      *time.Time               "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy      *string                  "json:\"createdBy,omitempty\" graphql:\"createdBy\""
@@ -39719,23 +39744,12 @@ func (t *UpdateJobResult_UpdateJobResult) GetJobResult() *UpdateJobResult_Update
 	return &t.JobResult
 }
 
-type DeleteJobResult_DeleteJobResult struct {
-	DeletedID string "json:\"deletedID\" graphql:\"deletedID\""
-}
-
-func (t *DeleteJobResult_DeleteJobResult) GetDeletedID() string {
-	if t == nil {
-		t = &DeleteJobResult_DeleteJobResult{}
-	}
-	return t.DeletedID
-}
-
 type CreateJobRunner_CreateJobRunner_JobRunner struct {
 	CreatedAt *time.Time            "json:\"createdAt,omitempty\" graphql:\"createdAt\""
 	CreatedBy *string               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	DisplayID string                "json:\"displayID\" graphql:\"displayID\""
 	ID        string                "json:\"id\" graphql:\"id\""
-	IPAddress string                "json:\"ipAddress\" graphql:\"ipAddress\""
+	IPAddress *string               "json:\"ipAddress,omitempty\" graphql:\"ipAddress\""
 	Name      string                "json:\"name\" graphql:\"name\""
 	OwnerID   *string               "json:\"ownerID,omitempty\" graphql:\"ownerID\""
 	Status    enums.JobRunnerStatus "json:\"status\" graphql:\"status\""
@@ -39768,7 +39782,7 @@ func (t *CreateJobRunner_CreateJobRunner_JobRunner) GetID() string {
 	}
 	return t.ID
 }
-func (t *CreateJobRunner_CreateJobRunner_JobRunner) GetIPAddress() string {
+func (t *CreateJobRunner_CreateJobRunner_JobRunner) GetIPAddress() *string {
 	if t == nil {
 		t = &CreateJobRunner_CreateJobRunner_JobRunner{}
 	}
@@ -39870,7 +39884,7 @@ type GetAllJobRunners_JobRunners_Edges_Node struct {
 	CreatedBy *string               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	DisplayID string                "json:\"displayID\" graphql:\"displayID\""
 	ID        string                "json:\"id\" graphql:\"id\""
-	IPAddress string                "json:\"ipAddress\" graphql:\"ipAddress\""
+	IPAddress *string               "json:\"ipAddress,omitempty\" graphql:\"ipAddress\""
 	Name      string                "json:\"name\" graphql:\"name\""
 	OwnerID   *string               "json:\"ownerID,omitempty\" graphql:\"ownerID\""
 	Status    enums.JobRunnerStatus "json:\"status\" graphql:\"status\""
@@ -39903,7 +39917,7 @@ func (t *GetAllJobRunners_JobRunners_Edges_Node) GetID() string {
 	}
 	return t.ID
 }
-func (t *GetAllJobRunners_JobRunners_Edges_Node) GetIPAddress() string {
+func (t *GetAllJobRunners_JobRunners_Edges_Node) GetIPAddress() *string {
 	if t == nil {
 		t = &GetAllJobRunners_JobRunners_Edges_Node{}
 	}
@@ -39987,7 +40001,7 @@ type GetJobRunnerByID_JobRunner struct {
 	CreatedBy *string               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	DisplayID string                "json:\"displayID\" graphql:\"displayID\""
 	ID        string                "json:\"id\" graphql:\"id\""
-	IPAddress string                "json:\"ipAddress\" graphql:\"ipAddress\""
+	IPAddress *string               "json:\"ipAddress,omitempty\" graphql:\"ipAddress\""
 	Name      string                "json:\"name\" graphql:\"name\""
 	OwnerID   *string               "json:\"ownerID,omitempty\" graphql:\"ownerID\""
 	Status    enums.JobRunnerStatus "json:\"status\" graphql:\"status\""
@@ -40020,7 +40034,7 @@ func (t *GetJobRunnerByID_JobRunner) GetID() string {
 	}
 	return t.ID
 }
-func (t *GetJobRunnerByID_JobRunner) GetIPAddress() string {
+func (t *GetJobRunnerByID_JobRunner) GetIPAddress() *string {
 	if t == nil {
 		t = &GetJobRunnerByID_JobRunner{}
 	}
@@ -40100,7 +40114,7 @@ type GetJobRunners_JobRunners_Edges_Node struct {
 	CreatedBy *string               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	DisplayID string                "json:\"displayID\" graphql:\"displayID\""
 	ID        string                "json:\"id\" graphql:\"id\""
-	IPAddress string                "json:\"ipAddress\" graphql:\"ipAddress\""
+	IPAddress *string               "json:\"ipAddress,omitempty\" graphql:\"ipAddress\""
 	Name      string                "json:\"name\" graphql:\"name\""
 	OwnerID   *string               "json:\"ownerID,omitempty\" graphql:\"ownerID\""
 	Status    enums.JobRunnerStatus "json:\"status\" graphql:\"status\""
@@ -40133,7 +40147,7 @@ func (t *GetJobRunners_JobRunners_Edges_Node) GetID() string {
 	}
 	return t.ID
 }
-func (t *GetJobRunners_JobRunners_Edges_Node) GetIPAddress() string {
+func (t *GetJobRunners_JobRunners_Edges_Node) GetIPAddress() *string {
 	if t == nil {
 		t = &GetJobRunners_JobRunners_Edges_Node{}
 	}
@@ -40217,7 +40231,7 @@ type UpdateJobRunner_UpdateJobRunner_JobRunner struct {
 	CreatedBy *string               "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	DisplayID string                "json:\"displayID\" graphql:\"displayID\""
 	ID        string                "json:\"id\" graphql:\"id\""
-	IPAddress string                "json:\"ipAddress\" graphql:\"ipAddress\""
+	IPAddress *string               "json:\"ipAddress,omitempty\" graphql:\"ipAddress\""
 	Name      string                "json:\"name\" graphql:\"name\""
 	OwnerID   *string               "json:\"ownerID,omitempty\" graphql:\"ownerID\""
 	Status    enums.JobRunnerStatus "json:\"status\" graphql:\"status\""
@@ -40250,7 +40264,7 @@ func (t *UpdateJobRunner_UpdateJobRunner_JobRunner) GetID() string {
 	}
 	return t.ID
 }
-func (t *UpdateJobRunner_UpdateJobRunner_JobRunner) GetIPAddress() string {
+func (t *UpdateJobRunner_UpdateJobRunner_JobRunner) GetIPAddress() *string {
 	if t == nil {
 		t = &UpdateJobRunner_UpdateJobRunner_JobRunner{}
 	}
@@ -92099,6 +92113,28 @@ func (t *InvitesByOrgID) GetInvites() *InvitesByOrgID_Invites {
 	return &t.Invites
 }
 
+type CreateJobResult struct {
+	CreateJobResult CreateJobResult_CreateJobResult "json:\"createJobResult\" graphql:\"createJobResult\""
+}
+
+func (t *CreateJobResult) GetCreateJobResult() *CreateJobResult_CreateJobResult {
+	if t == nil {
+		t = &CreateJobResult{}
+	}
+	return &t.CreateJobResult
+}
+
+type DeleteJobResult struct {
+	DeleteJobResult DeleteJobResult_DeleteJobResult "json:\"deleteJobResult\" graphql:\"deleteJobResult\""
+}
+
+func (t *DeleteJobResult) GetDeleteJobResult() *DeleteJobResult_DeleteJobResult {
+	if t == nil {
+		t = &DeleteJobResult{}
+	}
+	return &t.DeleteJobResult
+}
+
 type GetAllJobResults struct {
 	JobResults GetAllJobResults_JobResults "json:\"jobResults\" graphql:\"jobResults\""
 }
@@ -92132,17 +92168,6 @@ func (t *GetJobResults) GetJobResults() *GetJobResults_JobResults {
 	return &t.JobResults
 }
 
-type CreateJobResult struct {
-	CreateJobResult CreateJobResult_CreateJobResult "json:\"createJobResult\" graphql:\"createJobResult\""
-}
-
-func (t *CreateJobResult) GetCreateJobResult() *CreateJobResult_CreateJobResult {
-	if t == nil {
-		t = &CreateJobResult{}
-	}
-	return &t.CreateJobResult
-}
-
 type UpdateJobResult struct {
 	UpdateJobResult UpdateJobResult_UpdateJobResult "json:\"updateJobResult\" graphql:\"updateJobResult\""
 }
@@ -92152,17 +92177,6 @@ func (t *UpdateJobResult) GetUpdateJobResult() *UpdateJobResult_UpdateJobResult 
 		t = &UpdateJobResult{}
 	}
 	return &t.UpdateJobResult
-}
-
-type DeleteJobResult struct {
-	DeleteJobResult DeleteJobResult_DeleteJobResult "json:\"deleteJobResult\" graphql:\"deleteJobResult\""
-}
-
-func (t *DeleteJobResult) GetDeleteJobResult() *DeleteJobResult_DeleteJobResult {
-	if t == nil {
-		t = &DeleteJobResult{}
-	}
-	return &t.DeleteJobResult
 }
 
 type CreateJobRunner struct {
@@ -96202,6 +96216,8 @@ const AdminSearchDocument = `query AdminSearch ($query: String!) {
 					ownerID
 					name
 					ipAddress
+					version
+					os
 				}
 			}
 		}
@@ -106031,6 +106047,67 @@ func (c *Client) InvitesByOrgID(ctx context.Context, where *InviteWhereInput, in
 	return &res, nil
 }
 
+const CreateJobResultDocument = `mutation CreateJobResult ($input: CreateJobResultInput!) {
+	createJobResult(input: $input) {
+		jobResult {
+			id
+			createdAt
+			createdBy
+			updatedAt
+			updatedBy
+			ownerID
+			scheduledJobID
+			status
+			exitCode
+			startedAt
+			finishedAt
+			fileID
+		}
+	}
+}
+`
+
+func (c *Client) CreateJobResult(ctx context.Context, input CreateJobResultInput, interceptors ...clientv2.RequestInterceptor) (*CreateJobResult, error) {
+	vars := map[string]any{
+		"input": input,
+	}
+
+	var res CreateJobResult
+	if err := c.Client.Post(ctx, "CreateJobResult", CreateJobResultDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+const DeleteJobResultDocument = `mutation DeleteJobResult ($deleteJobResultId: ID!) {
+	deleteJobResult(id: $deleteJobResultId) {
+		deletedID
+	}
+}
+`
+
+func (c *Client) DeleteJobResult(ctx context.Context, deleteJobResultID string, interceptors ...clientv2.RequestInterceptor) (*DeleteJobResult, error) {
+	vars := map[string]any{
+		"deleteJobResultId": deleteJobResultID,
+	}
+
+	var res DeleteJobResult
+	if err := c.Client.Post(ctx, "DeleteJobResult", DeleteJobResultDocument, &res, vars, interceptors...); err != nil {
+		if c.Client.ParseDataWhenErrors {
+			return &res, err
+		}
+
+		return nil, err
+	}
+
+	return &res, nil
+}
+
 const GetAllJobResultsDocument = `query GetAllJobResults {
 	jobResults {
 		totalCount
@@ -106158,43 +106235,6 @@ func (c *Client) GetJobResults(ctx context.Context, first *int64, last *int64, w
 	return &res, nil
 }
 
-const CreateJobResultDocument = `mutation CreateJobResult ($input: CreateJobResultInput!) {
-	createJobResult(input: $input) {
-		jobResult {
-			id
-			createdAt
-			createdBy
-			updatedAt
-			updatedBy
-			ownerID
-			scheduledJobID
-			status
-			exitCode
-			startedAt
-			finishedAt
-			fileID
-		}
-	}
-}
-`
-
-func (c *Client) CreateJobResult(ctx context.Context, input CreateJobResultInput, interceptors ...clientv2.RequestInterceptor) (*CreateJobResult, error) {
-	vars := map[string]any{
-		"input": input,
-	}
-
-	var res CreateJobResult
-	if err := c.Client.Post(ctx, "CreateJobResult", CreateJobResultDocument, &res, vars, interceptors...); err != nil {
-		if c.Client.ParseDataWhenErrors {
-			return &res, err
-		}
-
-		return nil, err
-	}
-
-	return &res, nil
-}
-
 const UpdateJobResultDocument = `mutation UpdateJobResult ($updateJobResultId: ID!, $input: UpdateJobResultInput!) {
 	updateJobResult(id: $updateJobResultId, input: $input) {
 		jobResult {
@@ -106223,30 +106263,6 @@ func (c *Client) UpdateJobResult(ctx context.Context, updateJobResultID string, 
 
 	var res UpdateJobResult
 	if err := c.Client.Post(ctx, "UpdateJobResult", UpdateJobResultDocument, &res, vars, interceptors...); err != nil {
-		if c.Client.ParseDataWhenErrors {
-			return &res, err
-		}
-
-		return nil, err
-	}
-
-	return &res, nil
-}
-
-const DeleteJobResultDocument = `mutation DeleteJobResult ($deleteJobResultId: ID!) {
-	deleteJobResult(id: $deleteJobResultId) {
-		deletedID
-	}
-}
-`
-
-func (c *Client) DeleteJobResult(ctx context.Context, deleteJobResultID string, interceptors ...clientv2.RequestInterceptor) (*DeleteJobResult, error) {
-	vars := map[string]any{
-		"deleteJobResultId": deleteJobResultID,
-	}
-
-	var res DeleteJobResult
-	if err := c.Client.Post(ctx, "DeleteJobResult", DeleteJobResultDocument, &res, vars, interceptors...); err != nil {
 		if c.Client.ParseDataWhenErrors {
 			return &res, err
 		}
@@ -120589,12 +120605,12 @@ var DocumentOperationNames = map[string]string{
 	GetAllInvitesDocument:                          "GetAllInvites",
 	GetInviteByIDDocument:                          "GetInviteByID",
 	InvitesByOrgIDDocument:                         "InvitesByOrgID",
+	CreateJobResultDocument:                        "CreateJobResult",
+	DeleteJobResultDocument:                        "DeleteJobResult",
 	GetAllJobResultsDocument:                       "GetAllJobResults",
 	GetJobResultByIDDocument:                       "GetJobResultByID",
 	GetJobResultsDocument:                          "GetJobResults",
-	CreateJobResultDocument:                        "CreateJobResult",
 	UpdateJobResultDocument:                        "UpdateJobResult",
-	DeleteJobResultDocument:                        "DeleteJobResult",
 	CreateJobRunnerDocument:                        "CreateJobRunner",
 	DeleteJobRunnerDocument:                        "DeleteJobRunner",
 	GetAllJobRunnersDocument:                       "GetAllJobRunners",

--- a/pkg/openlaneclient/models.go
+++ b/pkg/openlaneclient/models.go
@@ -4847,10 +4847,12 @@ type CreateJobResultInput struct {
 	// The time the job finished it's execution. This is different from the db insertion time
 	FinishedAt *time.Time `json:"finishedAt,omitempty"`
 	// The time the job started it's execution. This is different from the db insertion time
-	StartedAt      *time.Time `json:"startedAt,omitempty"`
-	OwnerID        *string    `json:"ownerID,omitempty"`
-	ScheduledJobID string     `json:"scheduledJobID"`
-	FileID         string     `json:"fileID"`
+	StartedAt *time.Time `json:"startedAt,omitempty"`
+	// the log output from the job
+	Log            *string `json:"log,omitempty"`
+	OwnerID        *string `json:"ownerID,omitempty"`
+	ScheduledJobID string  `json:"scheduledJobID"`
+	FileID         string  `json:"fileID"`
 }
 
 // CreateJobRunnerInput is used for create JobRunner object.
@@ -4861,7 +4863,13 @@ type CreateJobRunnerInput struct {
 	// the name of the runner
 	Name string `json:"name"`
 	// the IP address of this runner
-	IPAddress         string   `json:"ipAddress"`
+	IPAddress *string `json:"ipAddress,omitempty"`
+	// the last time this runner was seen
+	LastSeen *time.Time `json:"lastSeen,omitempty"`
+	// the version of the runner
+	Version *string `json:"version,omitempty"`
+	// the operating system of the runner
+	Os                *string  `json:"os,omitempty"`
 	OwnerID           *string  `json:"ownerID,omitempty"`
 	JobRunnerTokenIDs []string `json:"jobRunnerTokenIDs,omitempty"`
 }
@@ -12961,8 +12969,10 @@ type JobResult struct {
 	// The time the job finished it's execution. This is different from the db insertion time
 	FinishedAt time.Time `json:"finishedAt"`
 	// The time the job started it's execution. This is different from the db insertion time
-	StartedAt    time.Time     `json:"startedAt"`
-	FileID       string        `json:"fileID"`
+	StartedAt time.Time `json:"startedAt"`
+	FileID    string    `json:"fileID"`
+	// the log output from the job
+	Log          *string       `json:"log,omitempty"`
 	Owner        *Organization `json:"owner,omitempty"`
 	ScheduledJob *ScheduledJob `json:"scheduledJob"`
 	File         *File         `json:"file"`
@@ -13161,6 +13171,22 @@ type JobResultWhereInput struct {
 	FileIDHasSuffix    *string  `json:"fileIDHasSuffix,omitempty"`
 	FileIDEqualFold    *string  `json:"fileIDEqualFold,omitempty"`
 	FileIDContainsFold *string  `json:"fileIDContainsFold,omitempty"`
+	// log field predicates
+	Log             *string  `json:"log,omitempty"`
+	LogNeq          *string  `json:"logNEQ,omitempty"`
+	LogIn           []string `json:"logIn,omitempty"`
+	LogNotIn        []string `json:"logNotIn,omitempty"`
+	LogGt           *string  `json:"logGT,omitempty"`
+	LogGte          *string  `json:"logGTE,omitempty"`
+	LogLt           *string  `json:"logLT,omitempty"`
+	LogLte          *string  `json:"logLTE,omitempty"`
+	LogContains     *string  `json:"logContains,omitempty"`
+	LogHasPrefix    *string  `json:"logHasPrefix,omitempty"`
+	LogHasSuffix    *string  `json:"logHasSuffix,omitempty"`
+	LogIsNil        *bool    `json:"logIsNil,omitempty"`
+	LogNotNil       *bool    `json:"logNotNil,omitempty"`
+	LogEqualFold    *string  `json:"logEqualFold,omitempty"`
+	LogContainsFold *string  `json:"logContainsFold,omitempty"`
 	// owner edge predicates
 	HasOwner     *bool                     `json:"hasOwner,omitempty"`
 	HasOwnerWith []*OrganizationWhereInput `json:"hasOwnerWith,omitempty"`
@@ -13191,7 +13217,13 @@ type JobRunner struct {
 	// the status of this runner
 	Status enums.JobRunnerStatus `json:"status"`
 	// the IP address of this runner
-	IPAddress       string                    `json:"ipAddress"`
+	IPAddress *string `json:"ipAddress,omitempty"`
+	// the last time this runner was seen
+	LastSeen *time.Time `json:"lastSeen,omitempty"`
+	// the version of the runner
+	Version *string `json:"version,omitempty"`
+	// the operating system of the runner
+	Os              *string                   `json:"os,omitempty"`
 	Owner           *Organization             `json:"owner,omitempty"`
 	JobRunnerTokens *JobRunnerTokenConnection `json:"jobRunnerTokens"`
 }
@@ -13804,8 +13836,53 @@ type JobRunnerWhereInput struct {
 	IPAddressContains     *string  `json:"ipAddressContains,omitempty"`
 	IPAddressHasPrefix    *string  `json:"ipAddressHasPrefix,omitempty"`
 	IPAddressHasSuffix    *string  `json:"ipAddressHasSuffix,omitempty"`
+	IPAddressIsNil        *bool    `json:"ipAddressIsNil,omitempty"`
+	IPAddressNotNil       *bool    `json:"ipAddressNotNil,omitempty"`
 	IPAddressEqualFold    *string  `json:"ipAddressEqualFold,omitempty"`
 	IPAddressContainsFold *string  `json:"ipAddressContainsFold,omitempty"`
+	// last_seen field predicates
+	LastSeen       *time.Time   `json:"lastSeen,omitempty"`
+	LastSeenNeq    *time.Time   `json:"lastSeenNEQ,omitempty"`
+	LastSeenIn     []*time.Time `json:"lastSeenIn,omitempty"`
+	LastSeenNotIn  []*time.Time `json:"lastSeenNotIn,omitempty"`
+	LastSeenGt     *time.Time   `json:"lastSeenGT,omitempty"`
+	LastSeenGte    *time.Time   `json:"lastSeenGTE,omitempty"`
+	LastSeenLt     *time.Time   `json:"lastSeenLT,omitempty"`
+	LastSeenLte    *time.Time   `json:"lastSeenLTE,omitempty"`
+	LastSeenIsNil  *bool        `json:"lastSeenIsNil,omitempty"`
+	LastSeenNotNil *bool        `json:"lastSeenNotNil,omitempty"`
+	// version field predicates
+	Version             *string  `json:"version,omitempty"`
+	VersionNeq          *string  `json:"versionNEQ,omitempty"`
+	VersionIn           []string `json:"versionIn,omitempty"`
+	VersionNotIn        []string `json:"versionNotIn,omitempty"`
+	VersionGt           *string  `json:"versionGT,omitempty"`
+	VersionGte          *string  `json:"versionGTE,omitempty"`
+	VersionLt           *string  `json:"versionLT,omitempty"`
+	VersionLte          *string  `json:"versionLTE,omitempty"`
+	VersionContains     *string  `json:"versionContains,omitempty"`
+	VersionHasPrefix    *string  `json:"versionHasPrefix,omitempty"`
+	VersionHasSuffix    *string  `json:"versionHasSuffix,omitempty"`
+	VersionIsNil        *bool    `json:"versionIsNil,omitempty"`
+	VersionNotNil       *bool    `json:"versionNotNil,omitempty"`
+	VersionEqualFold    *string  `json:"versionEqualFold,omitempty"`
+	VersionContainsFold *string  `json:"versionContainsFold,omitempty"`
+	// os field predicates
+	Os             *string  `json:"os,omitempty"`
+	OsNeq          *string  `json:"osNEQ,omitempty"`
+	OsIn           []string `json:"osIn,omitempty"`
+	OsNotIn        []string `json:"osNotIn,omitempty"`
+	OsGt           *string  `json:"osGT,omitempty"`
+	OsGte          *string  `json:"osGTE,omitempty"`
+	OsLt           *string  `json:"osLT,omitempty"`
+	OsLte          *string  `json:"osLTE,omitempty"`
+	OsContains     *string  `json:"osContains,omitempty"`
+	OsHasPrefix    *string  `json:"osHasPrefix,omitempty"`
+	OsHasSuffix    *string  `json:"osHasSuffix,omitempty"`
+	OsIsNil        *bool    `json:"osIsNil,omitempty"`
+	OsNotNil       *bool    `json:"osNotNil,omitempty"`
+	OsEqualFold    *string  `json:"osEqualFold,omitempty"`
+	OsContainsFold *string  `json:"osContainsFold,omitempty"`
 	// owner edge predicates
 	HasOwner     *bool                     `json:"hasOwner,omitempty"`
 	HasOwnerWith []*OrganizationWhereInput `json:"hasOwnerWith,omitempty"`
@@ -28778,11 +28855,14 @@ type UpdateInviteInput struct {
 // Input was generated by ent.
 type UpdateJobResultInput struct {
 	// the status of this job. did it fail? did it succeed?
-	Status         *enums.JobExecutionStatus `json:"status,omitempty"`
-	OwnerID        *string                   `json:"ownerID,omitempty"`
-	ClearOwner     *bool                     `json:"clearOwner,omitempty"`
-	ScheduledJobID *string                   `json:"scheduledJobID,omitempty"`
-	FileID         *string                   `json:"fileID,omitempty"`
+	Status *enums.JobExecutionStatus `json:"status,omitempty"`
+	// the log output from the job
+	Log            *string `json:"log,omitempty"`
+	ClearLog       *bool   `json:"clearLog,omitempty"`
+	OwnerID        *string `json:"ownerID,omitempty"`
+	ClearOwner     *bool   `json:"clearOwner,omitempty"`
+	ScheduledJobID *string `json:"scheduledJobID,omitempty"`
+	FileID         *string `json:"fileID,omitempty"`
 }
 
 // UpdateJobRunnerInput is used for update JobRunner object.
@@ -28793,7 +28873,19 @@ type UpdateJobRunnerInput struct {
 	AppendTags []string `json:"appendTags,omitempty"`
 	ClearTags  *bool    `json:"clearTags,omitempty"`
 	// the name of the runner
-	Name                    *string  `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
+	// the IP address of this runner
+	IPAddress      *string `json:"ipAddress,omitempty"`
+	ClearIPAddress *bool   `json:"clearIPAddress,omitempty"`
+	// the last time this runner was seen
+	LastSeen      *time.Time `json:"lastSeen,omitempty"`
+	ClearLastSeen *bool      `json:"clearLastSeen,omitempty"`
+	// the version of the runner
+	Version      *string `json:"version,omitempty"`
+	ClearVersion *bool   `json:"clearVersion,omitempty"`
+	// the operating system of the runner
+	Os                      *string  `json:"os,omitempty"`
+	ClearOs                 *bool    `json:"clearOs,omitempty"`
 	OwnerID                 *string  `json:"ownerID,omitempty"`
 	ClearOwner              *bool    `json:"clearOwner,omitempty"`
 	AddJobRunnerTokenIDs    []string `json:"addJobRunnerTokenIDs,omitempty"`


### PR DESCRIPTION
- IP address(es) will frequently come from the same IP even when running multiple agents, so the field should not be unique
- The validation is requiring strict non-loopback IP's or localhost IP's which is not only prohibitive for testing but wouldn't practically work that well when our customers would run the agent in a containerized environment, so removing it for now
- Adds some other agent fields relevant for agent runtime (host, version, etc.)
- Adds a text field for raw log output in job status