### PR TITLE
bug: double content type on graphql requests

### DIFF
--- a/internal/httpserve/route/router.go
+++ b/internal/httpserve/route/router.go
@@ -9,11 +9,12 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 	echo "github.com/theopenlane/echox"
-	"github.com/theopenlane/echox/middleware"
+	"github.com/theopenlane/httpsling"
 
 	"github.com/theopenlane/core/internal/httpserve/common"
 	"github.com/theopenlane/core/internal/httpserve/handlers"
 	"github.com/theopenlane/core/pkg/middleware/impersonation"
+	"github.com/theopenlane/core/pkg/middleware/mime"
 	"github.com/theopenlane/core/pkg/middleware/ratelimit"
 	"github.com/theopenlane/core/pkg/middleware/transaction"
 	"github.com/theopenlane/utils/contextx"
@@ -601,7 +602,9 @@ func baseMiddleware(router *Router) []echo.MiddlewareFunc {
 		EntDBClient: router.Handler.DBClient,
 	}
 
-	return append(mw, middleware.Recover(), transactionConfig.Middleware)
+	mimeMiddleware := mime.NewWithConfig(mime.Config{DefaultContentType: httpsling.ContentTypeJSONUTF8})
+
+	return append(mw, mimeMiddleware, transactionConfig.Middleware)
 }
 
 // restrictedMiddleware returns the middleware for the router that is used on restricted routes

--- a/internal/httpserve/route/router.go
+++ b/internal/httpserve/route/router.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 	echo "github.com/theopenlane/echox"
+	"github.com/theopenlane/echox/middleware"
 	"github.com/theopenlane/httpsling"
 
 	"github.com/theopenlane/core/internal/httpserve/common"
@@ -604,7 +605,7 @@ func baseMiddleware(router *Router) []echo.MiddlewareFunc {
 
 	mimeMiddleware := mime.NewWithConfig(mime.Config{DefaultContentType: httpsling.ContentTypeJSONUTF8})
 
-	return append(mw, mimeMiddleware, transactionConfig.Middleware)
+	return append(mw, middleware.Recover(), mimeMiddleware, transactionConfig.Middleware)
 }
 
 // restrictedMiddleware returns the middleware for the router that is used on restricted routes

--- a/internal/httpserve/serveropts/option.go
+++ b/internal/httpserve/serveropts/option.go
@@ -19,7 +19,6 @@ import (
 	echo "github.com/theopenlane/echox"
 
 	"github.com/theopenlane/entx"
-	"github.com/theopenlane/httpsling"
 	"github.com/theopenlane/iam/fgax"
 	"github.com/theopenlane/iam/providers/webauthn"
 	"github.com/theopenlane/iam/sessions"
@@ -42,7 +41,6 @@ import (
 	"github.com/theopenlane/core/pkg/middleware/cachecontrol"
 	"github.com/theopenlane/core/pkg/middleware/cors"
 	"github.com/theopenlane/core/pkg/middleware/csrf"
-	"github.com/theopenlane/core/pkg/middleware/mime"
 	"github.com/theopenlane/core/pkg/middleware/ratelimit"
 	"github.com/theopenlane/core/pkg/middleware/redirect"
 	"github.com/theopenlane/core/pkg/middleware/secure"
@@ -256,9 +254,9 @@ func WithMiddleware() ServerOption {
 
 		// default middleware
 		s.Config.DefaultMiddleware = append(s.Config.DefaultMiddleware,
-			echoprometheus.MetricsMiddleware(),                                                 // add prometheus metrics
-			echocontext.EchoContextToContextMiddleware(),                                       // adds echo context to parent
-			mime.NewWithConfig(mime.Config{DefaultContentType: httpsling.ContentTypeJSONUTF8}), // add mime middleware
+			echoprometheus.MetricsMiddleware(),
+			// add prometheus metrics
+			echocontext.EchoContextToContextMiddleware(), // adds echo context to parent
 		)
 	})
 }

--- a/internal/httpserve/serveropts/option.go
+++ b/internal/httpserve/serveropts/option.go
@@ -254,8 +254,7 @@ func WithMiddleware() ServerOption {
 
 		// default middleware
 		s.Config.DefaultMiddleware = append(s.Config.DefaultMiddleware,
-			echoprometheus.MetricsMiddleware(),
-			// add prometheus metrics
+			echoprometheus.MetricsMiddleware(),           // add prometheus metrics
 			echocontext.EchoContextToContextMiddleware(), // adds echo context to parent
 		)
 	})

--- a/pkg/corejobs/export.go
+++ b/pkg/corejobs/export.go
@@ -117,8 +117,8 @@ func (w *ExportContentWorker) Work(ctx context.Context, job *river.Job[ExportCon
 		w.requester, err = httpsling.New(
 			httpsling.URL(w.Config.OpenlaneAPIHost),
 			httpsling.BearerAuth(w.Config.OpenlaneAPIToken),
-			httpsling.Header("Content-Type", "application/json"),
-			httpsling.Header("Accept", "application/graphql-response+json"),
+			httpsling.Header(httpsling.HeaderContentType, httpsling.ContentTypeJSONUTF8),
+			httpsling.Header(httpsling.HeaderAccept, "application/graphql-response+json"),
 		)
 		if err != nil {
 			return err
@@ -161,12 +161,11 @@ func (w *ExportContentWorker) Work(ctx context.Context, job *river.Job[ExportCon
 	hasWhere := len(where) > 0
 
 	exportType := strings.ToLower(export.Export.ExportType.String())
-	singular := exportType
-	rootQuery := pluralize.NewClient().Plural(singular)
+	rootQuery := pluralize.NewClient().Plural(exportType)
 
 	fields := export.Export.Fields
 
-	query := w.buildGraphQLQuery(rootQuery, singular, fields, hasWhere)
+	query := w.buildGraphQLQuery(rootQuery, exportType, fields, hasWhere)
 
 	var allNodes []map[string]any
 	var after *string

--- a/pkg/windmill/client.go
+++ b/pkg/windmill/client.go
@@ -97,8 +97,8 @@ func createRequester(cfg entconfig.Config) (*httpsling.Requester, error) {
 		),
 
 		httpsling.URL(cfg.Windmill.BaseURL),
-		httpsling.AddHeader(httpsling.HeaderAuthorization, "Bearer "+cfg.Windmill.Token),
-		httpsling.AddHeader(httpsling.HeaderContentType, httpsling.ContentTypeJSON),
+		httpsling.Header(httpsling.HeaderAuthorization, "Bearer "+cfg.Windmill.Token),
+		httpsling.Header(httpsling.HeaderContentType, httpsling.ContentTypeJSON),
 	)
 }
 


### PR DESCRIPTION
- Fixes mime type error for exports (or really anything passing `Accept` header

[gqlgqen/graphql ](https://github.com/99designs/gqlgen/blob/d5384a284c196f667c3533a87c580f6a012d2476/graphql/handler/transport/headers.go#L14) already sets a `Content-Type` header; and if an `Accept` is passed in, the current state ends up with a double `Content-Type` Header.

Current state, notice the double `Content-Type` when passing `Accept`. 

```
curl  -v http://localhost:17608/query  -H "Authorization: Bearer tola_REDACTED"  -H 'Accept: application/graphql-response+json'  --data '{"query":"query __typename { __typename }"}'   -H 'Content-Type: application/json'
 ...
< Content-Type: application/json;charset=utf-8
< Content-Type: application/graphql-response+json\
```

This causes the following error when going through Cloudflare, because the headers are combined:

```
mime: invalid media parameter: failed to parse content type: application/json;charset=utf-8,application/graphql-response+json
```


After the fix: 
Without accept:
```
curl  -v http://localhost:17608/query  -H "Authorization: Bearer tola_REDCATED"  --data '{"query":"query __typename { __typename }"}'   -H 'Content-Type: application/json'
* Host localhost:17608 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:17608...
* Connected to localhost (::1) port 17608
* using HTTP/1.x
> POST /query HTTP/1.1
> Host: localhost:17608
> User-Agent: curl/8.10.1
> Accept: */*
> Authorization: Bearer tola_c9q5JWClsGlFPanPYH6RTPuKb0mzO1bN9G15QKA0BY5pg2odxDYqaNBlU5sD5oVk
> Content-Type: application/json
> Content-Length: 43
> 
* upload completely sent off: 43 bytes
< HTTP/1.1 200 OK
< Content-Security-Policy: default-src 'self'
< Content-Type: application/json
< Referrer-Policy: same-origin
< Vary: Origin
< X-Content-Type-Options: nosniff
< X-Frame-Options: SAMEORIGIN
< X-Request-Id: QruyVEMjLVmehcaDRxjPeZiudfHSanRu
< X-Xss-Protection: 1; mode=block
< Date: Mon, 01 Sep 2025 21:39:49 GMT
< Content-Length: 222
< 
* Connection #0 to host localhost left intact
{"data":{"__typename":"Query"},"extensions":{"auth":{"authentication_type":"api_token","authorized_organization":["01K43FHQJVC1K1J8R7SY1C858D"]},"server_latency":"446.542µs","trace_id":"QruyVEMjLVmehcaDRxjPeZiudfHSanRu"}}%
```

With Accept:
```
curl  -v http://localhost:17608/query  -H "Authorization: Bearer tola_REDCATED"  -H 'Accept: application/graphql-response+json'  --data '{"query":"query __typename { __typename }"}'   -H 'Content-Type: application/json' 
* Host localhost:17608 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:17608...
* Connected to localhost (::1) port 17608
* using HTTP/1.x
> POST /query HTTP/1.1
> Host: localhost:17608
> User-Agent: curl/8.10.1
> Authorization: Bearer tola_c9q5JWClsGlFPanPYH6RTPuKb0mzO1bN9G15QKA0BY5pg2odxDYqaNBlU5sD5oVk
> Accept: application/graphql-response+json
> Content-Type: application/json
> Content-Length: 43
> 
* upload completely sent off: 43 bytes
< HTTP/1.1 200 OK
< Content-Security-Policy: default-src 'self'
< Content-Type: application/graphql-response+json
< Referrer-Policy: same-origin
< Vary: Origin
< X-Content-Type-Options: nosniff
< X-Frame-Options: SAMEORIGIN
< X-Request-Id: eYIuMrBSvgczhVoTNRqiwOrrYJkJkOri
< X-Xss-Protection: 1; mode=block
< Date: Mon, 01 Sep 2025 21:40:07 GMT
< Content-Length: 221
< 
* Connection #0 to host localhost left intact
{"data":{"__typename":"Query"},"extensions":{"auth":{"authentication_type":"api_token","authorized_organization":["01K43FHQJVC1K1J8R7SY1C858D"]},"server_latency":"27.916µs","trace_id":"eYIuMrBSvgczhVoTNRqiwOrrYJkJkOri"}}%  
```

