### PR TITLE
bug: add owner to managed group iss-296

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -377,6 +377,7 @@ tasks:
   run-dev:
     dotenv: ["{{.ENV}}/.env-dev"]
     desc: runs the core server in dev mode
+    deps: ['go:build-cli']
     cmds:
       - task: compose:redis
       - task: compose:fga

--- a/internal/graphapi/organization_test.go
+++ b/internal/graphapi/organization_test.go
@@ -508,6 +508,15 @@ func TestMutationCreateOrganization(t *testing.T) {
 
 			assert.ErrorContains(t, err, interceptors.ErrFeatureNotEnabled.Error())
 
+			// ensure owner is in the managed group
+			for _, g := range managedGroups.Groups.Edges {
+				if g.Node.Name == "Viewers" {
+					assert.Check(t, is.Len(g.Node.Members.Edges, 0))
+				} else {
+					assert.Check(t, is.Len(g.Node.Members.Edges, 1))
+				}
+			}
+
 			// while group is in the base module, this query includes programs and others
 			// which are in other modules
 			assert.Check(t, is.Len(managedGroups.Groups.Edges, 3))


### PR DESCRIPTION
- fixes a bug that was introduced when we no longer added users to a group by default
- adds a test
- adds cli build as a dep to `task run-dev` so it will compile in parallel with the server