### PR TITLE
General billing fixes and updates

### DIFF
--- a/pkg/entitlements/portalsession.go
+++ b/pkg/entitlements/portalsession.go
@@ -11,12 +11,6 @@ func (sc *StripeClient) CreateBillingPortalUpdateSession(ctx context.Context, su
 	params := &stripe.BillingPortalSessionCreateParams{
 		Customer:  &custID,
 		ReturnURL: &sc.Config.StripeBillingPortalSuccessURL,
-		FlowData: &stripe.BillingPortalSessionCreateFlowDataParams{
-			Type: stripe.String("subscription_update"),
-			SubscriptionUpdate: &stripe.BillingPortalSessionCreateFlowDataSubscriptionUpdateParams{
-				Subscription: &subsID,
-			},
-		},
 	}
 
 	billingPortalSession, err := sc.Client.V1BillingPortalSessions.Create(ctx, params)


### PR DESCRIPTION
- [x] subscription update flow cannot be used when a subscription contains multiple products https://docs.stripe.com/api/subscription_schedules/create#create_subscription_schedule-billing_mode
