### PR TITLE
verbose + remove goamd64

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean
+          args: release --clean --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,7 +28,6 @@ builds:
           - CGO_ENABLED=1
       - goos: darwin
         goarch: amd64
-        goamd64: v1
         env:
           - CGO_ENABLED=1
     main: ./cmd/cli


### PR DESCRIPTION
Seems to work locally:

```
    • added new artifact                             name=openlane type=Binary path=dist/openlane_darwin_amd64_v1/openlane
    • added new artifact                             name=openlane type=Binary path=dist/openlane_darwin_arm64_v8.0/openlane
```