### PR TITLE
bug: duplicate org modules after sub update fix, adds all fields

### DIFF
--- a/internal/entitlements/entmapping/mapping.go
+++ b/internal/entitlements/entmapping/mapping.go
@@ -348,7 +348,7 @@ func ApplyStripeSubscriptionItem[T OrgModuleSetter[T]](ctx context.Context, b T,
 		Currency: string(item.Price.Currency),
 	}
 
-	productMetadata := getProductMetadata(ctx, item.Price.Product, client)
+	productMetadata := GetProductMetadata(ctx, item.Price.Product, client)
 	if moduleKey := strings.TrimSpace(productMetadata["module"]); moduleKey != "" {
 		b.SetModule(models.OrgModule(moduleKey))
 	}
@@ -383,7 +383,9 @@ func PopulatePricesForOrganizationCustomer(o *entitlements.OrganizationCustomer,
 	return o
 }
 
-func getProductMetadata(ctx context.Context, product *stripe.Product, client *entitlements.StripeClient) map[string]string {
+// GetProductMetadata retrieves the metadata for a Stripe product, either from the provided
+// product object or by fetching the full product details using the Stripe client.
+func GetProductMetadata(ctx context.Context, product *stripe.Product, client *entitlements.StripeClient) map[string]string {
 	if product == nil {
 		return nil
 	}

--- a/pkg/entitlements/subscriptions.go
+++ b/pkg/entitlements/subscriptions.go
@@ -145,10 +145,6 @@ func (sc *StripeClient) MapStripeSubscription(ctx context.Context, subs *stripe.
 		return nil
 	}
 
-	if len(subs.Items.Data) > 1 {
-		log.Warn().Msg("customer has more than one subscription")
-	}
-
 	for _, item := range subs.Items.Data {
 		if item.Price == nil || item.Price.Product == nil {
 			log.Warn().Msg("failed to map subscription item")


### PR DESCRIPTION
Previously, when a subscription was updated, since we were only looking up existing subs based on price id, and not settting the price id when the trial was created, we ended up with duplicate modules for anything in the trial (base + compliance). 

This addresses:
-  that issue
- ensures all known fields are set on creation of subscription + modules. 
- Removes feature + feature lookup keys updates from org sub table - these were from before modules and were the features included. These are all currently empty + not used
- removes the warning on multiples items on a subscription - customers will always have multiple modules (eg base + compliance)