### PR TITLE
bug: need river migrations to setup a user

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -383,6 +383,7 @@ tasks:
     cmds:
       - task: compose:redis
       - task: compose:fga
+      - task: compose:riverboat
       - task: run-api
 
   run-dev-full:


### PR DESCRIPTION
this needs to be here because it creates the river sql migrations. need being a strong work; we could turn off the email stuff and it should also work, but this is the easiest way right now. 