### PR TITLE
bug: ability to get templates created before adding interceptor

### DIFF
--- a/cmd/cli/Taskfile.yaml
+++ b/cmd/cli/Taskfile.yaml
@@ -3,6 +3,7 @@ version: "3"
 env:
   DEFAULT_USER_EMAIL: "mitb@theopenlane.io"
   ADMIN_USER_EMAIL: "admin@admin.theopenlane.io"
+  SECOND_USER_EMAIL: "funk@example.com"
   DEFAULT_ORG_NAME: "meowmeow"
   OPENLANE_API_HOST: "http://localhost:17608"
 

--- a/internal/ent/schema/template.go
+++ b/internal/ent/schema/template.go
@@ -93,8 +93,9 @@ func (t Template) Mixin() []ent.Mixin {
 	return mixinConfig{
 		additionalMixins: []ent.Mixin{
 			newObjectOwnedMixin[generated.Template](t,
-				withParents(TrustCenter{}, Organization{}),
+				withParents(Organization{}, TrustCenter{}),
 				withOrganizationOwner(true),
+				withSkipperFunc(skipInterceptorForOrgMembers),
 			),
 			mixin.NewSystemOwnedMixin(),
 		},


### PR DESCRIPTION
A recent change started adding tuples for `templates`, however, this means any existing templates were no longer able to be retrieved. This now bypasses the filter to allow all users in the organization to view the templates (questionnaires). The explicit tuple check is required for checks for questionnaires/ndas sent to users. 

Also adds the `SECOND_USER_EMAIL` var back, it was falling back to the `DEFAULT_USER_EMAIL` when running `task cli:user:all:another` 