### PR TITLE
fix flakey tests

### DIFF
--- a/internal/graphapi/organization_test.go
+++ b/internal/graphapi/organization_test.go
@@ -851,8 +851,6 @@ func TestMutationUpdateOrganization(t *testing.T) {
 }
 
 func TestMutationDeleteOrganization(t *testing.T) {
-	t.Parallel()
-
 	// create another user for this test
 	// so it doesn't interfere with the other tests
 	orgUser := suite.userBuilder(context.Background(), t)


### PR DESCRIPTION
trust center tests need to create their own users because of top level restrictions on number of trust centers