### PR TITLE
Block all updates to archived programs

### DIFF
--- a/internal/ent/hooks/errors.go
+++ b/internal/ent/hooks/errors.go
@@ -73,6 +73,9 @@ var (
 	ErrFieldRequired = errors.New("field is required but not provided")
 	// ErrOwnerIDNotExists is returned when an owner_id cannot be found
 	ErrOwnerIDNotExists = errors.New("owner_id is required")
+	// ErrArchivedProgramUpdateNotAllowed is returned when an archived program is updated. It only
+	// allows updates if the status is changed
+	ErrArchivedProgramUpdateNotAllowed = errors.New("you cannot update an archived program")
 )
 
 // IsUniqueConstraintError reports if the error resulted from a DB uniqueness constraint violation.


### PR DESCRIPTION
Only allow passthrough if the update contains a status update that moves it from archived to another status