### PR TITLE
bug: export internalPolicy schema 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -91,7 +91,7 @@ require (
 	github.com/theopenlane/echo-prometheus v0.1.0
 	github.com/theopenlane/echox v0.2.4
 	github.com/theopenlane/emailtemplates v0.2.4
-	github.com/theopenlane/entx v0.14.0
+	github.com/theopenlane/entx v0.14.1
 	github.com/theopenlane/gqlgen-plugins v0.7.1
 	github.com/theopenlane/httpsling v0.2.2
 	github.com/theopenlane/iam v0.16.1

--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/theopenlane/httpsling v0.2.2
 	github.com/theopenlane/iam v0.16.1
 	github.com/theopenlane/newman v0.2.0
-	github.com/theopenlane/riverboat v0.3.0
+	github.com/theopenlane/riverboat v0.3.1
 	github.com/theopenlane/utils v0.4.8
 	github.com/tink-crypto/tink-go/v2 v2.4.0
 	github.com/tmc/langchaingo v0.1.13

--- a/go.sum
+++ b/go.sum
@@ -654,8 +654,8 @@ github.com/theopenlane/iam v0.16.1 h1:BVZQYAJ+nXSsdYXWQifsuUOj7q3XgyZ3o4Ed+DPDI/
 github.com/theopenlane/iam v0.16.1/go.mod h1:79njIMkH7rf3tfPSmBnfuY1YgvnlZKocPERc4yRggPM=
 github.com/theopenlane/newman v0.2.0 h1:kgiDIq8m2lRM9mGVzzuZrmo3KN4FAZB2Eu2CxAdqgFI=
 github.com/theopenlane/newman v0.2.0/go.mod h1:JaSL7sgV7VJD5RMkhUESA3kDxX4TeP6XIdg6vUDDfoE=
-github.com/theopenlane/riverboat v0.3.0 h1:qylL7AaPer1ZKu6O6nYDsYH/YISU2VhHjArwGn0iTc0=
-github.com/theopenlane/riverboat v0.3.0/go.mod h1:aUEw289EFd6cB6WMr+Gx9ZVr7VHCQklCQFfU8OpBxbc=
+github.com/theopenlane/riverboat v0.3.1 h1:NJIzHx9t0olw/Zwb/kez2EyEuh9kZYSuELngs1Q3g1s=
+github.com/theopenlane/riverboat v0.3.1/go.mod h1:uV6NSxeX5mwP6cKWfAxvAuNq9z01qkPVcC5vJ8toTyQ=
 github.com/theopenlane/utils v0.4.8 h1:f0bqpTGSQZnO7G95m+6Ct0iAKLhoz8AzqODMogEsRU0=
 github.com/theopenlane/utils v0.4.8/go.mod h1:SfXJyOVF/GDD5Rvtq+n+csTw0i0RnqRIvvBTPd8rRdo=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=

--- a/go.sum
+++ b/go.sum
@@ -644,8 +644,8 @@ github.com/theopenlane/echox v0.2.4 h1:bocz1Dfs7d2fkNa8foQqdmeTtkMTQNwe1v20bIGID
 github.com/theopenlane/echox v0.2.4/go.mod h1:0cPOHe4SSQHmqP0/n2LsIEzRSogkxSX653bE+PIOVZ8=
 github.com/theopenlane/emailtemplates v0.2.4 h1:xmTp0woiTuMrypnY6Spu63VPPdVjK18+zPJ/CdwXUMc=
 github.com/theopenlane/emailtemplates v0.2.4/go.mod h1:vjIIpb1Okb4BMs1Zv319gy8z9KbljD+JZ1Srh6VPEiw=
-github.com/theopenlane/entx v0.14.0 h1:sTCPb0StjnFgvT6jqPLMAkA/onJ+GhsVTnuabxDlzlU=
-github.com/theopenlane/entx v0.14.0/go.mod h1:yVuy4DgEWUaU94/B3nBXRckW5K+gr/yh7sUg2jdqb1M=
+github.com/theopenlane/entx v0.14.1 h1:H2ARn0hox31IsK8EI+r9oGE/2Me7qufCYvtVI8IPw00=
+github.com/theopenlane/entx v0.14.1/go.mod h1:yVuy4DgEWUaU94/B3nBXRckW5K+gr/yh7sUg2jdqb1M=
 github.com/theopenlane/gqlgen-plugins v0.7.1 h1:kPjeWGIETWhMFv3eJvBimDUXzfTITlVJCJt5jz9N5NI=
 github.com/theopenlane/gqlgen-plugins v0.7.1/go.mod h1:+hXH0/+u8AEXg1/Y1QGSuoFo6febI8ig9IigUCMnppM=
 github.com/theopenlane/httpsling v0.2.2 h1:QqJo/VsjeiM6/RnWZpRQX3I7T62j5u9WdXo52zUWyi0=

--- a/internal/ent/generate/entc.go
+++ b/internal/ent/generate/entc.go
@@ -81,10 +81,6 @@ func main() {
 		accessmap.WithSchemaPath(schemaPath),
 	)
 
-	exportEnumsExt := exportenums.New(
-		exportenums.WithSchemaPath(schemaPath),
-	)
-
 	log.Info().Msg("running ent codegen with extensions")
 
 	if err := entc.Generate(schemaPath, &gen.Config{
@@ -95,7 +91,7 @@ func main() {
 			genhooks.GenQuery(graphSimpleQueryDir),
 			genhooks.GenSearchSchema(graphSchemaDir, graphQueryDir),
 			accessMapExt.Hook(),
-			exportEnumsExt.Hook(),
+			exportenums.New().Hook(),
 		},
 		Package: "github.com/theopenlane/core/internal/ent/generated",
 		Features: []gen.Feature{

--- a/internal/ent/generate/entc.go
+++ b/internal/ent/generate/entc.go
@@ -6,14 +6,9 @@ package main
 
 import (
 	"embed"
-	"fmt"
 	"os"
-	"path/filepath"
-	"strings"
-	"text/template"
 
 	"github.com/rs/zerolog/log"
-	"github.com/stoewer/go-strcase"
 
 	"entgo.io/contrib/entgql"
 	"entgo.io/ent/entc"
@@ -22,9 +17,9 @@ import (
 	"gocloud.dev/secrets"
 
 	"github.com/theopenlane/core/internal/ent/entconfig"
-	"github.com/theopenlane/core/internal/entitlements/genfeatures"
 	"github.com/theopenlane/core/internal/genhelpers"
 	"github.com/theopenlane/core/pkg/entitlements"
+	"github.com/theopenlane/core/pkg/enums/exportenums"
 	"github.com/theopenlane/core/pkg/events/soiree"
 	"github.com/theopenlane/core/pkg/objects"
 	"github.com/theopenlane/core/pkg/summarizer"
@@ -86,6 +81,10 @@ func main() {
 		accessmap.WithSchemaPath(schemaPath),
 	)
 
+	exportEnumsExt := exportenums.New(
+		exportenums.WithSchemaPath(schemaPath),
+	)
+
 	log.Info().Msg("running ent codegen with extensions")
 
 	if err := entc.Generate(schemaPath, &gen.Config{
@@ -96,6 +95,7 @@ func main() {
 			genhooks.GenQuery(graphSimpleQueryDir),
 			genhooks.GenSearchSchema(graphSchemaDir, graphQueryDir),
 			accessMapExt.Hook(),
+			exportEnumsExt.Hook(),
 		},
 		Package: "github.com/theopenlane/core/internal/ent/generated",
 		Features: []gen.Feature{
@@ -225,24 +225,13 @@ func preRun() (*history.Extension, *entfga.AuthzExtension) {
 		log.Fatal().Err(err).Msg("generating exportable validation")
 	}
 
-	// extract exportable schemas and generate ExportType enum here
-	exportableSchemas, err := extractExportableSchemasFromGenerated()
-	if err != nil {
-		log.Fatal().Err(err).Msg("extracting exportable schemas")
-	}
-
-	if err := generateExportTypeEnum(exportableSchemas); err != nil {
-		log.Fatal().Err(err).Msg("generating ExportType enum")
-	}
-
-	log.Info().Msg("pre-run: generating feature modules")
-
-	if err := genfeatures.GenerateModulePerSchema(schemaPath, featureMapDir); err != nil {
-		log.Fatal().Err(err).Msg("generating feature modules")
-	}
-
 	return historyExt, entfgaExt
 }
+
+var (
+	//go:embed templates/entgql/*.tmpl
+	_entqlTemplates embed.FS
+)
 
 // WithGqlWithTemplates is a schema hook to replace entgql default template used for pagination
 // The only change to the template is the function used to get the totalCount field uses
@@ -253,184 +242,3 @@ func WithGqlWithTemplates() entgql.ExtensionOption {
 		Funcs(entgql.TemplateFuncs).ParseFS(_entqlTemplates, "templates/entgql/gql_where.tmpl", "templates/entgql/pagination.tmpl"))
 	return entgql.WithTemplates(append(entgql.AllTemplates, paginationTmpl)...)
 }
-
-// extractExportableSchemasFromGenerated reads the generated exportable validation file
-// and extracts the schema names from the ExportableSchemas map
-func extractExportableSchemasFromGenerated() ([]string, error) {
-	filePath := "internal/ent/hooks/exportable_generated.go"
-	content, err := os.ReadFile(filePath)
-	if err != nil {
-		return nil, fmt.Errorf("reading exportable generated file: %w", err)
-	}
-
-	var schemas []string
-	lines := strings.Split(string(content), "\n")
-	inMap := false
-
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if strings.Contains(line, "var ExportableSchemas = map[string]bool{") {
-			inMap = true
-			continue
-		}
-		if inMap && line == "}" {
-			break
-		}
-		if inMap && strings.Contains(line, ":") {
-			// extract schema name from lines like: "control": true,
-			parts := strings.Split(line, ":")
-			if len(parts) > 0 {
-				schemaName := strings.Trim(strings.TrimSpace(parts[0]), `"`)
-				if schemaName != "" {
-					schemas = append(schemas, schemaName)
-				}
-			}
-		}
-	}
-
-	return schemas, nil
-}
-
-func generateExportTypeEnum(schemas []string) error {
-	if len(schemas) == 0 {
-		return nil
-	}
-
-	var enumValues []string
-	for _, schema := range schemas {
-		enumValues = append(enumValues, strings.ToUpper(schema))
-	}
-
-	log.Info().Str("values", strings.Join(enumValues, ",")).Msg("generating ExportType enum")
-
-	return generateEnum("ExportType", enumValues)
-}
-
-func generateEnum(name string, values []string) error {
-	lowerToSentence := func(s string) string {
-		s = strings.ReplaceAll(s, "_", " ")
-		s = strings.ToLower(s)
-		return s
-	}
-
-	funcMap := template.FuncMap{
-		"ToCamel":         strcase.UpperCamelCase,
-		"ToUpper":         strings.ToUpper,
-		"lowerToSentence": lowerToSentence,
-	}
-
-	tmpl, err := template.New("enum").Funcs(funcMap).Parse(enumTemplate)
-	if err != nil {
-		return fmt.Errorf("parsing template: %w", err)
-	}
-
-	outputDir := "pkg/enums"
-	if err := os.MkdirAll(outputDir, 0755); err != nil {
-		return fmt.Errorf("creating output directory: %w", err)
-	}
-
-	outputFile := strcase.SnakeCase(strings.ToLower(name)) + ".go"
-	outputPath := filepath.Join(outputDir, outputFile)
-
-	file, err := os.Create(outputPath)
-	if err != nil {
-		return fmt.Errorf("creating output file: %w", err)
-	}
-	defer file.Close()
-
-	seen := map[string]struct{}{}
-	uniqueValues := []string{}
-
-	for _, v := range values {
-		val := strings.ToUpper(v)
-		if _, exists := seen[val]; !exists {
-			seen[val] = struct{}{}
-			uniqueValues = append(uniqueValues, val)
-		}
-	}
-
-	data := struct {
-		Name   string
-		Values []string
-	}{
-		Name:   name,
-		Values: uniqueValues,
-	}
-
-	if err := tmpl.Execute(file, data); err != nil {
-		return fmt.Errorf("executing template: %w", err)
-	}
-
-	log.Info().Str("file", outputPath).Msg("generated enum file")
-	return nil
-}
-
-var (
-	//go:embed templates/entgql/*.tmpl
-	_entqlTemplates embed.FS
-
-	// enumTemplate is the template for generating enum files
-	enumTemplate = `package enums
-
-import (
-	"fmt"
-	"io"
-	"strings"
-)
-
-// {{ .Name }} is a custom type representing the various states of {{ .Name | ToCamel }}.
-type {{ .Name }} string
-
-var (
-{{- range .Values }}
-	// {{ $.Name }}{{ . | ToCamel }} indicates the {{ lowerToSentence . }}.
-	{{ $.Name }}{{ . | ToCamel }} {{ $.Name }} = "{{ . }}"
-{{- end }}
-	// {{ $.Name }}Invalid is used when an unknown or unsupported value is provided.
-	{{ $.Name }}Invalid {{ $.Name }} = "{{ .Name | ToUpper }}_INVALID"
-)
-
-// Values returns a slice of strings representing all valid {{ .Name }} values.
-func ({{ .Name }}) Values() []string {
-	return []string{
-	{{- range .Values }}
-		string({{ $.Name }}{{ . | ToCamel }}),
-	{{- end }}
-	}
-}
-
-// String returns the string representation of the {{ .Name }} value.
-func (r {{ .Name }}) String() string {
-	return string(r)
-}
-
-// To{{ .Name }} converts a string to its corresponding {{ .Name }} enum value.
-func To{{ .Name }}(r string) *{{ .Name }} {
-	switch strings.ToUpper(r) {
-	{{- range .Values }}
-	case {{ $.Name }}{{ . | ToCamel }}.String():
-		return &{{ $.Name }}{{ . | ToCamel }}
-	{{- end }}
-	default:
-		return &{{ $.Name }}Invalid
-	}
-}
-
-// MarshalGQL implements the gqlgen Marshaler interface.
-func (r {{ .Name }}) MarshalGQL(w io.Writer) {
-	_, _ = w.Write([]byte(` + "`" + `"` + "`" + ` + r.String() + ` + "`" + `"` + "`" + `))
-}
-
-// UnmarshalGQL implements the gqlgen Unmarshaler interface.
-func (r *{{ .Name }}) UnmarshalGQL(v interface{}) error {
-	str, ok := v.(string)
-	if !ok {
-		return fmt.Errorf("wrong type for {{ .Name }}, got: %T", v) //nolint:err113
-	}
-
-	*r = {{ .Name }}(str)
-
-	return nil
-}
-`
-)

--- a/internal/ent/generated/export/export.go
+++ b/internal/ent/generated/export/export.go
@@ -132,7 +132,7 @@ var (
 // ExportTypeValidator is a validator for the "export_type" field enum values. It is called by the builders before save.
 func ExportTypeValidator(et enums.ExportType) error {
 	switch et.String() {
-	case "CONTROL", "EVIDENCE", "INTERNALPOLICY", "PROCEDURE", "RISK", "SUBSCRIBER", "TASK":
+	case "CONTROL", "EVIDENCE", "INTERNAL_POLICY", "PROCEDURE", "RISK", "SUBSCRIBER", "TASK":
 		return nil
 	default:
 		return fmt.Errorf("export: invalid enum value for export_type field: %q", et)

--- a/internal/ent/generated/migrate/schema.go
+++ b/internal/ent/generated/migrate/schema.go
@@ -1315,7 +1315,7 @@ var (
 		{Name: "updated_by", Type: field.TypeString, Nullable: true},
 		{Name: "deleted_at", Type: field.TypeTime, Nullable: true},
 		{Name: "deleted_by", Type: field.TypeString, Nullable: true},
-		{Name: "export_type", Type: field.TypeEnum, Enums: []string{"CONTROL", "EVIDENCE", "INTERNALPOLICY", "PROCEDURE", "RISK", "SUBSCRIBER", "TASK"}},
+		{Name: "export_type", Type: field.TypeEnum, Enums: []string{"CONTROL", "EVIDENCE", "INTERNAL_POLICY", "PROCEDURE", "RISK", "SUBSCRIBER", "TASK"}},
 		{Name: "format", Type: field.TypeEnum, Enums: []string{"CSV"}},
 		{Name: "status", Type: field.TypeEnum, Enums: []string{"PENDING", "FAILED", "READY", "NODATA"}, Default: "PENDING"},
 		{Name: "requestor_id", Type: field.TypeString, Nullable: true},

--- a/internal/ent/hooks/exportable_generated.go
+++ b/internal/ent/hooks/exportable_generated.go
@@ -4,29 +4,27 @@ package hooks
 
 import (
 	"fmt"
-	"strings"
 )
 
 // ExportableSchemas contains all schemas that have Exportable annotation
 var ExportableSchemas = map[string]bool{
-	"control":        true,
-	"evidence":       true,
-	"internalpolicy": true,
-	"procedure":      true,
-	"risk":           true,
-	"subscriber":     true,
-	"task":           true,
+	"CONTROL":         true,
+	"EVIDENCE":        true,
+	"INTERNAL_POLICY": true,
+	"PROCEDURE":       true,
+	"RISK":            true,
+	"SUBSCRIBER":      true,
+	"TASK":            true,
 }
 
 // IsSchemaExportable checks if a schema name is exportable
 func IsSchemaExportable(schemaName string) bool {
-	return ExportableSchemas[strings.ToLower(schemaName)]
+	return ExportableSchemas[schemaName]
 }
 
 // ValidateExportType validates that an export type corresponds to an exportable schema
 func ValidateExportType(exportType string) error {
-	schemaName := strings.ToLower(exportType)
-	if !IsSchemaExportable(schemaName) {
+	if !IsSchemaExportable(exportType) {
 		return fmt.Errorf("schema %s is not exportable (missing Exportable annotation)", exportType)
 	}
 	return nil

--- a/internal/graphapi/clientschema/schema.graphql
+++ b/internal/graphapi/clientschema/schema.graphql
@@ -14911,7 +14911,7 @@ ExportExportType is enum for the field export_type
 enum ExportExportType @goModel(model: "github.com/theopenlane/core/pkg/enums.ExportType") {
 	CONTROL
 	EVIDENCE
-	INTERNALPOLICY
+	INTERNAL_POLICY
 	PROCEDURE
 	RISK
 	SUBSCRIBER

--- a/internal/graphapi/export_test.go
+++ b/internal/graphapi/export_test.go
@@ -22,9 +22,9 @@ func TestMutationCreateExport(t *testing.T) {
 		{
 			name: "happy path, create export with regular user",
 			request: testclient.CreateExportInput{
-				ExportType: enums.ExportTypeInternalpolicy,
-				OwnerID:    &testUser1.OrganizationID,
+				ExportType: enums.ExportTypeInternalPolicy,
 				Format:     enums.ExportFormatCsv,
+				Fields:     []string{"name", "details"},
 			},
 			client: suite.client.api,
 			ctx:    testUser1.UserCtx,

--- a/internal/graphapi/export_test.go
+++ b/internal/graphapi/export_test.go
@@ -22,7 +22,7 @@ func TestMutationCreateExport(t *testing.T) {
 		{
 			name: "happy path, create export with regular user",
 			request: testclient.CreateExportInput{
-				ExportType: enums.ExportTypeControl,
+				ExportType: enums.ExportTypeInternalpolicy,
 				OwnerID:    &testUser1.OrganizationID,
 				Format:     enums.ExportFormatCsv,
 			},

--- a/internal/graphapi/generated/root_.generated.go
+++ b/internal/graphapi/generated/root_.generated.go
@@ -50174,7 +50174,7 @@ ExportExportType is enum for the field export_type
 enum ExportExportType @goModel(model: "github.com/theopenlane/core/pkg/enums.ExportType") {
   CONTROL
   EVIDENCE
-  INTERNALPOLICY
+  INTERNAL_POLICY
   PROCEDURE
   RISK
   SUBSCRIBER

--- a/internal/graphapi/schema/ent.graphql
+++ b/internal/graphapi/schema/ent.graphql
@@ -14101,7 +14101,7 @@ ExportExportType is enum for the field export_type
 enum ExportExportType @goModel(model: "github.com/theopenlane/core/pkg/enums.ExportType") {
   CONTROL
   EVIDENCE
-  INTERNALPOLICY
+  INTERNAL_POLICY
   PROCEDURE
   RISK
   SUBSCRIBER

--- a/pkg/enums/exportenums/doc.go
+++ b/pkg/enums/exportenums/doc.go
@@ -1,0 +1,2 @@
+// package exportenums generates the enums for the export types based on the entx annotation
+package exportenums

--- a/pkg/enums/exportenums/generate.go
+++ b/pkg/enums/exportenums/generate.go
@@ -123,7 +123,7 @@ func (e Extension) Hook() gen.Hook {
 			}
 
 			outputDir := e.config.OutputDir
-			if err := os.MkdirAll(outputDir, 0755); err != nil {
+			if err := os.MkdirAll(outputDir, 0755); err != nil { //nolint: mnd
 				return fmt.Errorf("creating output directory: %w", err)
 			}
 

--- a/pkg/enums/exportenums/generate.go
+++ b/pkg/enums/exportenums/generate.go
@@ -1,0 +1,232 @@
+package exportenums
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"entgo.io/ent/entc"
+	"entgo.io/ent/entc/gen"
+	"github.com/rs/zerolog/log"
+	"github.com/stoewer/go-strcase"
+	"github.com/theopenlane/entx"
+)
+
+// ExtensionOption is a function that modifies the Extension configuration.
+type ExtensionOption = func(*Extension)
+
+// Config is the configuration for the accessmap extension.
+type Config struct {
+	SchemaPath  string
+	OutputDir   string
+	PackageName string
+}
+
+// New creates a new accessmap extension
+func New(opts ...ExtensionOption) *Extension {
+	extension := &Extension{
+		// Set configuration defaults that can get overridden with ExtensionOption
+		config: &Config{
+			SchemaPath:  "./schema",
+			OutputDir:   "./pkg/enums",
+			PackageName: "enums",
+		},
+	}
+
+	for _, opt := range opts {
+		opt(extension)
+	}
+
+	return extension
+}
+
+// Extension implements entc.Extension
+type Extension struct {
+	entc.DefaultExtension
+	config *Config
+}
+
+// WithSchemaPath allows you to set an alternative schemaPath
+// Defaults to "./schema"
+func WithSchemaPath(schemaPath string) ExtensionOption {
+	return func(h *Extension) {
+		h.config.SchemaPath = schemaPath
+	}
+}
+
+// WithGeneratedDir allows you to set an alternative output directory
+// Defaults to "./internal/ent/generated"
+func WithGeneratedDir(outputDir string) ExtensionOption {
+	return func(h *Extension) {
+		h.config.OutputDir = outputDir
+	}
+}
+
+// WithPackageName allows you to set an alternative package name for the generated file
+// Defaults to "generated"
+func WithPackageName(packageName string) ExtensionOption {
+	return func(h *Extension) {
+		h.config.PackageName = packageName
+	}
+}
+
+// Hooks satisfies the entc.Extension interface
+func (e Extension) Hooks() []gen.Hook {
+	return []gen.Hook{
+		e.Hook(),
+	}
+}
+
+// checkHasExportAnnotation checks if the type has the Export annotation
+func checkHasExportAnnotation(node *gen.Type) bool {
+	exportAnt := entx.Exportable{}
+
+	if ant, ok := node.Annotations[exportAnt.Name()]; ok {
+		if err := exportAnt.Decode(ant); err != nil {
+			return false
+		}
+
+		return true
+	}
+
+	return false
+}
+
+func (e Extension) Hook() gen.Hook {
+	return func(next gen.Generator) gen.Generator {
+		return gen.GenerateFunc(func(g *gen.Graph) error {
+			if err := next.Generate(g); err != nil {
+				return err
+			}
+
+			// set the package name for the generated file
+			g.Package = e.config.PackageName
+
+			name := "ExportType"
+
+			lowerToSentence := func(s string) string {
+				s = strings.ReplaceAll(s, "_", " ")
+				s = strings.ToLower(s)
+				return s
+			}
+
+			funcMap := template.FuncMap{
+				"ToCamel":         strcase.UpperCamelCase,
+				"ToSnake":         strcase.UpperSnakeCase,
+				"lowerToSentence": lowerToSentence,
+			}
+
+			// loop through all nodes and generate schema if not specified to be skipped
+			schemas := []string{}
+			for _, node := range g.Nodes {
+				if checkHasExportAnnotation(node) {
+					schemas = append(schemas, node.Name)
+				}
+			}
+
+			tmpl, err := template.New("enum").Funcs(funcMap).Parse(enumTemplate)
+			if err != nil {
+				return fmt.Errorf("parsing template: %w", err)
+			}
+
+			outputDir := "pkg/enums"
+			if err := os.MkdirAll(outputDir, 0755); err != nil {
+				return fmt.Errorf("creating output directory: %w", err)
+			}
+
+			outputFile := strcase.SnakeCase(strings.ToLower(name)) + ".go"
+			outputPath := filepath.Join(outputDir, outputFile)
+
+			file, err := os.Create(outputPath)
+			if err != nil {
+				return fmt.Errorf("creating output file: %w", err)
+			}
+			defer file.Close()
+
+			data := struct {
+				Name   string
+				Values []string
+			}{
+				Name:   name,
+				Values: schemas,
+			}
+
+			if err := tmpl.Execute(file, data); err != nil {
+				return fmt.Errorf("executing template: %w", err)
+			}
+
+			log.Info().Str("file", outputPath).Msg("generated enum file")
+			return nil
+		})
+	}
+}
+
+var (
+
+	// enumTemplate is the template for generating enum files
+	enumTemplate = `package enums
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// {{ .Name }} is a custom type representing the various states of {{ .Name | ToCamel }}.
+type {{ .Name }} string
+
+var (
+{{- range .Values }}
+	// {{ $.Name }}{{ . | ToCamel }} indicates the {{ lowerToSentence . }}.
+	{{ $.Name }}{{ . | ToCamel }} {{ $.Name }} = "{{ . | ToSnake }}"
+{{- end }}
+	// {{ $.Name }}Invalid is used when an unknown or unsupported value is provided.
+	{{ $.Name }}Invalid {{ $.Name }} = "{{ .Name }}_INVALID"
+)
+
+// Values returns a slice of strings representing all valid {{ .Name }} values.
+func ({{ .Name }}) Values() []string {
+	return []string{
+	{{- range .Values }}
+		string({{ $.Name }}{{ . | ToCamel }}),
+	{{- end }}
+	}
+}
+
+// String returns the string representation of the {{ .Name }} value.
+func (r {{ .Name }}) String() string {
+	return string(r)
+}
+
+// To{{ .Name }} converts a string to its corresponding {{ .Name }} enum value.
+func To{{ .Name }}(r string) *{{ .Name }} {
+	switch strings.ToUpper(r) {
+	{{- range .Values }}
+	case {{ $.Name }}{{ . | ToCamel }}.String():
+		return &{{ $.Name }}{{ . | ToCamel }}
+	{{- end }}
+	default:
+		return &{{ $.Name }}Invalid
+	}
+}
+
+// MarshalGQL implements the gqlgen Marshaler interface.
+func (r {{ .Name }}) MarshalGQL(w io.Writer) {
+	_, _ = w.Write([]byte(` + "`" + `"` + "`" + ` + r.String() + ` + "`" + `"` + "`" + `))
+}
+
+// UnmarshalGQL implements the gqlgen Unmarshaler interface.
+func (r *{{ .Name }}) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("wrong type for {{ .Name }}, got: %T", v) //nolint:err113
+	}
+
+	*r = {{ .Name }}(str)
+
+	return nil
+}
+`
+)

--- a/pkg/enums/exportenums/generate.go
+++ b/pkg/enums/exportenums/generate.go
@@ -108,7 +108,7 @@ func (e Extension) Hook() gen.Hook {
 				"lowerToSentence": lowerToSentence,
 			}
 
-			// loop through all nodes and generate schema if not specified to be skipped
+			// loop through all nodes and generate a list of schemas with the Export annotation
 			schemas := []string{}
 			for _, node := range g.Nodes {
 				if checkHasExportAnnotation(node) {

--- a/pkg/enums/exportenums/generate.go
+++ b/pkg/enums/exportenums/generate.go
@@ -103,6 +103,7 @@ func (e Extension) Hook() gen.Hook {
 			}
 
 			funcMap := template.FuncMap{
+				"ToUpper":         strings.ToUpper,
 				"ToCamel":         strcase.UpperCamelCase,
 				"ToSnake":         strcase.UpperSnakeCase,
 				"lowerToSentence": lowerToSentence,
@@ -173,7 +174,7 @@ var (
 	{{ $.Name }}{{ . | ToCamel }} {{ $.Name }} = "{{ . | ToSnake }}"
 {{- end }}
 	// {{ $.Name }}Invalid is used when an unknown or unsupported value is provided.
-	{{ $.Name }}Invalid {{ $.Name }} = "{{ .Name }}_INVALID"
+	{{ $.Name }}Invalid {{ $.Name }} = "{{ .Name | ToUpper }}_INVALID"
 )
 
 // Values returns a slice of strings representing all valid {{ .Name }} values.

--- a/pkg/enums/exportenums/generate.go
+++ b/pkg/enums/exportenums/generate.go
@@ -19,7 +19,6 @@ type ExtensionOption = func(*Extension)
 
 // Config is the configuration for the export enums extension.
 type Config struct {
-	SchemaPath  string
 	OutputDir   string
 	PackageName string
 }
@@ -29,7 +28,6 @@ func New(opts ...ExtensionOption) *Extension {
 	extension := &Extension{
 		// Set configuration defaults that can get overridden with ExtensionOption
 		config: &Config{
-			SchemaPath:  "./schema",
 			OutputDir:   "./pkg/enums",
 			PackageName: "enums",
 		},
@@ -46,14 +44,6 @@ func New(opts ...ExtensionOption) *Extension {
 type Extension struct {
 	entc.DefaultExtension
 	config *Config
-}
-
-// WithSchemaPath allows you to set an alternative schemaPath
-// Defaults to "./schema"
-func WithSchemaPath(schemaPath string) ExtensionOption {
-	return func(h *Extension) {
-		h.config.SchemaPath = schemaPath
-	}
 }
 
 // WithGeneratedDir allows you to set an alternative output directory

--- a/pkg/enums/exportenums/generate.go
+++ b/pkg/enums/exportenums/generate.go
@@ -17,14 +17,14 @@ import (
 // ExtensionOption is a function that modifies the Extension configuration.
 type ExtensionOption = func(*Extension)
 
-// Config is the configuration for the accessmap extension.
+// Config is the configuration for the export enums extension.
 type Config struct {
 	SchemaPath  string
 	OutputDir   string
 	PackageName string
 }
 
-// New creates a new accessmap extension
+// New creates a new export enums extension
 func New(opts ...ExtensionOption) *Extension {
 	extension := &Extension{
 		// Set configuration defaults that can get overridden with ExtensionOption
@@ -57,7 +57,7 @@ func WithSchemaPath(schemaPath string) ExtensionOption {
 }
 
 // WithGeneratedDir allows you to set an alternative output directory
-// Defaults to "./internal/ent/generated"
+// Defaults to "./pkg/enums"
 func WithGeneratedDir(outputDir string) ExtensionOption {
 	return func(h *Extension) {
 		h.config.OutputDir = outputDir
@@ -65,7 +65,7 @@ func WithGeneratedDir(outputDir string) ExtensionOption {
 }
 
 // WithPackageName allows you to set an alternative package name for the generated file
-// Defaults to "generated"
+// Defaults to "enums"
 func WithPackageName(packageName string) ExtensionOption {
 	return func(h *Extension) {
 		h.config.PackageName = packageName
@@ -131,7 +131,7 @@ func (e Extension) Hook() gen.Hook {
 				return fmt.Errorf("parsing template: %w", err)
 			}
 
-			outputDir := "pkg/enums"
+			outputDir := e.config.OutputDir
 			if err := os.MkdirAll(outputDir, 0755); err != nil {
 				return fmt.Errorf("creating output directory: %w", err)
 			}

--- a/pkg/enums/exporttype.go
+++ b/pkg/enums/exporttype.go
@@ -14,8 +14,8 @@ var (
 	ExportTypeControl ExportType = "CONTROL"
 	// ExportTypeEvidence indicates the evidence.
 	ExportTypeEvidence ExportType = "EVIDENCE"
-	// ExportTypeInternalpolicy indicates the internalpolicy.
-	ExportTypeInternalpolicy ExportType = "INTERNALPOLICY"
+	// ExportTypeInternalPolicy indicates the internalpolicy.
+	ExportTypeInternalPolicy ExportType = "INTERNAL_POLICY"
 	// ExportTypeProcedure indicates the procedure.
 	ExportTypeProcedure ExportType = "PROCEDURE"
 	// ExportTypeRisk indicates the risk.
@@ -25,7 +25,7 @@ var (
 	// ExportTypeTask indicates the task.
 	ExportTypeTask ExportType = "TASK"
 	// ExportTypeInvalid is used when an unknown or unsupported value is provided.
-	ExportTypeInvalid ExportType = "EXPORTTYPE_INVALID"
+	ExportTypeInvalid ExportType = "ExportType_INVALID"
 )
 
 // Values returns a slice of strings representing all valid ExportType values.
@@ -33,7 +33,7 @@ func (ExportType) Values() []string {
 	return []string{
 		string(ExportTypeControl),
 		string(ExportTypeEvidence),
-		string(ExportTypeInternalpolicy),
+		string(ExportTypeInternalPolicy),
 		string(ExportTypeProcedure),
 		string(ExportTypeRisk),
 		string(ExportTypeSubscriber),
@@ -53,8 +53,8 @@ func ToExportType(r string) *ExportType {
 		return &ExportTypeControl
 	case ExportTypeEvidence.String():
 		return &ExportTypeEvidence
-	case ExportTypeInternalpolicy.String():
-		return &ExportTypeInternalpolicy
+	case ExportTypeInternalPolicy.String():
+		return &ExportTypeInternalPolicy
 	case ExportTypeProcedure.String():
 		return &ExportTypeProcedure
 	case ExportTypeRisk.String():

--- a/pkg/enums/exporttype.go
+++ b/pkg/enums/exporttype.go
@@ -25,7 +25,7 @@ var (
 	// ExportTypeTask indicates the task.
 	ExportTypeTask ExportType = "TASK"
 	// ExportTypeInvalid is used when an unknown or unsupported value is provided.
-	ExportTypeInvalid ExportType = "ExportType_INVALID"
+	ExportTypeInvalid ExportType = "EXPORTTYPE_INVALID"
 )
 
 // Values returns a slice of strings representing all valid ExportType values.


### PR DESCRIPTION
requires: https://github.com/theopenlane/entx/pull/181

fixes a bug with exporting data from the `internalPolicy` table, which was translated as `internalpolicy` which is not a valid graphql schema 