### PR TITLE
trust center doc schema updates for watermarking

### DIFF
--- a/internal/ent/generated/accessmap.go
+++ b/internal/ent/generated/accessmap.go
@@ -1810,6 +1810,10 @@ var EdgeAccessMap = map[string]map[string]EdgeAccess{"api_token": {"owner": {
 	ObjectType:      "file",
 	SkipEditCheck:   false,
 	CheckViewAccess: false,
+}, "original_file": {
+	ObjectType:      "original_file",
+	SkipEditCheck:   false,
+	CheckViewAccess: false,
 },
 }, "trust_center_setting": {"trust_center": {
 	ObjectType:      "trust_center",

--- a/internal/ent/generated/auditing.go
+++ b/internal/ent/generated/auditing.go
@@ -3533,6 +3533,15 @@ func (_m *TrustCenterDocHistory) changes(new *TrustCenterDocHistory) []Change {
 	if !reflect.DeepEqual(_m.FileID, new.FileID) {
 		changes = append(changes, NewChange(trustcenterdochistory.FieldFileID, _m.FileID, new.FileID))
 	}
+	if !reflect.DeepEqual(_m.OriginalFileID, new.OriginalFileID) {
+		changes = append(changes, NewChange(trustcenterdochistory.FieldOriginalFileID, _m.OriginalFileID, new.OriginalFileID))
+	}
+	if !reflect.DeepEqual(_m.WatermarkingEnabled, new.WatermarkingEnabled) {
+		changes = append(changes, NewChange(trustcenterdochistory.FieldWatermarkingEnabled, _m.WatermarkingEnabled, new.WatermarkingEnabled))
+	}
+	if !reflect.DeepEqual(_m.WatermarkStatus, new.WatermarkStatus) {
+		changes = append(changes, NewChange(trustcenterdochistory.FieldWatermarkStatus, _m.WatermarkStatus, new.WatermarkStatus))
+	}
 	if !reflect.DeepEqual(_m.Visibility, new.Visibility) {
 		changes = append(changes, NewChange(trustcenterdochistory.FieldVisibility, _m.Visibility, new.Visibility))
 	}

--- a/internal/ent/generated/client.go
+++ b/internal/ent/generated/client.go
@@ -23097,6 +23097,25 @@ func (c *TrustCenterDocClient) QueryFile(_m *TrustCenterDoc) *FileQuery {
 	return query
 }
 
+// QueryOriginalFile queries the original_file edge of a TrustCenterDoc.
+func (c *TrustCenterDocClient) QueryOriginalFile(_m *TrustCenterDoc) *FileQuery {
+	query := (&FileClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(trustcenterdoc.Table, trustcenterdoc.FieldID, id),
+			sqlgraph.To(file.Table, file.FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, false, trustcenterdoc.OriginalFileTable, trustcenterdoc.OriginalFileColumn),
+		)
+		schemaConfig := _m.schemaConfig
+		step.To.Schema = schemaConfig.File
+		step.Edge.Schema = schemaConfig.TrustCenterDoc
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
 // Hooks returns the client hooks.
 func (c *TrustCenterDocClient) Hooks() []Hook {
 	hooks := c.hooks.TrustCenterDoc

--- a/internal/ent/generated/entql.go
+++ b/internal/ent/generated/entql.go
@@ -3230,18 +3230,21 @@ var schemaGraph = func() *sqlgraph.Schema {
 		},
 		Type: "TrustCenterDoc",
 		Fields: map[string]*sqlgraph.FieldSpec{
-			trustcenterdoc.FieldCreatedAt:     {Type: field.TypeTime, Column: trustcenterdoc.FieldCreatedAt},
-			trustcenterdoc.FieldUpdatedAt:     {Type: field.TypeTime, Column: trustcenterdoc.FieldUpdatedAt},
-			trustcenterdoc.FieldCreatedBy:     {Type: field.TypeString, Column: trustcenterdoc.FieldCreatedBy},
-			trustcenterdoc.FieldUpdatedBy:     {Type: field.TypeString, Column: trustcenterdoc.FieldUpdatedBy},
-			trustcenterdoc.FieldDeletedAt:     {Type: field.TypeTime, Column: trustcenterdoc.FieldDeletedAt},
-			trustcenterdoc.FieldDeletedBy:     {Type: field.TypeString, Column: trustcenterdoc.FieldDeletedBy},
-			trustcenterdoc.FieldTags:          {Type: field.TypeJSON, Column: trustcenterdoc.FieldTags},
-			trustcenterdoc.FieldTrustCenterID: {Type: field.TypeString, Column: trustcenterdoc.FieldTrustCenterID},
-			trustcenterdoc.FieldTitle:         {Type: field.TypeString, Column: trustcenterdoc.FieldTitle},
-			trustcenterdoc.FieldCategory:      {Type: field.TypeString, Column: trustcenterdoc.FieldCategory},
-			trustcenterdoc.FieldFileID:        {Type: field.TypeString, Column: trustcenterdoc.FieldFileID},
-			trustcenterdoc.FieldVisibility:    {Type: field.TypeEnum, Column: trustcenterdoc.FieldVisibility},
+			trustcenterdoc.FieldCreatedAt:           {Type: field.TypeTime, Column: trustcenterdoc.FieldCreatedAt},
+			trustcenterdoc.FieldUpdatedAt:           {Type: field.TypeTime, Column: trustcenterdoc.FieldUpdatedAt},
+			trustcenterdoc.FieldCreatedBy:           {Type: field.TypeString, Column: trustcenterdoc.FieldCreatedBy},
+			trustcenterdoc.FieldUpdatedBy:           {Type: field.TypeString, Column: trustcenterdoc.FieldUpdatedBy},
+			trustcenterdoc.FieldDeletedAt:           {Type: field.TypeTime, Column: trustcenterdoc.FieldDeletedAt},
+			trustcenterdoc.FieldDeletedBy:           {Type: field.TypeString, Column: trustcenterdoc.FieldDeletedBy},
+			trustcenterdoc.FieldTags:                {Type: field.TypeJSON, Column: trustcenterdoc.FieldTags},
+			trustcenterdoc.FieldTrustCenterID:       {Type: field.TypeString, Column: trustcenterdoc.FieldTrustCenterID},
+			trustcenterdoc.FieldTitle:               {Type: field.TypeString, Column: trustcenterdoc.FieldTitle},
+			trustcenterdoc.FieldCategory:            {Type: field.TypeString, Column: trustcenterdoc.FieldCategory},
+			trustcenterdoc.FieldFileID:              {Type: field.TypeString, Column: trustcenterdoc.FieldFileID},
+			trustcenterdoc.FieldOriginalFileID:      {Type: field.TypeString, Column: trustcenterdoc.FieldOriginalFileID},
+			trustcenterdoc.FieldWatermarkingEnabled: {Type: field.TypeBool, Column: trustcenterdoc.FieldWatermarkingEnabled},
+			trustcenterdoc.FieldWatermarkStatus:     {Type: field.TypeEnum, Column: trustcenterdoc.FieldWatermarkStatus},
+			trustcenterdoc.FieldVisibility:          {Type: field.TypeEnum, Column: trustcenterdoc.FieldVisibility},
 		},
 	}
 	graph.Nodes[100] = &sqlgraph.Node{
@@ -3255,21 +3258,24 @@ var schemaGraph = func() *sqlgraph.Schema {
 		},
 		Type: "TrustCenterDocHistory",
 		Fields: map[string]*sqlgraph.FieldSpec{
-			trustcenterdochistory.FieldHistoryTime:   {Type: field.TypeTime, Column: trustcenterdochistory.FieldHistoryTime},
-			trustcenterdochistory.FieldRef:           {Type: field.TypeString, Column: trustcenterdochistory.FieldRef},
-			trustcenterdochistory.FieldOperation:     {Type: field.TypeEnum, Column: trustcenterdochistory.FieldOperation},
-			trustcenterdochistory.FieldCreatedAt:     {Type: field.TypeTime, Column: trustcenterdochistory.FieldCreatedAt},
-			trustcenterdochistory.FieldUpdatedAt:     {Type: field.TypeTime, Column: trustcenterdochistory.FieldUpdatedAt},
-			trustcenterdochistory.FieldCreatedBy:     {Type: field.TypeString, Column: trustcenterdochistory.FieldCreatedBy},
-			trustcenterdochistory.FieldUpdatedBy:     {Type: field.TypeString, Column: trustcenterdochistory.FieldUpdatedBy},
-			trustcenterdochistory.FieldDeletedAt:     {Type: field.TypeTime, Column: trustcenterdochistory.FieldDeletedAt},
-			trustcenterdochistory.FieldDeletedBy:     {Type: field.TypeString, Column: trustcenterdochistory.FieldDeletedBy},
-			trustcenterdochistory.FieldTags:          {Type: field.TypeJSON, Column: trustcenterdochistory.FieldTags},
-			trustcenterdochistory.FieldTrustCenterID: {Type: field.TypeString, Column: trustcenterdochistory.FieldTrustCenterID},
-			trustcenterdochistory.FieldTitle:         {Type: field.TypeString, Column: trustcenterdochistory.FieldTitle},
-			trustcenterdochistory.FieldCategory:      {Type: field.TypeString, Column: trustcenterdochistory.FieldCategory},
-			trustcenterdochistory.FieldFileID:        {Type: field.TypeString, Column: trustcenterdochistory.FieldFileID},
-			trustcenterdochistory.FieldVisibility:    {Type: field.TypeEnum, Column: trustcenterdochistory.FieldVisibility},
+			trustcenterdochistory.FieldHistoryTime:         {Type: field.TypeTime, Column: trustcenterdochistory.FieldHistoryTime},
+			trustcenterdochistory.FieldRef:                 {Type: field.TypeString, Column: trustcenterdochistory.FieldRef},
+			trustcenterdochistory.FieldOperation:           {Type: field.TypeEnum, Column: trustcenterdochistory.FieldOperation},
+			trustcenterdochistory.FieldCreatedAt:           {Type: field.TypeTime, Column: trustcenterdochistory.FieldCreatedAt},
+			trustcenterdochistory.FieldUpdatedAt:           {Type: field.TypeTime, Column: trustcenterdochistory.FieldUpdatedAt},
+			trustcenterdochistory.FieldCreatedBy:           {Type: field.TypeString, Column: trustcenterdochistory.FieldCreatedBy},
+			trustcenterdochistory.FieldUpdatedBy:           {Type: field.TypeString, Column: trustcenterdochistory.FieldUpdatedBy},
+			trustcenterdochistory.FieldDeletedAt:           {Type: field.TypeTime, Column: trustcenterdochistory.FieldDeletedAt},
+			trustcenterdochistory.FieldDeletedBy:           {Type: field.TypeString, Column: trustcenterdochistory.FieldDeletedBy},
+			trustcenterdochistory.FieldTags:                {Type: field.TypeJSON, Column: trustcenterdochistory.FieldTags},
+			trustcenterdochistory.FieldTrustCenterID:       {Type: field.TypeString, Column: trustcenterdochistory.FieldTrustCenterID},
+			trustcenterdochistory.FieldTitle:               {Type: field.TypeString, Column: trustcenterdochistory.FieldTitle},
+			trustcenterdochistory.FieldCategory:            {Type: field.TypeString, Column: trustcenterdochistory.FieldCategory},
+			trustcenterdochistory.FieldFileID:              {Type: field.TypeString, Column: trustcenterdochistory.FieldFileID},
+			trustcenterdochistory.FieldOriginalFileID:      {Type: field.TypeString, Column: trustcenterdochistory.FieldOriginalFileID},
+			trustcenterdochistory.FieldWatermarkingEnabled: {Type: field.TypeBool, Column: trustcenterdochistory.FieldWatermarkingEnabled},
+			trustcenterdochistory.FieldWatermarkStatus:     {Type: field.TypeEnum, Column: trustcenterdochistory.FieldWatermarkStatus},
+			trustcenterdochistory.FieldVisibility:          {Type: field.TypeEnum, Column: trustcenterdochistory.FieldVisibility},
 		},
 	}
 	graph.Nodes[101] = &sqlgraph.Node{
@@ -8849,6 +8855,18 @@ var schemaGraph = func() *sqlgraph.Schema {
 			Inverse: false,
 			Table:   trustcenterdoc.FileTable,
 			Columns: []string{trustcenterdoc.FileColumn},
+			Bidi:    false,
+		},
+		"TrustCenterDoc",
+		"File",
+	)
+	graph.MustAddE(
+		"original_file",
+		&sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: false,
+			Table:   trustcenterdoc.OriginalFileTable,
+			Columns: []string{trustcenterdoc.OriginalFileColumn},
 			Bidi:    false,
 		},
 		"TrustCenterDoc",
@@ -28389,6 +28407,21 @@ func (f *TrustCenterDocFilter) WhereFileID(p entql.StringP) {
 	f.Where(p.Field(trustcenterdoc.FieldFileID))
 }
 
+// WhereOriginalFileID applies the entql string predicate on the original_file_id field.
+func (f *TrustCenterDocFilter) WhereOriginalFileID(p entql.StringP) {
+	f.Where(p.Field(trustcenterdoc.FieldOriginalFileID))
+}
+
+// WhereWatermarkingEnabled applies the entql bool predicate on the watermarking_enabled field.
+func (f *TrustCenterDocFilter) WhereWatermarkingEnabled(p entql.BoolP) {
+	f.Where(p.Field(trustcenterdoc.FieldWatermarkingEnabled))
+}
+
+// WhereWatermarkStatus applies the entql string predicate on the watermark_status field.
+func (f *TrustCenterDocFilter) WhereWatermarkStatus(p entql.StringP) {
+	f.Where(p.Field(trustcenterdoc.FieldWatermarkStatus))
+}
+
 // WhereVisibility applies the entql string predicate on the visibility field.
 func (f *TrustCenterDocFilter) WhereVisibility(p entql.StringP) {
 	f.Where(p.Field(trustcenterdoc.FieldVisibility))
@@ -28416,6 +28449,20 @@ func (f *TrustCenterDocFilter) WhereHasFile() {
 // WhereHasFileWith applies a predicate to check if query has an edge file with a given conditions (other predicates).
 func (f *TrustCenterDocFilter) WhereHasFileWith(preds ...predicate.File) {
 	f.Where(entql.HasEdgeWith("file", sqlgraph.WrapFunc(func(s *sql.Selector) {
+		for _, p := range preds {
+			p(s)
+		}
+	})))
+}
+
+// WhereHasOriginalFile applies a predicate to check if query has an edge original_file.
+func (f *TrustCenterDocFilter) WhereHasOriginalFile() {
+	f.Where(entql.HasEdge("original_file"))
+}
+
+// WhereHasOriginalFileWith applies a predicate to check if query has an edge original_file with a given conditions (other predicates).
+func (f *TrustCenterDocFilter) WhereHasOriginalFileWith(preds ...predicate.File) {
+	f.Where(entql.HasEdgeWith("original_file", sqlgraph.WrapFunc(func(s *sql.Selector) {
 		for _, p := range preds {
 			p(s)
 		}
@@ -28530,6 +28577,21 @@ func (f *TrustCenterDocHistoryFilter) WhereCategory(p entql.StringP) {
 // WhereFileID applies the entql string predicate on the file_id field.
 func (f *TrustCenterDocHistoryFilter) WhereFileID(p entql.StringP) {
 	f.Where(p.Field(trustcenterdochistory.FieldFileID))
+}
+
+// WhereOriginalFileID applies the entql string predicate on the original_file_id field.
+func (f *TrustCenterDocHistoryFilter) WhereOriginalFileID(p entql.StringP) {
+	f.Where(p.Field(trustcenterdochistory.FieldOriginalFileID))
+}
+
+// WhereWatermarkingEnabled applies the entql bool predicate on the watermarking_enabled field.
+func (f *TrustCenterDocHistoryFilter) WhereWatermarkingEnabled(p entql.BoolP) {
+	f.Where(p.Field(trustcenterdochistory.FieldWatermarkingEnabled))
+}
+
+// WhereWatermarkStatus applies the entql string predicate on the watermark_status field.
+func (f *TrustCenterDocHistoryFilter) WhereWatermarkStatus(p entql.StringP) {
+	f.Where(p.Field(trustcenterdochistory.FieldWatermarkStatus))
 }
 
 // WhereVisibility applies the entql string predicate on the visibility field.

--- a/internal/ent/generated/gql_collection.go
+++ b/internal/ent/generated/gql_collection.go
@@ -45134,6 +45134,21 @@ func (_q *TrustCenterDocQuery) collectField(ctx context.Context, oneNode bool, o
 				selectedFields = append(selectedFields, trustcenterdoc.FieldFileID)
 				fieldSeen[trustcenterdoc.FieldFileID] = struct{}{}
 			}
+
+		case "originalFile":
+			var (
+				alias = field.Alias
+				path  = append(path, alias)
+				query = (&FileClient{config: _q.config}).Query()
+			)
+			if err := query.collectField(ctx, oneNode, opCtx, field, path, mayAddCondition(satisfies, fileImplementors)...); err != nil {
+				return err
+			}
+			_q.withOriginalFile = query
+			if _, ok := fieldSeen[trustcenterdoc.FieldOriginalFileID]; !ok {
+				selectedFields = append(selectedFields, trustcenterdoc.FieldOriginalFileID)
+				fieldSeen[trustcenterdoc.FieldOriginalFileID] = struct{}{}
+			}
 		case "createdAt":
 			if _, ok := fieldSeen[trustcenterdoc.FieldCreatedAt]; !ok {
 				selectedFields = append(selectedFields, trustcenterdoc.FieldCreatedAt)
@@ -45178,6 +45193,21 @@ func (_q *TrustCenterDocQuery) collectField(ctx context.Context, oneNode bool, o
 			if _, ok := fieldSeen[trustcenterdoc.FieldFileID]; !ok {
 				selectedFields = append(selectedFields, trustcenterdoc.FieldFileID)
 				fieldSeen[trustcenterdoc.FieldFileID] = struct{}{}
+			}
+		case "originalFileID":
+			if _, ok := fieldSeen[trustcenterdoc.FieldOriginalFileID]; !ok {
+				selectedFields = append(selectedFields, trustcenterdoc.FieldOriginalFileID)
+				fieldSeen[trustcenterdoc.FieldOriginalFileID] = struct{}{}
+			}
+		case "watermarkingEnabled":
+			if _, ok := fieldSeen[trustcenterdoc.FieldWatermarkingEnabled]; !ok {
+				selectedFields = append(selectedFields, trustcenterdoc.FieldWatermarkingEnabled)
+				fieldSeen[trustcenterdoc.FieldWatermarkingEnabled] = struct{}{}
+			}
+		case "watermarkStatus":
+			if _, ok := fieldSeen[trustcenterdoc.FieldWatermarkStatus]; !ok {
+				selectedFields = append(selectedFields, trustcenterdoc.FieldWatermarkStatus)
+				fieldSeen[trustcenterdoc.FieldWatermarkStatus] = struct{}{}
 			}
 		case "visibility":
 			if _, ok := fieldSeen[trustcenterdoc.FieldVisibility]; !ok {
@@ -45333,6 +45363,21 @@ func (_q *TrustCenterDocHistoryQuery) collectField(ctx context.Context, oneNode 
 			if _, ok := fieldSeen[trustcenterdochistory.FieldFileID]; !ok {
 				selectedFields = append(selectedFields, trustcenterdochistory.FieldFileID)
 				fieldSeen[trustcenterdochistory.FieldFileID] = struct{}{}
+			}
+		case "originalFileID":
+			if _, ok := fieldSeen[trustcenterdochistory.FieldOriginalFileID]; !ok {
+				selectedFields = append(selectedFields, trustcenterdochistory.FieldOriginalFileID)
+				fieldSeen[trustcenterdochistory.FieldOriginalFileID] = struct{}{}
+			}
+		case "watermarkingEnabled":
+			if _, ok := fieldSeen[trustcenterdochistory.FieldWatermarkingEnabled]; !ok {
+				selectedFields = append(selectedFields, trustcenterdochistory.FieldWatermarkingEnabled)
+				fieldSeen[trustcenterdochistory.FieldWatermarkingEnabled] = struct{}{}
+			}
+		case "watermarkStatus":
+			if _, ok := fieldSeen[trustcenterdochistory.FieldWatermarkStatus]; !ok {
+				selectedFields = append(selectedFields, trustcenterdochistory.FieldWatermarkStatus)
+				fieldSeen[trustcenterdochistory.FieldWatermarkStatus] = struct{}{}
 			}
 		case "visibility":
 			if _, ok := fieldSeen[trustcenterdochistory.FieldVisibility]; !ok {

--- a/internal/ent/generated/gql_edge.go
+++ b/internal/ent/generated/gql_edge.go
@@ -7224,6 +7224,14 @@ func (_m *TrustCenterDoc) File(ctx context.Context) (*File, error) {
 	return result, MaskNotFound(err)
 }
 
+func (_m *TrustCenterDoc) OriginalFile(ctx context.Context) (*File, error) {
+	result, err := _m.Edges.OriginalFileOrErr()
+	if IsNotLoaded(err) {
+		result, err = _m.QueryOriginalFile().Only(ctx)
+	}
+	return result, MaskNotFound(err)
+}
+
 func (_m *TrustCenterSetting) TrustCenter(ctx context.Context) (*TrustCenter, error) {
 	result, err := _m.Edges.TrustCenterOrErr()
 	if IsNotLoaded(err) {

--- a/internal/ent/generated/gql_mutation_input.go
+++ b/internal/ent/generated/gql_mutation_input.go
@@ -12111,12 +12111,15 @@ func (c *TrustCenterComplianceUpdateOne) SetInput(i UpdateTrustCenterComplianceI
 
 // CreateTrustCenterDocInput represents a mutation input for creating trustcenterdocs.
 type CreateTrustCenterDocInput struct {
-	Tags          []string
-	Title         string
-	Category      string
-	Visibility    *enums.TrustCenterDocumentVisibility
-	TrustCenterID *string
-	FileID        *string
+	Tags                []string
+	Title               string
+	Category            string
+	WatermarkingEnabled *bool
+	WatermarkStatus     *enums.WatermarkStatus
+	Visibility          *enums.TrustCenterDocumentVisibility
+	TrustCenterID       *string
+	FileID              *string
+	OriginalFileID      *string
 }
 
 // Mutate applies the CreateTrustCenterDocInput on the TrustCenterDocMutation builder.
@@ -12126,6 +12129,12 @@ func (i *CreateTrustCenterDocInput) Mutate(m *TrustCenterDocMutation) {
 	}
 	m.SetTitle(i.Title)
 	m.SetCategory(i.Category)
+	if v := i.WatermarkingEnabled; v != nil {
+		m.SetWatermarkingEnabled(*v)
+	}
+	if v := i.WatermarkStatus; v != nil {
+		m.SetWatermarkStatus(*v)
+	}
 	if v := i.Visibility; v != nil {
 		m.SetVisibility(*v)
 	}
@@ -12134,6 +12143,9 @@ func (i *CreateTrustCenterDocInput) Mutate(m *TrustCenterDocMutation) {
 	}
 	if v := i.FileID; v != nil {
 		m.SetFileID(*v)
+	}
+	if v := i.OriginalFileID; v != nil {
+		m.SetOriginalFileID(*v)
 	}
 }
 
@@ -12145,17 +12157,22 @@ func (c *TrustCenterDocCreate) SetInput(i CreateTrustCenterDocInput) *TrustCente
 
 // UpdateTrustCenterDocInput represents a mutation input for updating trustcenterdocs.
 type UpdateTrustCenterDocInput struct {
-	ClearTags        bool
-	Tags             []string
-	AppendTags       []string
-	Title            *string
-	Category         *string
-	ClearVisibility  bool
-	Visibility       *enums.TrustCenterDocumentVisibility
-	ClearTrustCenter bool
-	TrustCenterID    *string
-	ClearFile        bool
-	FileID           *string
+	ClearTags            bool
+	Tags                 []string
+	AppendTags           []string
+	Title                *string
+	Category             *string
+	WatermarkingEnabled  *bool
+	ClearWatermarkStatus bool
+	WatermarkStatus      *enums.WatermarkStatus
+	ClearVisibility      bool
+	Visibility           *enums.TrustCenterDocumentVisibility
+	ClearTrustCenter     bool
+	TrustCenterID        *string
+	ClearFile            bool
+	FileID               *string
+	ClearOriginalFile    bool
+	OriginalFileID       *string
 }
 
 // Mutate applies the UpdateTrustCenterDocInput on the TrustCenterDocMutation builder.
@@ -12175,6 +12192,15 @@ func (i *UpdateTrustCenterDocInput) Mutate(m *TrustCenterDocMutation) {
 	if v := i.Category; v != nil {
 		m.SetCategory(*v)
 	}
+	if v := i.WatermarkingEnabled; v != nil {
+		m.SetWatermarkingEnabled(*v)
+	}
+	if i.ClearWatermarkStatus {
+		m.ClearWatermarkStatus()
+	}
+	if v := i.WatermarkStatus; v != nil {
+		m.SetWatermarkStatus(*v)
+	}
 	if i.ClearVisibility {
 		m.ClearVisibility()
 	}
@@ -12192,6 +12218,12 @@ func (i *UpdateTrustCenterDocInput) Mutate(m *TrustCenterDocMutation) {
 	}
 	if v := i.FileID; v != nil {
 		m.SetFileID(*v)
+	}
+	if i.ClearOriginalFile {
+		m.ClearOriginalFile()
+	}
+	if v := i.OriginalFileID; v != nil {
+		m.SetOriginalFileID(*v)
 	}
 }
 

--- a/internal/ent/generated/gql_where_input.go
+++ b/internal/ent/generated/gql_where_input.go
@@ -86502,6 +86502,35 @@ type TrustCenterDocWhereInput struct {
 	FileIDEqualFold    *string  `json:"fileIDEqualFold,omitempty"`
 	FileIDContainsFold *string  `json:"fileIDContainsFold,omitempty"`
 
+	// "original_file_id" field predicates.
+	OriginalFileID             *string  `json:"originalFileID,omitempty"`
+	OriginalFileIDNEQ          *string  `json:"originalFileIDNEQ,omitempty"`
+	OriginalFileIDIn           []string `json:"originalFileIDIn,omitempty"`
+	OriginalFileIDNotIn        []string `json:"originalFileIDNotIn,omitempty"`
+	OriginalFileIDGT           *string  `json:"originalFileIDGT,omitempty"`
+	OriginalFileIDGTE          *string  `json:"originalFileIDGTE,omitempty"`
+	OriginalFileIDLT           *string  `json:"originalFileIDLT,omitempty"`
+	OriginalFileIDLTE          *string  `json:"originalFileIDLTE,omitempty"`
+	OriginalFileIDContains     *string  `json:"originalFileIDContains,omitempty"`
+	OriginalFileIDHasPrefix    *string  `json:"originalFileIDHasPrefix,omitempty"`
+	OriginalFileIDHasSuffix    *string  `json:"originalFileIDHasSuffix,omitempty"`
+	OriginalFileIDIsNil        bool     `json:"originalFileIDIsNil,omitempty"`
+	OriginalFileIDNotNil       bool     `json:"originalFileIDNotNil,omitempty"`
+	OriginalFileIDEqualFold    *string  `json:"originalFileIDEqualFold,omitempty"`
+	OriginalFileIDContainsFold *string  `json:"originalFileIDContainsFold,omitempty"`
+
+	// "watermarking_enabled" field predicates.
+	WatermarkingEnabled    *bool `json:"watermarkingEnabled,omitempty"`
+	WatermarkingEnabledNEQ *bool `json:"watermarkingEnabledNEQ,omitempty"`
+
+	// "watermark_status" field predicates.
+	WatermarkStatus       *enums.WatermarkStatus  `json:"watermarkStatus,omitempty"`
+	WatermarkStatusNEQ    *enums.WatermarkStatus  `json:"watermarkStatusNEQ,omitempty"`
+	WatermarkStatusIn     []enums.WatermarkStatus `json:"watermarkStatusIn,omitempty"`
+	WatermarkStatusNotIn  []enums.WatermarkStatus `json:"watermarkStatusNotIn,omitempty"`
+	WatermarkStatusIsNil  bool                    `json:"watermarkStatusIsNil,omitempty"`
+	WatermarkStatusNotNil bool                    `json:"watermarkStatusNotNil,omitempty"`
+
 	// "visibility" field predicates.
 	Visibility       *enums.TrustCenterDocumentVisibility  `json:"visibility,omitempty"`
 	VisibilityNEQ    *enums.TrustCenterDocumentVisibility  `json:"visibilityNEQ,omitempty"`
@@ -86517,6 +86546,10 @@ type TrustCenterDocWhereInput struct {
 	// "file" edge predicates.
 	HasFile     *bool             `json:"hasFile,omitempty"`
 	HasFileWith []*FileWhereInput `json:"hasFileWith,omitempty"`
+
+	// "original_file" edge predicates.
+	HasOriginalFile     *bool             `json:"hasOriginalFile,omitempty"`
+	HasOriginalFileWith []*FileWhereInput `json:"hasOriginalFileWith,omitempty"`
 }
 
 // AddPredicates adds custom predicates to the where input to be used during the filtering phase.
@@ -86938,6 +86971,75 @@ func (i *TrustCenterDocWhereInput) P() (predicate.TrustCenterDoc, error) {
 	if i.FileIDContainsFold != nil {
 		predicates = append(predicates, trustcenterdoc.FileIDContainsFold(*i.FileIDContainsFold))
 	}
+	if i.OriginalFileID != nil {
+		predicates = append(predicates, trustcenterdoc.OriginalFileIDEQ(*i.OriginalFileID))
+	}
+	if i.OriginalFileIDNEQ != nil {
+		predicates = append(predicates, trustcenterdoc.OriginalFileIDNEQ(*i.OriginalFileIDNEQ))
+	}
+	if len(i.OriginalFileIDIn) > 0 {
+		predicates = append(predicates, trustcenterdoc.OriginalFileIDIn(i.OriginalFileIDIn...))
+	}
+	if len(i.OriginalFileIDNotIn) > 0 {
+		predicates = append(predicates, trustcenterdoc.OriginalFileIDNotIn(i.OriginalFileIDNotIn...))
+	}
+	if i.OriginalFileIDGT != nil {
+		predicates = append(predicates, trustcenterdoc.OriginalFileIDGT(*i.OriginalFileIDGT))
+	}
+	if i.OriginalFileIDGTE != nil {
+		predicates = append(predicates, trustcenterdoc.OriginalFileIDGTE(*i.OriginalFileIDGTE))
+	}
+	if i.OriginalFileIDLT != nil {
+		predicates = append(predicates, trustcenterdoc.OriginalFileIDLT(*i.OriginalFileIDLT))
+	}
+	if i.OriginalFileIDLTE != nil {
+		predicates = append(predicates, trustcenterdoc.OriginalFileIDLTE(*i.OriginalFileIDLTE))
+	}
+	if i.OriginalFileIDContains != nil {
+		predicates = append(predicates, trustcenterdoc.OriginalFileIDContains(*i.OriginalFileIDContains))
+	}
+	if i.OriginalFileIDHasPrefix != nil {
+		predicates = append(predicates, trustcenterdoc.OriginalFileIDHasPrefix(*i.OriginalFileIDHasPrefix))
+	}
+	if i.OriginalFileIDHasSuffix != nil {
+		predicates = append(predicates, trustcenterdoc.OriginalFileIDHasSuffix(*i.OriginalFileIDHasSuffix))
+	}
+	if i.OriginalFileIDIsNil {
+		predicates = append(predicates, trustcenterdoc.OriginalFileIDIsNil())
+	}
+	if i.OriginalFileIDNotNil {
+		predicates = append(predicates, trustcenterdoc.OriginalFileIDNotNil())
+	}
+	if i.OriginalFileIDEqualFold != nil {
+		predicates = append(predicates, trustcenterdoc.OriginalFileIDEqualFold(*i.OriginalFileIDEqualFold))
+	}
+	if i.OriginalFileIDContainsFold != nil {
+		predicates = append(predicates, trustcenterdoc.OriginalFileIDContainsFold(*i.OriginalFileIDContainsFold))
+	}
+	if i.WatermarkingEnabled != nil {
+		predicates = append(predicates, trustcenterdoc.WatermarkingEnabledEQ(*i.WatermarkingEnabled))
+	}
+	if i.WatermarkingEnabledNEQ != nil {
+		predicates = append(predicates, trustcenterdoc.WatermarkingEnabledNEQ(*i.WatermarkingEnabledNEQ))
+	}
+	if i.WatermarkStatus != nil {
+		predicates = append(predicates, trustcenterdoc.WatermarkStatusEQ(*i.WatermarkStatus))
+	}
+	if i.WatermarkStatusNEQ != nil {
+		predicates = append(predicates, trustcenterdoc.WatermarkStatusNEQ(*i.WatermarkStatusNEQ))
+	}
+	if len(i.WatermarkStatusIn) > 0 {
+		predicates = append(predicates, trustcenterdoc.WatermarkStatusIn(i.WatermarkStatusIn...))
+	}
+	if len(i.WatermarkStatusNotIn) > 0 {
+		predicates = append(predicates, trustcenterdoc.WatermarkStatusNotIn(i.WatermarkStatusNotIn...))
+	}
+	if i.WatermarkStatusIsNil {
+		predicates = append(predicates, trustcenterdoc.WatermarkStatusIsNil())
+	}
+	if i.WatermarkStatusNotNil {
+		predicates = append(predicates, trustcenterdoc.WatermarkStatusNotNil())
+	}
 	if i.Visibility != nil {
 		predicates = append(predicates, trustcenterdoc.VisibilityEQ(*i.Visibility))
 	}
@@ -86992,6 +87094,24 @@ func (i *TrustCenterDocWhereInput) P() (predicate.TrustCenterDoc, error) {
 			with = append(with, p)
 		}
 		predicates = append(predicates, trustcenterdoc.HasFileWith(with...))
+	}
+	if i.HasOriginalFile != nil {
+		p := trustcenterdoc.HasOriginalFile()
+		if !*i.HasOriginalFile {
+			p = trustcenterdoc.Not(p)
+		}
+		predicates = append(predicates, p)
+	}
+	if len(i.HasOriginalFileWith) > 0 {
+		with := make([]predicate.File, 0, len(i.HasOriginalFileWith))
+		for _, w := range i.HasOriginalFileWith {
+			p, err := w.P()
+			if err != nil {
+				return nil, fmt.Errorf("%w: field 'HasOriginalFileWith'", err)
+			}
+			with = append(with, p)
+		}
+		predicates = append(predicates, trustcenterdoc.HasOriginalFileWith(with...))
 	}
 	switch len(predicates) {
 	case 0:
@@ -87176,6 +87296,35 @@ type TrustCenterDocHistoryWhereInput struct {
 	FileIDNotNil       bool     `json:"fileIDNotNil,omitempty"`
 	FileIDEqualFold    *string  `json:"fileIDEqualFold,omitempty"`
 	FileIDContainsFold *string  `json:"fileIDContainsFold,omitempty"`
+
+	// "original_file_id" field predicates.
+	OriginalFileID             *string  `json:"originalFileID,omitempty"`
+	OriginalFileIDNEQ          *string  `json:"originalFileIDNEQ,omitempty"`
+	OriginalFileIDIn           []string `json:"originalFileIDIn,omitempty"`
+	OriginalFileIDNotIn        []string `json:"originalFileIDNotIn,omitempty"`
+	OriginalFileIDGT           *string  `json:"originalFileIDGT,omitempty"`
+	OriginalFileIDGTE          *string  `json:"originalFileIDGTE,omitempty"`
+	OriginalFileIDLT           *string  `json:"originalFileIDLT,omitempty"`
+	OriginalFileIDLTE          *string  `json:"originalFileIDLTE,omitempty"`
+	OriginalFileIDContains     *string  `json:"originalFileIDContains,omitempty"`
+	OriginalFileIDHasPrefix    *string  `json:"originalFileIDHasPrefix,omitempty"`
+	OriginalFileIDHasSuffix    *string  `json:"originalFileIDHasSuffix,omitempty"`
+	OriginalFileIDIsNil        bool     `json:"originalFileIDIsNil,omitempty"`
+	OriginalFileIDNotNil       bool     `json:"originalFileIDNotNil,omitempty"`
+	OriginalFileIDEqualFold    *string  `json:"originalFileIDEqualFold,omitempty"`
+	OriginalFileIDContainsFold *string  `json:"originalFileIDContainsFold,omitempty"`
+
+	// "watermarking_enabled" field predicates.
+	WatermarkingEnabled    *bool `json:"watermarkingEnabled,omitempty"`
+	WatermarkingEnabledNEQ *bool `json:"watermarkingEnabledNEQ,omitempty"`
+
+	// "watermark_status" field predicates.
+	WatermarkStatus       *enums.WatermarkStatus  `json:"watermarkStatus,omitempty"`
+	WatermarkStatusNEQ    *enums.WatermarkStatus  `json:"watermarkStatusNEQ,omitempty"`
+	WatermarkStatusIn     []enums.WatermarkStatus `json:"watermarkStatusIn,omitempty"`
+	WatermarkStatusNotIn  []enums.WatermarkStatus `json:"watermarkStatusNotIn,omitempty"`
+	WatermarkStatusIsNil  bool                    `json:"watermarkStatusIsNil,omitempty"`
+	WatermarkStatusNotNil bool                    `json:"watermarkStatusNotNil,omitempty"`
 
 	// "visibility" field predicates.
 	Visibility       *enums.TrustCenterDocumentVisibility  `json:"visibility,omitempty"`
@@ -87685,6 +87834,75 @@ func (i *TrustCenterDocHistoryWhereInput) P() (predicate.TrustCenterDocHistory, 
 	}
 	if i.FileIDContainsFold != nil {
 		predicates = append(predicates, trustcenterdochistory.FileIDContainsFold(*i.FileIDContainsFold))
+	}
+	if i.OriginalFileID != nil {
+		predicates = append(predicates, trustcenterdochistory.OriginalFileIDEQ(*i.OriginalFileID))
+	}
+	if i.OriginalFileIDNEQ != nil {
+		predicates = append(predicates, trustcenterdochistory.OriginalFileIDNEQ(*i.OriginalFileIDNEQ))
+	}
+	if len(i.OriginalFileIDIn) > 0 {
+		predicates = append(predicates, trustcenterdochistory.OriginalFileIDIn(i.OriginalFileIDIn...))
+	}
+	if len(i.OriginalFileIDNotIn) > 0 {
+		predicates = append(predicates, trustcenterdochistory.OriginalFileIDNotIn(i.OriginalFileIDNotIn...))
+	}
+	if i.OriginalFileIDGT != nil {
+		predicates = append(predicates, trustcenterdochistory.OriginalFileIDGT(*i.OriginalFileIDGT))
+	}
+	if i.OriginalFileIDGTE != nil {
+		predicates = append(predicates, trustcenterdochistory.OriginalFileIDGTE(*i.OriginalFileIDGTE))
+	}
+	if i.OriginalFileIDLT != nil {
+		predicates = append(predicates, trustcenterdochistory.OriginalFileIDLT(*i.OriginalFileIDLT))
+	}
+	if i.OriginalFileIDLTE != nil {
+		predicates = append(predicates, trustcenterdochistory.OriginalFileIDLTE(*i.OriginalFileIDLTE))
+	}
+	if i.OriginalFileIDContains != nil {
+		predicates = append(predicates, trustcenterdochistory.OriginalFileIDContains(*i.OriginalFileIDContains))
+	}
+	if i.OriginalFileIDHasPrefix != nil {
+		predicates = append(predicates, trustcenterdochistory.OriginalFileIDHasPrefix(*i.OriginalFileIDHasPrefix))
+	}
+	if i.OriginalFileIDHasSuffix != nil {
+		predicates = append(predicates, trustcenterdochistory.OriginalFileIDHasSuffix(*i.OriginalFileIDHasSuffix))
+	}
+	if i.OriginalFileIDIsNil {
+		predicates = append(predicates, trustcenterdochistory.OriginalFileIDIsNil())
+	}
+	if i.OriginalFileIDNotNil {
+		predicates = append(predicates, trustcenterdochistory.OriginalFileIDNotNil())
+	}
+	if i.OriginalFileIDEqualFold != nil {
+		predicates = append(predicates, trustcenterdochistory.OriginalFileIDEqualFold(*i.OriginalFileIDEqualFold))
+	}
+	if i.OriginalFileIDContainsFold != nil {
+		predicates = append(predicates, trustcenterdochistory.OriginalFileIDContainsFold(*i.OriginalFileIDContainsFold))
+	}
+	if i.WatermarkingEnabled != nil {
+		predicates = append(predicates, trustcenterdochistory.WatermarkingEnabledEQ(*i.WatermarkingEnabled))
+	}
+	if i.WatermarkingEnabledNEQ != nil {
+		predicates = append(predicates, trustcenterdochistory.WatermarkingEnabledNEQ(*i.WatermarkingEnabledNEQ))
+	}
+	if i.WatermarkStatus != nil {
+		predicates = append(predicates, trustcenterdochistory.WatermarkStatusEQ(*i.WatermarkStatus))
+	}
+	if i.WatermarkStatusNEQ != nil {
+		predicates = append(predicates, trustcenterdochistory.WatermarkStatusNEQ(*i.WatermarkStatusNEQ))
+	}
+	if len(i.WatermarkStatusIn) > 0 {
+		predicates = append(predicates, trustcenterdochistory.WatermarkStatusIn(i.WatermarkStatusIn...))
+	}
+	if len(i.WatermarkStatusNotIn) > 0 {
+		predicates = append(predicates, trustcenterdochistory.WatermarkStatusNotIn(i.WatermarkStatusNotIn...))
+	}
+	if i.WatermarkStatusIsNil {
+		predicates = append(predicates, trustcenterdochistory.WatermarkStatusIsNil())
+	}
+	if i.WatermarkStatusNotNil {
+		predicates = append(predicates, trustcenterdochistory.WatermarkStatusNotNil())
 	}
 	if i.Visibility != nil {
 		predicates = append(predicates, trustcenterdochistory.VisibilityEQ(*i.Visibility))

--- a/internal/ent/generated/history_from_mutation.go
+++ b/internal/ent/generated/history_from_mutation.go
@@ -11750,6 +11750,18 @@ func (m *TrustCenterDocMutation) CreateHistoryFromCreate(ctx context.Context) er
 		create = create.SetNillableFileID(&fileID)
 	}
 
+	if originalFileID, exists := m.OriginalFileID(); exists {
+		create = create.SetNillableOriginalFileID(&originalFileID)
+	}
+
+	if watermarkingEnabled, exists := m.WatermarkingEnabled(); exists {
+		create = create.SetWatermarkingEnabled(watermarkingEnabled)
+	}
+
+	if watermarkStatus, exists := m.WatermarkStatus(); exists {
+		create = create.SetWatermarkStatus(watermarkStatus)
+	}
+
 	if visibility, exists := m.Visibility(); exists {
 		create = create.SetVisibility(visibility)
 	}
@@ -11851,6 +11863,24 @@ func (m *TrustCenterDocMutation) CreateHistoryFromUpdate(ctx context.Context) er
 			create = create.SetNillableFileID(trustcenterdoc.FileID)
 		}
 
+		if originalFileID, exists := m.OriginalFileID(); exists {
+			create = create.SetNillableOriginalFileID(&originalFileID)
+		} else {
+			create = create.SetNillableOriginalFileID(trustcenterdoc.OriginalFileID)
+		}
+
+		if watermarkingEnabled, exists := m.WatermarkingEnabled(); exists {
+			create = create.SetWatermarkingEnabled(watermarkingEnabled)
+		} else {
+			create = create.SetWatermarkingEnabled(trustcenterdoc.WatermarkingEnabled)
+		}
+
+		if watermarkStatus, exists := m.WatermarkStatus(); exists {
+			create = create.SetWatermarkStatus(watermarkStatus)
+		} else {
+			create = create.SetWatermarkStatus(trustcenterdoc.WatermarkStatus)
+		}
+
 		if visibility, exists := m.Visibility(); exists {
 			create = create.SetVisibility(visibility)
 		} else {
@@ -11903,6 +11933,9 @@ func (m *TrustCenterDocMutation) CreateHistoryFromDelete(ctx context.Context) er
 			SetTitle(trustcenterdoc.Title).
 			SetCategory(trustcenterdoc.Category).
 			SetNillableFileID(trustcenterdoc.FileID).
+			SetNillableOriginalFileID(trustcenterdoc.OriginalFileID).
+			SetWatermarkingEnabled(trustcenterdoc.WatermarkingEnabled).
+			SetWatermarkStatus(trustcenterdoc.WatermarkStatus).
 			SetVisibility(trustcenterdoc.Visibility).
 			Save(ctx)
 		if err != nil {

--- a/internal/ent/generated/migrate/schema.go
+++ b/internal/ent/generated/migrate/schema.go
@@ -4892,9 +4892,12 @@ var (
 		{Name: "tags", Type: field.TypeJSON, Nullable: true},
 		{Name: "title", Type: field.TypeString},
 		{Name: "category", Type: field.TypeString},
+		{Name: "watermarking_enabled", Type: field.TypeBool, Default: true},
+		{Name: "watermark_status", Type: field.TypeEnum, Nullable: true, Enums: []string{"PENDING", "IN_PROGRESS", "SUCCESS", "FAILED", "DISABLED"}, Default: "DISABLED"},
 		{Name: "visibility", Type: field.TypeEnum, Nullable: true, Enums: []string{"PUBLICLY_VISIBLE", "PROTECTED", "NOT_VISIBLE"}, Default: "NOT_VISIBLE"},
 		{Name: "trust_center_id", Type: field.TypeString, Nullable: true},
 		{Name: "file_id", Type: field.TypeString, Nullable: true},
+		{Name: "original_file_id", Type: field.TypeString, Nullable: true},
 	}
 	// TrustCenterDocsTable holds the schema information for the "trust_center_docs" table.
 	TrustCenterDocsTable = &schema.Table{
@@ -4904,13 +4907,19 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "trust_center_docs_trust_centers_trust_center_docs",
-				Columns:    []*schema.Column{TrustCenterDocsColumns[11]},
+				Columns:    []*schema.Column{TrustCenterDocsColumns[13]},
 				RefColumns: []*schema.Column{TrustCentersColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "trust_center_docs_files_file",
-				Columns:    []*schema.Column{TrustCenterDocsColumns[12]},
+				Columns:    []*schema.Column{TrustCenterDocsColumns[14]},
+				RefColumns: []*schema.Column{FilesColumns[0]},
+				OnDelete:   schema.SetNull,
+			},
+			{
+				Symbol:     "trust_center_docs_files_original_file",
+				Columns:    []*schema.Column{TrustCenterDocsColumns[15]},
 				RefColumns: []*schema.Column{FilesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -4933,6 +4942,9 @@ var (
 		{Name: "title", Type: field.TypeString},
 		{Name: "category", Type: field.TypeString},
 		{Name: "file_id", Type: field.TypeString, Nullable: true},
+		{Name: "original_file_id", Type: field.TypeString, Nullable: true},
+		{Name: "watermarking_enabled", Type: field.TypeBool, Default: true},
+		{Name: "watermark_status", Type: field.TypeEnum, Nullable: true, Enums: []string{"PENDING", "IN_PROGRESS", "SUCCESS", "FAILED", "DISABLED"}, Default: "DISABLED"},
 		{Name: "visibility", Type: field.TypeEnum, Nullable: true, Enums: []string{"PUBLICLY_VISIBLE", "PROTECTED", "NOT_VISIBLE"}, Default: "NOT_VISIBLE"},
 	}
 	// TrustCenterDocHistoryTable holds the schema information for the "trust_center_doc_history" table.
@@ -8745,6 +8757,7 @@ func init() {
 	}
 	TrustCenterDocsTable.ForeignKeys[0].RefTable = TrustCentersTable
 	TrustCenterDocsTable.ForeignKeys[1].RefTable = FilesTable
+	TrustCenterDocsTable.ForeignKeys[2].RefTable = FilesTable
 	TrustCenterDocHistoryTable.Annotation = &entsql.Annotation{
 		Table: "trust_center_doc_history",
 	}

--- a/internal/ent/generated/runtime/runtime.go
+++ b/internal/ent/generated/runtime/runtime.go
@@ -6628,6 +6628,10 @@ func init() {
 	trustcenterdocDescCategory := trustcenterdocFields[2].Descriptor()
 	// trustcenterdoc.CategoryValidator is a validator for the "category" field. It is called by the builders before save.
 	trustcenterdoc.CategoryValidator = trustcenterdocDescCategory.Validators[0].(func(string) error)
+	// trustcenterdocDescWatermarkingEnabled is the schema descriptor for watermarking_enabled field.
+	trustcenterdocDescWatermarkingEnabled := trustcenterdocFields[5].Descriptor()
+	// trustcenterdoc.DefaultWatermarkingEnabled holds the default value on creation for the watermarking_enabled field.
+	trustcenterdoc.DefaultWatermarkingEnabled = trustcenterdocDescWatermarkingEnabled.Default.(bool)
 	// trustcenterdocDescID is the schema descriptor for id field.
 	trustcenterdocDescID := trustcenterdocMixinFields3[0].Descriptor()
 	// trustcenterdoc.DefaultID holds the default value on creation for the id field.
@@ -6663,6 +6667,10 @@ func init() {
 	trustcenterdochistoryDescTags := trustcenterdochistoryFields[10].Descriptor()
 	// trustcenterdochistory.DefaultTags holds the default value on creation for the tags field.
 	trustcenterdochistory.DefaultTags = trustcenterdochistoryDescTags.Default.([]string)
+	// trustcenterdochistoryDescWatermarkingEnabled is the schema descriptor for watermarking_enabled field.
+	trustcenterdochistoryDescWatermarkingEnabled := trustcenterdochistoryFields[16].Descriptor()
+	// trustcenterdochistory.DefaultWatermarkingEnabled holds the default value on creation for the watermarking_enabled field.
+	trustcenterdochistory.DefaultWatermarkingEnabled = trustcenterdochistoryDescWatermarkingEnabled.Default.(bool)
 	// trustcenterdochistoryDescID is the schema descriptor for id field.
 	trustcenterdochistoryDescID := trustcenterdochistoryFields[9].Descriptor()
 	// trustcenterdochistory.DefaultID holds the default value on creation for the id field.

--- a/internal/ent/generated/trustcenterdoc/where.go
+++ b/internal/ent/generated/trustcenterdoc/where.go
@@ -118,6 +118,16 @@ func FileID(v string) predicate.TrustCenterDoc {
 	return predicate.TrustCenterDoc(sql.FieldEQ(FieldFileID, v))
 }
 
+// OriginalFileID applies equality check predicate on the "original_file_id" field. It's identical to OriginalFileIDEQ.
+func OriginalFileID(v string) predicate.TrustCenterDoc {
+	return predicate.TrustCenterDoc(sql.FieldEQ(FieldOriginalFileID, v))
+}
+
+// WatermarkingEnabled applies equality check predicate on the "watermarking_enabled" field. It's identical to WatermarkingEnabledEQ.
+func WatermarkingEnabled(v bool) predicate.TrustCenterDoc {
+	return predicate.TrustCenterDoc(sql.FieldEQ(FieldWatermarkingEnabled, v))
+}
+
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
 func CreatedAtEQ(v time.Time) predicate.TrustCenterDoc {
 	return predicate.TrustCenterDoc(sql.FieldEQ(FieldCreatedAt, v))
@@ -783,6 +793,131 @@ func FileIDContainsFold(v string) predicate.TrustCenterDoc {
 	return predicate.TrustCenterDoc(sql.FieldContainsFold(FieldFileID, v))
 }
 
+// OriginalFileIDEQ applies the EQ predicate on the "original_file_id" field.
+func OriginalFileIDEQ(v string) predicate.TrustCenterDoc {
+	return predicate.TrustCenterDoc(sql.FieldEQ(FieldOriginalFileID, v))
+}
+
+// OriginalFileIDNEQ applies the NEQ predicate on the "original_file_id" field.
+func OriginalFileIDNEQ(v string) predicate.TrustCenterDoc {
+	return predicate.TrustCenterDoc(sql.FieldNEQ(FieldOriginalFileID, v))
+}
+
+// OriginalFileIDIn applies the In predicate on the "original_file_id" field.
+func OriginalFileIDIn(vs ...string) predicate.TrustCenterDoc {
+	return predicate.TrustCenterDoc(sql.FieldIn(FieldOriginalFileID, vs...))
+}
+
+// OriginalFileIDNotIn applies the NotIn predicate on the "original_file_id" field.
+func OriginalFileIDNotIn(vs ...string) predicate.TrustCenterDoc {
+	return predicate.TrustCenterDoc(sql.FieldNotIn(FieldOriginalFileID, vs...))
+}
+
+// OriginalFileIDGT applies the GT predicate on the "original_file_id" field.
+func OriginalFileIDGT(v string) predicate.TrustCenterDoc {
+	return predicate.TrustCenterDoc(sql.FieldGT(FieldOriginalFileID, v))
+}
+
+// OriginalFileIDGTE applies the GTE predicate on the "original_file_id" field.
+func OriginalFileIDGTE(v string) predicate.TrustCenterDoc {
+	return predicate.TrustCenterDoc(sql.FieldGTE(FieldOriginalFileID, v))
+}
+
+// OriginalFileIDLT applies the LT predicate on the "original_file_id" field.
+func OriginalFileIDLT(v string) predicate.TrustCenterDoc {
+	return predicate.TrustCenterDoc(sql.FieldLT(FieldOriginalFileID, v))
+}
+
+// OriginalFileIDLTE applies the LTE predicate on the "original_file_id" field.
+func OriginalFileIDLTE(v string) predicate.TrustCenterDoc {
+	return predicate.TrustCenterDoc(sql.FieldLTE(FieldOriginalFileID, v))
+}
+
+// OriginalFileIDContains applies the Contains predicate on the "original_file_id" field.
+func OriginalFileIDContains(v string) predicate.TrustCenterDoc {
+	return predicate.TrustCenterDoc(sql.FieldContains(FieldOriginalFileID, v))
+}
+
+// OriginalFileIDHasPrefix applies the HasPrefix predicate on the "original_file_id" field.
+func OriginalFileIDHasPrefix(v string) predicate.TrustCenterDoc {
+	return predicate.TrustCenterDoc(sql.FieldHasPrefix(FieldOriginalFileID, v))
+}
+
+// OriginalFileIDHasSuffix applies the HasSuffix predicate on the "original_file_id" field.
+func OriginalFileIDHasSuffix(v string) predicate.TrustCenterDoc {
+	return predicate.TrustCenterDoc(sql.FieldHasSuffix(FieldOriginalFileID, v))
+}
+
+// OriginalFileIDIsNil applies the IsNil predicate on the "original_file_id" field.
+func OriginalFileIDIsNil() predicate.TrustCenterDoc {
+	return predicate.TrustCenterDoc(sql.FieldIsNull(FieldOriginalFileID))
+}
+
+// OriginalFileIDNotNil applies the NotNil predicate on the "original_file_id" field.
+func OriginalFileIDNotNil() predicate.TrustCenterDoc {
+	return predicate.TrustCenterDoc(sql.FieldNotNull(FieldOriginalFileID))
+}
+
+// OriginalFileIDEqualFold applies the EqualFold predicate on the "original_file_id" field.
+func OriginalFileIDEqualFold(v string) predicate.TrustCenterDoc {
+	return predicate.TrustCenterDoc(sql.FieldEqualFold(FieldOriginalFileID, v))
+}
+
+// OriginalFileIDContainsFold applies the ContainsFold predicate on the "original_file_id" field.
+func OriginalFileIDContainsFold(v string) predicate.TrustCenterDoc {
+	return predicate.TrustCenterDoc(sql.FieldContainsFold(FieldOriginalFileID, v))
+}
+
+// WatermarkingEnabledEQ applies the EQ predicate on the "watermarking_enabled" field.
+func WatermarkingEnabledEQ(v bool) predicate.TrustCenterDoc {
+	return predicate.TrustCenterDoc(sql.FieldEQ(FieldWatermarkingEnabled, v))
+}
+
+// WatermarkingEnabledNEQ applies the NEQ predicate on the "watermarking_enabled" field.
+func WatermarkingEnabledNEQ(v bool) predicate.TrustCenterDoc {
+	return predicate.TrustCenterDoc(sql.FieldNEQ(FieldWatermarkingEnabled, v))
+}
+
+// WatermarkStatusEQ applies the EQ predicate on the "watermark_status" field.
+func WatermarkStatusEQ(v enums.WatermarkStatus) predicate.TrustCenterDoc {
+	vc := v
+	return predicate.TrustCenterDoc(sql.FieldEQ(FieldWatermarkStatus, vc))
+}
+
+// WatermarkStatusNEQ applies the NEQ predicate on the "watermark_status" field.
+func WatermarkStatusNEQ(v enums.WatermarkStatus) predicate.TrustCenterDoc {
+	vc := v
+	return predicate.TrustCenterDoc(sql.FieldNEQ(FieldWatermarkStatus, vc))
+}
+
+// WatermarkStatusIn applies the In predicate on the "watermark_status" field.
+func WatermarkStatusIn(vs ...enums.WatermarkStatus) predicate.TrustCenterDoc {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.TrustCenterDoc(sql.FieldIn(FieldWatermarkStatus, v...))
+}
+
+// WatermarkStatusNotIn applies the NotIn predicate on the "watermark_status" field.
+func WatermarkStatusNotIn(vs ...enums.WatermarkStatus) predicate.TrustCenterDoc {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.TrustCenterDoc(sql.FieldNotIn(FieldWatermarkStatus, v...))
+}
+
+// WatermarkStatusIsNil applies the IsNil predicate on the "watermark_status" field.
+func WatermarkStatusIsNil() predicate.TrustCenterDoc {
+	return predicate.TrustCenterDoc(sql.FieldIsNull(FieldWatermarkStatus))
+}
+
+// WatermarkStatusNotNil applies the NotNil predicate on the "watermark_status" field.
+func WatermarkStatusNotNil() predicate.TrustCenterDoc {
+	return predicate.TrustCenterDoc(sql.FieldNotNull(FieldWatermarkStatus))
+}
+
 // VisibilityEQ applies the EQ predicate on the "visibility" field.
 func VisibilityEQ(v enums.TrustCenterDocumentVisibility) predicate.TrustCenterDoc {
 	vc := v
@@ -870,6 +1005,35 @@ func HasFile() predicate.TrustCenterDoc {
 func HasFileWith(preds ...predicate.File) predicate.TrustCenterDoc {
 	return predicate.TrustCenterDoc(func(s *sql.Selector) {
 		step := newFileStep()
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.File
+		step.Edge.Schema = schemaConfig.TrustCenterDoc
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasOriginalFile applies the HasEdge predicate on the "original_file" edge.
+func HasOriginalFile() predicate.TrustCenterDoc {
+	return predicate.TrustCenterDoc(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, false, OriginalFileTable, OriginalFileColumn),
+		)
+		schemaConfig := internal.SchemaConfigFromContext(s.Context())
+		step.To.Schema = schemaConfig.File
+		step.Edge.Schema = schemaConfig.TrustCenterDoc
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasOriginalFileWith applies the HasEdge predicate on the "original_file" edge with a given conditions (other predicates).
+func HasOriginalFileWith(preds ...predicate.File) predicate.TrustCenterDoc {
+	return predicate.TrustCenterDoc(func(s *sql.Selector) {
+		step := newOriginalFileStep()
 		schemaConfig := internal.SchemaConfigFromContext(s.Context())
 		step.To.Schema = schemaConfig.File
 		step.Edge.Schema = schemaConfig.TrustCenterDoc

--- a/internal/ent/generated/trustcenterdoc_create.go
+++ b/internal/ent/generated/trustcenterdoc_create.go
@@ -153,6 +153,48 @@ func (_c *TrustCenterDocCreate) SetNillableFileID(v *string) *TrustCenterDocCrea
 	return _c
 }
 
+// SetOriginalFileID sets the "original_file_id" field.
+func (_c *TrustCenterDocCreate) SetOriginalFileID(v string) *TrustCenterDocCreate {
+	_c.mutation.SetOriginalFileID(v)
+	return _c
+}
+
+// SetNillableOriginalFileID sets the "original_file_id" field if the given value is not nil.
+func (_c *TrustCenterDocCreate) SetNillableOriginalFileID(v *string) *TrustCenterDocCreate {
+	if v != nil {
+		_c.SetOriginalFileID(*v)
+	}
+	return _c
+}
+
+// SetWatermarkingEnabled sets the "watermarking_enabled" field.
+func (_c *TrustCenterDocCreate) SetWatermarkingEnabled(v bool) *TrustCenterDocCreate {
+	_c.mutation.SetWatermarkingEnabled(v)
+	return _c
+}
+
+// SetNillableWatermarkingEnabled sets the "watermarking_enabled" field if the given value is not nil.
+func (_c *TrustCenterDocCreate) SetNillableWatermarkingEnabled(v *bool) *TrustCenterDocCreate {
+	if v != nil {
+		_c.SetWatermarkingEnabled(*v)
+	}
+	return _c
+}
+
+// SetWatermarkStatus sets the "watermark_status" field.
+func (_c *TrustCenterDocCreate) SetWatermarkStatus(v enums.WatermarkStatus) *TrustCenterDocCreate {
+	_c.mutation.SetWatermarkStatus(v)
+	return _c
+}
+
+// SetNillableWatermarkStatus sets the "watermark_status" field if the given value is not nil.
+func (_c *TrustCenterDocCreate) SetNillableWatermarkStatus(v *enums.WatermarkStatus) *TrustCenterDocCreate {
+	if v != nil {
+		_c.SetWatermarkStatus(*v)
+	}
+	return _c
+}
+
 // SetVisibility sets the "visibility" field.
 func (_c *TrustCenterDocCreate) SetVisibility(v enums.TrustCenterDocumentVisibility) *TrustCenterDocCreate {
 	_c.mutation.SetVisibility(v)
@@ -189,6 +231,11 @@ func (_c *TrustCenterDocCreate) SetTrustCenter(v *TrustCenter) *TrustCenterDocCr
 // SetFile sets the "file" edge to the File entity.
 func (_c *TrustCenterDocCreate) SetFile(v *File) *TrustCenterDocCreate {
 	return _c.SetFileID(v.ID)
+}
+
+// SetOriginalFile sets the "original_file" edge to the File entity.
+func (_c *TrustCenterDocCreate) SetOriginalFile(v *File) *TrustCenterDocCreate {
+	return _c.SetOriginalFileID(v.ID)
 }
 
 // Mutation returns the TrustCenterDocMutation object of the builder.
@@ -246,6 +293,14 @@ func (_c *TrustCenterDocCreate) defaults() error {
 		v := trustcenterdoc.DefaultTags
 		_c.mutation.SetTags(v)
 	}
+	if _, ok := _c.mutation.WatermarkingEnabled(); !ok {
+		v := trustcenterdoc.DefaultWatermarkingEnabled
+		_c.mutation.SetWatermarkingEnabled(v)
+	}
+	if _, ok := _c.mutation.WatermarkStatus(); !ok {
+		v := trustcenterdoc.DefaultWatermarkStatus
+		_c.mutation.SetWatermarkStatus(v)
+	}
 	if _, ok := _c.mutation.Visibility(); !ok {
 		v := trustcenterdoc.DefaultVisibility
 		_c.mutation.SetVisibility(v)
@@ -281,6 +336,14 @@ func (_c *TrustCenterDocCreate) check() error {
 	if v, ok := _c.mutation.Category(); ok {
 		if err := trustcenterdoc.CategoryValidator(v); err != nil {
 			return &ValidationError{Name: "category", err: fmt.Errorf(`generated: validator failed for field "TrustCenterDoc.category": %w`, err)}
+		}
+	}
+	if _, ok := _c.mutation.WatermarkingEnabled(); !ok {
+		return &ValidationError{Name: "watermarking_enabled", err: errors.New(`generated: missing required field "TrustCenterDoc.watermarking_enabled"`)}
+	}
+	if v, ok := _c.mutation.WatermarkStatus(); ok {
+		if err := trustcenterdoc.WatermarkStatusValidator(v); err != nil {
+			return &ValidationError{Name: "watermark_status", err: fmt.Errorf(`generated: validator failed for field "TrustCenterDoc.watermark_status": %w`, err)}
 		}
 	}
 	if v, ok := _c.mutation.Visibility(); ok {
@@ -360,6 +423,14 @@ func (_c *TrustCenterDocCreate) createSpec() (*TrustCenterDoc, *sqlgraph.CreateS
 		_spec.SetField(trustcenterdoc.FieldCategory, field.TypeString, value)
 		_node.Category = value
 	}
+	if value, ok := _c.mutation.WatermarkingEnabled(); ok {
+		_spec.SetField(trustcenterdoc.FieldWatermarkingEnabled, field.TypeBool, value)
+		_node.WatermarkingEnabled = value
+	}
+	if value, ok := _c.mutation.WatermarkStatus(); ok {
+		_spec.SetField(trustcenterdoc.FieldWatermarkStatus, field.TypeEnum, value)
+		_node.WatermarkStatus = value
+	}
 	if value, ok := _c.mutation.Visibility(); ok {
 		_spec.SetField(trustcenterdoc.FieldVisibility, field.TypeEnum, value)
 		_node.Visibility = value
@@ -398,6 +469,24 @@ func (_c *TrustCenterDocCreate) createSpec() (*TrustCenterDoc, *sqlgraph.CreateS
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
 		_node.FileID = &nodes[0]
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := _c.mutation.OriginalFileIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: false,
+			Table:   trustcenterdoc.OriginalFileTable,
+			Columns: []string{trustcenterdoc.OriginalFileColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(file.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = _c.schemaConfig.TrustCenterDoc
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_node.OriginalFileID = &nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	return _node, _spec

--- a/internal/ent/generated/trustcenterdoc_update.go
+++ b/internal/ent/generated/trustcenterdoc_update.go
@@ -193,6 +193,60 @@ func (_u *TrustCenterDocUpdate) ClearFileID() *TrustCenterDocUpdate {
 	return _u
 }
 
+// SetOriginalFileID sets the "original_file_id" field.
+func (_u *TrustCenterDocUpdate) SetOriginalFileID(v string) *TrustCenterDocUpdate {
+	_u.mutation.SetOriginalFileID(v)
+	return _u
+}
+
+// SetNillableOriginalFileID sets the "original_file_id" field if the given value is not nil.
+func (_u *TrustCenterDocUpdate) SetNillableOriginalFileID(v *string) *TrustCenterDocUpdate {
+	if v != nil {
+		_u.SetOriginalFileID(*v)
+	}
+	return _u
+}
+
+// ClearOriginalFileID clears the value of the "original_file_id" field.
+func (_u *TrustCenterDocUpdate) ClearOriginalFileID() *TrustCenterDocUpdate {
+	_u.mutation.ClearOriginalFileID()
+	return _u
+}
+
+// SetWatermarkingEnabled sets the "watermarking_enabled" field.
+func (_u *TrustCenterDocUpdate) SetWatermarkingEnabled(v bool) *TrustCenterDocUpdate {
+	_u.mutation.SetWatermarkingEnabled(v)
+	return _u
+}
+
+// SetNillableWatermarkingEnabled sets the "watermarking_enabled" field if the given value is not nil.
+func (_u *TrustCenterDocUpdate) SetNillableWatermarkingEnabled(v *bool) *TrustCenterDocUpdate {
+	if v != nil {
+		_u.SetWatermarkingEnabled(*v)
+	}
+	return _u
+}
+
+// SetWatermarkStatus sets the "watermark_status" field.
+func (_u *TrustCenterDocUpdate) SetWatermarkStatus(v enums.WatermarkStatus) *TrustCenterDocUpdate {
+	_u.mutation.SetWatermarkStatus(v)
+	return _u
+}
+
+// SetNillableWatermarkStatus sets the "watermark_status" field if the given value is not nil.
+func (_u *TrustCenterDocUpdate) SetNillableWatermarkStatus(v *enums.WatermarkStatus) *TrustCenterDocUpdate {
+	if v != nil {
+		_u.SetWatermarkStatus(*v)
+	}
+	return _u
+}
+
+// ClearWatermarkStatus clears the value of the "watermark_status" field.
+func (_u *TrustCenterDocUpdate) ClearWatermarkStatus() *TrustCenterDocUpdate {
+	_u.mutation.ClearWatermarkStatus()
+	return _u
+}
+
 // SetVisibility sets the "visibility" field.
 func (_u *TrustCenterDocUpdate) SetVisibility(v enums.TrustCenterDocumentVisibility) *TrustCenterDocUpdate {
 	_u.mutation.SetVisibility(v)
@@ -223,6 +277,11 @@ func (_u *TrustCenterDocUpdate) SetFile(v *File) *TrustCenterDocUpdate {
 	return _u.SetFileID(v.ID)
 }
 
+// SetOriginalFile sets the "original_file" edge to the File entity.
+func (_u *TrustCenterDocUpdate) SetOriginalFile(v *File) *TrustCenterDocUpdate {
+	return _u.SetOriginalFileID(v.ID)
+}
+
 // Mutation returns the TrustCenterDocMutation object of the builder.
 func (_u *TrustCenterDocUpdate) Mutation() *TrustCenterDocMutation {
 	return _u.mutation
@@ -237,6 +296,12 @@ func (_u *TrustCenterDocUpdate) ClearTrustCenter() *TrustCenterDocUpdate {
 // ClearFile clears the "file" edge to the File entity.
 func (_u *TrustCenterDocUpdate) ClearFile() *TrustCenterDocUpdate {
 	_u.mutation.ClearFile()
+	return _u
+}
+
+// ClearOriginalFile clears the "original_file" edge to the File entity.
+func (_u *TrustCenterDocUpdate) ClearOriginalFile() *TrustCenterDocUpdate {
+	_u.mutation.ClearOriginalFile()
 	return _u
 }
 
@@ -297,6 +362,11 @@ func (_u *TrustCenterDocUpdate) check() error {
 	if v, ok := _u.mutation.Category(); ok {
 		if err := trustcenterdoc.CategoryValidator(v); err != nil {
 			return &ValidationError{Name: "category", err: fmt.Errorf(`generated: validator failed for field "TrustCenterDoc.category": %w`, err)}
+		}
+	}
+	if v, ok := _u.mutation.WatermarkStatus(); ok {
+		if err := trustcenterdoc.WatermarkStatusValidator(v); err != nil {
+			return &ValidationError{Name: "watermark_status", err: fmt.Errorf(`generated: validator failed for field "TrustCenterDoc.watermark_status": %w`, err)}
 		}
 	}
 	if v, ok := _u.mutation.Visibility(); ok {
@@ -372,6 +442,15 @@ func (_u *TrustCenterDocUpdate) sqlSave(ctx context.Context) (_node int, err err
 	if value, ok := _u.mutation.Category(); ok {
 		_spec.SetField(trustcenterdoc.FieldCategory, field.TypeString, value)
 	}
+	if value, ok := _u.mutation.WatermarkingEnabled(); ok {
+		_spec.SetField(trustcenterdoc.FieldWatermarkingEnabled, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.WatermarkStatus(); ok {
+		_spec.SetField(trustcenterdoc.FieldWatermarkStatus, field.TypeEnum, value)
+	}
+	if _u.mutation.WatermarkStatusCleared() {
+		_spec.ClearField(trustcenterdoc.FieldWatermarkStatus, field.TypeEnum)
+	}
 	if value, ok := _u.mutation.Visibility(); ok {
 		_spec.SetField(trustcenterdoc.FieldVisibility, field.TypeEnum, value)
 	}
@@ -429,6 +508,37 @@ func (_u *TrustCenterDocUpdate) sqlSave(ctx context.Context) (_node int, err err
 			Inverse: false,
 			Table:   trustcenterdoc.FileTable,
 			Columns: []string{trustcenterdoc.FileColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(file.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = _u.schemaConfig.TrustCenterDoc
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.OriginalFileCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: false,
+			Table:   trustcenterdoc.OriginalFileTable,
+			Columns: []string{trustcenterdoc.OriginalFileColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(file.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = _u.schemaConfig.TrustCenterDoc
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.OriginalFileIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: false,
+			Table:   trustcenterdoc.OriginalFileTable,
+			Columns: []string{trustcenterdoc.OriginalFileColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(file.FieldID, field.TypeString),
@@ -622,6 +732,60 @@ func (_u *TrustCenterDocUpdateOne) ClearFileID() *TrustCenterDocUpdateOne {
 	return _u
 }
 
+// SetOriginalFileID sets the "original_file_id" field.
+func (_u *TrustCenterDocUpdateOne) SetOriginalFileID(v string) *TrustCenterDocUpdateOne {
+	_u.mutation.SetOriginalFileID(v)
+	return _u
+}
+
+// SetNillableOriginalFileID sets the "original_file_id" field if the given value is not nil.
+func (_u *TrustCenterDocUpdateOne) SetNillableOriginalFileID(v *string) *TrustCenterDocUpdateOne {
+	if v != nil {
+		_u.SetOriginalFileID(*v)
+	}
+	return _u
+}
+
+// ClearOriginalFileID clears the value of the "original_file_id" field.
+func (_u *TrustCenterDocUpdateOne) ClearOriginalFileID() *TrustCenterDocUpdateOne {
+	_u.mutation.ClearOriginalFileID()
+	return _u
+}
+
+// SetWatermarkingEnabled sets the "watermarking_enabled" field.
+func (_u *TrustCenterDocUpdateOne) SetWatermarkingEnabled(v bool) *TrustCenterDocUpdateOne {
+	_u.mutation.SetWatermarkingEnabled(v)
+	return _u
+}
+
+// SetNillableWatermarkingEnabled sets the "watermarking_enabled" field if the given value is not nil.
+func (_u *TrustCenterDocUpdateOne) SetNillableWatermarkingEnabled(v *bool) *TrustCenterDocUpdateOne {
+	if v != nil {
+		_u.SetWatermarkingEnabled(*v)
+	}
+	return _u
+}
+
+// SetWatermarkStatus sets the "watermark_status" field.
+func (_u *TrustCenterDocUpdateOne) SetWatermarkStatus(v enums.WatermarkStatus) *TrustCenterDocUpdateOne {
+	_u.mutation.SetWatermarkStatus(v)
+	return _u
+}
+
+// SetNillableWatermarkStatus sets the "watermark_status" field if the given value is not nil.
+func (_u *TrustCenterDocUpdateOne) SetNillableWatermarkStatus(v *enums.WatermarkStatus) *TrustCenterDocUpdateOne {
+	if v != nil {
+		_u.SetWatermarkStatus(*v)
+	}
+	return _u
+}
+
+// ClearWatermarkStatus clears the value of the "watermark_status" field.
+func (_u *TrustCenterDocUpdateOne) ClearWatermarkStatus() *TrustCenterDocUpdateOne {
+	_u.mutation.ClearWatermarkStatus()
+	return _u
+}
+
 // SetVisibility sets the "visibility" field.
 func (_u *TrustCenterDocUpdateOne) SetVisibility(v enums.TrustCenterDocumentVisibility) *TrustCenterDocUpdateOne {
 	_u.mutation.SetVisibility(v)
@@ -652,6 +816,11 @@ func (_u *TrustCenterDocUpdateOne) SetFile(v *File) *TrustCenterDocUpdateOne {
 	return _u.SetFileID(v.ID)
 }
 
+// SetOriginalFile sets the "original_file" edge to the File entity.
+func (_u *TrustCenterDocUpdateOne) SetOriginalFile(v *File) *TrustCenterDocUpdateOne {
+	return _u.SetOriginalFileID(v.ID)
+}
+
 // Mutation returns the TrustCenterDocMutation object of the builder.
 func (_u *TrustCenterDocUpdateOne) Mutation() *TrustCenterDocMutation {
 	return _u.mutation
@@ -666,6 +835,12 @@ func (_u *TrustCenterDocUpdateOne) ClearTrustCenter() *TrustCenterDocUpdateOne {
 // ClearFile clears the "file" edge to the File entity.
 func (_u *TrustCenterDocUpdateOne) ClearFile() *TrustCenterDocUpdateOne {
 	_u.mutation.ClearFile()
+	return _u
+}
+
+// ClearOriginalFile clears the "original_file" edge to the File entity.
+func (_u *TrustCenterDocUpdateOne) ClearOriginalFile() *TrustCenterDocUpdateOne {
+	_u.mutation.ClearOriginalFile()
 	return _u
 }
 
@@ -739,6 +914,11 @@ func (_u *TrustCenterDocUpdateOne) check() error {
 	if v, ok := _u.mutation.Category(); ok {
 		if err := trustcenterdoc.CategoryValidator(v); err != nil {
 			return &ValidationError{Name: "category", err: fmt.Errorf(`generated: validator failed for field "TrustCenterDoc.category": %w`, err)}
+		}
+	}
+	if v, ok := _u.mutation.WatermarkStatus(); ok {
+		if err := trustcenterdoc.WatermarkStatusValidator(v); err != nil {
+			return &ValidationError{Name: "watermark_status", err: fmt.Errorf(`generated: validator failed for field "TrustCenterDoc.watermark_status": %w`, err)}
 		}
 	}
 	if v, ok := _u.mutation.Visibility(); ok {
@@ -831,6 +1011,15 @@ func (_u *TrustCenterDocUpdateOne) sqlSave(ctx context.Context) (_node *TrustCen
 	if value, ok := _u.mutation.Category(); ok {
 		_spec.SetField(trustcenterdoc.FieldCategory, field.TypeString, value)
 	}
+	if value, ok := _u.mutation.WatermarkingEnabled(); ok {
+		_spec.SetField(trustcenterdoc.FieldWatermarkingEnabled, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.WatermarkStatus(); ok {
+		_spec.SetField(trustcenterdoc.FieldWatermarkStatus, field.TypeEnum, value)
+	}
+	if _u.mutation.WatermarkStatusCleared() {
+		_spec.ClearField(trustcenterdoc.FieldWatermarkStatus, field.TypeEnum)
+	}
 	if value, ok := _u.mutation.Visibility(); ok {
 		_spec.SetField(trustcenterdoc.FieldVisibility, field.TypeEnum, value)
 	}
@@ -888,6 +1077,37 @@ func (_u *TrustCenterDocUpdateOne) sqlSave(ctx context.Context) (_node *TrustCen
 			Inverse: false,
 			Table:   trustcenterdoc.FileTable,
 			Columns: []string{trustcenterdoc.FileColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(file.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = _u.schemaConfig.TrustCenterDoc
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.OriginalFileCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: false,
+			Table:   trustcenterdoc.OriginalFileTable,
+			Columns: []string{trustcenterdoc.OriginalFileColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(file.FieldID, field.TypeString),
+			},
+		}
+		edge.Schema = _u.schemaConfig.TrustCenterDoc
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.OriginalFileIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: false,
+			Table:   trustcenterdoc.OriginalFileTable,
+			Columns: []string{trustcenterdoc.OriginalFileColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(file.FieldID, field.TypeString),

--- a/internal/ent/generated/trustcenterdochistory.go
+++ b/internal/ent/generated/trustcenterdochistory.go
@@ -48,6 +48,12 @@ type TrustCenterDocHistory struct {
 	Category string `json:"category,omitempty"`
 	// ID of the file containing the document
 	FileID *string `json:"file_id,omitempty"`
+	// ID of the file containing the document, before any watermarking
+	OriginalFileID *string `json:"original_file_id,omitempty"`
+	// whether watermarking is enabled for the document. this will only take effect if watermarking is configured for the trust center
+	WatermarkingEnabled bool `json:"watermarking_enabled,omitempty"`
+	// status of the watermarking
+	WatermarkStatus enums.WatermarkStatus `json:"watermark_status,omitempty"`
 	// visibility of the document
 	Visibility   enums.TrustCenterDocumentVisibility `json:"visibility,omitempty"`
 	selectValues sql.SelectValues
@@ -62,7 +68,9 @@ func (*TrustCenterDocHistory) scanValues(columns []string) ([]any, error) {
 			values[i] = new([]byte)
 		case trustcenterdochistory.FieldOperation:
 			values[i] = new(history.OpType)
-		case trustcenterdochistory.FieldID, trustcenterdochistory.FieldRef, trustcenterdochistory.FieldCreatedBy, trustcenterdochistory.FieldUpdatedBy, trustcenterdochistory.FieldDeletedBy, trustcenterdochistory.FieldTrustCenterID, trustcenterdochistory.FieldTitle, trustcenterdochistory.FieldCategory, trustcenterdochistory.FieldFileID, trustcenterdochistory.FieldVisibility:
+		case trustcenterdochistory.FieldWatermarkingEnabled:
+			values[i] = new(sql.NullBool)
+		case trustcenterdochistory.FieldID, trustcenterdochistory.FieldRef, trustcenterdochistory.FieldCreatedBy, trustcenterdochistory.FieldUpdatedBy, trustcenterdochistory.FieldDeletedBy, trustcenterdochistory.FieldTrustCenterID, trustcenterdochistory.FieldTitle, trustcenterdochistory.FieldCategory, trustcenterdochistory.FieldFileID, trustcenterdochistory.FieldOriginalFileID, trustcenterdochistory.FieldWatermarkStatus, trustcenterdochistory.FieldVisibility:
 			values[i] = new(sql.NullString)
 		case trustcenterdochistory.FieldHistoryTime, trustcenterdochistory.FieldCreatedAt, trustcenterdochistory.FieldUpdatedAt, trustcenterdochistory.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
@@ -174,6 +182,25 @@ func (_m *TrustCenterDocHistory) assignValues(columns []string, values []any) er
 				_m.FileID = new(string)
 				*_m.FileID = value.String
 			}
+		case trustcenterdochistory.FieldOriginalFileID:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field original_file_id", values[i])
+			} else if value.Valid {
+				_m.OriginalFileID = new(string)
+				*_m.OriginalFileID = value.String
+			}
+		case trustcenterdochistory.FieldWatermarkingEnabled:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field watermarking_enabled", values[i])
+			} else if value.Valid {
+				_m.WatermarkingEnabled = value.Bool
+			}
+		case trustcenterdochistory.FieldWatermarkStatus:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field watermark_status", values[i])
+			} else if value.Valid {
+				_m.WatermarkStatus = enums.WatermarkStatus(value.String)
+			}
 		case trustcenterdochistory.FieldVisibility:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field visibility", values[i])
@@ -259,6 +286,17 @@ func (_m *TrustCenterDocHistory) String() string {
 		builder.WriteString("file_id=")
 		builder.WriteString(*v)
 	}
+	builder.WriteString(", ")
+	if v := _m.OriginalFileID; v != nil {
+		builder.WriteString("original_file_id=")
+		builder.WriteString(*v)
+	}
+	builder.WriteString(", ")
+	builder.WriteString("watermarking_enabled=")
+	builder.WriteString(fmt.Sprintf("%v", _m.WatermarkingEnabled))
+	builder.WriteString(", ")
+	builder.WriteString("watermark_status=")
+	builder.WriteString(fmt.Sprintf("%v", _m.WatermarkStatus))
 	builder.WriteString(", ")
 	builder.WriteString("visibility=")
 	builder.WriteString(fmt.Sprintf("%v", _m.Visibility))

--- a/internal/ent/generated/trustcenterdochistory/trustcenterdochistory.go
+++ b/internal/ent/generated/trustcenterdochistory/trustcenterdochistory.go
@@ -46,6 +46,12 @@ const (
 	FieldCategory = "category"
 	// FieldFileID holds the string denoting the file_id field in the database.
 	FieldFileID = "file_id"
+	// FieldOriginalFileID holds the string denoting the original_file_id field in the database.
+	FieldOriginalFileID = "original_file_id"
+	// FieldWatermarkingEnabled holds the string denoting the watermarking_enabled field in the database.
+	FieldWatermarkingEnabled = "watermarking_enabled"
+	// FieldWatermarkStatus holds the string denoting the watermark_status field in the database.
+	FieldWatermarkStatus = "watermark_status"
 	// FieldVisibility holds the string denoting the visibility field in the database.
 	FieldVisibility = "visibility"
 	// Table holds the table name of the trustcenterdochistory in the database.
@@ -69,6 +75,9 @@ var Columns = []string{
 	FieldTitle,
 	FieldCategory,
 	FieldFileID,
+	FieldOriginalFileID,
+	FieldWatermarkingEnabled,
+	FieldWatermarkStatus,
 	FieldVisibility,
 }
 
@@ -101,6 +110,8 @@ var (
 	UpdateDefaultUpdatedAt func() time.Time
 	// DefaultTags holds the default value on creation for the "tags" field.
 	DefaultTags []string
+	// DefaultWatermarkingEnabled holds the default value on creation for the "watermarking_enabled" field.
+	DefaultWatermarkingEnabled bool
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() string
 )
@@ -112,6 +123,18 @@ func OperationValidator(o history.OpType) error {
 		return nil
 	default:
 		return fmt.Errorf("trustcenterdochistory: invalid enum value for operation field: %q", o)
+	}
+}
+
+const DefaultWatermarkStatus enums.WatermarkStatus = "DISABLED"
+
+// WatermarkStatusValidator is a validator for the "watermark_status" field enum values. It is called by the builders before save.
+func WatermarkStatusValidator(ws enums.WatermarkStatus) error {
+	switch ws.String() {
+	case "PENDING", "IN_PROGRESS", "SUCCESS", "FAILED", "DISABLED":
+		return nil
+	default:
+		return fmt.Errorf("trustcenterdochistory: invalid enum value for watermark_status field: %q", ws)
 	}
 }
 
@@ -200,6 +223,21 @@ func ByFileID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldFileID, opts...).ToFunc()
 }
 
+// ByOriginalFileID orders the results by the original_file_id field.
+func ByOriginalFileID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldOriginalFileID, opts...).ToFunc()
+}
+
+// ByWatermarkingEnabled orders the results by the watermarking_enabled field.
+func ByWatermarkingEnabled(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldWatermarkingEnabled, opts...).ToFunc()
+}
+
+// ByWatermarkStatus orders the results by the watermark_status field.
+func ByWatermarkStatus(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldWatermarkStatus, opts...).ToFunc()
+}
+
 // ByVisibility orders the results by the visibility field.
 func ByVisibility(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldVisibility, opts...).ToFunc()
@@ -210,6 +248,13 @@ var (
 	_ graphql.Marshaler = (*history.OpType)(nil)
 	// history.OpType must implement graphql.Unmarshaler.
 	_ graphql.Unmarshaler = (*history.OpType)(nil)
+)
+
+var (
+	// enums.WatermarkStatus must implement graphql.Marshaler.
+	_ graphql.Marshaler = (*enums.WatermarkStatus)(nil)
+	// enums.WatermarkStatus must implement graphql.Unmarshaler.
+	_ graphql.Unmarshaler = (*enums.WatermarkStatus)(nil)
 )
 
 var (

--- a/internal/ent/generated/trustcenterdochistory/where.go
+++ b/internal/ent/generated/trustcenterdochistory/where.go
@@ -126,6 +126,16 @@ func FileID(v string) predicate.TrustCenterDocHistory {
 	return predicate.TrustCenterDocHistory(sql.FieldEQ(FieldFileID, v))
 }
 
+// OriginalFileID applies equality check predicate on the "original_file_id" field. It's identical to OriginalFileIDEQ.
+func OriginalFileID(v string) predicate.TrustCenterDocHistory {
+	return predicate.TrustCenterDocHistory(sql.FieldEQ(FieldOriginalFileID, v))
+}
+
+// WatermarkingEnabled applies equality check predicate on the "watermarking_enabled" field. It's identical to WatermarkingEnabledEQ.
+func WatermarkingEnabled(v bool) predicate.TrustCenterDocHistory {
+	return predicate.TrustCenterDocHistory(sql.FieldEQ(FieldWatermarkingEnabled, v))
+}
+
 // HistoryTimeEQ applies the EQ predicate on the "history_time" field.
 func HistoryTimeEQ(v time.Time) predicate.TrustCenterDocHistory {
 	return predicate.TrustCenterDocHistory(sql.FieldEQ(FieldHistoryTime, v))
@@ -924,6 +934,131 @@ func FileIDEqualFold(v string) predicate.TrustCenterDocHistory {
 // FileIDContainsFold applies the ContainsFold predicate on the "file_id" field.
 func FileIDContainsFold(v string) predicate.TrustCenterDocHistory {
 	return predicate.TrustCenterDocHistory(sql.FieldContainsFold(FieldFileID, v))
+}
+
+// OriginalFileIDEQ applies the EQ predicate on the "original_file_id" field.
+func OriginalFileIDEQ(v string) predicate.TrustCenterDocHistory {
+	return predicate.TrustCenterDocHistory(sql.FieldEQ(FieldOriginalFileID, v))
+}
+
+// OriginalFileIDNEQ applies the NEQ predicate on the "original_file_id" field.
+func OriginalFileIDNEQ(v string) predicate.TrustCenterDocHistory {
+	return predicate.TrustCenterDocHistory(sql.FieldNEQ(FieldOriginalFileID, v))
+}
+
+// OriginalFileIDIn applies the In predicate on the "original_file_id" field.
+func OriginalFileIDIn(vs ...string) predicate.TrustCenterDocHistory {
+	return predicate.TrustCenterDocHistory(sql.FieldIn(FieldOriginalFileID, vs...))
+}
+
+// OriginalFileIDNotIn applies the NotIn predicate on the "original_file_id" field.
+func OriginalFileIDNotIn(vs ...string) predicate.TrustCenterDocHistory {
+	return predicate.TrustCenterDocHistory(sql.FieldNotIn(FieldOriginalFileID, vs...))
+}
+
+// OriginalFileIDGT applies the GT predicate on the "original_file_id" field.
+func OriginalFileIDGT(v string) predicate.TrustCenterDocHistory {
+	return predicate.TrustCenterDocHistory(sql.FieldGT(FieldOriginalFileID, v))
+}
+
+// OriginalFileIDGTE applies the GTE predicate on the "original_file_id" field.
+func OriginalFileIDGTE(v string) predicate.TrustCenterDocHistory {
+	return predicate.TrustCenterDocHistory(sql.FieldGTE(FieldOriginalFileID, v))
+}
+
+// OriginalFileIDLT applies the LT predicate on the "original_file_id" field.
+func OriginalFileIDLT(v string) predicate.TrustCenterDocHistory {
+	return predicate.TrustCenterDocHistory(sql.FieldLT(FieldOriginalFileID, v))
+}
+
+// OriginalFileIDLTE applies the LTE predicate on the "original_file_id" field.
+func OriginalFileIDLTE(v string) predicate.TrustCenterDocHistory {
+	return predicate.TrustCenterDocHistory(sql.FieldLTE(FieldOriginalFileID, v))
+}
+
+// OriginalFileIDContains applies the Contains predicate on the "original_file_id" field.
+func OriginalFileIDContains(v string) predicate.TrustCenterDocHistory {
+	return predicate.TrustCenterDocHistory(sql.FieldContains(FieldOriginalFileID, v))
+}
+
+// OriginalFileIDHasPrefix applies the HasPrefix predicate on the "original_file_id" field.
+func OriginalFileIDHasPrefix(v string) predicate.TrustCenterDocHistory {
+	return predicate.TrustCenterDocHistory(sql.FieldHasPrefix(FieldOriginalFileID, v))
+}
+
+// OriginalFileIDHasSuffix applies the HasSuffix predicate on the "original_file_id" field.
+func OriginalFileIDHasSuffix(v string) predicate.TrustCenterDocHistory {
+	return predicate.TrustCenterDocHistory(sql.FieldHasSuffix(FieldOriginalFileID, v))
+}
+
+// OriginalFileIDIsNil applies the IsNil predicate on the "original_file_id" field.
+func OriginalFileIDIsNil() predicate.TrustCenterDocHistory {
+	return predicate.TrustCenterDocHistory(sql.FieldIsNull(FieldOriginalFileID))
+}
+
+// OriginalFileIDNotNil applies the NotNil predicate on the "original_file_id" field.
+func OriginalFileIDNotNil() predicate.TrustCenterDocHistory {
+	return predicate.TrustCenterDocHistory(sql.FieldNotNull(FieldOriginalFileID))
+}
+
+// OriginalFileIDEqualFold applies the EqualFold predicate on the "original_file_id" field.
+func OriginalFileIDEqualFold(v string) predicate.TrustCenterDocHistory {
+	return predicate.TrustCenterDocHistory(sql.FieldEqualFold(FieldOriginalFileID, v))
+}
+
+// OriginalFileIDContainsFold applies the ContainsFold predicate on the "original_file_id" field.
+func OriginalFileIDContainsFold(v string) predicate.TrustCenterDocHistory {
+	return predicate.TrustCenterDocHistory(sql.FieldContainsFold(FieldOriginalFileID, v))
+}
+
+// WatermarkingEnabledEQ applies the EQ predicate on the "watermarking_enabled" field.
+func WatermarkingEnabledEQ(v bool) predicate.TrustCenterDocHistory {
+	return predicate.TrustCenterDocHistory(sql.FieldEQ(FieldWatermarkingEnabled, v))
+}
+
+// WatermarkingEnabledNEQ applies the NEQ predicate on the "watermarking_enabled" field.
+func WatermarkingEnabledNEQ(v bool) predicate.TrustCenterDocHistory {
+	return predicate.TrustCenterDocHistory(sql.FieldNEQ(FieldWatermarkingEnabled, v))
+}
+
+// WatermarkStatusEQ applies the EQ predicate on the "watermark_status" field.
+func WatermarkStatusEQ(v enums.WatermarkStatus) predicate.TrustCenterDocHistory {
+	vc := v
+	return predicate.TrustCenterDocHistory(sql.FieldEQ(FieldWatermarkStatus, vc))
+}
+
+// WatermarkStatusNEQ applies the NEQ predicate on the "watermark_status" field.
+func WatermarkStatusNEQ(v enums.WatermarkStatus) predicate.TrustCenterDocHistory {
+	vc := v
+	return predicate.TrustCenterDocHistory(sql.FieldNEQ(FieldWatermarkStatus, vc))
+}
+
+// WatermarkStatusIn applies the In predicate on the "watermark_status" field.
+func WatermarkStatusIn(vs ...enums.WatermarkStatus) predicate.TrustCenterDocHistory {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.TrustCenterDocHistory(sql.FieldIn(FieldWatermarkStatus, v...))
+}
+
+// WatermarkStatusNotIn applies the NotIn predicate on the "watermark_status" field.
+func WatermarkStatusNotIn(vs ...enums.WatermarkStatus) predicate.TrustCenterDocHistory {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.TrustCenterDocHistory(sql.FieldNotIn(FieldWatermarkStatus, v...))
+}
+
+// WatermarkStatusIsNil applies the IsNil predicate on the "watermark_status" field.
+func WatermarkStatusIsNil() predicate.TrustCenterDocHistory {
+	return predicate.TrustCenterDocHistory(sql.FieldIsNull(FieldWatermarkStatus))
+}
+
+// WatermarkStatusNotNil applies the NotNil predicate on the "watermark_status" field.
+func WatermarkStatusNotNil() predicate.TrustCenterDocHistory {
+	return predicate.TrustCenterDocHistory(sql.FieldNotNull(FieldWatermarkStatus))
 }
 
 // VisibilityEQ applies the EQ predicate on the "visibility" field.

--- a/internal/ent/generated/trustcenterdochistory_create.go
+++ b/internal/ent/generated/trustcenterdochistory_create.go
@@ -186,6 +186,48 @@ func (_c *TrustCenterDocHistoryCreate) SetNillableFileID(v *string) *TrustCenter
 	return _c
 }
 
+// SetOriginalFileID sets the "original_file_id" field.
+func (_c *TrustCenterDocHistoryCreate) SetOriginalFileID(v string) *TrustCenterDocHistoryCreate {
+	_c.mutation.SetOriginalFileID(v)
+	return _c
+}
+
+// SetNillableOriginalFileID sets the "original_file_id" field if the given value is not nil.
+func (_c *TrustCenterDocHistoryCreate) SetNillableOriginalFileID(v *string) *TrustCenterDocHistoryCreate {
+	if v != nil {
+		_c.SetOriginalFileID(*v)
+	}
+	return _c
+}
+
+// SetWatermarkingEnabled sets the "watermarking_enabled" field.
+func (_c *TrustCenterDocHistoryCreate) SetWatermarkingEnabled(v bool) *TrustCenterDocHistoryCreate {
+	_c.mutation.SetWatermarkingEnabled(v)
+	return _c
+}
+
+// SetNillableWatermarkingEnabled sets the "watermarking_enabled" field if the given value is not nil.
+func (_c *TrustCenterDocHistoryCreate) SetNillableWatermarkingEnabled(v *bool) *TrustCenterDocHistoryCreate {
+	if v != nil {
+		_c.SetWatermarkingEnabled(*v)
+	}
+	return _c
+}
+
+// SetWatermarkStatus sets the "watermark_status" field.
+func (_c *TrustCenterDocHistoryCreate) SetWatermarkStatus(v enums.WatermarkStatus) *TrustCenterDocHistoryCreate {
+	_c.mutation.SetWatermarkStatus(v)
+	return _c
+}
+
+// SetNillableWatermarkStatus sets the "watermark_status" field if the given value is not nil.
+func (_c *TrustCenterDocHistoryCreate) SetNillableWatermarkStatus(v *enums.WatermarkStatus) *TrustCenterDocHistoryCreate {
+	if v != nil {
+		_c.SetWatermarkStatus(*v)
+	}
+	return _c
+}
+
 // SetVisibility sets the "visibility" field.
 func (_c *TrustCenterDocHistoryCreate) SetVisibility(v enums.TrustCenterDocumentVisibility) *TrustCenterDocHistoryCreate {
 	_c.mutation.SetVisibility(v)
@@ -276,6 +318,14 @@ func (_c *TrustCenterDocHistoryCreate) defaults() error {
 		v := trustcenterdochistory.DefaultTags
 		_c.mutation.SetTags(v)
 	}
+	if _, ok := _c.mutation.WatermarkingEnabled(); !ok {
+		v := trustcenterdochistory.DefaultWatermarkingEnabled
+		_c.mutation.SetWatermarkingEnabled(v)
+	}
+	if _, ok := _c.mutation.WatermarkStatus(); !ok {
+		v := trustcenterdochistory.DefaultWatermarkStatus
+		_c.mutation.SetWatermarkStatus(v)
+	}
 	if _, ok := _c.mutation.Visibility(); !ok {
 		v := trustcenterdochistory.DefaultVisibility
 		_c.mutation.SetVisibility(v)
@@ -308,6 +358,14 @@ func (_c *TrustCenterDocHistoryCreate) check() error {
 	}
 	if _, ok := _c.mutation.Category(); !ok {
 		return &ValidationError{Name: "category", err: errors.New(`generated: missing required field "TrustCenterDocHistory.category"`)}
+	}
+	if _, ok := _c.mutation.WatermarkingEnabled(); !ok {
+		return &ValidationError{Name: "watermarking_enabled", err: errors.New(`generated: missing required field "TrustCenterDocHistory.watermarking_enabled"`)}
+	}
+	if v, ok := _c.mutation.WatermarkStatus(); ok {
+		if err := trustcenterdochistory.WatermarkStatusValidator(v); err != nil {
+			return &ValidationError{Name: "watermark_status", err: fmt.Errorf(`generated: validator failed for field "TrustCenterDocHistory.watermark_status": %w`, err)}
+		}
 	}
 	if v, ok := _c.mutation.Visibility(); ok {
 		if err := trustcenterdochistory.VisibilityValidator(v); err != nil {
@@ -405,6 +463,18 @@ func (_c *TrustCenterDocHistoryCreate) createSpec() (*TrustCenterDocHistory, *sq
 	if value, ok := _c.mutation.FileID(); ok {
 		_spec.SetField(trustcenterdochistory.FieldFileID, field.TypeString, value)
 		_node.FileID = &value
+	}
+	if value, ok := _c.mutation.OriginalFileID(); ok {
+		_spec.SetField(trustcenterdochistory.FieldOriginalFileID, field.TypeString, value)
+		_node.OriginalFileID = &value
+	}
+	if value, ok := _c.mutation.WatermarkingEnabled(); ok {
+		_spec.SetField(trustcenterdochistory.FieldWatermarkingEnabled, field.TypeBool, value)
+		_node.WatermarkingEnabled = value
+	}
+	if value, ok := _c.mutation.WatermarkStatus(); ok {
+		_spec.SetField(trustcenterdochistory.FieldWatermarkStatus, field.TypeEnum, value)
+		_node.WatermarkStatus = value
 	}
 	if value, ok := _c.mutation.Visibility(); ok {
 		_spec.SetField(trustcenterdochistory.FieldVisibility, field.TypeEnum, value)

--- a/internal/ent/generated/trustcenterdochistory_update.go
+++ b/internal/ent/generated/trustcenterdochistory_update.go
@@ -191,6 +191,60 @@ func (_u *TrustCenterDocHistoryUpdate) ClearFileID() *TrustCenterDocHistoryUpdat
 	return _u
 }
 
+// SetOriginalFileID sets the "original_file_id" field.
+func (_u *TrustCenterDocHistoryUpdate) SetOriginalFileID(v string) *TrustCenterDocHistoryUpdate {
+	_u.mutation.SetOriginalFileID(v)
+	return _u
+}
+
+// SetNillableOriginalFileID sets the "original_file_id" field if the given value is not nil.
+func (_u *TrustCenterDocHistoryUpdate) SetNillableOriginalFileID(v *string) *TrustCenterDocHistoryUpdate {
+	if v != nil {
+		_u.SetOriginalFileID(*v)
+	}
+	return _u
+}
+
+// ClearOriginalFileID clears the value of the "original_file_id" field.
+func (_u *TrustCenterDocHistoryUpdate) ClearOriginalFileID() *TrustCenterDocHistoryUpdate {
+	_u.mutation.ClearOriginalFileID()
+	return _u
+}
+
+// SetWatermarkingEnabled sets the "watermarking_enabled" field.
+func (_u *TrustCenterDocHistoryUpdate) SetWatermarkingEnabled(v bool) *TrustCenterDocHistoryUpdate {
+	_u.mutation.SetWatermarkingEnabled(v)
+	return _u
+}
+
+// SetNillableWatermarkingEnabled sets the "watermarking_enabled" field if the given value is not nil.
+func (_u *TrustCenterDocHistoryUpdate) SetNillableWatermarkingEnabled(v *bool) *TrustCenterDocHistoryUpdate {
+	if v != nil {
+		_u.SetWatermarkingEnabled(*v)
+	}
+	return _u
+}
+
+// SetWatermarkStatus sets the "watermark_status" field.
+func (_u *TrustCenterDocHistoryUpdate) SetWatermarkStatus(v enums.WatermarkStatus) *TrustCenterDocHistoryUpdate {
+	_u.mutation.SetWatermarkStatus(v)
+	return _u
+}
+
+// SetNillableWatermarkStatus sets the "watermark_status" field if the given value is not nil.
+func (_u *TrustCenterDocHistoryUpdate) SetNillableWatermarkStatus(v *enums.WatermarkStatus) *TrustCenterDocHistoryUpdate {
+	if v != nil {
+		_u.SetWatermarkStatus(*v)
+	}
+	return _u
+}
+
+// ClearWatermarkStatus clears the value of the "watermark_status" field.
+func (_u *TrustCenterDocHistoryUpdate) ClearWatermarkStatus() *TrustCenterDocHistoryUpdate {
+	_u.mutation.ClearWatermarkStatus()
+	return _u
+}
+
 // SetVisibility sets the "visibility" field.
 func (_u *TrustCenterDocHistoryUpdate) SetVisibility(v enums.TrustCenterDocumentVisibility) *TrustCenterDocHistoryUpdate {
 	_u.mutation.SetVisibility(v)
@@ -260,6 +314,11 @@ func (_u *TrustCenterDocHistoryUpdate) defaults() error {
 
 // check runs all checks and user-defined validators on the builder.
 func (_u *TrustCenterDocHistoryUpdate) check() error {
+	if v, ok := _u.mutation.WatermarkStatus(); ok {
+		if err := trustcenterdochistory.WatermarkStatusValidator(v); err != nil {
+			return &ValidationError{Name: "watermark_status", err: fmt.Errorf(`generated: validator failed for field "TrustCenterDocHistory.watermark_status": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.Visibility(); ok {
 		if err := trustcenterdochistory.VisibilityValidator(v); err != nil {
 			return &ValidationError{Name: "visibility", err: fmt.Errorf(`generated: validator failed for field "TrustCenterDocHistory.visibility": %w`, err)}
@@ -347,6 +406,21 @@ func (_u *TrustCenterDocHistoryUpdate) sqlSave(ctx context.Context) (_node int, 
 	}
 	if _u.mutation.FileIDCleared() {
 		_spec.ClearField(trustcenterdochistory.FieldFileID, field.TypeString)
+	}
+	if value, ok := _u.mutation.OriginalFileID(); ok {
+		_spec.SetField(trustcenterdochistory.FieldOriginalFileID, field.TypeString, value)
+	}
+	if _u.mutation.OriginalFileIDCleared() {
+		_spec.ClearField(trustcenterdochistory.FieldOriginalFileID, field.TypeString)
+	}
+	if value, ok := _u.mutation.WatermarkingEnabled(); ok {
+		_spec.SetField(trustcenterdochistory.FieldWatermarkingEnabled, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.WatermarkStatus(); ok {
+		_spec.SetField(trustcenterdochistory.FieldWatermarkStatus, field.TypeEnum, value)
+	}
+	if _u.mutation.WatermarkStatusCleared() {
+		_spec.ClearField(trustcenterdochistory.FieldWatermarkStatus, field.TypeEnum)
 	}
 	if value, ok := _u.mutation.Visibility(); ok {
 		_spec.SetField(trustcenterdochistory.FieldVisibility, field.TypeEnum, value)
@@ -536,6 +610,60 @@ func (_u *TrustCenterDocHistoryUpdateOne) ClearFileID() *TrustCenterDocHistoryUp
 	return _u
 }
 
+// SetOriginalFileID sets the "original_file_id" field.
+func (_u *TrustCenterDocHistoryUpdateOne) SetOriginalFileID(v string) *TrustCenterDocHistoryUpdateOne {
+	_u.mutation.SetOriginalFileID(v)
+	return _u
+}
+
+// SetNillableOriginalFileID sets the "original_file_id" field if the given value is not nil.
+func (_u *TrustCenterDocHistoryUpdateOne) SetNillableOriginalFileID(v *string) *TrustCenterDocHistoryUpdateOne {
+	if v != nil {
+		_u.SetOriginalFileID(*v)
+	}
+	return _u
+}
+
+// ClearOriginalFileID clears the value of the "original_file_id" field.
+func (_u *TrustCenterDocHistoryUpdateOne) ClearOriginalFileID() *TrustCenterDocHistoryUpdateOne {
+	_u.mutation.ClearOriginalFileID()
+	return _u
+}
+
+// SetWatermarkingEnabled sets the "watermarking_enabled" field.
+func (_u *TrustCenterDocHistoryUpdateOne) SetWatermarkingEnabled(v bool) *TrustCenterDocHistoryUpdateOne {
+	_u.mutation.SetWatermarkingEnabled(v)
+	return _u
+}
+
+// SetNillableWatermarkingEnabled sets the "watermarking_enabled" field if the given value is not nil.
+func (_u *TrustCenterDocHistoryUpdateOne) SetNillableWatermarkingEnabled(v *bool) *TrustCenterDocHistoryUpdateOne {
+	if v != nil {
+		_u.SetWatermarkingEnabled(*v)
+	}
+	return _u
+}
+
+// SetWatermarkStatus sets the "watermark_status" field.
+func (_u *TrustCenterDocHistoryUpdateOne) SetWatermarkStatus(v enums.WatermarkStatus) *TrustCenterDocHistoryUpdateOne {
+	_u.mutation.SetWatermarkStatus(v)
+	return _u
+}
+
+// SetNillableWatermarkStatus sets the "watermark_status" field if the given value is not nil.
+func (_u *TrustCenterDocHistoryUpdateOne) SetNillableWatermarkStatus(v *enums.WatermarkStatus) *TrustCenterDocHistoryUpdateOne {
+	if v != nil {
+		_u.SetWatermarkStatus(*v)
+	}
+	return _u
+}
+
+// ClearWatermarkStatus clears the value of the "watermark_status" field.
+func (_u *TrustCenterDocHistoryUpdateOne) ClearWatermarkStatus() *TrustCenterDocHistoryUpdateOne {
+	_u.mutation.ClearWatermarkStatus()
+	return _u
+}
+
 // SetVisibility sets the "visibility" field.
 func (_u *TrustCenterDocHistoryUpdateOne) SetVisibility(v enums.TrustCenterDocumentVisibility) *TrustCenterDocHistoryUpdateOne {
 	_u.mutation.SetVisibility(v)
@@ -618,6 +746,11 @@ func (_u *TrustCenterDocHistoryUpdateOne) defaults() error {
 
 // check runs all checks and user-defined validators on the builder.
 func (_u *TrustCenterDocHistoryUpdateOne) check() error {
+	if v, ok := _u.mutation.WatermarkStatus(); ok {
+		if err := trustcenterdochistory.WatermarkStatusValidator(v); err != nil {
+			return &ValidationError{Name: "watermark_status", err: fmt.Errorf(`generated: validator failed for field "TrustCenterDocHistory.watermark_status": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.Visibility(); ok {
 		if err := trustcenterdochistory.VisibilityValidator(v); err != nil {
 			return &ValidationError{Name: "visibility", err: fmt.Errorf(`generated: validator failed for field "TrustCenterDocHistory.visibility": %w`, err)}
@@ -722,6 +855,21 @@ func (_u *TrustCenterDocHistoryUpdateOne) sqlSave(ctx context.Context) (_node *T
 	}
 	if _u.mutation.FileIDCleared() {
 		_spec.ClearField(trustcenterdochistory.FieldFileID, field.TypeString)
+	}
+	if value, ok := _u.mutation.OriginalFileID(); ok {
+		_spec.SetField(trustcenterdochistory.FieldOriginalFileID, field.TypeString, value)
+	}
+	if _u.mutation.OriginalFileIDCleared() {
+		_spec.ClearField(trustcenterdochistory.FieldOriginalFileID, field.TypeString)
+	}
+	if value, ok := _u.mutation.WatermarkingEnabled(); ok {
+		_spec.SetField(trustcenterdochistory.FieldWatermarkingEnabled, field.TypeBool, value)
+	}
+	if value, ok := _u.mutation.WatermarkStatus(); ok {
+		_spec.SetField(trustcenterdochistory.FieldWatermarkStatus, field.TypeEnum, value)
+	}
+	if _u.mutation.WatermarkStatusCleared() {
+		_spec.ClearField(trustcenterdochistory.FieldWatermarkStatus, field.TypeEnum)
 	}
 	if value, ok := _u.mutation.Visibility(); ok {
 		_spec.SetField(trustcenterdochistory.FieldVisibility, field.TypeEnum, value)

--- a/internal/ent/hooks/trustcenterdoc.go
+++ b/internal/ent/hooks/trustcenterdoc.go
@@ -49,7 +49,9 @@ func HookTrustCenterDoc() ent.Hook {
 			if !ok {
 				return v, nil
 			}
-			// this should never happen
+
+			// TODO: this will happen once watermarking is enabled, and we do this async.
+			// will need to re-write the file viewer logic once this happens
 			if trustCenterDoc.FileID == nil {
 				return nil, errMissingFileID
 			}
@@ -151,6 +153,10 @@ func checkTrustCenterDocFile(ctx context.Context, m *generated.TrustCenterDocMut
 		if len(docFile) > 1 {
 			return ctx, ErrNotSingularUpload
 		}
+		m.SetOriginalFileID(docFile[0].ID)
+
+		// TODO: once the watermarking job is implemented, we will not set the file ID here, and instead kick off a riverboat job to watermark the doc
+		// If watermarking is disabled, we will continue to just set this file ID
 		m.SetFileID(docFile[0].ID)
 
 		docFile[0].Parent.ID, _ = m.ID()

--- a/internal/ent/schema/trustcenterdocument.go
+++ b/internal/ent/schema/trustcenterdocument.go
@@ -61,6 +61,22 @@ func (TrustCenterDoc) Fields() []ent.Field {
 			).
 			Optional().
 			Nillable(),
+		field.String("original_file_id").
+			Comment("ID of the file containing the document, before any watermarking").
+			Annotations(
+				// this field is not exposed to the graphql schema, it is set by the file upload handler
+				entgql.Skip(entgql.SkipMutationCreateInput, entgql.SkipMutationUpdateInput),
+			).
+			Optional().
+			Nillable(),
+		field.Bool("watermarking_enabled").
+			Default(true).
+			Comment("whether watermarking is enabled for the document. this will only take effect if watermarking is configured for the trust center"),
+		field.Enum("watermark_status").
+			GoType(enums.WatermarkStatus("")).
+			Default(enums.WatermarkStatusDisabled.String()).
+			Optional().
+			Comment("status of the watermarking"),
 		field.Enum("visibility").
 			GoType(enums.TrustCenterDocumentVisibility("")).
 			Default(enums.TrustCenterDocumentVisibilityNotVisible.String()).
@@ -93,6 +109,13 @@ func (t TrustCenterDoc) Edges() []ent.Edge {
 			edgeSchema: File{},
 			field:      "file_id",
 			comment:    "the file containing the document content",
+		}),
+		uniqueEdgeTo(&edgeDefinition{
+			name:       "original_file",
+			fromSchema: t,
+			t:          File.Type,
+			field:      "original_file_id",
+			comment:    "the file containing the document content, pre watermarking",
 		}),
 	}
 }

--- a/internal/graphapi/clientschema/schema.graphql
+++ b/internal/graphapi/clientschema/schema.graphql
@@ -10125,11 +10125,20 @@ input CreateTrustCenterDocInput {
 	"""
 	category: String!
 	"""
+	whether watermarking is enabled for the document. this will only take effect if watermarking is configured for the trust center
+	"""
+	watermarkingEnabled: Boolean
+	"""
+	status of the watermarking
+	"""
+	watermarkStatus: TrustCenterDocWatermarkStatus
+	"""
 	visibility of the document
 	"""
 	visibility: TrustCenterDocTrustCenterDocumentVisibility
 	trustCenterID: ID
 	fileID: ID
+	originalFileID: ID
 }
 """
 Input for createTrustCenterDomain mutation
@@ -58251,6 +58260,18 @@ type TrustCenterDoc implements Node {
 	"""
 	fileID: ID
 	"""
+	ID of the file containing the document, before any watermarking
+	"""
+	originalFileID: ID
+	"""
+	whether watermarking is enabled for the document. this will only take effect if watermarking is configured for the trust center
+	"""
+	watermarkingEnabled: Boolean!
+	"""
+	status of the watermarking
+	"""
+	watermarkStatus: TrustCenterDocWatermarkStatus
+	"""
 	visibility of the document
 	"""
 	visibility: TrustCenterDocTrustCenterDocumentVisibility
@@ -58259,6 +58280,10 @@ type TrustCenterDoc implements Node {
 	the file containing the document content
 	"""
 	file: File
+	"""
+	the file containing the document content, pre watermarking
+	"""
+	originalFile: File
 }
 """
 Return response for createBulkTrustCenterDoc mutation
@@ -58347,6 +58372,18 @@ type TrustCenterDocHistory implements Node {
 	"""
 	fileID: String
 	"""
+	ID of the file containing the document, before any watermarking
+	"""
+	originalFileID: String
+	"""
+	whether watermarking is enabled for the document. this will only take effect if watermarking is configured for the trust center
+	"""
+	watermarkingEnabled: Boolean!
+	"""
+	status of the watermarking
+	"""
+	watermarkStatus: TrustCenterDocHistoryWatermarkStatus
+	"""
 	visibility of the document
 	"""
 	visibility: TrustCenterDocHistoryTrustCenterDocumentVisibility
@@ -58417,6 +58454,16 @@ enum TrustCenterDocHistoryTrustCenterDocumentVisibility @goModel(model: "github.
 	PUBLICLY_VISIBLE
 	PROTECTED
 	NOT_VISIBLE
+}
+"""
+TrustCenterDocHistoryWatermarkStatus is enum for the field watermark_status
+"""
+enum TrustCenterDocHistoryWatermarkStatus @goModel(model: "github.com/theopenlane/core/pkg/enums.WatermarkStatus") {
+	PENDING
+	IN_PROGRESS
+	SUCCESS
+	FAILED
+	DISABLED
 }
 """
 TrustCenterDocHistoryWhereInput is used for filtering TrustCenterDocHistory objects.
@@ -58606,6 +58653,38 @@ input TrustCenterDocHistoryWhereInput {
 	fileIDEqualFold: String
 	fileIDContainsFold: String
 	"""
+	original_file_id field predicates
+	"""
+	originalFileID: String
+	originalFileIDNEQ: String
+	originalFileIDIn: [String!]
+	originalFileIDNotIn: [String!]
+	originalFileIDGT: String
+	originalFileIDGTE: String
+	originalFileIDLT: String
+	originalFileIDLTE: String
+	originalFileIDContains: String
+	originalFileIDHasPrefix: String
+	originalFileIDHasSuffix: String
+	originalFileIDIsNil: Boolean
+	originalFileIDNotNil: Boolean
+	originalFileIDEqualFold: String
+	originalFileIDContainsFold: String
+	"""
+	watermarking_enabled field predicates
+	"""
+	watermarkingEnabled: Boolean
+	watermarkingEnabledNEQ: Boolean
+	"""
+	watermark_status field predicates
+	"""
+	watermarkStatus: TrustCenterDocHistoryWatermarkStatus
+	watermarkStatusNEQ: TrustCenterDocHistoryWatermarkStatus
+	watermarkStatusIn: [TrustCenterDocHistoryWatermarkStatus!]
+	watermarkStatusNotIn: [TrustCenterDocHistoryWatermarkStatus!]
+	watermarkStatusIsNil: Boolean
+	watermarkStatusNotNil: Boolean
+	"""
 	visibility field predicates
 	"""
 	visibility: TrustCenterDocHistoryTrustCenterDocumentVisibility
@@ -58651,6 +58730,16 @@ type TrustCenterDocUpdatePayload {
 	Updated trustCenterDoc
 	"""
 	trustCenterDoc: TrustCenterDoc!
+}
+"""
+TrustCenterDocWatermarkStatus is enum for the field watermark_status
+"""
+enum TrustCenterDocWatermarkStatus @goModel(model: "github.com/theopenlane/core/pkg/enums.WatermarkStatus") {
+	PENDING
+	IN_PROGRESS
+	SUCCESS
+	FAILED
+	DISABLED
 }
 """
 TrustCenterDocWhereInput is used for filtering TrustCenterDoc objects.
@@ -58804,6 +58893,38 @@ input TrustCenterDocWhereInput {
 	fileIDEqualFold: ID
 	fileIDContainsFold: ID
 	"""
+	original_file_id field predicates
+	"""
+	originalFileID: ID
+	originalFileIDNEQ: ID
+	originalFileIDIn: [ID!]
+	originalFileIDNotIn: [ID!]
+	originalFileIDGT: ID
+	originalFileIDGTE: ID
+	originalFileIDLT: ID
+	originalFileIDLTE: ID
+	originalFileIDContains: ID
+	originalFileIDHasPrefix: ID
+	originalFileIDHasSuffix: ID
+	originalFileIDIsNil: Boolean
+	originalFileIDNotNil: Boolean
+	originalFileIDEqualFold: ID
+	originalFileIDContainsFold: ID
+	"""
+	watermarking_enabled field predicates
+	"""
+	watermarkingEnabled: Boolean
+	watermarkingEnabledNEQ: Boolean
+	"""
+	watermark_status field predicates
+	"""
+	watermarkStatus: TrustCenterDocWatermarkStatus
+	watermarkStatusNEQ: TrustCenterDocWatermarkStatus
+	watermarkStatusIn: [TrustCenterDocWatermarkStatus!]
+	watermarkStatusNotIn: [TrustCenterDocWatermarkStatus!]
+	watermarkStatusIsNil: Boolean
+	watermarkStatusNotNil: Boolean
+	"""
 	visibility field predicates
 	"""
 	visibility: TrustCenterDocTrustCenterDocumentVisibility
@@ -58822,6 +58943,11 @@ input TrustCenterDocWhereInput {
 	"""
 	hasFile: Boolean
 	hasFileWith: [FileWhereInput!]
+	"""
+	original_file edge predicates
+	"""
+	hasOriginalFile: Boolean
+	hasOriginalFileWith: [FileWhereInput!]
 }
 """
 Return response for createTrustCenterDomain mutation
@@ -64851,6 +64977,15 @@ input UpdateTrustCenterDocInput {
 	"""
 	category: String
 	"""
+	whether watermarking is enabled for the document. this will only take effect if watermarking is configured for the trust center
+	"""
+	watermarkingEnabled: Boolean
+	"""
+	status of the watermarking
+	"""
+	watermarkStatus: TrustCenterDocWatermarkStatus
+	clearWatermarkStatus: Boolean
+	"""
 	visibility of the document
 	"""
 	visibility: TrustCenterDocTrustCenterDocumentVisibility
@@ -64859,6 +64994,8 @@ input UpdateTrustCenterDocInput {
 	clearTrustCenter: Boolean
 	fileID: ID
 	clearFile: Boolean
+	originalFileID: ID
+	clearOriginalFile: Boolean
 }
 """
 UpdateTrustCenterInput is used for update TrustCenter object.

--- a/internal/graphapi/generated/root_.generated.go
+++ b/internal/graphapi/generated/root_.generated.go
@@ -4906,19 +4906,23 @@ type ComplexityRoot struct {
 	}
 
 	TrustCenterDoc struct {
-		Category      func(childComplexity int) int
-		CreatedAt     func(childComplexity int) int
-		CreatedBy     func(childComplexity int) int
-		File          func(childComplexity int) int
-		FileID        func(childComplexity int) int
-		ID            func(childComplexity int) int
-		Tags          func(childComplexity int) int
-		Title         func(childComplexity int) int
-		TrustCenter   func(childComplexity int) int
-		TrustCenterID func(childComplexity int) int
-		UpdatedAt     func(childComplexity int) int
-		UpdatedBy     func(childComplexity int) int
-		Visibility    func(childComplexity int) int
+		Category            func(childComplexity int) int
+		CreatedAt           func(childComplexity int) int
+		CreatedBy           func(childComplexity int) int
+		File                func(childComplexity int) int
+		FileID              func(childComplexity int) int
+		ID                  func(childComplexity int) int
+		OriginalFile        func(childComplexity int) int
+		OriginalFileID      func(childComplexity int) int
+		Tags                func(childComplexity int) int
+		Title               func(childComplexity int) int
+		TrustCenter         func(childComplexity int) int
+		TrustCenterID       func(childComplexity int) int
+		UpdatedAt           func(childComplexity int) int
+		UpdatedBy           func(childComplexity int) int
+		Visibility          func(childComplexity int) int
+		WatermarkStatus     func(childComplexity int) int
+		WatermarkingEnabled func(childComplexity int) int
 	}
 
 	TrustCenterDocBulkCreatePayload struct {
@@ -4945,20 +4949,23 @@ type ComplexityRoot struct {
 	}
 
 	TrustCenterDocHistory struct {
-		Category      func(childComplexity int) int
-		CreatedAt     func(childComplexity int) int
-		CreatedBy     func(childComplexity int) int
-		FileID        func(childComplexity int) int
-		HistoryTime   func(childComplexity int) int
-		ID            func(childComplexity int) int
-		Operation     func(childComplexity int) int
-		Ref           func(childComplexity int) int
-		Tags          func(childComplexity int) int
-		Title         func(childComplexity int) int
-		TrustCenterID func(childComplexity int) int
-		UpdatedAt     func(childComplexity int) int
-		UpdatedBy     func(childComplexity int) int
-		Visibility    func(childComplexity int) int
+		Category            func(childComplexity int) int
+		CreatedAt           func(childComplexity int) int
+		CreatedBy           func(childComplexity int) int
+		FileID              func(childComplexity int) int
+		HistoryTime         func(childComplexity int) int
+		ID                  func(childComplexity int) int
+		Operation           func(childComplexity int) int
+		OriginalFileID      func(childComplexity int) int
+		Ref                 func(childComplexity int) int
+		Tags                func(childComplexity int) int
+		Title               func(childComplexity int) int
+		TrustCenterID       func(childComplexity int) int
+		UpdatedAt           func(childComplexity int) int
+		UpdatedBy           func(childComplexity int) int
+		Visibility          func(childComplexity int) int
+		WatermarkStatus     func(childComplexity int) int
+		WatermarkingEnabled func(childComplexity int) int
 	}
 
 	TrustCenterDocHistoryConnection struct {
@@ -33163,6 +33170,20 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.TrustCenterDoc.ID(childComplexity), true
 
+	case "TrustCenterDoc.originalFile":
+		if e.complexity.TrustCenterDoc.OriginalFile == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterDoc.OriginalFile(childComplexity), true
+
+	case "TrustCenterDoc.originalFileID":
+		if e.complexity.TrustCenterDoc.OriginalFileID == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterDoc.OriginalFileID(childComplexity), true
+
 	case "TrustCenterDoc.tags":
 		if e.complexity.TrustCenterDoc.Tags == nil {
 			break
@@ -33211,6 +33232,20 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.TrustCenterDoc.Visibility(childComplexity), true
+
+	case "TrustCenterDoc.watermarkStatus":
+		if e.complexity.TrustCenterDoc.WatermarkStatus == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterDoc.WatermarkStatus(childComplexity), true
+
+	case "TrustCenterDoc.watermarkingEnabled":
+		if e.complexity.TrustCenterDoc.WatermarkingEnabled == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterDoc.WatermarkingEnabled(childComplexity), true
 
 	case "TrustCenterDocBulkCreatePayload.trustCenterDocs":
 		if e.complexity.TrustCenterDocBulkCreatePayload.TrustCenterDocs == nil {
@@ -33317,6 +33352,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.TrustCenterDocHistory.Operation(childComplexity), true
 
+	case "TrustCenterDocHistory.originalFileID":
+		if e.complexity.TrustCenterDocHistory.OriginalFileID == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterDocHistory.OriginalFileID(childComplexity), true
+
 	case "TrustCenterDocHistory.ref":
 		if e.complexity.TrustCenterDocHistory.Ref == nil {
 			break
@@ -33365,6 +33407,20 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.TrustCenterDocHistory.Visibility(childComplexity), true
+
+	case "TrustCenterDocHistory.watermarkStatus":
+		if e.complexity.TrustCenterDocHistory.WatermarkStatus == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterDocHistory.WatermarkStatus(childComplexity), true
+
+	case "TrustCenterDocHistory.watermarkingEnabled":
+		if e.complexity.TrustCenterDocHistory.WatermarkingEnabled == nil {
+			break
+		}
+
+		return e.complexity.TrustCenterDocHistory.WatermarkingEnabled(childComplexity), true
 
 	case "TrustCenterDocHistoryConnection.edges":
 		if e.complexity.TrustCenterDocHistoryConnection.Edges == nil {
@@ -48228,11 +48284,20 @@ input CreateTrustCenterDocInput {
   """
   category: String!
   """
+  whether watermarking is enabled for the document. this will only take effect if watermarking is configured for the trust center
+  """
+  watermarkingEnabled: Boolean
+  """
+  status of the watermarking
+  """
+  watermarkStatus: TrustCenterDocWatermarkStatus
+  """
   visibility of the document
   """
   visibility: TrustCenterDocTrustCenterDocumentVisibility
   trustCenterID: ID
   fileID: ID
+  originalFileID: ID
 }
 """
 CreateTrustCenterInput is used for create TrustCenter object.
@@ -88293,6 +88358,18 @@ type TrustCenterDoc implements Node {
   """
   fileID: ID
   """
+  ID of the file containing the document, before any watermarking
+  """
+  originalFileID: ID
+  """
+  whether watermarking is enabled for the document. this will only take effect if watermarking is configured for the trust center
+  """
+  watermarkingEnabled: Boolean!
+  """
+  status of the watermarking
+  """
+  watermarkStatus: TrustCenterDocWatermarkStatus
+  """
   visibility of the document
   """
   visibility: TrustCenterDocTrustCenterDocumentVisibility
@@ -88301,6 +88378,10 @@ type TrustCenterDoc implements Node {
   the file containing the document content
   """
   file: File
+  """
+  the file containing the document content, pre watermarking
+  """
+  originalFile: File
 }
 """
 A connection to a list of items.
@@ -88361,6 +88442,18 @@ type TrustCenterDocHistory implements Node {
   ID of the file containing the document
   """
   fileID: String
+  """
+  ID of the file containing the document, before any watermarking
+  """
+  originalFileID: String
+  """
+  whether watermarking is enabled for the document. this will only take effect if watermarking is configured for the trust center
+  """
+  watermarkingEnabled: Boolean!
+  """
+  status of the watermarking
+  """
+  watermarkStatus: TrustCenterDocHistoryWatermarkStatus
   """
   visibility of the document
   """
@@ -88432,6 +88525,16 @@ enum TrustCenterDocHistoryTrustCenterDocumentVisibility @goModel(model: "github.
   PUBLICLY_VISIBLE
   PROTECTED
   NOT_VISIBLE
+}
+"""
+TrustCenterDocHistoryWatermarkStatus is enum for the field watermark_status
+"""
+enum TrustCenterDocHistoryWatermarkStatus @goModel(model: "github.com/theopenlane/core/pkg/enums.WatermarkStatus") {
+  PENDING
+  IN_PROGRESS
+  SUCCESS
+  FAILED
+  DISABLED
 }
 """
 TrustCenterDocHistoryWhereInput is used for filtering TrustCenterDocHistory objects.
@@ -88621,6 +88724,38 @@ input TrustCenterDocHistoryWhereInput {
   fileIDEqualFold: String
   fileIDContainsFold: String
   """
+  original_file_id field predicates
+  """
+  originalFileID: String
+  originalFileIDNEQ: String
+  originalFileIDIn: [String!]
+  originalFileIDNotIn: [String!]
+  originalFileIDGT: String
+  originalFileIDGTE: String
+  originalFileIDLT: String
+  originalFileIDLTE: String
+  originalFileIDContains: String
+  originalFileIDHasPrefix: String
+  originalFileIDHasSuffix: String
+  originalFileIDIsNil: Boolean
+  originalFileIDNotNil: Boolean
+  originalFileIDEqualFold: String
+  originalFileIDContainsFold: String
+  """
+  watermarking_enabled field predicates
+  """
+  watermarkingEnabled: Boolean
+  watermarkingEnabledNEQ: Boolean
+  """
+  watermark_status field predicates
+  """
+  watermarkStatus: TrustCenterDocHistoryWatermarkStatus
+  watermarkStatusNEQ: TrustCenterDocHistoryWatermarkStatus
+  watermarkStatusIn: [TrustCenterDocHistoryWatermarkStatus!]
+  watermarkStatusNotIn: [TrustCenterDocHistoryWatermarkStatus!]
+  watermarkStatusIsNil: Boolean
+  watermarkStatusNotNil: Boolean
+  """
   visibility field predicates
   """
   visibility: TrustCenterDocHistoryTrustCenterDocumentVisibility
@@ -88657,6 +88792,16 @@ enum TrustCenterDocTrustCenterDocumentVisibility @goModel(model: "github.com/the
   PUBLICLY_VISIBLE
   PROTECTED
   NOT_VISIBLE
+}
+"""
+TrustCenterDocWatermarkStatus is enum for the field watermark_status
+"""
+enum TrustCenterDocWatermarkStatus @goModel(model: "github.com/theopenlane/core/pkg/enums.WatermarkStatus") {
+  PENDING
+  IN_PROGRESS
+  SUCCESS
+  FAILED
+  DISABLED
 }
 """
 TrustCenterDocWhereInput is used for filtering TrustCenterDoc objects.
@@ -88810,6 +88955,38 @@ input TrustCenterDocWhereInput {
   fileIDEqualFold: ID
   fileIDContainsFold: ID
   """
+  original_file_id field predicates
+  """
+  originalFileID: ID
+  originalFileIDNEQ: ID
+  originalFileIDIn: [ID!]
+  originalFileIDNotIn: [ID!]
+  originalFileIDGT: ID
+  originalFileIDGTE: ID
+  originalFileIDLT: ID
+  originalFileIDLTE: ID
+  originalFileIDContains: ID
+  originalFileIDHasPrefix: ID
+  originalFileIDHasSuffix: ID
+  originalFileIDIsNil: Boolean
+  originalFileIDNotNil: Boolean
+  originalFileIDEqualFold: ID
+  originalFileIDContainsFold: ID
+  """
+  watermarking_enabled field predicates
+  """
+  watermarkingEnabled: Boolean
+  watermarkingEnabledNEQ: Boolean
+  """
+  watermark_status field predicates
+  """
+  watermarkStatus: TrustCenterDocWatermarkStatus
+  watermarkStatusNEQ: TrustCenterDocWatermarkStatus
+  watermarkStatusIn: [TrustCenterDocWatermarkStatus!]
+  watermarkStatusNotIn: [TrustCenterDocWatermarkStatus!]
+  watermarkStatusIsNil: Boolean
+  watermarkStatusNotNil: Boolean
+  """
   visibility field predicates
   """
   visibility: TrustCenterDocTrustCenterDocumentVisibility
@@ -88828,6 +89005,11 @@ input TrustCenterDocWhereInput {
   """
   hasFile: Boolean
   hasFileWith: [FileWhereInput!]
+  """
+  original_file edge predicates
+  """
+  hasOriginalFile: Boolean
+  hasOriginalFileWith: [FileWhereInput!]
 }
 """
 An edge in a connection.
@@ -94689,6 +94871,15 @@ input UpdateTrustCenterDocInput {
   """
   category: String
   """
+  whether watermarking is enabled for the document. this will only take effect if watermarking is configured for the trust center
+  """
+  watermarkingEnabled: Boolean
+  """
+  status of the watermarking
+  """
+  watermarkStatus: TrustCenterDocWatermarkStatus
+  clearWatermarkStatus: Boolean
+  """
   visibility of the document
   """
   visibility: TrustCenterDocTrustCenterDocumentVisibility
@@ -94697,6 +94888,8 @@ input UpdateTrustCenterDocInput {
   clearTrustCenter: Boolean
   fileID: ID
   clearFile: Boolean
+  originalFileID: ID
+  clearOriginalFile: Boolean
 }
 """
 UpdateTrustCenterInput is used for update TrustCenter object.

--- a/internal/graphapi/generated/trustcenterdoc.generated.go
+++ b/internal/graphapi/generated/trustcenterdoc.generated.go
@@ -70,12 +70,20 @@ func (ec *executionContext) fieldContext_TrustCenterDocBulkCreatePayload_trustCe
 				return ec.fieldContext_TrustCenterDoc_category(ctx, field)
 			case "fileID":
 				return ec.fieldContext_TrustCenterDoc_fileID(ctx, field)
+			case "originalFileID":
+				return ec.fieldContext_TrustCenterDoc_originalFileID(ctx, field)
+			case "watermarkingEnabled":
+				return ec.fieldContext_TrustCenterDoc_watermarkingEnabled(ctx, field)
+			case "watermarkStatus":
+				return ec.fieldContext_TrustCenterDoc_watermarkStatus(ctx, field)
 			case "visibility":
 				return ec.fieldContext_TrustCenterDoc_visibility(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_TrustCenterDoc_trustCenter(ctx, field)
 			case "file":
 				return ec.fieldContext_TrustCenterDoc_file(ctx, field)
+			case "originalFile":
+				return ec.fieldContext_TrustCenterDoc_originalFile(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TrustCenterDoc", field.Name)
 		},
@@ -125,12 +133,20 @@ func (ec *executionContext) fieldContext_TrustCenterDocCreatePayload_trustCenter
 				return ec.fieldContext_TrustCenterDoc_category(ctx, field)
 			case "fileID":
 				return ec.fieldContext_TrustCenterDoc_fileID(ctx, field)
+			case "originalFileID":
+				return ec.fieldContext_TrustCenterDoc_originalFileID(ctx, field)
+			case "watermarkingEnabled":
+				return ec.fieldContext_TrustCenterDoc_watermarkingEnabled(ctx, field)
+			case "watermarkStatus":
+				return ec.fieldContext_TrustCenterDoc_watermarkStatus(ctx, field)
 			case "visibility":
 				return ec.fieldContext_TrustCenterDoc_visibility(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_TrustCenterDoc_trustCenter(ctx, field)
 			case "file":
 				return ec.fieldContext_TrustCenterDoc_file(ctx, field)
+			case "originalFile":
+				return ec.fieldContext_TrustCenterDoc_originalFile(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TrustCenterDoc", field.Name)
 		},
@@ -207,12 +223,20 @@ func (ec *executionContext) fieldContext_TrustCenterDocUpdatePayload_trustCenter
 				return ec.fieldContext_TrustCenterDoc_category(ctx, field)
 			case "fileID":
 				return ec.fieldContext_TrustCenterDoc_fileID(ctx, field)
+			case "originalFileID":
+				return ec.fieldContext_TrustCenterDoc_originalFileID(ctx, field)
+			case "watermarkingEnabled":
+				return ec.fieldContext_TrustCenterDoc_watermarkingEnabled(ctx, field)
+			case "watermarkStatus":
+				return ec.fieldContext_TrustCenterDoc_watermarkStatus(ctx, field)
 			case "visibility":
 				return ec.fieldContext_TrustCenterDoc_visibility(ctx, field)
 			case "trustCenter":
 				return ec.fieldContext_TrustCenterDoc_trustCenter(ctx, field)
 			case "file":
 				return ec.fieldContext_TrustCenterDoc_file(ctx, field)
+			case "originalFile":
+				return ec.fieldContext_TrustCenterDoc_originalFile(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TrustCenterDoc", field.Name)
 		},

--- a/internal/graphapi/query/adminsearch.graphql
+++ b/internal/graphapi/query/adminsearch.graphql
@@ -978,6 +978,7 @@ query AdminSearch($query: String!) {
           title
           category
           fileID
+          originalFileID
         }
       }
     }

--- a/internal/graphapi/schema/ent.graphql
+++ b/internal/graphapi/schema/ent.graphql
@@ -9602,11 +9602,20 @@ input CreateTrustCenterDocInput {
   """
   category: String!
   """
+  whether watermarking is enabled for the document. this will only take effect if watermarking is configured for the trust center
+  """
+  watermarkingEnabled: Boolean
+  """
+  status of the watermarking
+  """
+  watermarkStatus: TrustCenterDocWatermarkStatus
+  """
   visibility of the document
   """
   visibility: TrustCenterDocTrustCenterDocumentVisibility
   trustCenterID: ID
   fileID: ID
+  originalFileID: ID
 }
 """
 CreateTrustCenterInput is used for create TrustCenter object.
@@ -49667,6 +49676,18 @@ type TrustCenterDoc implements Node {
   """
   fileID: ID
   """
+  ID of the file containing the document, before any watermarking
+  """
+  originalFileID: ID
+  """
+  whether watermarking is enabled for the document. this will only take effect if watermarking is configured for the trust center
+  """
+  watermarkingEnabled: Boolean!
+  """
+  status of the watermarking
+  """
+  watermarkStatus: TrustCenterDocWatermarkStatus
+  """
   visibility of the document
   """
   visibility: TrustCenterDocTrustCenterDocumentVisibility
@@ -49675,6 +49696,10 @@ type TrustCenterDoc implements Node {
   the file containing the document content
   """
   file: File
+  """
+  the file containing the document content, pre watermarking
+  """
+  originalFile: File
 }
 """
 A connection to a list of items.
@@ -49735,6 +49760,18 @@ type TrustCenterDocHistory implements Node {
   ID of the file containing the document
   """
   fileID: String
+  """
+  ID of the file containing the document, before any watermarking
+  """
+  originalFileID: String
+  """
+  whether watermarking is enabled for the document. this will only take effect if watermarking is configured for the trust center
+  """
+  watermarkingEnabled: Boolean!
+  """
+  status of the watermarking
+  """
+  watermarkStatus: TrustCenterDocHistoryWatermarkStatus
   """
   visibility of the document
   """
@@ -49806,6 +49843,16 @@ enum TrustCenterDocHistoryTrustCenterDocumentVisibility @goModel(model: "github.
   PUBLICLY_VISIBLE
   PROTECTED
   NOT_VISIBLE
+}
+"""
+TrustCenterDocHistoryWatermarkStatus is enum for the field watermark_status
+"""
+enum TrustCenterDocHistoryWatermarkStatus @goModel(model: "github.com/theopenlane/core/pkg/enums.WatermarkStatus") {
+  PENDING
+  IN_PROGRESS
+  SUCCESS
+  FAILED
+  DISABLED
 }
 """
 TrustCenterDocHistoryWhereInput is used for filtering TrustCenterDocHistory objects.
@@ -49995,6 +50042,38 @@ input TrustCenterDocHistoryWhereInput {
   fileIDEqualFold: String
   fileIDContainsFold: String
   """
+  original_file_id field predicates
+  """
+  originalFileID: String
+  originalFileIDNEQ: String
+  originalFileIDIn: [String!]
+  originalFileIDNotIn: [String!]
+  originalFileIDGT: String
+  originalFileIDGTE: String
+  originalFileIDLT: String
+  originalFileIDLTE: String
+  originalFileIDContains: String
+  originalFileIDHasPrefix: String
+  originalFileIDHasSuffix: String
+  originalFileIDIsNil: Boolean
+  originalFileIDNotNil: Boolean
+  originalFileIDEqualFold: String
+  originalFileIDContainsFold: String
+  """
+  watermarking_enabled field predicates
+  """
+  watermarkingEnabled: Boolean
+  watermarkingEnabledNEQ: Boolean
+  """
+  watermark_status field predicates
+  """
+  watermarkStatus: TrustCenterDocHistoryWatermarkStatus
+  watermarkStatusNEQ: TrustCenterDocHistoryWatermarkStatus
+  watermarkStatusIn: [TrustCenterDocHistoryWatermarkStatus!]
+  watermarkStatusNotIn: [TrustCenterDocHistoryWatermarkStatus!]
+  watermarkStatusIsNil: Boolean
+  watermarkStatusNotNil: Boolean
+  """
   visibility field predicates
   """
   visibility: TrustCenterDocHistoryTrustCenterDocumentVisibility
@@ -50031,6 +50110,16 @@ enum TrustCenterDocTrustCenterDocumentVisibility @goModel(model: "github.com/the
   PUBLICLY_VISIBLE
   PROTECTED
   NOT_VISIBLE
+}
+"""
+TrustCenterDocWatermarkStatus is enum for the field watermark_status
+"""
+enum TrustCenterDocWatermarkStatus @goModel(model: "github.com/theopenlane/core/pkg/enums.WatermarkStatus") {
+  PENDING
+  IN_PROGRESS
+  SUCCESS
+  FAILED
+  DISABLED
 }
 """
 TrustCenterDocWhereInput is used for filtering TrustCenterDoc objects.
@@ -50184,6 +50273,38 @@ input TrustCenterDocWhereInput {
   fileIDEqualFold: ID
   fileIDContainsFold: ID
   """
+  original_file_id field predicates
+  """
+  originalFileID: ID
+  originalFileIDNEQ: ID
+  originalFileIDIn: [ID!]
+  originalFileIDNotIn: [ID!]
+  originalFileIDGT: ID
+  originalFileIDGTE: ID
+  originalFileIDLT: ID
+  originalFileIDLTE: ID
+  originalFileIDContains: ID
+  originalFileIDHasPrefix: ID
+  originalFileIDHasSuffix: ID
+  originalFileIDIsNil: Boolean
+  originalFileIDNotNil: Boolean
+  originalFileIDEqualFold: ID
+  originalFileIDContainsFold: ID
+  """
+  watermarking_enabled field predicates
+  """
+  watermarkingEnabled: Boolean
+  watermarkingEnabledNEQ: Boolean
+  """
+  watermark_status field predicates
+  """
+  watermarkStatus: TrustCenterDocWatermarkStatus
+  watermarkStatusNEQ: TrustCenterDocWatermarkStatus
+  watermarkStatusIn: [TrustCenterDocWatermarkStatus!]
+  watermarkStatusNotIn: [TrustCenterDocWatermarkStatus!]
+  watermarkStatusIsNil: Boolean
+  watermarkStatusNotNil: Boolean
+  """
   visibility field predicates
   """
   visibility: TrustCenterDocTrustCenterDocumentVisibility
@@ -50202,6 +50323,11 @@ input TrustCenterDocWhereInput {
   """
   hasFile: Boolean
   hasFileWith: [FileWhereInput!]
+  """
+  original_file edge predicates
+  """
+  hasOriginalFile: Boolean
+  hasOriginalFileWith: [FileWhereInput!]
 }
 """
 An edge in a connection.
@@ -56063,6 +56189,15 @@ input UpdateTrustCenterDocInput {
   """
   category: String
   """
+  whether watermarking is enabled for the document. this will only take effect if watermarking is configured for the trust center
+  """
+  watermarkingEnabled: Boolean
+  """
+  status of the watermarking
+  """
+  watermarkStatus: TrustCenterDocWatermarkStatus
+  clearWatermarkStatus: Boolean
+  """
   visibility of the document
   """
   visibility: TrustCenterDocTrustCenterDocumentVisibility
@@ -56071,6 +56206,8 @@ input UpdateTrustCenterDocInput {
   clearTrustCenter: Boolean
   fileID: ID
   clearFile: Boolean
+  originalFileID: ID
+  clearOriginalFile: Boolean
 }
 """
 UpdateTrustCenterInput is used for update TrustCenter object.

--- a/internal/graphapi/search.go
+++ b/internal/graphapi/search.go
@@ -1995,10 +1995,11 @@ func adminSearchTrustCenterDocs(ctx context.Context, query string, after *entgql
 					likeQuery := "%" + query + "%"
 					s.Where(sql.ExprP("(tags)::text LIKE $2", likeQuery)) // search by Tags
 				},
-				trustcenterdoc.TrustCenterIDContainsFold(query), // search by TrustCenterID
-				trustcenterdoc.TitleContainsFold(query),         // search by Title
-				trustcenterdoc.CategoryContainsFold(query),      // search by Category
-				trustcenterdoc.FileIDContainsFold(query),        // search by FileID
+				trustcenterdoc.TrustCenterIDContainsFold(query),  // search by TrustCenterID
+				trustcenterdoc.TitleContainsFold(query),          // search by Title
+				trustcenterdoc.CategoryContainsFold(query),       // search by Category
+				trustcenterdoc.FileIDContainsFold(query),         // search by FileID
+				trustcenterdoc.OriginalFileIDContainsFold(query), // search by OriginalFileID
 			),
 		)
 

--- a/internal/graphapi/testclient/models.go
+++ b/internal/graphapi/testclient/models.go
@@ -6129,10 +6129,15 @@ type CreateTrustCenterDocInput struct {
 	Title string `json:"title"`
 	// category of the document
 	Category string `json:"category"`
+	// whether watermarking is enabled for the document. this will only take effect if watermarking is configured for the trust center
+	WatermarkingEnabled *bool `json:"watermarkingEnabled,omitempty"`
+	// status of the watermarking
+	WatermarkStatus *enums.WatermarkStatus `json:"watermarkStatus,omitempty"`
 	// visibility of the document
-	Visibility    *enums.TrustCenterDocumentVisibility `json:"visibility,omitempty"`
-	TrustCenterID *string                              `json:"trustCenterID,omitempty"`
-	FileID        *string                              `json:"fileID,omitempty"`
+	Visibility     *enums.TrustCenterDocumentVisibility `json:"visibility,omitempty"`
+	TrustCenterID  *string                              `json:"trustCenterID,omitempty"`
+	FileID         *string                              `json:"fileID,omitempty"`
+	OriginalFileID *string                              `json:"originalFileID,omitempty"`
 }
 
 // Input for createTrustCenterDomain mutation
@@ -28798,11 +28803,19 @@ type TrustCenterDoc struct {
 	Category string `json:"category"`
 	// ID of the file containing the document
 	FileID *string `json:"fileID,omitempty"`
+	// ID of the file containing the document, before any watermarking
+	OriginalFileID *string `json:"originalFileID,omitempty"`
+	// whether watermarking is enabled for the document. this will only take effect if watermarking is configured for the trust center
+	WatermarkingEnabled bool `json:"watermarkingEnabled"`
+	// status of the watermarking
+	WatermarkStatus *enums.WatermarkStatus `json:"watermarkStatus,omitempty"`
 	// visibility of the document
 	Visibility  *enums.TrustCenterDocumentVisibility `json:"visibility,omitempty"`
 	TrustCenter *TrustCenter                         `json:"trustCenter,omitempty"`
 	// the file containing the document content
 	File *File `json:"file,omitempty"`
+	// the file containing the document content, pre watermarking
+	OriginalFile *File `json:"originalFile,omitempty"`
 }
 
 func (TrustCenterDoc) IsNode() {}
@@ -28862,6 +28875,12 @@ type TrustCenterDocHistory struct {
 	Category string `json:"category"`
 	// ID of the file containing the document
 	FileID *string `json:"fileID,omitempty"`
+	// ID of the file containing the document, before any watermarking
+	OriginalFileID *string `json:"originalFileID,omitempty"`
+	// whether watermarking is enabled for the document. this will only take effect if watermarking is configured for the trust center
+	WatermarkingEnabled bool `json:"watermarkingEnabled"`
+	// status of the watermarking
+	WatermarkStatus *enums.WatermarkStatus `json:"watermarkStatus,omitempty"`
 	// visibility of the document
 	Visibility *enums.TrustCenterDocumentVisibility `json:"visibility,omitempty"`
 }
@@ -29055,6 +29074,32 @@ type TrustCenterDocHistoryWhereInput struct {
 	FileIDNotNil       *bool    `json:"fileIDNotNil,omitempty"`
 	FileIDEqualFold    *string  `json:"fileIDEqualFold,omitempty"`
 	FileIDContainsFold *string  `json:"fileIDContainsFold,omitempty"`
+	// original_file_id field predicates
+	OriginalFileID             *string  `json:"originalFileID,omitempty"`
+	OriginalFileIdneq          *string  `json:"originalFileIDNEQ,omitempty"`
+	OriginalFileIDIn           []string `json:"originalFileIDIn,omitempty"`
+	OriginalFileIDNotIn        []string `json:"originalFileIDNotIn,omitempty"`
+	OriginalFileIdgt           *string  `json:"originalFileIDGT,omitempty"`
+	OriginalFileIdgte          *string  `json:"originalFileIDGTE,omitempty"`
+	OriginalFileIdlt           *string  `json:"originalFileIDLT,omitempty"`
+	OriginalFileIdlte          *string  `json:"originalFileIDLTE,omitempty"`
+	OriginalFileIDContains     *string  `json:"originalFileIDContains,omitempty"`
+	OriginalFileIDHasPrefix    *string  `json:"originalFileIDHasPrefix,omitempty"`
+	OriginalFileIDHasSuffix    *string  `json:"originalFileIDHasSuffix,omitempty"`
+	OriginalFileIDIsNil        *bool    `json:"originalFileIDIsNil,omitempty"`
+	OriginalFileIDNotNil       *bool    `json:"originalFileIDNotNil,omitempty"`
+	OriginalFileIDEqualFold    *string  `json:"originalFileIDEqualFold,omitempty"`
+	OriginalFileIDContainsFold *string  `json:"originalFileIDContainsFold,omitempty"`
+	// watermarking_enabled field predicates
+	WatermarkingEnabled    *bool `json:"watermarkingEnabled,omitempty"`
+	WatermarkingEnabledNeq *bool `json:"watermarkingEnabledNEQ,omitempty"`
+	// watermark_status field predicates
+	WatermarkStatus       *enums.WatermarkStatus  `json:"watermarkStatus,omitempty"`
+	WatermarkStatusNeq    *enums.WatermarkStatus  `json:"watermarkStatusNEQ,omitempty"`
+	WatermarkStatusIn     []enums.WatermarkStatus `json:"watermarkStatusIn,omitempty"`
+	WatermarkStatusNotIn  []enums.WatermarkStatus `json:"watermarkStatusNotIn,omitempty"`
+	WatermarkStatusIsNil  *bool                   `json:"watermarkStatusIsNil,omitempty"`
+	WatermarkStatusNotNil *bool                   `json:"watermarkStatusNotNil,omitempty"`
 	// visibility field predicates
 	Visibility       *enums.TrustCenterDocumentVisibility  `json:"visibility,omitempty"`
 	VisibilityNeq    *enums.TrustCenterDocumentVisibility  `json:"visibilityNEQ,omitempty"`
@@ -29209,6 +29254,32 @@ type TrustCenterDocWhereInput struct {
 	FileIDNotNil       *bool    `json:"fileIDNotNil,omitempty"`
 	FileIDEqualFold    *string  `json:"fileIDEqualFold,omitempty"`
 	FileIDContainsFold *string  `json:"fileIDContainsFold,omitempty"`
+	// original_file_id field predicates
+	OriginalFileID             *string  `json:"originalFileID,omitempty"`
+	OriginalFileIdneq          *string  `json:"originalFileIDNEQ,omitempty"`
+	OriginalFileIDIn           []string `json:"originalFileIDIn,omitempty"`
+	OriginalFileIDNotIn        []string `json:"originalFileIDNotIn,omitempty"`
+	OriginalFileIdgt           *string  `json:"originalFileIDGT,omitempty"`
+	OriginalFileIdgte          *string  `json:"originalFileIDGTE,omitempty"`
+	OriginalFileIdlt           *string  `json:"originalFileIDLT,omitempty"`
+	OriginalFileIdlte          *string  `json:"originalFileIDLTE,omitempty"`
+	OriginalFileIDContains     *string  `json:"originalFileIDContains,omitempty"`
+	OriginalFileIDHasPrefix    *string  `json:"originalFileIDHasPrefix,omitempty"`
+	OriginalFileIDHasSuffix    *string  `json:"originalFileIDHasSuffix,omitempty"`
+	OriginalFileIDIsNil        *bool    `json:"originalFileIDIsNil,omitempty"`
+	OriginalFileIDNotNil       *bool    `json:"originalFileIDNotNil,omitempty"`
+	OriginalFileIDEqualFold    *string  `json:"originalFileIDEqualFold,omitempty"`
+	OriginalFileIDContainsFold *string  `json:"originalFileIDContainsFold,omitempty"`
+	// watermarking_enabled field predicates
+	WatermarkingEnabled    *bool `json:"watermarkingEnabled,omitempty"`
+	WatermarkingEnabledNeq *bool `json:"watermarkingEnabledNEQ,omitempty"`
+	// watermark_status field predicates
+	WatermarkStatus       *enums.WatermarkStatus  `json:"watermarkStatus,omitempty"`
+	WatermarkStatusNeq    *enums.WatermarkStatus  `json:"watermarkStatusNEQ,omitempty"`
+	WatermarkStatusIn     []enums.WatermarkStatus `json:"watermarkStatusIn,omitempty"`
+	WatermarkStatusNotIn  []enums.WatermarkStatus `json:"watermarkStatusNotIn,omitempty"`
+	WatermarkStatusIsNil  *bool                   `json:"watermarkStatusIsNil,omitempty"`
+	WatermarkStatusNotNil *bool                   `json:"watermarkStatusNotNil,omitempty"`
 	// visibility field predicates
 	Visibility       *enums.TrustCenterDocumentVisibility  `json:"visibility,omitempty"`
 	VisibilityNeq    *enums.TrustCenterDocumentVisibility  `json:"visibilityNEQ,omitempty"`
@@ -29222,6 +29293,9 @@ type TrustCenterDocWhereInput struct {
 	// file edge predicates
 	HasFile     *bool             `json:"hasFile,omitempty"`
 	HasFileWith []*FileWhereInput `json:"hasFileWith,omitempty"`
+	// original_file edge predicates
+	HasOriginalFile     *bool             `json:"hasOriginalFile,omitempty"`
+	HasOriginalFileWith []*FileWhereInput `json:"hasOriginalFileWith,omitempty"`
 }
 
 // Return response for createTrustCenterDomain mutation
@@ -33741,13 +33815,20 @@ type UpdateTrustCenterDocInput struct {
 	Title *string `json:"title,omitempty"`
 	// category of the document
 	Category *string `json:"category,omitempty"`
+	// whether watermarking is enabled for the document. this will only take effect if watermarking is configured for the trust center
+	WatermarkingEnabled *bool `json:"watermarkingEnabled,omitempty"`
+	// status of the watermarking
+	WatermarkStatus      *enums.WatermarkStatus `json:"watermarkStatus,omitempty"`
+	ClearWatermarkStatus *bool                  `json:"clearWatermarkStatus,omitempty"`
 	// visibility of the document
-	Visibility       *enums.TrustCenterDocumentVisibility `json:"visibility,omitempty"`
-	ClearVisibility  *bool                                `json:"clearVisibility,omitempty"`
-	TrustCenterID    *string                              `json:"trustCenterID,omitempty"`
-	ClearTrustCenter *bool                                `json:"clearTrustCenter,omitempty"`
-	FileID           *string                              `json:"fileID,omitempty"`
-	ClearFile        *bool                                `json:"clearFile,omitempty"`
+	Visibility        *enums.TrustCenterDocumentVisibility `json:"visibility,omitempty"`
+	ClearVisibility   *bool                                `json:"clearVisibility,omitempty"`
+	TrustCenterID     *string                              `json:"trustCenterID,omitempty"`
+	ClearTrustCenter  *bool                                `json:"clearTrustCenter,omitempty"`
+	FileID            *string                              `json:"fileID,omitempty"`
+	ClearFile         *bool                                `json:"clearFile,omitempty"`
+	OriginalFileID    *string                              `json:"originalFileID,omitempty"`
+	ClearOriginalFile *bool                                `json:"clearOriginalFile,omitempty"`
 }
 
 // UpdateTrustCenterInput is used for update TrustCenter object.

--- a/internal/httpserve/handlers/csv/sample_trustcenterdoc.csv
+++ b/internal/httpserve/handlers/csv/sample_trustcenterdoc.csv
@@ -1,2 +1,2 @@
-Tags,Title,Category,Visibility,TrustCenterId,FileId
-example_tags,example_title,example_category,example_visibility,example_trustcenterid,example_fileid
+Tags,Title,Category,WatermarkingEnabled,WatermarkStatus,Visibility,TrustCenterId,FileId,OriginalFileId
+example_tags,example_title,example_category,example_watermarkingenabled,example_watermarkstatus,example_visibility,example_trustcenterid,example_fileid,example_originalfileid

--- a/pkg/corejobs/watermark_doc.go
+++ b/pkg/corejobs/watermark_doc.go
@@ -1,0 +1,49 @@
+package corejobs
+
+import (
+	"context"
+
+	"github.com/riverqueue/river"
+	"github.com/rs/zerolog"
+
+	"github.com/theopenlane/core/pkg/corejobs/internal/olclient"
+)
+
+// WatermarkDocArgs for the worker to process watermarking of a document
+type WatermarkDocArgs struct {
+	// ID of the trust center document
+	TrustCenterDocumentID string `json:"trust_center_document_id"`
+}
+
+// Kind satisfies the river.Job interface
+func (WatermarkDocArgs) Kind() string { return "watermark_doc" }
+
+type WatermarkWorkerConfig struct {
+	Enabled bool `koanf:"enabled" json:"enabled" jsonschema:"required description=whether the watermark worker is enabled"`
+
+	OpenlaneAPIHost  string `koanf:"openlaneAPIHost" json:"openlaneAPIHost" jsonschema:"required description=the openlane api host"`
+	OpenlaneAPIToken string `koanf:"openlaneAPIToken" json:"openlaneAPIToken" jsonschema:"required description=the openlane api token"`
+}
+
+// WatermarkDocWorker is the worker to process watermarking of a document
+type WatermarkDocWorker struct {
+	river.WorkerDefaults[WatermarkDocArgs]
+
+	Config WatermarkWorkerConfig `koanf:"config" json:"config" jsonschema:"description=the configuration for watermarking"`
+
+	olClient olclient.OpenlaneClient
+}
+
+// WithOpenlaneClient sets the openlane client to use for API requests
+func (w *WatermarkDocWorker) WithOpenlaneClient(cl olclient.OpenlaneClient) *WatermarkDocWorker {
+	w.olClient = cl
+	return w
+}
+
+// Work satisfies the river.Worker interface for the watermark doc worker
+func (w *WatermarkDocWorker) Work(ctx context.Context, job *river.Job[WatermarkDocArgs]) error {
+	// TODO: implement watermarking
+	zerolog.Ctx(ctx).Info().Str("trust_center_document_id", job.Args.TrustCenterDocumentID).Msg("would watermark document")
+
+	return nil
+}

--- a/pkg/enums/watermarkstatus.go
+++ b/pkg/enums/watermarkstatus.go
@@ -1,0 +1,64 @@
+package enums
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+type WatermarkStatus string
+
+var (
+	WatermarkStatusDisabled WatermarkStatus = "DISABLED"
+	// WatermarkStatusPending indicates that the watermarking job is pending
+	WatermarkStatusPending WatermarkStatus = "PENDING"
+	// WatermarkStatusInProgress indicates that the watermarking job is in progress
+	WatermarkStatusInProgress WatermarkStatus = "IN_PROGRESS"
+	// WatermarkStatusSuccess indicates that the watermarking job has completed successfully
+	WatermarkStatusSuccess WatermarkStatus = "SUCCESS"
+	// WatermarkStatusFailed indicates that the watermarking job has failed
+	WatermarkStatusFailed  WatermarkStatus = "FAILED"
+	WatermarkStatusInvalid WatermarkStatus = "INVALID"
+)
+
+func (WatermarkStatus) Values() []string {
+	return []string{
+		string(WatermarkStatusPending),
+		string(WatermarkStatusInProgress),
+		string(WatermarkStatusSuccess),
+		string(WatermarkStatusFailed),
+		string(WatermarkStatusDisabled),
+	}
+}
+
+func (w WatermarkStatus) String() string { return string(w) }
+
+func ToWatermarkStatus(str string) *WatermarkStatus {
+	switch strings.ToUpper(str) {
+	case WatermarkStatusPending.String():
+		return &WatermarkStatusPending
+	case WatermarkStatusInProgress.String():
+		return &WatermarkStatusInProgress
+	case WatermarkStatusSuccess.String():
+		return &WatermarkStatusSuccess
+	case WatermarkStatusFailed.String():
+		return &WatermarkStatusFailed
+	case WatermarkStatusDisabled.String():
+		return &WatermarkStatusDisabled
+	default:
+		return &WatermarkStatusInvalid
+	}
+}
+
+func (w WatermarkStatus) MarshalGQL(i io.Writer) { _, _ = i.Write([]byte(`"` + w.String() + `"`)) }
+
+func (w *WatermarkStatus) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("wrong type for WatermarkStatus, got: %T", v) //nolint:err113
+	}
+
+	*w = WatermarkStatus(str)
+
+	return nil
+}

--- a/pkg/openlaneclient/models.go
+++ b/pkg/openlaneclient/models.go
@@ -6129,10 +6129,15 @@ type CreateTrustCenterDocInput struct {
 	Title string `json:"title"`
 	// category of the document
 	Category string `json:"category"`
+	// whether watermarking is enabled for the document. this will only take effect if watermarking is configured for the trust center
+	WatermarkingEnabled *bool `json:"watermarkingEnabled,omitempty"`
+	// status of the watermarking
+	WatermarkStatus *enums.WatermarkStatus `json:"watermarkStatus,omitempty"`
 	// visibility of the document
-	Visibility    *enums.TrustCenterDocumentVisibility `json:"visibility,omitempty"`
-	TrustCenterID *string                              `json:"trustCenterID,omitempty"`
-	FileID        *string                              `json:"fileID,omitempty"`
+	Visibility     *enums.TrustCenterDocumentVisibility `json:"visibility,omitempty"`
+	TrustCenterID  *string                              `json:"trustCenterID,omitempty"`
+	FileID         *string                              `json:"fileID,omitempty"`
+	OriginalFileID *string                              `json:"originalFileID,omitempty"`
 }
 
 // Input for createTrustCenterDomain mutation
@@ -28798,11 +28803,19 @@ type TrustCenterDoc struct {
 	Category string `json:"category"`
 	// ID of the file containing the document
 	FileID *string `json:"fileID,omitempty"`
+	// ID of the file containing the document, before any watermarking
+	OriginalFileID *string `json:"originalFileID,omitempty"`
+	// whether watermarking is enabled for the document. this will only take effect if watermarking is configured for the trust center
+	WatermarkingEnabled bool `json:"watermarkingEnabled"`
+	// status of the watermarking
+	WatermarkStatus *enums.WatermarkStatus `json:"watermarkStatus,omitempty"`
 	// visibility of the document
 	Visibility  *enums.TrustCenterDocumentVisibility `json:"visibility,omitempty"`
 	TrustCenter *TrustCenter                         `json:"trustCenter,omitempty"`
 	// the file containing the document content
 	File *File `json:"file,omitempty"`
+	// the file containing the document content, pre watermarking
+	OriginalFile *File `json:"originalFile,omitempty"`
 }
 
 func (TrustCenterDoc) IsNode() {}
@@ -28862,6 +28875,12 @@ type TrustCenterDocHistory struct {
 	Category string `json:"category"`
 	// ID of the file containing the document
 	FileID *string `json:"fileID,omitempty"`
+	// ID of the file containing the document, before any watermarking
+	OriginalFileID *string `json:"originalFileID,omitempty"`
+	// whether watermarking is enabled for the document. this will only take effect if watermarking is configured for the trust center
+	WatermarkingEnabled bool `json:"watermarkingEnabled"`
+	// status of the watermarking
+	WatermarkStatus *enums.WatermarkStatus `json:"watermarkStatus,omitempty"`
 	// visibility of the document
 	Visibility *enums.TrustCenterDocumentVisibility `json:"visibility,omitempty"`
 }
@@ -29055,6 +29074,32 @@ type TrustCenterDocHistoryWhereInput struct {
 	FileIDNotNil       *bool    `json:"fileIDNotNil,omitempty"`
 	FileIDEqualFold    *string  `json:"fileIDEqualFold,omitempty"`
 	FileIDContainsFold *string  `json:"fileIDContainsFold,omitempty"`
+	// original_file_id field predicates
+	OriginalFileID             *string  `json:"originalFileID,omitempty"`
+	OriginalFileIdneq          *string  `json:"originalFileIDNEQ,omitempty"`
+	OriginalFileIDIn           []string `json:"originalFileIDIn,omitempty"`
+	OriginalFileIDNotIn        []string `json:"originalFileIDNotIn,omitempty"`
+	OriginalFileIdgt           *string  `json:"originalFileIDGT,omitempty"`
+	OriginalFileIdgte          *string  `json:"originalFileIDGTE,omitempty"`
+	OriginalFileIdlt           *string  `json:"originalFileIDLT,omitempty"`
+	OriginalFileIdlte          *string  `json:"originalFileIDLTE,omitempty"`
+	OriginalFileIDContains     *string  `json:"originalFileIDContains,omitempty"`
+	OriginalFileIDHasPrefix    *string  `json:"originalFileIDHasPrefix,omitempty"`
+	OriginalFileIDHasSuffix    *string  `json:"originalFileIDHasSuffix,omitempty"`
+	OriginalFileIDIsNil        *bool    `json:"originalFileIDIsNil,omitempty"`
+	OriginalFileIDNotNil       *bool    `json:"originalFileIDNotNil,omitempty"`
+	OriginalFileIDEqualFold    *string  `json:"originalFileIDEqualFold,omitempty"`
+	OriginalFileIDContainsFold *string  `json:"originalFileIDContainsFold,omitempty"`
+	// watermarking_enabled field predicates
+	WatermarkingEnabled    *bool `json:"watermarkingEnabled,omitempty"`
+	WatermarkingEnabledNeq *bool `json:"watermarkingEnabledNEQ,omitempty"`
+	// watermark_status field predicates
+	WatermarkStatus       *enums.WatermarkStatus  `json:"watermarkStatus,omitempty"`
+	WatermarkStatusNeq    *enums.WatermarkStatus  `json:"watermarkStatusNEQ,omitempty"`
+	WatermarkStatusIn     []enums.WatermarkStatus `json:"watermarkStatusIn,omitempty"`
+	WatermarkStatusNotIn  []enums.WatermarkStatus `json:"watermarkStatusNotIn,omitempty"`
+	WatermarkStatusIsNil  *bool                   `json:"watermarkStatusIsNil,omitempty"`
+	WatermarkStatusNotNil *bool                   `json:"watermarkStatusNotNil,omitempty"`
 	// visibility field predicates
 	Visibility       *enums.TrustCenterDocumentVisibility  `json:"visibility,omitempty"`
 	VisibilityNeq    *enums.TrustCenterDocumentVisibility  `json:"visibilityNEQ,omitempty"`
@@ -29209,6 +29254,32 @@ type TrustCenterDocWhereInput struct {
 	FileIDNotNil       *bool    `json:"fileIDNotNil,omitempty"`
 	FileIDEqualFold    *string  `json:"fileIDEqualFold,omitempty"`
 	FileIDContainsFold *string  `json:"fileIDContainsFold,omitempty"`
+	// original_file_id field predicates
+	OriginalFileID             *string  `json:"originalFileID,omitempty"`
+	OriginalFileIdneq          *string  `json:"originalFileIDNEQ,omitempty"`
+	OriginalFileIDIn           []string `json:"originalFileIDIn,omitempty"`
+	OriginalFileIDNotIn        []string `json:"originalFileIDNotIn,omitempty"`
+	OriginalFileIdgt           *string  `json:"originalFileIDGT,omitempty"`
+	OriginalFileIdgte          *string  `json:"originalFileIDGTE,omitempty"`
+	OriginalFileIdlt           *string  `json:"originalFileIDLT,omitempty"`
+	OriginalFileIdlte          *string  `json:"originalFileIDLTE,omitempty"`
+	OriginalFileIDContains     *string  `json:"originalFileIDContains,omitempty"`
+	OriginalFileIDHasPrefix    *string  `json:"originalFileIDHasPrefix,omitempty"`
+	OriginalFileIDHasSuffix    *string  `json:"originalFileIDHasSuffix,omitempty"`
+	OriginalFileIDIsNil        *bool    `json:"originalFileIDIsNil,omitempty"`
+	OriginalFileIDNotNil       *bool    `json:"originalFileIDNotNil,omitempty"`
+	OriginalFileIDEqualFold    *string  `json:"originalFileIDEqualFold,omitempty"`
+	OriginalFileIDContainsFold *string  `json:"originalFileIDContainsFold,omitempty"`
+	// watermarking_enabled field predicates
+	WatermarkingEnabled    *bool `json:"watermarkingEnabled,omitempty"`
+	WatermarkingEnabledNeq *bool `json:"watermarkingEnabledNEQ,omitempty"`
+	// watermark_status field predicates
+	WatermarkStatus       *enums.WatermarkStatus  `json:"watermarkStatus,omitempty"`
+	WatermarkStatusNeq    *enums.WatermarkStatus  `json:"watermarkStatusNEQ,omitempty"`
+	WatermarkStatusIn     []enums.WatermarkStatus `json:"watermarkStatusIn,omitempty"`
+	WatermarkStatusNotIn  []enums.WatermarkStatus `json:"watermarkStatusNotIn,omitempty"`
+	WatermarkStatusIsNil  *bool                   `json:"watermarkStatusIsNil,omitempty"`
+	WatermarkStatusNotNil *bool                   `json:"watermarkStatusNotNil,omitempty"`
 	// visibility field predicates
 	Visibility       *enums.TrustCenterDocumentVisibility  `json:"visibility,omitempty"`
 	VisibilityNeq    *enums.TrustCenterDocumentVisibility  `json:"visibilityNEQ,omitempty"`
@@ -29222,6 +29293,9 @@ type TrustCenterDocWhereInput struct {
 	// file edge predicates
 	HasFile     *bool             `json:"hasFile,omitempty"`
 	HasFileWith []*FileWhereInput `json:"hasFileWith,omitempty"`
+	// original_file edge predicates
+	HasOriginalFile     *bool             `json:"hasOriginalFile,omitempty"`
+	HasOriginalFileWith []*FileWhereInput `json:"hasOriginalFileWith,omitempty"`
 }
 
 // Return response for createTrustCenterDomain mutation
@@ -33741,13 +33815,20 @@ type UpdateTrustCenterDocInput struct {
 	Title *string `json:"title,omitempty"`
 	// category of the document
 	Category *string `json:"category,omitempty"`
+	// whether watermarking is enabled for the document. this will only take effect if watermarking is configured for the trust center
+	WatermarkingEnabled *bool `json:"watermarkingEnabled,omitempty"`
+	// status of the watermarking
+	WatermarkStatus      *enums.WatermarkStatus `json:"watermarkStatus,omitempty"`
+	ClearWatermarkStatus *bool                  `json:"clearWatermarkStatus,omitempty"`
 	// visibility of the document
-	Visibility       *enums.TrustCenterDocumentVisibility `json:"visibility,omitempty"`
-	ClearVisibility  *bool                                `json:"clearVisibility,omitempty"`
-	TrustCenterID    *string                              `json:"trustCenterID,omitempty"`
-	ClearTrustCenter *bool                                `json:"clearTrustCenter,omitempty"`
-	FileID           *string                              `json:"fileID,omitempty"`
-	ClearFile        *bool                                `json:"clearFile,omitempty"`
+	Visibility        *enums.TrustCenterDocumentVisibility `json:"visibility,omitempty"`
+	ClearVisibility   *bool                                `json:"clearVisibility,omitempty"`
+	TrustCenterID     *string                              `json:"trustCenterID,omitempty"`
+	ClearTrustCenter  *bool                                `json:"clearTrustCenter,omitempty"`
+	FileID            *string                              `json:"fileID,omitempty"`
+	ClearFile         *bool                                `json:"clearFile,omitempty"`
+	OriginalFileID    *string                              `json:"originalFileID,omitempty"`
+	ClearOriginalFile *bool                                `json:"clearOriginalFile,omitempty"`
 }
 
 // UpdateTrustCenterInput is used for update TrustCenter object.


### PR DESCRIPTION
Trust center doc schema updates for watermarking.

Includes having an "original" file ID, which we will keep in case the watermarking changes or they need to get rid of the watermarking.


Also including the job scaffolding here.
