### PR TITLE
bug: ensure order is preserved after acces checks

### DIFF
--- a/internal/ent/interceptors/filter.go
+++ b/internal/ent/interceptors/filter.go
@@ -276,19 +276,22 @@ func filterListObjects[T any](ctx context.Context, v ent.Value, q intercept.Quer
 	}
 
 	// filter the results based on the allowed ids
-	filteredResults := make([]*T, 0, len(allowedIDs))
-
+	// this must be done in the same order as the original list
+	// to maintain the order of the results
+	allowed := make(map[string]struct{}, len(allowedIDs))
 	for _, id := range allowedIDs {
-		for _, item := range listResults {
-			objID, err := getObjectIDFromEntValue(item)
-			if err != nil {
-				return nil, err
-			}
+		allowed[id] = struct{}{}
+	}
 
-			if id == objID {
-				filteredResults = append(filteredResults, item)
-				break
-			}
+	filteredResults := make([]*T, 0, len(allowedIDs))
+	for _, item := range listResults {
+		objID, err := getObjectIDFromEntValue(item)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, ok := allowed[objID]; ok {
+			filteredResults = append(filteredResults, item)
 		}
 	}
 


### PR DESCRIPTION
This bug affected all pagination; but was more noticeable on tasks because a user might have intermittent access across objects in a table like tasks vs. controls. 

The issue was we were creating a new slice based on the ids returned from fga; instead we needed to preserve the order of the results from the database and check access in that order. 
Tests added to sort both on `CreatedAt` (default) as well as `Due` - used in the UI for task sort. 

resolves iss-64 (task pagination)