### PR TITLE
fixup anon userid format

### DIFF
--- a/internal/ent/interceptors/filter.go
+++ b/internal/ent/interceptors/filter.go
@@ -385,7 +385,7 @@ func filterAuthorizedObjectIDs(ctx context.Context, objectType string, objectIDs
 	var context *map[string]any
 	var subjectID string
 	if anon, ok := auth.AnonymousTrustCenterUserFromContext(ctx); ok {
-		subjectID = strings.ReplaceAll(anon.SubjectID, "anon:", "")
+		subjectID = anon.SubjectID
 	} else {
 		user, err := auth.GetAuthenticatedUserFromContext(ctx)
 		if err != nil {

--- a/internal/graphapi/trustcenter_test.go
+++ b/internal/graphapi/trustcenter_test.go
@@ -612,7 +612,7 @@ func TestMutationDeleteTrustCenter(t *testing.T) {
 
 // createAnonymousTrustCenterContext creates a context for an anonymous trust center user
 func createAnonymousTrustCenterContext(trustCenterID, organizationID string) context.Context {
-	anonUserID := fmt.Sprintf("anon:%s", ulids.New().String())
+	anonUserID := fmt.Sprintf("anon_%s", ulids.New().String())
 
 	anonUser := &auth.AnonymousTrustCenterUser{
 		SubjectID:          anonUserID,

--- a/internal/httpserve/authmanager/authmanager.go
+++ b/internal/httpserve/authmanager/authmanager.go
@@ -87,7 +87,7 @@ func (a *Client) GenerateUserAuthSession(ctx context.Context, w http.ResponseWri
 
 // GenerateAnonymousTrustCenterSession creates a new auth session for the anonymous trust center user
 func (a *Client) GenerateAnonymousTrustCenterSession(ctx context.Context, w http.ResponseWriter, targetOrgID string, targetTrustCenterID string) (*models.AuthData, error) {
-	anonUserID := fmt.Sprintf("anon:%s", uuid.New().String())
+	anonUserID := fmt.Sprintf("anon_%s", uuid.New().String())
 
 	// create new claims for the user
 	newClaims := &tokens.Claims{

--- a/pkg/middleware/auth/auth.go
+++ b/pkg/middleware/auth/auth.go
@@ -104,7 +104,7 @@ func Authenticate(conf *Options) echo.MiddlewareFunc {
 					return unauthorized(c, err, conf, validator)
 				}
 
-				if strings.HasPrefix(claims.UserID, "anon:") {
+				if strings.HasPrefix(claims.UserID, "anon_") {
 					if !conf.AllowAnonymous {
 						return unauthorized(c, ErrAnonymousAccessNotAllowed, conf, validator)
 					}


### PR DESCRIPTION
Fixup the anonymous user id format, so that the ID can be used directly in fga queries/tuples.
