### PR TITLE
Fix OpenAPI specification route pathing

### DIFF
--- a/internal/httpserve/route/router.go
+++ b/internal/httpserve/route/router.go
@@ -426,7 +426,7 @@ func (r *Router) AddV1HandlerRoute(config Config) error {
 	}
 
 	// Add operation to OpenAPI schema (convert Echo path syntax to OpenAPI syntax)
-	openAPIPath := convertEchoPathToOpenAPI(config.Path)
+	openAPIPath := convertEchoPathToOpenAPI("/v1" + config.Path)
 	r.OAS.AddOperation(openAPIPath, config.Method, operation)
 
 	return nil

--- a/internal/httpserve/server/openapi.go
+++ b/internal/httpserve/server/openapi.go
@@ -88,7 +88,7 @@ func NewOpenAPISpec() (*openapi3.T, error) {
 		Servers: openapi3.Servers{
 			&openapi3.Server{
 				Description: "Openlane API Server",
-				URL:         "https://api.theopenlane.io/v1",
+				URL:         "https://api.theopenlane.io",
 			},
 		},
 		ExternalDocs: &openapi3.ExternalDocs{


### PR DESCRIPTION
When attempting to add OpenAPI schema validation rules in Cloudflare, I uploaded our latest schema and enforced the rules which caused an outage due to incorrect pathing. The enforcement logic only allows requests to be processed as long as they match the published OpenAPI schema, so when requests came in for something like `https://api.theopenlane.io/livez` or graph requests against `https://api.theopenlane.io/query` they failed because the schema had these nested under a `v1` path. This was partially due to the fact that the top-most level definition for our API endpoint included a hard-coded prefix, but additionally because once removing that prefix we then had no prefixes at all. To address this, I elected for the simplest approach of string concatenation inside of the `AddV1` route helper function. After this change, paths we create off the root (e.g. `/.well-known/`) are now no longer prefixed properly, and paths added via the route group (e.g. `/v1/login`) are correctly prefixed.

Additionally, because we do not register our GraphQL route in the same fashion as our REST endpoints, and attempting to use the same dynamic registration code that looks at things like Request and Response struct models to construct the specification would not work for graphQL requests, I added a small helper function that manually specifies generic request and response payloads that should match general graphQL patterns. This will at a minimum allow us to add this updated specification to cloudflare and have any "fallthrough requests" properly mapped to the published `/query` endpoint.