### PR TITLE
fix: reconcile fixes, delete org sub fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,7 +71,7 @@ results.txt
 *.env
 *.env-dev
 *.config.yaml
-*.config.docker.yaml
+*.config*yaml
 .hermit
 
 junit.xml

--- a/cmd/cli/cmd/orgsubscription/root.go
+++ b/cmd/cli/cmd/orgsubscription/root.go
@@ -83,13 +83,8 @@ func jsonOutput(out any) error {
 // tableOutput prints the output in a table format
 func tableOutput(out []openlaneclient.OrgSubscription) {
 	// create a table writer
-	writer := tables.NewTableWriter(command.OutOrStdout(), "ID", "Active", "StripeSubscriptionStatus", "Features", "Price", "ExpiresAt")
+	writer := tables.NewTableWriter(command.OutOrStdout(), "ID", "Active", "StripeSubscriptionStatus", "ExpiresAt")
 	for _, i := range out {
-		features := []string{}
-		if i.Features != nil {
-			features = i.Features
-		}
-
 		exp := ""
 		if i.ExpiresAt != nil {
 			exp = i.ExpiresAt.String()
@@ -97,16 +92,9 @@ func tableOutput(out []openlaneclient.OrgSubscription) {
 			exp = i.TrialExpiresAt.String()
 		}
 
-		price := ""
-		if i.ProductPrice != nil {
-			price = i.ProductPrice.String()
-		}
-
 		writer.AddRow(i.ID,
 			i.Active,
 			*i.StripeSubscriptionStatus,
-			strings.Join(features, ", "),
-			price,
 			exp,
 		)
 	}

--- a/internal/ent/generated/auditing.go
+++ b/internal/ent/generated/auditing.go
@@ -2198,9 +2198,6 @@ func (_m *OrgSubscriptionHistory) changes(new *OrgSubscriptionHistory) []Change 
 	if !reflect.DeepEqual(_m.StripeSubscriptionID, new.StripeSubscriptionID) {
 		changes = append(changes, NewChange(orgsubscriptionhistory.FieldStripeSubscriptionID, _m.StripeSubscriptionID, new.StripeSubscriptionID))
 	}
-	if !reflect.DeepEqual(_m.ProductPrice, new.ProductPrice) {
-		changes = append(changes, NewChange(orgsubscriptionhistory.FieldProductPrice, _m.ProductPrice, new.ProductPrice))
-	}
 	if !reflect.DeepEqual(_m.StripeSubscriptionStatus, new.StripeSubscriptionStatus) {
 		changes = append(changes, NewChange(orgsubscriptionhistory.FieldStripeSubscriptionStatus, _m.StripeSubscriptionStatus, new.StripeSubscriptionStatus))
 	}
@@ -2215,12 +2212,6 @@ func (_m *OrgSubscriptionHistory) changes(new *OrgSubscriptionHistory) []Change 
 	}
 	if !reflect.DeepEqual(_m.DaysUntilDue, new.DaysUntilDue) {
 		changes = append(changes, NewChange(orgsubscriptionhistory.FieldDaysUntilDue, _m.DaysUntilDue, new.DaysUntilDue))
-	}
-	if !reflect.DeepEqual(_m.Features, new.Features) {
-		changes = append(changes, NewChange(orgsubscriptionhistory.FieldFeatures, _m.Features, new.Features))
-	}
-	if !reflect.DeepEqual(_m.FeatureLookupKeys, new.FeatureLookupKeys) {
-		changes = append(changes, NewChange(orgsubscriptionhistory.FieldFeatureLookupKeys, _m.FeatureLookupKeys, new.FeatureLookupKeys))
 	}
 	return changes
 }

--- a/internal/ent/generated/entql.go
+++ b/internal/ent/generated/entql.go
@@ -2065,14 +2065,11 @@ var schemaGraph = func() *sqlgraph.Schema {
 			orgsubscription.FieldTags:                     {Type: field.TypeJSON, Column: orgsubscription.FieldTags},
 			orgsubscription.FieldOwnerID:                  {Type: field.TypeString, Column: orgsubscription.FieldOwnerID},
 			orgsubscription.FieldStripeSubscriptionID:     {Type: field.TypeString, Column: orgsubscription.FieldStripeSubscriptionID},
-			orgsubscription.FieldProductPrice:             {Type: field.TypeJSON, Column: orgsubscription.FieldProductPrice},
 			orgsubscription.FieldStripeSubscriptionStatus: {Type: field.TypeString, Column: orgsubscription.FieldStripeSubscriptionStatus},
 			orgsubscription.FieldActive:                   {Type: field.TypeBool, Column: orgsubscription.FieldActive},
 			orgsubscription.FieldExpiresAt:                {Type: field.TypeTime, Column: orgsubscription.FieldExpiresAt},
 			orgsubscription.FieldTrialExpiresAt:           {Type: field.TypeTime, Column: orgsubscription.FieldTrialExpiresAt},
 			orgsubscription.FieldDaysUntilDue:             {Type: field.TypeString, Column: orgsubscription.FieldDaysUntilDue},
-			orgsubscription.FieldFeatures:                 {Type: field.TypeJSON, Column: orgsubscription.FieldFeatures},
-			orgsubscription.FieldFeatureLookupKeys:        {Type: field.TypeJSON, Column: orgsubscription.FieldFeatureLookupKeys},
 		},
 	}
 	graph.Nodes[64] = &sqlgraph.Node{
@@ -2098,14 +2095,11 @@ var schemaGraph = func() *sqlgraph.Schema {
 			orgsubscriptionhistory.FieldTags:                     {Type: field.TypeJSON, Column: orgsubscriptionhistory.FieldTags},
 			orgsubscriptionhistory.FieldOwnerID:                  {Type: field.TypeString, Column: orgsubscriptionhistory.FieldOwnerID},
 			orgsubscriptionhistory.FieldStripeSubscriptionID:     {Type: field.TypeString, Column: orgsubscriptionhistory.FieldStripeSubscriptionID},
-			orgsubscriptionhistory.FieldProductPrice:             {Type: field.TypeJSON, Column: orgsubscriptionhistory.FieldProductPrice},
 			orgsubscriptionhistory.FieldStripeSubscriptionStatus: {Type: field.TypeString, Column: orgsubscriptionhistory.FieldStripeSubscriptionStatus},
 			orgsubscriptionhistory.FieldActive:                   {Type: field.TypeBool, Column: orgsubscriptionhistory.FieldActive},
 			orgsubscriptionhistory.FieldExpiresAt:                {Type: field.TypeTime, Column: orgsubscriptionhistory.FieldExpiresAt},
 			orgsubscriptionhistory.FieldTrialExpiresAt:           {Type: field.TypeTime, Column: orgsubscriptionhistory.FieldTrialExpiresAt},
 			orgsubscriptionhistory.FieldDaysUntilDue:             {Type: field.TypeString, Column: orgsubscriptionhistory.FieldDaysUntilDue},
-			orgsubscriptionhistory.FieldFeatures:                 {Type: field.TypeJSON, Column: orgsubscriptionhistory.FieldFeatures},
-			orgsubscriptionhistory.FieldFeatureLookupKeys:        {Type: field.TypeJSON, Column: orgsubscriptionhistory.FieldFeatureLookupKeys},
 		},
 	}
 	graph.Nodes[65] = &sqlgraph.Node{
@@ -20669,11 +20663,6 @@ func (f *OrgSubscriptionFilter) WhereStripeSubscriptionID(p entql.StringP) {
 	f.Where(p.Field(orgsubscription.FieldStripeSubscriptionID))
 }
 
-// WhereProductPrice applies the entql json.RawMessage predicate on the product_price field.
-func (f *OrgSubscriptionFilter) WhereProductPrice(p entql.BytesP) {
-	f.Where(p.Field(orgsubscription.FieldProductPrice))
-}
-
 // WhereStripeSubscriptionStatus applies the entql string predicate on the stripe_subscription_status field.
 func (f *OrgSubscriptionFilter) WhereStripeSubscriptionStatus(p entql.StringP) {
 	f.Where(p.Field(orgsubscription.FieldStripeSubscriptionStatus))
@@ -20697,16 +20686,6 @@ func (f *OrgSubscriptionFilter) WhereTrialExpiresAt(p entql.TimeP) {
 // WhereDaysUntilDue applies the entql string predicate on the days_until_due field.
 func (f *OrgSubscriptionFilter) WhereDaysUntilDue(p entql.StringP) {
 	f.Where(p.Field(orgsubscription.FieldDaysUntilDue))
-}
-
-// WhereFeatures applies the entql json.RawMessage predicate on the features field.
-func (f *OrgSubscriptionFilter) WhereFeatures(p entql.BytesP) {
-	f.Where(p.Field(orgsubscription.FieldFeatures))
-}
-
-// WhereFeatureLookupKeys applies the entql json.RawMessage predicate on the feature_lookup_keys field.
-func (f *OrgSubscriptionFilter) WhereFeatureLookupKeys(p entql.BytesP) {
-	f.Where(p.Field(orgsubscription.FieldFeatureLookupKeys))
 }
 
 // WhereHasOwner applies a predicate to check if query has an edge owner.
@@ -20879,11 +20858,6 @@ func (f *OrgSubscriptionHistoryFilter) WhereStripeSubscriptionID(p entql.StringP
 	f.Where(p.Field(orgsubscriptionhistory.FieldStripeSubscriptionID))
 }
 
-// WhereProductPrice applies the entql json.RawMessage predicate on the product_price field.
-func (f *OrgSubscriptionHistoryFilter) WhereProductPrice(p entql.BytesP) {
-	f.Where(p.Field(orgsubscriptionhistory.FieldProductPrice))
-}
-
 // WhereStripeSubscriptionStatus applies the entql string predicate on the stripe_subscription_status field.
 func (f *OrgSubscriptionHistoryFilter) WhereStripeSubscriptionStatus(p entql.StringP) {
 	f.Where(p.Field(orgsubscriptionhistory.FieldStripeSubscriptionStatus))
@@ -20907,16 +20881,6 @@ func (f *OrgSubscriptionHistoryFilter) WhereTrialExpiresAt(p entql.TimeP) {
 // WhereDaysUntilDue applies the entql string predicate on the days_until_due field.
 func (f *OrgSubscriptionHistoryFilter) WhereDaysUntilDue(p entql.StringP) {
 	f.Where(p.Field(orgsubscriptionhistory.FieldDaysUntilDue))
-}
-
-// WhereFeatures applies the entql json.RawMessage predicate on the features field.
-func (f *OrgSubscriptionHistoryFilter) WhereFeatures(p entql.BytesP) {
-	f.Where(p.Field(orgsubscriptionhistory.FieldFeatures))
-}
-
-// WhereFeatureLookupKeys applies the entql json.RawMessage predicate on the feature_lookup_keys field.
-func (f *OrgSubscriptionHistoryFilter) WhereFeatureLookupKeys(p entql.BytesP) {
-	f.Where(p.Field(orgsubscriptionhistory.FieldFeatureLookupKeys))
 }
 
 // addPredicate implements the predicateAdder interface.

--- a/internal/ent/generated/gql_collection.go
+++ b/internal/ent/generated/gql_collection.go
@@ -25458,11 +25458,6 @@ func (_q *OrgSubscriptionQuery) collectField(ctx context.Context, oneNode bool, 
 				selectedFields = append(selectedFields, orgsubscription.FieldStripeSubscriptionID)
 				fieldSeen[orgsubscription.FieldStripeSubscriptionID] = struct{}{}
 			}
-		case "productPrice":
-			if _, ok := fieldSeen[orgsubscription.FieldProductPrice]; !ok {
-				selectedFields = append(selectedFields, orgsubscription.FieldProductPrice)
-				fieldSeen[orgsubscription.FieldProductPrice] = struct{}{}
-			}
 		case "stripeSubscriptionStatus":
 			if _, ok := fieldSeen[orgsubscription.FieldStripeSubscriptionStatus]; !ok {
 				selectedFields = append(selectedFields, orgsubscription.FieldStripeSubscriptionStatus)
@@ -25487,16 +25482,6 @@ func (_q *OrgSubscriptionQuery) collectField(ctx context.Context, oneNode bool, 
 			if _, ok := fieldSeen[orgsubscription.FieldDaysUntilDue]; !ok {
 				selectedFields = append(selectedFields, orgsubscription.FieldDaysUntilDue)
 				fieldSeen[orgsubscription.FieldDaysUntilDue] = struct{}{}
-			}
-		case "features":
-			if _, ok := fieldSeen[orgsubscription.FieldFeatures]; !ok {
-				selectedFields = append(selectedFields, orgsubscription.FieldFeatures)
-				fieldSeen[orgsubscription.FieldFeatures] = struct{}{}
-			}
-		case "featureLookupKeys":
-			if _, ok := fieldSeen[orgsubscription.FieldFeatureLookupKeys]; !ok {
-				selectedFields = append(selectedFields, orgsubscription.FieldFeatureLookupKeys)
-				fieldSeen[orgsubscription.FieldFeatureLookupKeys] = struct{}{}
 			}
 		case "id":
 		case "__typename":
@@ -25632,11 +25617,6 @@ func (_q *OrgSubscriptionHistoryQuery) collectField(ctx context.Context, oneNode
 				selectedFields = append(selectedFields, orgsubscriptionhistory.FieldStripeSubscriptionID)
 				fieldSeen[orgsubscriptionhistory.FieldStripeSubscriptionID] = struct{}{}
 			}
-		case "productPrice":
-			if _, ok := fieldSeen[orgsubscriptionhistory.FieldProductPrice]; !ok {
-				selectedFields = append(selectedFields, orgsubscriptionhistory.FieldProductPrice)
-				fieldSeen[orgsubscriptionhistory.FieldProductPrice] = struct{}{}
-			}
 		case "stripeSubscriptionStatus":
 			if _, ok := fieldSeen[orgsubscriptionhistory.FieldStripeSubscriptionStatus]; !ok {
 				selectedFields = append(selectedFields, orgsubscriptionhistory.FieldStripeSubscriptionStatus)
@@ -25661,16 +25641,6 @@ func (_q *OrgSubscriptionHistoryQuery) collectField(ctx context.Context, oneNode
 			if _, ok := fieldSeen[orgsubscriptionhistory.FieldDaysUntilDue]; !ok {
 				selectedFields = append(selectedFields, orgsubscriptionhistory.FieldDaysUntilDue)
 				fieldSeen[orgsubscriptionhistory.FieldDaysUntilDue] = struct{}{}
-			}
-		case "features":
-			if _, ok := fieldSeen[orgsubscriptionhistory.FieldFeatures]; !ok {
-				selectedFields = append(selectedFields, orgsubscriptionhistory.FieldFeatures)
-				fieldSeen[orgsubscriptionhistory.FieldFeatures] = struct{}{}
-			}
-		case "featureLookupKeys":
-			if _, ok := fieldSeen[orgsubscriptionhistory.FieldFeatureLookupKeys]; !ok {
-				selectedFields = append(selectedFields, orgsubscriptionhistory.FieldFeatureLookupKeys)
-				fieldSeen[orgsubscriptionhistory.FieldFeatureLookupKeys] = struct{}{}
 			}
 		case "id":
 		case "__typename":

--- a/internal/ent/generated/history_from_mutation.go
+++ b/internal/ent/generated/history_from_mutation.go
@@ -6997,10 +6997,6 @@ func (m *OrgSubscriptionMutation) CreateHistoryFromCreate(ctx context.Context) e
 		create = create.SetStripeSubscriptionID(stripeSubscriptionID)
 	}
 
-	if productPrice, exists := m.ProductPrice(); exists {
-		create = create.SetProductPrice(productPrice)
-	}
-
 	if stripeSubscriptionStatus, exists := m.StripeSubscriptionStatus(); exists {
 		create = create.SetStripeSubscriptionStatus(stripeSubscriptionStatus)
 	}
@@ -7019,14 +7015,6 @@ func (m *OrgSubscriptionMutation) CreateHistoryFromCreate(ctx context.Context) e
 
 	if daysUntilDue, exists := m.DaysUntilDue(); exists {
 		create = create.SetNillableDaysUntilDue(&daysUntilDue)
-	}
-
-	if features, exists := m.Features(); exists {
-		create = create.SetFeatures(features)
-	}
-
-	if featureLookupKeys, exists := m.FeatureLookupKeys(); exists {
-		create = create.SetFeatureLookupKeys(featureLookupKeys)
 	}
 
 	_, err := create.Save(ctx)
@@ -7114,12 +7102,6 @@ func (m *OrgSubscriptionMutation) CreateHistoryFromUpdate(ctx context.Context) e
 			create = create.SetStripeSubscriptionID(orgsubscription.StripeSubscriptionID)
 		}
 
-		if productPrice, exists := m.ProductPrice(); exists {
-			create = create.SetProductPrice(productPrice)
-		} else {
-			create = create.SetProductPrice(orgsubscription.ProductPrice)
-		}
-
 		if stripeSubscriptionStatus, exists := m.StripeSubscriptionStatus(); exists {
 			create = create.SetStripeSubscriptionStatus(stripeSubscriptionStatus)
 		} else {
@@ -7148,18 +7130,6 @@ func (m *OrgSubscriptionMutation) CreateHistoryFromUpdate(ctx context.Context) e
 			create = create.SetNillableDaysUntilDue(&daysUntilDue)
 		} else {
 			create = create.SetNillableDaysUntilDue(orgsubscription.DaysUntilDue)
-		}
-
-		if features, exists := m.Features(); exists {
-			create = create.SetFeatures(features)
-		} else {
-			create = create.SetFeatures(orgsubscription.Features)
-		}
-
-		if featureLookupKeys, exists := m.FeatureLookupKeys(); exists {
-			create = create.SetFeatureLookupKeys(featureLookupKeys)
-		} else {
-			create = create.SetFeatureLookupKeys(orgsubscription.FeatureLookupKeys)
 		}
 
 		if _, err := create.Save(ctx); err != nil {
@@ -7206,14 +7176,11 @@ func (m *OrgSubscriptionMutation) CreateHistoryFromDelete(ctx context.Context) e
 			SetTags(orgsubscription.Tags).
 			SetOwnerID(orgsubscription.OwnerID).
 			SetStripeSubscriptionID(orgsubscription.StripeSubscriptionID).
-			SetProductPrice(orgsubscription.ProductPrice).
 			SetStripeSubscriptionStatus(orgsubscription.StripeSubscriptionStatus).
 			SetActive(orgsubscription.Active).
 			SetNillableExpiresAt(orgsubscription.ExpiresAt).
 			SetNillableTrialExpiresAt(orgsubscription.TrialExpiresAt).
 			SetNillableDaysUntilDue(orgsubscription.DaysUntilDue).
-			SetFeatures(orgsubscription.Features).
-			SetFeatureLookupKeys(orgsubscription.FeatureLookupKeys).
 			Save(ctx)
 		if err != nil {
 			return err

--- a/internal/ent/generated/migrate/schema.go
+++ b/internal/ent/generated/migrate/schema.go
@@ -3089,14 +3089,11 @@ var (
 		{Name: "deleted_by", Type: field.TypeString, Nullable: true},
 		{Name: "tags", Type: field.TypeJSON, Nullable: true},
 		{Name: "stripe_subscription_id", Type: field.TypeString, Nullable: true},
-		{Name: "product_price", Type: field.TypeJSON, Nullable: true},
 		{Name: "stripe_subscription_status", Type: field.TypeString, Nullable: true},
 		{Name: "active", Type: field.TypeBool, Default: true},
 		{Name: "expires_at", Type: field.TypeTime, Nullable: true},
 		{Name: "trial_expires_at", Type: field.TypeTime, Nullable: true},
 		{Name: "days_until_due", Type: field.TypeString, Nullable: true},
-		{Name: "features", Type: field.TypeJSON, Nullable: true},
-		{Name: "feature_lookup_keys", Type: field.TypeJSON, Nullable: true},
 		{Name: "owner_id", Type: field.TypeString, Nullable: true},
 	}
 	// OrgSubscriptionsTable holds the schema information for the "org_subscriptions" table.
@@ -3107,7 +3104,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "org_subscriptions_organizations_org_subscriptions",
-				Columns:    []*schema.Column{OrgSubscriptionsColumns[17]},
+				Columns:    []*schema.Column{OrgSubscriptionsColumns[14]},
 				RefColumns: []*schema.Column{OrganizationsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -3116,7 +3113,7 @@ var (
 			{
 				Name:    "orgsubscription_owner_id",
 				Unique:  false,
-				Columns: []*schema.Column{OrgSubscriptionsColumns[17]},
+				Columns: []*schema.Column{OrgSubscriptionsColumns[14]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "deleted_at is NULL",
 				},
@@ -3138,14 +3135,11 @@ var (
 		{Name: "tags", Type: field.TypeJSON, Nullable: true},
 		{Name: "owner_id", Type: field.TypeString, Nullable: true},
 		{Name: "stripe_subscription_id", Type: field.TypeString, Nullable: true},
-		{Name: "product_price", Type: field.TypeJSON, Nullable: true},
 		{Name: "stripe_subscription_status", Type: field.TypeString, Nullable: true},
 		{Name: "active", Type: field.TypeBool, Default: true},
 		{Name: "expires_at", Type: field.TypeTime, Nullable: true},
 		{Name: "trial_expires_at", Type: field.TypeTime, Nullable: true},
 		{Name: "days_until_due", Type: field.TypeString, Nullable: true},
-		{Name: "features", Type: field.TypeJSON, Nullable: true},
-		{Name: "feature_lookup_keys", Type: field.TypeJSON, Nullable: true},
 	}
 	// OrgSubscriptionHistoryTable holds the schema information for the "org_subscription_history" table.
 	OrgSubscriptionHistoryTable = &schema.Table{

--- a/internal/ent/generated/orgsubscription.go
+++ b/internal/ent/generated/orgsubscription.go
@@ -12,7 +12,6 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"github.com/theopenlane/core/internal/ent/generated/organization"
 	"github.com/theopenlane/core/internal/ent/generated/orgsubscription"
-	"github.com/theopenlane/core/pkg/models"
 )
 
 // OrgSubscription is the model entity for the OrgSubscription schema.
@@ -38,8 +37,6 @@ type OrgSubscription struct {
 	OwnerID string `json:"owner_id,omitempty"`
 	// the stripe subscription id
 	StripeSubscriptionID string `json:"stripe_subscription_id,omitempty"`
-	// the price of the product tier
-	ProductPrice models.Price `json:"product_price,omitempty"`
 	// the status of the subscription in stripe -- see https://docs.stripe.com/api/subscriptions/object#subscription_object-status
 	StripeSubscriptionStatus string `json:"stripe_subscription_status,omitempty"`
 	// indicates if the subscription is active
@@ -50,10 +47,6 @@ type OrgSubscription struct {
 	TrialExpiresAt *time.Time `json:"trial_expires_at,omitempty"`
 	// number of days until there is a due payment
 	DaysUntilDue *string `json:"days_until_due,omitempty"`
-	// the features associated with the subscription
-	Features []string `json:"features,omitempty"`
-	// the feature lookup keys associated with the subscription
-	FeatureLookupKeys []string `json:"feature_lookup_keys,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the OrgSubscriptionQuery when eager-loading is set.
 	Edges        OrgSubscriptionEdges `json:"edges"`
@@ -139,7 +132,7 @@ func (*OrgSubscription) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case orgsubscription.FieldTags, orgsubscription.FieldProductPrice, orgsubscription.FieldFeatures, orgsubscription.FieldFeatureLookupKeys:
+		case orgsubscription.FieldTags:
 			values[i] = new([]byte)
 		case orgsubscription.FieldActive:
 			values[i] = new(sql.NullBool)
@@ -224,14 +217,6 @@ func (_m *OrgSubscription) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.StripeSubscriptionID = value.String
 			}
-		case orgsubscription.FieldProductPrice:
-			if value, ok := values[i].(*[]byte); !ok {
-				return fmt.Errorf("unexpected type %T for field product_price", values[i])
-			} else if value != nil && len(*value) > 0 {
-				if err := json.Unmarshal(*value, &_m.ProductPrice); err != nil {
-					return fmt.Errorf("unmarshal field product_price: %w", err)
-				}
-			}
 		case orgsubscription.FieldStripeSubscriptionStatus:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field stripe_subscription_status", values[i])
@@ -264,22 +249,6 @@ func (_m *OrgSubscription) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.DaysUntilDue = new(string)
 				*_m.DaysUntilDue = value.String
-			}
-		case orgsubscription.FieldFeatures:
-			if value, ok := values[i].(*[]byte); !ok {
-				return fmt.Errorf("unexpected type %T for field features", values[i])
-			} else if value != nil && len(*value) > 0 {
-				if err := json.Unmarshal(*value, &_m.Features); err != nil {
-					return fmt.Errorf("unmarshal field features: %w", err)
-				}
-			}
-		case orgsubscription.FieldFeatureLookupKeys:
-			if value, ok := values[i].(*[]byte); !ok {
-				return fmt.Errorf("unexpected type %T for field feature_lookup_keys", values[i])
-			} else if value != nil && len(*value) > 0 {
-				if err := json.Unmarshal(*value, &_m.FeatureLookupKeys); err != nil {
-					return fmt.Errorf("unmarshal field feature_lookup_keys: %w", err)
-				}
 			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
@@ -369,9 +338,6 @@ func (_m *OrgSubscription) String() string {
 	builder.WriteString("stripe_subscription_id=")
 	builder.WriteString(_m.StripeSubscriptionID)
 	builder.WriteString(", ")
-	builder.WriteString("product_price=")
-	builder.WriteString(fmt.Sprintf("%v", _m.ProductPrice))
-	builder.WriteString(", ")
 	builder.WriteString("stripe_subscription_status=")
 	builder.WriteString(_m.StripeSubscriptionStatus)
 	builder.WriteString(", ")
@@ -392,12 +358,6 @@ func (_m *OrgSubscription) String() string {
 		builder.WriteString("days_until_due=")
 		builder.WriteString(*v)
 	}
-	builder.WriteString(", ")
-	builder.WriteString("features=")
-	builder.WriteString(fmt.Sprintf("%v", _m.Features))
-	builder.WriteString(", ")
-	builder.WriteString("feature_lookup_keys=")
-	builder.WriteString(fmt.Sprintf("%v", _m.FeatureLookupKeys))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/internal/ent/generated/orgsubscription/orgsubscription.go
+++ b/internal/ent/generated/orgsubscription/orgsubscription.go
@@ -33,8 +33,6 @@ const (
 	FieldOwnerID = "owner_id"
 	// FieldStripeSubscriptionID holds the string denoting the stripe_subscription_id field in the database.
 	FieldStripeSubscriptionID = "stripe_subscription_id"
-	// FieldProductPrice holds the string denoting the product_price field in the database.
-	FieldProductPrice = "product_price"
 	// FieldStripeSubscriptionStatus holds the string denoting the stripe_subscription_status field in the database.
 	FieldStripeSubscriptionStatus = "stripe_subscription_status"
 	// FieldActive holds the string denoting the active field in the database.
@@ -45,10 +43,6 @@ const (
 	FieldTrialExpiresAt = "trial_expires_at"
 	// FieldDaysUntilDue holds the string denoting the days_until_due field in the database.
 	FieldDaysUntilDue = "days_until_due"
-	// FieldFeatures holds the string denoting the features field in the database.
-	FieldFeatures = "features"
-	// FieldFeatureLookupKeys holds the string denoting the feature_lookup_keys field in the database.
-	FieldFeatureLookupKeys = "feature_lookup_keys"
 	// EdgeOwner holds the string denoting the owner edge name in mutations.
 	EdgeOwner = "owner"
 	// EdgeEvents holds the string denoting the events edge name in mutations.
@@ -108,14 +102,11 @@ var Columns = []string{
 	FieldTags,
 	FieldOwnerID,
 	FieldStripeSubscriptionID,
-	FieldProductPrice,
 	FieldStripeSubscriptionStatus,
 	FieldActive,
 	FieldExpiresAt,
 	FieldTrialExpiresAt,
 	FieldDaysUntilDue,
-	FieldFeatures,
-	FieldFeatureLookupKeys,
 }
 
 var (

--- a/internal/ent/generated/orgsubscription/where.go
+++ b/internal/ent/generated/orgsubscription/where.go
@@ -667,16 +667,6 @@ func StripeSubscriptionIDContainsFold(v string) predicate.OrgSubscription {
 	return predicate.OrgSubscription(sql.FieldContainsFold(FieldStripeSubscriptionID, v))
 }
 
-// ProductPriceIsNil applies the IsNil predicate on the "product_price" field.
-func ProductPriceIsNil() predicate.OrgSubscription {
-	return predicate.OrgSubscription(sql.FieldIsNull(FieldProductPrice))
-}
-
-// ProductPriceNotNil applies the NotNil predicate on the "product_price" field.
-func ProductPriceNotNil() predicate.OrgSubscription {
-	return predicate.OrgSubscription(sql.FieldNotNull(FieldProductPrice))
-}
-
 // StripeSubscriptionStatusEQ applies the EQ predicate on the "stripe_subscription_status" field.
 func StripeSubscriptionStatusEQ(v string) predicate.OrgSubscription {
 	return predicate.OrgSubscription(sql.FieldEQ(FieldStripeSubscriptionStatus, v))
@@ -935,26 +925,6 @@ func DaysUntilDueEqualFold(v string) predicate.OrgSubscription {
 // DaysUntilDueContainsFold applies the ContainsFold predicate on the "days_until_due" field.
 func DaysUntilDueContainsFold(v string) predicate.OrgSubscription {
 	return predicate.OrgSubscription(sql.FieldContainsFold(FieldDaysUntilDue, v))
-}
-
-// FeaturesIsNil applies the IsNil predicate on the "features" field.
-func FeaturesIsNil() predicate.OrgSubscription {
-	return predicate.OrgSubscription(sql.FieldIsNull(FieldFeatures))
-}
-
-// FeaturesNotNil applies the NotNil predicate on the "features" field.
-func FeaturesNotNil() predicate.OrgSubscription {
-	return predicate.OrgSubscription(sql.FieldNotNull(FieldFeatures))
-}
-
-// FeatureLookupKeysIsNil applies the IsNil predicate on the "feature_lookup_keys" field.
-func FeatureLookupKeysIsNil() predicate.OrgSubscription {
-	return predicate.OrgSubscription(sql.FieldIsNull(FieldFeatureLookupKeys))
-}
-
-// FeatureLookupKeysNotNil applies the NotNil predicate on the "feature_lookup_keys" field.
-func FeatureLookupKeysNotNil() predicate.OrgSubscription {
-	return predicate.OrgSubscription(sql.FieldNotNull(FieldFeatureLookupKeys))
 }
 
 // HasOwner applies the HasEdge predicate on the "owner" edge.

--- a/internal/ent/generated/orgsubscription_create.go
+++ b/internal/ent/generated/orgsubscription_create.go
@@ -16,7 +16,6 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated/orgprice"
 	"github.com/theopenlane/core/internal/ent/generated/orgproduct"
 	"github.com/theopenlane/core/internal/ent/generated/orgsubscription"
-	"github.com/theopenlane/core/pkg/models"
 )
 
 // OrgSubscriptionCreate is the builder for creating a OrgSubscription entity.
@@ -144,20 +143,6 @@ func (_c *OrgSubscriptionCreate) SetNillableStripeSubscriptionID(v *string) *Org
 	return _c
 }
 
-// SetProductPrice sets the "product_price" field.
-func (_c *OrgSubscriptionCreate) SetProductPrice(v models.Price) *OrgSubscriptionCreate {
-	_c.mutation.SetProductPrice(v)
-	return _c
-}
-
-// SetNillableProductPrice sets the "product_price" field if the given value is not nil.
-func (_c *OrgSubscriptionCreate) SetNillableProductPrice(v *models.Price) *OrgSubscriptionCreate {
-	if v != nil {
-		_c.SetProductPrice(*v)
-	}
-	return _c
-}
-
 // SetStripeSubscriptionStatus sets the "stripe_subscription_status" field.
 func (_c *OrgSubscriptionCreate) SetStripeSubscriptionStatus(v string) *OrgSubscriptionCreate {
 	_c.mutation.SetStripeSubscriptionStatus(v)
@@ -225,18 +210,6 @@ func (_c *OrgSubscriptionCreate) SetNillableDaysUntilDue(v *string) *OrgSubscrip
 	if v != nil {
 		_c.SetDaysUntilDue(*v)
 	}
-	return _c
-}
-
-// SetFeatures sets the "features" field.
-func (_c *OrgSubscriptionCreate) SetFeatures(v []string) *OrgSubscriptionCreate {
-	_c.mutation.SetFeatures(v)
-	return _c
-}
-
-// SetFeatureLookupKeys sets the "feature_lookup_keys" field.
-func (_c *OrgSubscriptionCreate) SetFeatureLookupKeys(v []string) *OrgSubscriptionCreate {
-	_c.mutation.SetFeatureLookupKeys(v)
 	return _c
 }
 
@@ -466,10 +439,6 @@ func (_c *OrgSubscriptionCreate) createSpec() (*OrgSubscription, *sqlgraph.Creat
 		_spec.SetField(orgsubscription.FieldStripeSubscriptionID, field.TypeString, value)
 		_node.StripeSubscriptionID = value
 	}
-	if value, ok := _c.mutation.ProductPrice(); ok {
-		_spec.SetField(orgsubscription.FieldProductPrice, field.TypeJSON, value)
-		_node.ProductPrice = value
-	}
 	if value, ok := _c.mutation.StripeSubscriptionStatus(); ok {
 		_spec.SetField(orgsubscription.FieldStripeSubscriptionStatus, field.TypeString, value)
 		_node.StripeSubscriptionStatus = value
@@ -489,14 +458,6 @@ func (_c *OrgSubscriptionCreate) createSpec() (*OrgSubscription, *sqlgraph.Creat
 	if value, ok := _c.mutation.DaysUntilDue(); ok {
 		_spec.SetField(orgsubscription.FieldDaysUntilDue, field.TypeString, value)
 		_node.DaysUntilDue = &value
-	}
-	if value, ok := _c.mutation.Features(); ok {
-		_spec.SetField(orgsubscription.FieldFeatures, field.TypeJSON, value)
-		_node.Features = value
-	}
-	if value, ok := _c.mutation.FeatureLookupKeys(); ok {
-		_spec.SetField(orgsubscription.FieldFeatureLookupKeys, field.TypeJSON, value)
-		_node.FeatureLookupKeys = value
 	}
 	if nodes := _c.mutation.OwnerIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/internal/ent/generated/orgsubscription_update.go
+++ b/internal/ent/generated/orgsubscription_update.go
@@ -19,7 +19,6 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated/orgproduct"
 	"github.com/theopenlane/core/internal/ent/generated/orgsubscription"
 	"github.com/theopenlane/core/internal/ent/generated/predicate"
-	"github.com/theopenlane/core/pkg/models"
 
 	"github.com/theopenlane/core/internal/ent/generated/internal"
 )
@@ -168,26 +167,6 @@ func (_u *OrgSubscriptionUpdate) ClearStripeSubscriptionID() *OrgSubscriptionUpd
 	return _u
 }
 
-// SetProductPrice sets the "product_price" field.
-func (_u *OrgSubscriptionUpdate) SetProductPrice(v models.Price) *OrgSubscriptionUpdate {
-	_u.mutation.SetProductPrice(v)
-	return _u
-}
-
-// SetNillableProductPrice sets the "product_price" field if the given value is not nil.
-func (_u *OrgSubscriptionUpdate) SetNillableProductPrice(v *models.Price) *OrgSubscriptionUpdate {
-	if v != nil {
-		_u.SetProductPrice(*v)
-	}
-	return _u
-}
-
-// ClearProductPrice clears the value of the "product_price" field.
-func (_u *OrgSubscriptionUpdate) ClearProductPrice() *OrgSubscriptionUpdate {
-	_u.mutation.ClearProductPrice()
-	return _u
-}
-
 // SetStripeSubscriptionStatus sets the "stripe_subscription_status" field.
 func (_u *OrgSubscriptionUpdate) SetStripeSubscriptionStatus(v string) *OrgSubscriptionUpdate {
 	_u.mutation.SetStripeSubscriptionStatus(v)
@@ -279,42 +258,6 @@ func (_u *OrgSubscriptionUpdate) SetNillableDaysUntilDue(v *string) *OrgSubscrip
 // ClearDaysUntilDue clears the value of the "days_until_due" field.
 func (_u *OrgSubscriptionUpdate) ClearDaysUntilDue() *OrgSubscriptionUpdate {
 	_u.mutation.ClearDaysUntilDue()
-	return _u
-}
-
-// SetFeatures sets the "features" field.
-func (_u *OrgSubscriptionUpdate) SetFeatures(v []string) *OrgSubscriptionUpdate {
-	_u.mutation.SetFeatures(v)
-	return _u
-}
-
-// AppendFeatures appends value to the "features" field.
-func (_u *OrgSubscriptionUpdate) AppendFeatures(v []string) *OrgSubscriptionUpdate {
-	_u.mutation.AppendFeatures(v)
-	return _u
-}
-
-// ClearFeatures clears the value of the "features" field.
-func (_u *OrgSubscriptionUpdate) ClearFeatures() *OrgSubscriptionUpdate {
-	_u.mutation.ClearFeatures()
-	return _u
-}
-
-// SetFeatureLookupKeys sets the "feature_lookup_keys" field.
-func (_u *OrgSubscriptionUpdate) SetFeatureLookupKeys(v []string) *OrgSubscriptionUpdate {
-	_u.mutation.SetFeatureLookupKeys(v)
-	return _u
-}
-
-// AppendFeatureLookupKeys appends value to the "feature_lookup_keys" field.
-func (_u *OrgSubscriptionUpdate) AppendFeatureLookupKeys(v []string) *OrgSubscriptionUpdate {
-	_u.mutation.AppendFeatureLookupKeys(v)
-	return _u
-}
-
-// ClearFeatureLookupKeys clears the value of the "feature_lookup_keys" field.
-func (_u *OrgSubscriptionUpdate) ClearFeatureLookupKeys() *OrgSubscriptionUpdate {
-	_u.mutation.ClearFeatureLookupKeys()
 	return _u
 }
 
@@ -595,12 +538,6 @@ func (_u *OrgSubscriptionUpdate) sqlSave(ctx context.Context) (_node int, err er
 	if _u.mutation.StripeSubscriptionIDCleared() {
 		_spec.ClearField(orgsubscription.FieldStripeSubscriptionID, field.TypeString)
 	}
-	if value, ok := _u.mutation.ProductPrice(); ok {
-		_spec.SetField(orgsubscription.FieldProductPrice, field.TypeJSON, value)
-	}
-	if _u.mutation.ProductPriceCleared() {
-		_spec.ClearField(orgsubscription.FieldProductPrice, field.TypeJSON)
-	}
 	if value, ok := _u.mutation.StripeSubscriptionStatus(); ok {
 		_spec.SetField(orgsubscription.FieldStripeSubscriptionStatus, field.TypeString, value)
 	}
@@ -627,28 +564,6 @@ func (_u *OrgSubscriptionUpdate) sqlSave(ctx context.Context) (_node int, err er
 	}
 	if _u.mutation.DaysUntilDueCleared() {
 		_spec.ClearField(orgsubscription.FieldDaysUntilDue, field.TypeString)
-	}
-	if value, ok := _u.mutation.Features(); ok {
-		_spec.SetField(orgsubscription.FieldFeatures, field.TypeJSON, value)
-	}
-	if value, ok := _u.mutation.AppendedFeatures(); ok {
-		_spec.AddModifier(func(u *sql.UpdateBuilder) {
-			sqljson.Append(u, orgsubscription.FieldFeatures, value)
-		})
-	}
-	if _u.mutation.FeaturesCleared() {
-		_spec.ClearField(orgsubscription.FieldFeatures, field.TypeJSON)
-	}
-	if value, ok := _u.mutation.FeatureLookupKeys(); ok {
-		_spec.SetField(orgsubscription.FieldFeatureLookupKeys, field.TypeJSON, value)
-	}
-	if value, ok := _u.mutation.AppendedFeatureLookupKeys(); ok {
-		_spec.AddModifier(func(u *sql.UpdateBuilder) {
-			sqljson.Append(u, orgsubscription.FieldFeatureLookupKeys, value)
-		})
-	}
-	if _u.mutation.FeatureLookupKeysCleared() {
-		_spec.ClearField(orgsubscription.FieldFeatureLookupKeys, field.TypeJSON)
 	}
 	if _u.mutation.OwnerCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -1027,26 +942,6 @@ func (_u *OrgSubscriptionUpdateOne) ClearStripeSubscriptionID() *OrgSubscription
 	return _u
 }
 
-// SetProductPrice sets the "product_price" field.
-func (_u *OrgSubscriptionUpdateOne) SetProductPrice(v models.Price) *OrgSubscriptionUpdateOne {
-	_u.mutation.SetProductPrice(v)
-	return _u
-}
-
-// SetNillableProductPrice sets the "product_price" field if the given value is not nil.
-func (_u *OrgSubscriptionUpdateOne) SetNillableProductPrice(v *models.Price) *OrgSubscriptionUpdateOne {
-	if v != nil {
-		_u.SetProductPrice(*v)
-	}
-	return _u
-}
-
-// ClearProductPrice clears the value of the "product_price" field.
-func (_u *OrgSubscriptionUpdateOne) ClearProductPrice() *OrgSubscriptionUpdateOne {
-	_u.mutation.ClearProductPrice()
-	return _u
-}
-
 // SetStripeSubscriptionStatus sets the "stripe_subscription_status" field.
 func (_u *OrgSubscriptionUpdateOne) SetStripeSubscriptionStatus(v string) *OrgSubscriptionUpdateOne {
 	_u.mutation.SetStripeSubscriptionStatus(v)
@@ -1138,42 +1033,6 @@ func (_u *OrgSubscriptionUpdateOne) SetNillableDaysUntilDue(v *string) *OrgSubsc
 // ClearDaysUntilDue clears the value of the "days_until_due" field.
 func (_u *OrgSubscriptionUpdateOne) ClearDaysUntilDue() *OrgSubscriptionUpdateOne {
 	_u.mutation.ClearDaysUntilDue()
-	return _u
-}
-
-// SetFeatures sets the "features" field.
-func (_u *OrgSubscriptionUpdateOne) SetFeatures(v []string) *OrgSubscriptionUpdateOne {
-	_u.mutation.SetFeatures(v)
-	return _u
-}
-
-// AppendFeatures appends value to the "features" field.
-func (_u *OrgSubscriptionUpdateOne) AppendFeatures(v []string) *OrgSubscriptionUpdateOne {
-	_u.mutation.AppendFeatures(v)
-	return _u
-}
-
-// ClearFeatures clears the value of the "features" field.
-func (_u *OrgSubscriptionUpdateOne) ClearFeatures() *OrgSubscriptionUpdateOne {
-	_u.mutation.ClearFeatures()
-	return _u
-}
-
-// SetFeatureLookupKeys sets the "feature_lookup_keys" field.
-func (_u *OrgSubscriptionUpdateOne) SetFeatureLookupKeys(v []string) *OrgSubscriptionUpdateOne {
-	_u.mutation.SetFeatureLookupKeys(v)
-	return _u
-}
-
-// AppendFeatureLookupKeys appends value to the "feature_lookup_keys" field.
-func (_u *OrgSubscriptionUpdateOne) AppendFeatureLookupKeys(v []string) *OrgSubscriptionUpdateOne {
-	_u.mutation.AppendFeatureLookupKeys(v)
-	return _u
-}
-
-// ClearFeatureLookupKeys clears the value of the "feature_lookup_keys" field.
-func (_u *OrgSubscriptionUpdateOne) ClearFeatureLookupKeys() *OrgSubscriptionUpdateOne {
-	_u.mutation.ClearFeatureLookupKeys()
 	return _u
 }
 
@@ -1484,12 +1343,6 @@ func (_u *OrgSubscriptionUpdateOne) sqlSave(ctx context.Context) (_node *OrgSubs
 	if _u.mutation.StripeSubscriptionIDCleared() {
 		_spec.ClearField(orgsubscription.FieldStripeSubscriptionID, field.TypeString)
 	}
-	if value, ok := _u.mutation.ProductPrice(); ok {
-		_spec.SetField(orgsubscription.FieldProductPrice, field.TypeJSON, value)
-	}
-	if _u.mutation.ProductPriceCleared() {
-		_spec.ClearField(orgsubscription.FieldProductPrice, field.TypeJSON)
-	}
 	if value, ok := _u.mutation.StripeSubscriptionStatus(); ok {
 		_spec.SetField(orgsubscription.FieldStripeSubscriptionStatus, field.TypeString, value)
 	}
@@ -1516,28 +1369,6 @@ func (_u *OrgSubscriptionUpdateOne) sqlSave(ctx context.Context) (_node *OrgSubs
 	}
 	if _u.mutation.DaysUntilDueCleared() {
 		_spec.ClearField(orgsubscription.FieldDaysUntilDue, field.TypeString)
-	}
-	if value, ok := _u.mutation.Features(); ok {
-		_spec.SetField(orgsubscription.FieldFeatures, field.TypeJSON, value)
-	}
-	if value, ok := _u.mutation.AppendedFeatures(); ok {
-		_spec.AddModifier(func(u *sql.UpdateBuilder) {
-			sqljson.Append(u, orgsubscription.FieldFeatures, value)
-		})
-	}
-	if _u.mutation.FeaturesCleared() {
-		_spec.ClearField(orgsubscription.FieldFeatures, field.TypeJSON)
-	}
-	if value, ok := _u.mutation.FeatureLookupKeys(); ok {
-		_spec.SetField(orgsubscription.FieldFeatureLookupKeys, field.TypeJSON, value)
-	}
-	if value, ok := _u.mutation.AppendedFeatureLookupKeys(); ok {
-		_spec.AddModifier(func(u *sql.UpdateBuilder) {
-			sqljson.Append(u, orgsubscription.FieldFeatureLookupKeys, value)
-		})
-	}
-	if _u.mutation.FeatureLookupKeysCleared() {
-		_spec.ClearField(orgsubscription.FieldFeatureLookupKeys, field.TypeJSON)
 	}
 	if _u.mutation.OwnerCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/internal/ent/generated/orgsubscriptionhistory.go
+++ b/internal/ent/generated/orgsubscriptionhistory.go
@@ -11,7 +11,6 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"github.com/theopenlane/core/internal/ent/generated/orgsubscriptionhistory"
-	"github.com/theopenlane/core/pkg/models"
 	"github.com/theopenlane/entx/history"
 )
 
@@ -44,8 +43,6 @@ type OrgSubscriptionHistory struct {
 	OwnerID string `json:"owner_id,omitempty"`
 	// the stripe subscription id
 	StripeSubscriptionID string `json:"stripe_subscription_id,omitempty"`
-	// the price of the product tier
-	ProductPrice models.Price `json:"product_price,omitempty"`
 	// the status of the subscription in stripe -- see https://docs.stripe.com/api/subscriptions/object#subscription_object-status
 	StripeSubscriptionStatus string `json:"stripe_subscription_status,omitempty"`
 	// indicates if the subscription is active
@@ -56,11 +53,7 @@ type OrgSubscriptionHistory struct {
 	TrialExpiresAt *time.Time `json:"trial_expires_at,omitempty"`
 	// number of days until there is a due payment
 	DaysUntilDue *string `json:"days_until_due,omitempty"`
-	// the features associated with the subscription
-	Features []string `json:"features,omitempty"`
-	// the feature lookup keys associated with the subscription
-	FeatureLookupKeys []string `json:"feature_lookup_keys,omitempty"`
-	selectValues      sql.SelectValues
+	selectValues sql.SelectValues
 }
 
 // scanValues returns the types for scanning values from sql.Rows.
@@ -68,7 +61,7 @@ func (*OrgSubscriptionHistory) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case orgsubscriptionhistory.FieldTags, orgsubscriptionhistory.FieldProductPrice, orgsubscriptionhistory.FieldFeatures, orgsubscriptionhistory.FieldFeatureLookupKeys:
+		case orgsubscriptionhistory.FieldTags:
 			values[i] = new([]byte)
 		case orgsubscriptionhistory.FieldOperation:
 			values[i] = new(history.OpType)
@@ -173,14 +166,6 @@ func (_m *OrgSubscriptionHistory) assignValues(columns []string, values []any) e
 			} else if value.Valid {
 				_m.StripeSubscriptionID = value.String
 			}
-		case orgsubscriptionhistory.FieldProductPrice:
-			if value, ok := values[i].(*[]byte); !ok {
-				return fmt.Errorf("unexpected type %T for field product_price", values[i])
-			} else if value != nil && len(*value) > 0 {
-				if err := json.Unmarshal(*value, &_m.ProductPrice); err != nil {
-					return fmt.Errorf("unmarshal field product_price: %w", err)
-				}
-			}
 		case orgsubscriptionhistory.FieldStripeSubscriptionStatus:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field stripe_subscription_status", values[i])
@@ -213,22 +198,6 @@ func (_m *OrgSubscriptionHistory) assignValues(columns []string, values []any) e
 			} else if value.Valid {
 				_m.DaysUntilDue = new(string)
 				*_m.DaysUntilDue = value.String
-			}
-		case orgsubscriptionhistory.FieldFeatures:
-			if value, ok := values[i].(*[]byte); !ok {
-				return fmt.Errorf("unexpected type %T for field features", values[i])
-			} else if value != nil && len(*value) > 0 {
-				if err := json.Unmarshal(*value, &_m.Features); err != nil {
-					return fmt.Errorf("unmarshal field features: %w", err)
-				}
-			}
-		case orgsubscriptionhistory.FieldFeatureLookupKeys:
-			if value, ok := values[i].(*[]byte); !ok {
-				return fmt.Errorf("unexpected type %T for field feature_lookup_keys", values[i])
-			} else if value != nil && len(*value) > 0 {
-				if err := json.Unmarshal(*value, &_m.FeatureLookupKeys); err != nil {
-					return fmt.Errorf("unmarshal field feature_lookup_keys: %w", err)
-				}
 			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
@@ -302,9 +271,6 @@ func (_m *OrgSubscriptionHistory) String() string {
 	builder.WriteString("stripe_subscription_id=")
 	builder.WriteString(_m.StripeSubscriptionID)
 	builder.WriteString(", ")
-	builder.WriteString("product_price=")
-	builder.WriteString(fmt.Sprintf("%v", _m.ProductPrice))
-	builder.WriteString(", ")
 	builder.WriteString("stripe_subscription_status=")
 	builder.WriteString(_m.StripeSubscriptionStatus)
 	builder.WriteString(", ")
@@ -325,12 +291,6 @@ func (_m *OrgSubscriptionHistory) String() string {
 		builder.WriteString("days_until_due=")
 		builder.WriteString(*v)
 	}
-	builder.WriteString(", ")
-	builder.WriteString("features=")
-	builder.WriteString(fmt.Sprintf("%v", _m.Features))
-	builder.WriteString(", ")
-	builder.WriteString("feature_lookup_keys=")
-	builder.WriteString(fmt.Sprintf("%v", _m.FeatureLookupKeys))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/internal/ent/generated/orgsubscriptionhistory/orgsubscriptionhistory.go
+++ b/internal/ent/generated/orgsubscriptionhistory/orgsubscriptionhistory.go
@@ -40,8 +40,6 @@ const (
 	FieldOwnerID = "owner_id"
 	// FieldStripeSubscriptionID holds the string denoting the stripe_subscription_id field in the database.
 	FieldStripeSubscriptionID = "stripe_subscription_id"
-	// FieldProductPrice holds the string denoting the product_price field in the database.
-	FieldProductPrice = "product_price"
 	// FieldStripeSubscriptionStatus holds the string denoting the stripe_subscription_status field in the database.
 	FieldStripeSubscriptionStatus = "stripe_subscription_status"
 	// FieldActive holds the string denoting the active field in the database.
@@ -52,10 +50,6 @@ const (
 	FieldTrialExpiresAt = "trial_expires_at"
 	// FieldDaysUntilDue holds the string denoting the days_until_due field in the database.
 	FieldDaysUntilDue = "days_until_due"
-	// FieldFeatures holds the string denoting the features field in the database.
-	FieldFeatures = "features"
-	// FieldFeatureLookupKeys holds the string denoting the feature_lookup_keys field in the database.
-	FieldFeatureLookupKeys = "feature_lookup_keys"
 	// Table holds the table name of the orgsubscriptionhistory in the database.
 	Table = "org_subscription_history"
 )
@@ -75,14 +69,11 @@ var Columns = []string{
 	FieldTags,
 	FieldOwnerID,
 	FieldStripeSubscriptionID,
-	FieldProductPrice,
 	FieldStripeSubscriptionStatus,
 	FieldActive,
 	FieldExpiresAt,
 	FieldTrialExpiresAt,
 	FieldDaysUntilDue,
-	FieldFeatures,
-	FieldFeatureLookupKeys,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).

--- a/internal/ent/generated/orgsubscriptionhistory/where.go
+++ b/internal/ent/generated/orgsubscriptionhistory/where.go
@@ -810,16 +810,6 @@ func StripeSubscriptionIDContainsFold(v string) predicate.OrgSubscriptionHistory
 	return predicate.OrgSubscriptionHistory(sql.FieldContainsFold(FieldStripeSubscriptionID, v))
 }
 
-// ProductPriceIsNil applies the IsNil predicate on the "product_price" field.
-func ProductPriceIsNil() predicate.OrgSubscriptionHistory {
-	return predicate.OrgSubscriptionHistory(sql.FieldIsNull(FieldProductPrice))
-}
-
-// ProductPriceNotNil applies the NotNil predicate on the "product_price" field.
-func ProductPriceNotNil() predicate.OrgSubscriptionHistory {
-	return predicate.OrgSubscriptionHistory(sql.FieldNotNull(FieldProductPrice))
-}
-
 // StripeSubscriptionStatusEQ applies the EQ predicate on the "stripe_subscription_status" field.
 func StripeSubscriptionStatusEQ(v string) predicate.OrgSubscriptionHistory {
 	return predicate.OrgSubscriptionHistory(sql.FieldEQ(FieldStripeSubscriptionStatus, v))
@@ -1078,26 +1068,6 @@ func DaysUntilDueEqualFold(v string) predicate.OrgSubscriptionHistory {
 // DaysUntilDueContainsFold applies the ContainsFold predicate on the "days_until_due" field.
 func DaysUntilDueContainsFold(v string) predicate.OrgSubscriptionHistory {
 	return predicate.OrgSubscriptionHistory(sql.FieldContainsFold(FieldDaysUntilDue, v))
-}
-
-// FeaturesIsNil applies the IsNil predicate on the "features" field.
-func FeaturesIsNil() predicate.OrgSubscriptionHistory {
-	return predicate.OrgSubscriptionHistory(sql.FieldIsNull(FieldFeatures))
-}
-
-// FeaturesNotNil applies the NotNil predicate on the "features" field.
-func FeaturesNotNil() predicate.OrgSubscriptionHistory {
-	return predicate.OrgSubscriptionHistory(sql.FieldNotNull(FieldFeatures))
-}
-
-// FeatureLookupKeysIsNil applies the IsNil predicate on the "feature_lookup_keys" field.
-func FeatureLookupKeysIsNil() predicate.OrgSubscriptionHistory {
-	return predicate.OrgSubscriptionHistory(sql.FieldIsNull(FieldFeatureLookupKeys))
-}
-
-// FeatureLookupKeysNotNil applies the NotNil predicate on the "feature_lookup_keys" field.
-func FeatureLookupKeysNotNil() predicate.OrgSubscriptionHistory {
-	return predicate.OrgSubscriptionHistory(sql.FieldNotNull(FieldFeatureLookupKeys))
 }
 
 // And groups predicates with the AND operator between them.

--- a/internal/ent/generated/orgsubscriptionhistory_create.go
+++ b/internal/ent/generated/orgsubscriptionhistory_create.go
@@ -11,7 +11,6 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/theopenlane/core/internal/ent/generated/orgsubscriptionhistory"
-	"github.com/theopenlane/core/pkg/models"
 	"github.com/theopenlane/entx/history"
 )
 
@@ -174,20 +173,6 @@ func (_c *OrgSubscriptionHistoryCreate) SetNillableStripeSubscriptionID(v *strin
 	return _c
 }
 
-// SetProductPrice sets the "product_price" field.
-func (_c *OrgSubscriptionHistoryCreate) SetProductPrice(v models.Price) *OrgSubscriptionHistoryCreate {
-	_c.mutation.SetProductPrice(v)
-	return _c
-}
-
-// SetNillableProductPrice sets the "product_price" field if the given value is not nil.
-func (_c *OrgSubscriptionHistoryCreate) SetNillableProductPrice(v *models.Price) *OrgSubscriptionHistoryCreate {
-	if v != nil {
-		_c.SetProductPrice(*v)
-	}
-	return _c
-}
-
 // SetStripeSubscriptionStatus sets the "stripe_subscription_status" field.
 func (_c *OrgSubscriptionHistoryCreate) SetStripeSubscriptionStatus(v string) *OrgSubscriptionHistoryCreate {
 	_c.mutation.SetStripeSubscriptionStatus(v)
@@ -255,18 +240,6 @@ func (_c *OrgSubscriptionHistoryCreate) SetNillableDaysUntilDue(v *string) *OrgS
 	if v != nil {
 		_c.SetDaysUntilDue(*v)
 	}
-	return _c
-}
-
-// SetFeatures sets the "features" field.
-func (_c *OrgSubscriptionHistoryCreate) SetFeatures(v []string) *OrgSubscriptionHistoryCreate {
-	_c.mutation.SetFeatures(v)
-	return _c
-}
-
-// SetFeatureLookupKeys sets the "feature_lookup_keys" field.
-func (_c *OrgSubscriptionHistoryCreate) SetFeatureLookupKeys(v []string) *OrgSubscriptionHistoryCreate {
-	_c.mutation.SetFeatureLookupKeys(v)
 	return _c
 }
 
@@ -445,10 +418,6 @@ func (_c *OrgSubscriptionHistoryCreate) createSpec() (*OrgSubscriptionHistory, *
 		_spec.SetField(orgsubscriptionhistory.FieldStripeSubscriptionID, field.TypeString, value)
 		_node.StripeSubscriptionID = value
 	}
-	if value, ok := _c.mutation.ProductPrice(); ok {
-		_spec.SetField(orgsubscriptionhistory.FieldProductPrice, field.TypeJSON, value)
-		_node.ProductPrice = value
-	}
 	if value, ok := _c.mutation.StripeSubscriptionStatus(); ok {
 		_spec.SetField(orgsubscriptionhistory.FieldStripeSubscriptionStatus, field.TypeString, value)
 		_node.StripeSubscriptionStatus = value
@@ -468,14 +437,6 @@ func (_c *OrgSubscriptionHistoryCreate) createSpec() (*OrgSubscriptionHistory, *
 	if value, ok := _c.mutation.DaysUntilDue(); ok {
 		_spec.SetField(orgsubscriptionhistory.FieldDaysUntilDue, field.TypeString, value)
 		_node.DaysUntilDue = &value
-	}
-	if value, ok := _c.mutation.Features(); ok {
-		_spec.SetField(orgsubscriptionhistory.FieldFeatures, field.TypeJSON, value)
-		_node.Features = value
-	}
-	if value, ok := _c.mutation.FeatureLookupKeys(); ok {
-		_spec.SetField(orgsubscriptionhistory.FieldFeatureLookupKeys, field.TypeJSON, value)
-		_node.FeatureLookupKeys = value
 	}
 	return _node, _spec
 }

--- a/internal/ent/generated/orgsubscriptionhistory_update.go
+++ b/internal/ent/generated/orgsubscriptionhistory_update.go
@@ -14,7 +14,6 @@ import (
 	"entgo.io/ent/schema/field"
 	"github.com/theopenlane/core/internal/ent/generated/orgsubscriptionhistory"
 	"github.com/theopenlane/core/internal/ent/generated/predicate"
-	"github.com/theopenlane/core/pkg/models"
 
 	"github.com/theopenlane/core/internal/ent/generated/internal"
 )
@@ -163,26 +162,6 @@ func (_u *OrgSubscriptionHistoryUpdate) ClearStripeSubscriptionID() *OrgSubscrip
 	return _u
 }
 
-// SetProductPrice sets the "product_price" field.
-func (_u *OrgSubscriptionHistoryUpdate) SetProductPrice(v models.Price) *OrgSubscriptionHistoryUpdate {
-	_u.mutation.SetProductPrice(v)
-	return _u
-}
-
-// SetNillableProductPrice sets the "product_price" field if the given value is not nil.
-func (_u *OrgSubscriptionHistoryUpdate) SetNillableProductPrice(v *models.Price) *OrgSubscriptionHistoryUpdate {
-	if v != nil {
-		_u.SetProductPrice(*v)
-	}
-	return _u
-}
-
-// ClearProductPrice clears the value of the "product_price" field.
-func (_u *OrgSubscriptionHistoryUpdate) ClearProductPrice() *OrgSubscriptionHistoryUpdate {
-	_u.mutation.ClearProductPrice()
-	return _u
-}
-
 // SetStripeSubscriptionStatus sets the "stripe_subscription_status" field.
 func (_u *OrgSubscriptionHistoryUpdate) SetStripeSubscriptionStatus(v string) *OrgSubscriptionHistoryUpdate {
 	_u.mutation.SetStripeSubscriptionStatus(v)
@@ -274,42 +253,6 @@ func (_u *OrgSubscriptionHistoryUpdate) SetNillableDaysUntilDue(v *string) *OrgS
 // ClearDaysUntilDue clears the value of the "days_until_due" field.
 func (_u *OrgSubscriptionHistoryUpdate) ClearDaysUntilDue() *OrgSubscriptionHistoryUpdate {
 	_u.mutation.ClearDaysUntilDue()
-	return _u
-}
-
-// SetFeatures sets the "features" field.
-func (_u *OrgSubscriptionHistoryUpdate) SetFeatures(v []string) *OrgSubscriptionHistoryUpdate {
-	_u.mutation.SetFeatures(v)
-	return _u
-}
-
-// AppendFeatures appends value to the "features" field.
-func (_u *OrgSubscriptionHistoryUpdate) AppendFeatures(v []string) *OrgSubscriptionHistoryUpdate {
-	_u.mutation.AppendFeatures(v)
-	return _u
-}
-
-// ClearFeatures clears the value of the "features" field.
-func (_u *OrgSubscriptionHistoryUpdate) ClearFeatures() *OrgSubscriptionHistoryUpdate {
-	_u.mutation.ClearFeatures()
-	return _u
-}
-
-// SetFeatureLookupKeys sets the "feature_lookup_keys" field.
-func (_u *OrgSubscriptionHistoryUpdate) SetFeatureLookupKeys(v []string) *OrgSubscriptionHistoryUpdate {
-	_u.mutation.SetFeatureLookupKeys(v)
-	return _u
-}
-
-// AppendFeatureLookupKeys appends value to the "feature_lookup_keys" field.
-func (_u *OrgSubscriptionHistoryUpdate) AppendFeatureLookupKeys(v []string) *OrgSubscriptionHistoryUpdate {
-	_u.mutation.AppendFeatureLookupKeys(v)
-	return _u
-}
-
-// ClearFeatureLookupKeys clears the value of the "feature_lookup_keys" field.
-func (_u *OrgSubscriptionHistoryUpdate) ClearFeatureLookupKeys() *OrgSubscriptionHistoryUpdate {
-	_u.mutation.ClearFeatureLookupKeys()
 	return _u
 }
 
@@ -425,12 +368,6 @@ func (_u *OrgSubscriptionHistoryUpdate) sqlSave(ctx context.Context) (_node int,
 	if _u.mutation.StripeSubscriptionIDCleared() {
 		_spec.ClearField(orgsubscriptionhistory.FieldStripeSubscriptionID, field.TypeString)
 	}
-	if value, ok := _u.mutation.ProductPrice(); ok {
-		_spec.SetField(orgsubscriptionhistory.FieldProductPrice, field.TypeJSON, value)
-	}
-	if _u.mutation.ProductPriceCleared() {
-		_spec.ClearField(orgsubscriptionhistory.FieldProductPrice, field.TypeJSON)
-	}
 	if value, ok := _u.mutation.StripeSubscriptionStatus(); ok {
 		_spec.SetField(orgsubscriptionhistory.FieldStripeSubscriptionStatus, field.TypeString, value)
 	}
@@ -457,28 +394,6 @@ func (_u *OrgSubscriptionHistoryUpdate) sqlSave(ctx context.Context) (_node int,
 	}
 	if _u.mutation.DaysUntilDueCleared() {
 		_spec.ClearField(orgsubscriptionhistory.FieldDaysUntilDue, field.TypeString)
-	}
-	if value, ok := _u.mutation.Features(); ok {
-		_spec.SetField(orgsubscriptionhistory.FieldFeatures, field.TypeJSON, value)
-	}
-	if value, ok := _u.mutation.AppendedFeatures(); ok {
-		_spec.AddModifier(func(u *sql.UpdateBuilder) {
-			sqljson.Append(u, orgsubscriptionhistory.FieldFeatures, value)
-		})
-	}
-	if _u.mutation.FeaturesCleared() {
-		_spec.ClearField(orgsubscriptionhistory.FieldFeatures, field.TypeJSON)
-	}
-	if value, ok := _u.mutation.FeatureLookupKeys(); ok {
-		_spec.SetField(orgsubscriptionhistory.FieldFeatureLookupKeys, field.TypeJSON, value)
-	}
-	if value, ok := _u.mutation.AppendedFeatureLookupKeys(); ok {
-		_spec.AddModifier(func(u *sql.UpdateBuilder) {
-			sqljson.Append(u, orgsubscriptionhistory.FieldFeatureLookupKeys, value)
-		})
-	}
-	if _u.mutation.FeatureLookupKeysCleared() {
-		_spec.ClearField(orgsubscriptionhistory.FieldFeatureLookupKeys, field.TypeJSON)
 	}
 	_spec.Node.Schema = _u.schemaConfig.OrgSubscriptionHistory
 	ctx = internal.NewSchemaConfigContext(ctx, _u.schemaConfig)
@@ -634,26 +549,6 @@ func (_u *OrgSubscriptionHistoryUpdateOne) ClearStripeSubscriptionID() *OrgSubsc
 	return _u
 }
 
-// SetProductPrice sets the "product_price" field.
-func (_u *OrgSubscriptionHistoryUpdateOne) SetProductPrice(v models.Price) *OrgSubscriptionHistoryUpdateOne {
-	_u.mutation.SetProductPrice(v)
-	return _u
-}
-
-// SetNillableProductPrice sets the "product_price" field if the given value is not nil.
-func (_u *OrgSubscriptionHistoryUpdateOne) SetNillableProductPrice(v *models.Price) *OrgSubscriptionHistoryUpdateOne {
-	if v != nil {
-		_u.SetProductPrice(*v)
-	}
-	return _u
-}
-
-// ClearProductPrice clears the value of the "product_price" field.
-func (_u *OrgSubscriptionHistoryUpdateOne) ClearProductPrice() *OrgSubscriptionHistoryUpdateOne {
-	_u.mutation.ClearProductPrice()
-	return _u
-}
-
 // SetStripeSubscriptionStatus sets the "stripe_subscription_status" field.
 func (_u *OrgSubscriptionHistoryUpdateOne) SetStripeSubscriptionStatus(v string) *OrgSubscriptionHistoryUpdateOne {
 	_u.mutation.SetStripeSubscriptionStatus(v)
@@ -745,42 +640,6 @@ func (_u *OrgSubscriptionHistoryUpdateOne) SetNillableDaysUntilDue(v *string) *O
 // ClearDaysUntilDue clears the value of the "days_until_due" field.
 func (_u *OrgSubscriptionHistoryUpdateOne) ClearDaysUntilDue() *OrgSubscriptionHistoryUpdateOne {
 	_u.mutation.ClearDaysUntilDue()
-	return _u
-}
-
-// SetFeatures sets the "features" field.
-func (_u *OrgSubscriptionHistoryUpdateOne) SetFeatures(v []string) *OrgSubscriptionHistoryUpdateOne {
-	_u.mutation.SetFeatures(v)
-	return _u
-}
-
-// AppendFeatures appends value to the "features" field.
-func (_u *OrgSubscriptionHistoryUpdateOne) AppendFeatures(v []string) *OrgSubscriptionHistoryUpdateOne {
-	_u.mutation.AppendFeatures(v)
-	return _u
-}
-
-// ClearFeatures clears the value of the "features" field.
-func (_u *OrgSubscriptionHistoryUpdateOne) ClearFeatures() *OrgSubscriptionHistoryUpdateOne {
-	_u.mutation.ClearFeatures()
-	return _u
-}
-
-// SetFeatureLookupKeys sets the "feature_lookup_keys" field.
-func (_u *OrgSubscriptionHistoryUpdateOne) SetFeatureLookupKeys(v []string) *OrgSubscriptionHistoryUpdateOne {
-	_u.mutation.SetFeatureLookupKeys(v)
-	return _u
-}
-
-// AppendFeatureLookupKeys appends value to the "feature_lookup_keys" field.
-func (_u *OrgSubscriptionHistoryUpdateOne) AppendFeatureLookupKeys(v []string) *OrgSubscriptionHistoryUpdateOne {
-	_u.mutation.AppendFeatureLookupKeys(v)
-	return _u
-}
-
-// ClearFeatureLookupKeys clears the value of the "feature_lookup_keys" field.
-func (_u *OrgSubscriptionHistoryUpdateOne) ClearFeatureLookupKeys() *OrgSubscriptionHistoryUpdateOne {
-	_u.mutation.ClearFeatureLookupKeys()
 	return _u
 }
 
@@ -926,12 +785,6 @@ func (_u *OrgSubscriptionHistoryUpdateOne) sqlSave(ctx context.Context) (_node *
 	if _u.mutation.StripeSubscriptionIDCleared() {
 		_spec.ClearField(orgsubscriptionhistory.FieldStripeSubscriptionID, field.TypeString)
 	}
-	if value, ok := _u.mutation.ProductPrice(); ok {
-		_spec.SetField(orgsubscriptionhistory.FieldProductPrice, field.TypeJSON, value)
-	}
-	if _u.mutation.ProductPriceCleared() {
-		_spec.ClearField(orgsubscriptionhistory.FieldProductPrice, field.TypeJSON)
-	}
 	if value, ok := _u.mutation.StripeSubscriptionStatus(); ok {
 		_spec.SetField(orgsubscriptionhistory.FieldStripeSubscriptionStatus, field.TypeString, value)
 	}
@@ -958,28 +811,6 @@ func (_u *OrgSubscriptionHistoryUpdateOne) sqlSave(ctx context.Context) (_node *
 	}
 	if _u.mutation.DaysUntilDueCleared() {
 		_spec.ClearField(orgsubscriptionhistory.FieldDaysUntilDue, field.TypeString)
-	}
-	if value, ok := _u.mutation.Features(); ok {
-		_spec.SetField(orgsubscriptionhistory.FieldFeatures, field.TypeJSON, value)
-	}
-	if value, ok := _u.mutation.AppendedFeatures(); ok {
-		_spec.AddModifier(func(u *sql.UpdateBuilder) {
-			sqljson.Append(u, orgsubscriptionhistory.FieldFeatures, value)
-		})
-	}
-	if _u.mutation.FeaturesCleared() {
-		_spec.ClearField(orgsubscriptionhistory.FieldFeatures, field.TypeJSON)
-	}
-	if value, ok := _u.mutation.FeatureLookupKeys(); ok {
-		_spec.SetField(orgsubscriptionhistory.FieldFeatureLookupKeys, field.TypeJSON, value)
-	}
-	if value, ok := _u.mutation.AppendedFeatureLookupKeys(); ok {
-		_spec.AddModifier(func(u *sql.UpdateBuilder) {
-			sqljson.Append(u, orgsubscriptionhistory.FieldFeatureLookupKeys, value)
-		})
-	}
-	if _u.mutation.FeatureLookupKeysCleared() {
-		_spec.ClearField(orgsubscriptionhistory.FieldFeatureLookupKeys, field.TypeJSON)
 	}
 	_spec.Node.Schema = _u.schemaConfig.OrgSubscriptionHistory
 	ctx = internal.NewSchemaConfigContext(ctx, _u.schemaConfig)

--- a/internal/ent/generated/runtime/runtime.go
+++ b/internal/ent/generated/runtime/runtime.go
@@ -4167,7 +4167,7 @@ func init() {
 	// orgsubscription.OwnerIDValidator is a validator for the "owner_id" field. It is called by the builders before save.
 	orgsubscription.OwnerIDValidator = orgsubscriptionDescOwnerID.Validators[0].(func(string) error)
 	// orgsubscriptionDescActive is the schema descriptor for active field.
-	orgsubscriptionDescActive := orgsubscriptionFields[3].Descriptor()
+	orgsubscriptionDescActive := orgsubscriptionFields[2].Descriptor()
 	// orgsubscription.DefaultActive holds the default value on creation for the active field.
 	orgsubscription.DefaultActive = orgsubscriptionDescActive.Default.(bool)
 	// orgsubscriptionDescID is the schema descriptor for id field.
@@ -4195,7 +4195,7 @@ func init() {
 	// orgsubscriptionhistory.DefaultTags holds the default value on creation for the tags field.
 	orgsubscriptionhistory.DefaultTags = orgsubscriptionhistoryDescTags.Default.([]string)
 	// orgsubscriptionhistoryDescActive is the schema descriptor for active field.
-	orgsubscriptionhistoryDescActive := orgsubscriptionhistoryFields[15].Descriptor()
+	orgsubscriptionhistoryDescActive := orgsubscriptionhistoryFields[14].Descriptor()
 	// orgsubscriptionhistory.DefaultActive holds the default value on creation for the active field.
 	orgsubscriptionhistory.DefaultActive = orgsubscriptionhistoryDescActive.Default.(bool)
 	// orgsubscriptionhistoryDescID is the schema descriptor for id field.

--- a/internal/ent/hooks/errors.go
+++ b/internal/ent/hooks/errors.go
@@ -81,6 +81,8 @@ var (
 	ErrNotSingularUpload = errors.New("multiple uploads not supported")
 	// ErrSSONotEnforceable makes sure the connection has been tested before it can be enforced for an org
 	ErrSSONotEnforceable = errors.New("you cannot enforce sso without testing the connection works correctly")
+	// ErrUnableToDetermineEventID is returned when we cannot determine the event ID for an event
+	ErrUnableToDetermineEventID = errors.New("unable to determine event ID")
 )
 
 // IsUniqueConstraintError reports if the error resulted from a DB uniqueness constraint violation.

--- a/internal/ent/hooks/event.go
+++ b/internal/ent/hooks/event.go
@@ -129,7 +129,7 @@ func parseEventID(retVal ent.Value) (*EventID, error) {
 	return &event, nil
 }
 
-func parseSoftDeleteEventID(ctx context.Context, mutation ent.Mutation) (*EventID, error) {
+func parseSoftDeleteEventID(mutation ent.Mutation) (*EventID, error) {
 	m, ok := mutation.(*entgen.OrganizationMutation)
 	if !ok {
 		return nil, ErrUnableToDetermineEventID
@@ -166,7 +166,7 @@ func EmitEventHook(e *Eventer) ent.Hook {
 			emit := func() {
 				eventID := &EventID{}
 				if op == SoftDeleteOne {
-					eventID, err = parseSoftDeleteEventID(ctx, mutation)
+					eventID, err = parseSoftDeleteEventID(mutation)
 					if err != nil {
 						log.Err(err).Msg("Failed to parse soft delete event ID")
 

--- a/internal/ent/hooks/event.go
+++ b/internal/ent/hooks/event.go
@@ -129,6 +129,7 @@ func parseEventID(retVal ent.Value) (*EventID, error) {
 	return &event, nil
 }
 
+// parseSoftDeleteEventID parses the event ID from a soft delete organization mutation by casting the mutation to an organization mutation
 func parseSoftDeleteEventID(mutation ent.Mutation) (*EventID, error) {
 	m, ok := mutation.(*entgen.OrganizationMutation)
 	if !ok {

--- a/internal/ent/hooks/orgmembers.go
+++ b/internal/ent/hooks/orgmembers.go
@@ -122,7 +122,7 @@ func HookOrgMembersDelete() ent.Hook {
 			// deleteOrganization will be handled by the organization hook
 			rootFieldCtx := graphql.GetRootFieldContext(ctx)
 			if rootFieldCtx == nil || rootFieldCtx.Object != "deleteOrgMembership" {
-				zerolog.Ctx(ctx).Warn().Msg("skipping org membership delete hook")
+				zerolog.Ctx(ctx).Info().Msg("skipping org membership delete hook")
 
 				return next.Mutate(ctx, m)
 			}

--- a/internal/ent/schema/orgsubscription.go
+++ b/internal/ent/schema/orgsubscription.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/theopenlane/core/internal/ent/interceptors"
 	"github.com/theopenlane/core/internal/ent/privacy/token"
-	"github.com/theopenlane/core/pkg/models"
 )
 
 // OrgSubscription holds the schema definition for the OrgSubscription entity
@@ -43,9 +42,6 @@ func (OrgSubscription) Fields() []ent.Field {
 	return []ent.Field{
 		field.String("stripe_subscription_id").
 			Comment("the stripe subscription id").
-			Optional(),
-		field.JSON("product_price", models.Price{}).
-			Comment("the price of the product tier").
 			Optional(),
 		field.String("stripe_subscription_status").
 			Comment("the status of the subscription in stripe -- see https://docs.stripe.com/api/subscriptions/object#subscription_object-status").
@@ -80,12 +76,6 @@ func (OrgSubscription) Fields() []ent.Field {
 			).
 			Nillable().
 			Optional(),
-		field.JSON("features", []string{}).
-			Comment("the features associated with the subscription").
-			Optional(),
-		field.JSON("feature_lookup_keys", []string{}).
-			Comment("the feature lookup keys associated with the subscription").
-			Optional(),
 	}
 }
 
@@ -107,7 +97,6 @@ func (o OrgSubscription) Annotations() []schema.Annotation {
 	return []schema.Annotation{
 		entgql.QueryField(),
 		entgql.RelayConnection(),
-		// since we only have queries, we can just use the interceptors for queries and can skip the fga generated checks
 	}
 }
 

--- a/internal/entitlements/catalog_prices.go
+++ b/internal/entitlements/catalog_prices.go
@@ -5,11 +5,18 @@ import (
 
 	"github.com/theopenlane/core/pkg/catalog"
 	"github.com/theopenlane/core/pkg/catalog/gencatalog"
+	"github.com/theopenlane/core/pkg/entitlements"
 )
 
 // TrialMonthlyPriceIDs returns Stripe price IDs for monthly prices of modules included with trial subscriptions
 func TrialMonthlyPriceIDs(useSandbox bool) []string {
 	return monthlyPriceIDs(func(f catalog.Feature) bool {
+		return f.IncludeWithTrial
+	}, useSandbox)
+}
+
+func TrialMonthlyPrices(useSandbox bool) []entitlements.Price {
+	return monthlyPrices(func(f catalog.Feature) bool {
 		return f.IncludeWithTrial
 	}, useSandbox)
 }
@@ -30,4 +37,26 @@ func monthlyPriceIDs(filter func(catalog.Feature) bool, useSandbox bool) []strin
 	sort.Strings(ids)
 
 	return ids
+}
+
+// monthlyPriceIDs returns the entitlements.Prices for monthly prices of modules that match the provided filter function
+func monthlyPrices(filter func(catalog.Feature) bool, useSandbox bool) []entitlements.Price {
+	prices := make([]entitlements.Price, 0)
+	for module, f := range gencatalog.GetModules(useSandbox) {
+		if filter(f) {
+			for _, p := range f.Billing.Prices {
+				if p.Interval == "month" {
+					prices = append(prices, entitlements.Price{
+						ID:          p.PriceID,
+						Price:       float64(p.UnitAmount),
+						Interval:    p.Interval,
+						ProductID:   f.ProductID,
+						ProductName: module,
+					})
+				}
+			}
+		}
+	}
+
+	return prices
 }

--- a/internal/entitlements/entmapping/mapping.go
+++ b/internal/entitlements/entmapping/mapping.go
@@ -84,7 +84,7 @@ func StripeProductToOrgProduct(p *stripe.Product) *ent.OrgProduct {
 
 // StripeSubscriptionToOrgSubscription converts a stripe.Subscription and
 // OrganizationCustomer info to an OrgSubscription.
-func StripeSubscriptionToOrgSubscription(sub *stripe.Subscription, cust *entitlements.OrganizationCustomer) *ent.OrgSubscription {
+func StripeSubscriptionToOrgSubscription(sub *stripe.Subscription) *ent.OrgSubscription {
 	if sub == nil {
 		return nil
 	}
@@ -252,7 +252,7 @@ type OrgSubscriptionSetter[T any] interface {
 }
 
 // ApplyStripeSubscription sets fields on the ent builder from the stripe.Subscription and customer info
-func ApplyStripeSubscription[T OrgSubscriptionSetter[T]](b T, sub *stripe.Subscription, cust *entitlements.OrganizationCustomer) T {
+func ApplyStripeSubscription[T OrgSubscriptionSetter[T]](b T, sub *stripe.Subscription) T {
 	if sub == nil {
 		return b
 	}

--- a/internal/entitlements/entmapping/mapping_test.go
+++ b/internal/entitlements/entmapping/mapping_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stripe/stripe-go/v82"
 	ent "github.com/theopenlane/core/internal/ent/generated"
-	"github.com/theopenlane/core/pkg/entitlements"
 	"github.com/theopenlane/core/pkg/models"
 )
 
@@ -182,12 +181,7 @@ func TestStripeSubscriptionToOrgSubscription(t *testing.T) {
 		}},
 	}
 
-	cust := &entitlements.OrganizationCustomer{
-		Features:     []string{"f1"},
-		FeatureNames: []string{"Feature1"},
-	}
-
-	got := StripeSubscriptionToOrgSubscription(sub, cust)
+	got := StripeSubscriptionToOrgSubscription(sub)
 
 	want := &ent.OrgSubscription{
 		StripeSubscriptionID:     "sub_123",
@@ -298,13 +292,8 @@ func TestApplyStripeSubscription(t *testing.T) {
 		}},
 	}
 
-	cust := &entitlements.OrganizationCustomer{
-		Features:     []string{"f1"},
-		FeatureNames: []string{"Feature1"},
-	}
-
 	b := &subscriptionBuilder{}
-	got := ApplyStripeSubscription(b, sub, cust)
+	got := ApplyStripeSubscription(b, sub)
 
 	expected := &subscriptionBuilder{
 		stripeSubscriptionID:     "sub_123",

--- a/internal/entitlements/entmapping/mapping_test.go
+++ b/internal/entitlements/entmapping/mapping_test.go
@@ -193,11 +193,8 @@ func TestStripeSubscriptionToOrgSubscription(t *testing.T) {
 		StripeSubscriptionID:     "sub_123",
 		StripeSubscriptionStatus: "active",
 		Active:                   true,
-		ProductPrice:             models.Price{Amount: 20, Interval: "year", Currency: "usd"},
 		TrialExpiresAt:           timePtr(time.Unix(1700000000, 0)),
 		DaysUntilDue:             int64ToStringPtr(7),
-		Features:                 []string{"f1"},
-		FeatureLookupKeys:        []string{"Feature1"},
 	}
 
 	require.Equal(t, want, got)
@@ -317,8 +314,6 @@ func TestApplyStripeSubscription(t *testing.T) {
 		productPrice:             models.Price{Amount: 20, Interval: "year", Currency: "usd"},
 		trialExpiresAt:           time.Unix(1700000000, 0),
 		daysUntilDue:             "7",
-		features:                 []string{"f1"},
-		featureLookupKeys:        []string{"Feature1"},
 	}
 
 	require.Equal(t, b, got)

--- a/internal/entitlements/reconciler/reconciler.go
+++ b/internal/entitlements/reconciler/reconciler.go
@@ -2,19 +2,27 @@ package reconciler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/stripe/stripe-go/v82"
 
+	"github.com/theopenlane/core/internal/ent/generated"
 	ent "github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/organization"
+	"github.com/theopenlane/core/internal/ent/generated/predicate"
 	"github.com/theopenlane/core/internal/ent/privacy/rule"
+	"github.com/theopenlane/core/pkg/catalog"
+	"github.com/theopenlane/core/pkg/catalog/gencatalog"
 	"github.com/theopenlane/core/pkg/entitlements"
 	"github.com/theopenlane/core/pkg/models"
+	"github.com/theopenlane/iam/auth"
+	"github.com/theopenlane/utils/contextx"
 )
 
 // Reconciler reconciles organization subscriptions with Stripe
@@ -28,8 +36,9 @@ type Reconciler struct {
 
 // actionRow represents a single reconciliation action to be performed
 type actionRow struct {
-	OrgID  string
-	Action string
+	OrgID   string
+	OrgName string
+	Action  string
 }
 
 // Option configures the Reconciler using the functional options pattern
@@ -88,9 +97,21 @@ type ReconcileResult struct {
 }
 
 // Reconcile iterates through all organizations and ensures customer records and subscriptions exist in Stripe
-func (r *Reconciler) Reconcile(ctx context.Context) (*ReconcileResult, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, orgIDs []string) (*ReconcileResult, error) {
 	if r.db == nil {
 		return nil, ErrMissingDBClient
+	}
+
+	where := []predicate.Organization{
+		organization.And(
+			organization.DeletedAtIsNil(),
+			organization.IDNEQ("01101101011010010111010001100010"),
+			organization.PersonalOrg(false),
+		),
+	}
+
+	if len(orgIDs) > 0 {
+		where = append(where, organization.IDIn(orgIDs...))
 	}
 
 	// Add internal context for administrative operations
@@ -99,10 +120,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) (*ReconcileResult, error) {
 		WithOrgSubscriptions().
 		WithSetting().
 		Where(
-			organization.And(
-				organization.DeletedAtIsNil(),
-				organization.Not(organization.ID("01101101011010010111010001100010")),
-			),
+			where...,
 		).
 		All(internalCtx)
 	if err != nil {
@@ -118,7 +136,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) (*ReconcileResult, error) {
 			}
 
 			if action != "" {
-				rows = append(rows, actionRow{OrgID: org.ID, Action: action})
+				rows = append(rows, actionRow{OrgID: org.ID, OrgName: org.DisplayName, Action: action})
 			}
 
 			continue
@@ -173,7 +191,25 @@ func (r *Reconciler) reconcileOrg(ctx context.Context, org *ent.Organization) er
 	}
 
 	if err := r.stripe.FindOrCreateCustomer(ctx, cust); err != nil {
-		return fmt.Errorf("stripe customer: %w", err)
+		if !errors.Is(err, entitlements.ErrNoSubscriptions) && !errors.Is(err, entitlements.ErrNoSubscriptionItems) {
+			return fmt.Errorf("stripe customer: %w", err)
+		}
+	}
+
+	// make sure the customer id is set on the org
+	if org.StripeCustomerID == nil && cust.StripeCustomerID != "" {
+		err := r.db.Organization.UpdateOneID(cust.OrganizationID).
+			SetStripeCustomerID(cust.StripeCustomerID).
+			Exec(internalCtx)
+		if err != nil {
+			return err
+		}
+	}
+
+	if cust.StripeSubscriptionID == "" {
+		if err := r.createSubscription(ctx, cust); err != nil {
+			return fmt.Errorf("create subscription: %w", err)
+		}
 	}
 
 	if sub.StripeSubscriptionID == "" {
@@ -185,25 +221,49 @@ func (r *Reconciler) reconcileOrg(ctx context.Context, org *ent.Organization) er
 	return nil
 }
 
+var trialdays int64 = 30
+
+func (r *Reconciler) createSubscription(ctx context.Context, cust *entitlements.OrganizationCustomer) error {
+	customers, err := r.stripe.SearchCustomers(ctx, fmt.Sprintf("name: '%s'", cust.OrganizationID))
+	if err != nil {
+		return err
+	}
+
+	if len(customers) != 1 {
+		return fmt.Errorf("expected 1 customer for org %s, found %d", cust.OrganizationID, len(customers))
+	}
+
+	cust.Prices, err = GetDefaultPrices(ctx, r.db)
+	if err != nil {
+		return fmt.Errorf("get default prices: %w", err)
+	}
+
+	if len(cust.Prices) == 0 {
+		return fmt.Errorf("no prices found for to add for organization %s", cust.OrganizationID)
+	}
+
+	cust.Status = string(stripe.SubscriptionStatusTrialing)
+	cust.TrialEnd = time.Now().AddDate(0, 0, int(trialdays)).Unix()
+
+	_, err = r.stripe.CreateSubscriptionWithPrices(ctx, customers[0], cust)
+	if err != nil {
+		return err
+	}
+
+	// update subscription in db
+	if err := r.updateSubscription(ctx, cust); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // updateSubscription updates the organization subscription in the database with current Stripe data
 func (r *Reconciler) updateSubscription(ctx context.Context, c *entitlements.OrganizationCustomer) error {
 	// Add internal context for administrative operations
 	internalCtx := rule.WithInternalContext(ctx)
 	if c.OrganizationSubscriptionID == "" {
 		return ErrMissingSubscriptionID
-	}
-
-	if len(c.Prices) > 1 {
-		return ErrMultiplePrices
-	}
-
-	price := models.Price{}
-	if len(c.Prices) == 1 {
-		price = models.Price{
-			Amount:   c.Prices[0].Price,
-			Currency: c.Prices[0].Currency,
-			Interval: c.Prices[0].Interval,
-		}
 	}
 
 	trialExpiresAt := time.Unix(0, 0)
@@ -221,10 +281,7 @@ func (r *Reconciler) updateSubscription(ctx context.Context, c *entitlements.Org
 	update := r.db.OrgSubscription.UpdateOneID(c.OrganizationSubscriptionID).
 		SetStripeSubscriptionID(c.StripeSubscriptionID).
 		SetStripeSubscriptionStatus(c.Subscription.Status).
-		SetActive(active).
-		SetFeatures(c.FeatureNames).
-		SetFeatureLookupKeys(c.Features).
-		SetProductPrice(price)
+		SetActive(active)
 
 	if c.Status == string(stripe.SubscriptionStatusTrialing) {
 		update.SetTrialExpiresAt(trialExpiresAt)
@@ -243,6 +300,10 @@ func (r *Reconciler) updateSubscription(ctx context.Context, c *entitlements.Org
 
 // analyzeOrg checks the organization subscription status and returns a description of the action needed
 func (r *Reconciler) analyzeOrg(ctx context.Context, org *ent.Organization) (string, error) {
+	if r.stripe == nil {
+		return "", ErrMissingStripeClient
+	}
+
 	var sub *ent.OrgSubscription
 	if len(org.Edges.OrgSubscriptions) > 0 {
 		sub = org.Edges.OrgSubscriptions[0]
@@ -251,7 +312,7 @@ func (r *Reconciler) analyzeOrg(ctx context.Context, org *ent.Organization) (str
 	customerMissing := sub == nil
 	subscriptionMissing := sub == nil
 
-	if !customerMissing {
+	if !customerMissing && org != nil && org.StripeCustomerID != nil && *org.StripeCustomerID != "" {
 		if _, err := r.stripe.GetCustomerByStripeID(ctx, *org.StripeCustomerID); err != nil {
 			customerMissing = true
 		}
@@ -268,9 +329,162 @@ func (r *Reconciler) analyzeOrg(ctx context.Context, org *ent.Organization) (str
 		return "create stripe customer & subscription", nil
 	case customerMissing:
 		return "create stripe customer", nil
+	case !customerMissing && org.StripeCustomerID == nil && subscriptionMissing:
+		prices, err := GetDefaultPrices(ctx, r.db)
+		if err != nil {
+			return "", fmt.Errorf("get default prices: %w", err)
+		}
+		if len(prices) == 0 {
+			return "", fmt.Errorf("no prices found for to add for organization %s", org.ID)
+		}
+		return fmt.Sprintf("set stripe customer ID on organization and create stripe subscription with prices %v", prices), nil
+	case !customerMissing && org.StripeCustomerID == nil && !subscriptionMissing:
+		return "set stripe customer ID on organization", nil
 	case subscriptionMissing:
 		return "create stripe subscription", nil
 	default:
 		return "", nil
 	}
+}
+
+// orgModuleConfig controls which modules are selected when creating default module records - small functional options wrapper
+type orgModuleConfig struct {
+	trial bool
+}
+
+// orgModuleOption sets fields on orgModuleConfig
+type orgModuleOption func(*orgModuleConfig)
+
+// WithTrial sets the trial flag to true, allowing trial modules to be included
+func WithTrial() orgModuleOption {
+	return func(c *orgModuleConfig) {
+		c.trial = true
+	}
+}
+
+func CreateDefaultOrgModulesProductsPrices(ctx context.Context, db *ent.Client, orgSubs *generated.OrgSubscription, orgID string, opts ...orgModuleOption) ([]string, error) {
+	cfg := orgModuleConfig{}
+
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	modulesCreated := make([]string, 0)
+
+	// the catalog contains config for which things should be in a trial
+	if db.EntConfig == nil {
+		return nil, fmt.Errorf("ent config is nil")
+	}
+
+	for moduleName, mod := range gencatalog.GetModules(db.EntConfig.Modules.UseSandbox) {
+		if !cfg.trial || !mod.IncludeWithTrial {
+			continue
+		}
+
+		// Find the first price with "month" interval
+		// we want to create, by default, a monthly recurring price rather than a one-time or annual
+		var monthlyPrice *catalog.Price
+		for _, price := range mod.Billing.Prices {
+			if price.Interval == "month" {
+				monthlyPrice = &price
+				break
+			}
+		}
+
+		if monthlyPrice == nil {
+			continue // skip if no monthly price
+		}
+
+		newCtx := contextx.With(ctx, auth.OrganizationCreationContextKey{})
+		newCtx = contextx.With(newCtx, auth.OrgSubscriptionContextKey{})
+
+		// we set the price purely for reference; it will not be used for billing - we care mostly about the association of subscription to module
+		orgMod, err := db.OrgModule.Create().
+			SetModule(models.OrgModule(moduleName)).
+			SetSubscriptionID(orgSubs.ID).
+			SetStatus(string(stripe.SubscriptionStatusTrialing)).
+			SetOwnerID(orgID).
+			SetModuleLookupKey(mod.LookupKey).
+			SetStripePriceID(monthlyPrice.PriceID).
+			SetActive(true).
+			SetPrice(models.Price{Amount: float64(monthlyPrice.UnitAmount), Interval: monthlyPrice.Interval}).
+			Save(newCtx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create OrgModule for %s: %w", moduleName, err)
+		}
+
+		zerolog.Ctx(ctx).Debug().Msgf("created OrgModule for %s with ID %s", moduleName, orgMod.ID)
+
+		// the product and price entries are somewhat redundant but creating them for reference and future extensibility
+		orgProduct, err := db.OrgProduct.Create().
+			SetModule(moduleName).
+			SetOwnerID(orgID).
+			SetModule(orgMod.ID).
+			SetSubscriptionID(orgSubs.ID).
+			SetActive(true).
+			Save(newCtx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create OrgProduct for %s: %w", moduleName, err)
+		}
+
+		zerolog.Ctx(ctx).Debug().Msgf("created OrgProduct for %s with ID %s", moduleName, orgProduct.ID)
+
+		// we care mostly about which price ID we used in stripe, so we create the local reference for the price because it's the resource which dictates most of the billing toggles in stripe
+		// we don't actually care that it's active or not, but it's relevant to set because we could end up with many prices on a product, and many products on a module
+		orgPrice, err := db.OrgPrice.Create().
+			SetProductID(orgProduct.ID).
+			SetPrice(models.Price{Amount: float64(monthlyPrice.UnitAmount), Interval: monthlyPrice.Interval}).
+			SetOwnerID(orgID).
+			SetSubscriptionID(orgSubs.ID).
+			SetStripePriceID(monthlyPrice.PriceID).
+			SetActive(true).
+			Save(newCtx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create OrgPrice for module %s: %w", moduleName, err)
+		}
+
+		zerolog.Ctx(ctx).Debug().Msgf("created OrgPrice for %s with Stripe Price ID %s", moduleName, monthlyPrice.PriceID)
+
+		// update the org modules with the price ID
+		if _, err := db.OrgModule.UpdateOne(orgMod).SetPriceID(orgPrice.ID).Save(newCtx); err != nil {
+			return nil, fmt.Errorf("failed to update OrgModule with price ID for module %s: %w", moduleName, err)
+		}
+
+		modulesCreated = append(modulesCreated, moduleName)
+	}
+
+	return modulesCreated, nil
+}
+
+func GetDefaultPrices(ctx context.Context, db *ent.Client) ([]entitlements.Price, error) {
+	prices := []entitlements.Price{}
+	for moduleName, mod := range gencatalog.GetModules(db.EntConfig.Modules.UseSandbox) {
+		if !mod.IncludeWithTrial {
+			continue
+		}
+
+		// Find the first price with "month" interval
+		// we want to create, by default, a monthly recurring price rather than a one-time or annual
+		var monthlyPrice *catalog.Price
+		for _, price := range mod.Billing.Prices {
+			if price.Interval == "month" {
+				monthlyPrice = &price
+				break
+			}
+		}
+
+		if monthlyPrice == nil {
+			continue // skip if no monthly price
+		}
+
+		prices = append(prices, entitlements.Price{
+			ID:          monthlyPrice.PriceID,
+			Price:       float64(monthlyPrice.UnitAmount),
+			Interval:    monthlyPrice.Interval,
+			ProductID:   mod.ProductID,
+			ProductName: moduleName,
+		})
+	}
+
+	return prices, nil
 }

--- a/internal/entitlements/reconciler/reconciler.go
+++ b/internal/entitlements/reconciler/reconciler.go
@@ -225,6 +225,7 @@ func (r *Reconciler) reconcileOrg(ctx context.Context, org *ent.Organization) er
 
 var trialdays int64 = 30
 
+// createSubscription creates a new subscription in Stripe for the organization customer with the trial settings
 func (r *Reconciler) createSubscription(ctx context.Context, cust *entitlements.OrganizationCustomer) error {
 	customers, err := r.stripe.SearchCustomers(ctx, fmt.Sprintf("name: '%s'", cust.OrganizationID))
 	if err != nil {

--- a/internal/entitlements/reconciler/reconciler_test.go
+++ b/internal/entitlements/reconciler/reconciler_test.go
@@ -45,7 +45,15 @@ func TestNew_MissingDeps(t *testing.T) {
 }
 
 func TestAnalyzeOrgNoSubscription(t *testing.T) {
-	r := &Reconciler{}
+	WithStripeClient(&entitlements.StripeClient{})
+	r, err := New(
+		WithDB(&ent.Client{}),
+		WithStripeClient(&entitlements.StripeClient{}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
 	org := &ent.Organization{}
 	action, err := r.analyzeOrg(context.Background(), org)
 	if err != nil {

--- a/internal/graphapi/clientschema/schema.graphql
+++ b/internal/graphapi/clientschema/schema.graphql
@@ -32733,10 +32733,6 @@ type OrgSubscription implements Node {
 	"""
 	stripeSubscriptionID: String
 	"""
-	the price of the product tier
-	"""
-	productPrice: Price
-	"""
 	the status of the subscription in stripe -- see https://docs.stripe.com/api/subscriptions/object#subscription_object-status
 	"""
 	stripeSubscriptionStatus: String
@@ -32756,14 +32752,6 @@ type OrgSubscription implements Node {
 	number of days until there is a due payment
 	"""
 	daysUntilDue: String
-	"""
-	the features associated with the subscription
-	"""
-	features: [String!]
-	"""
-	the feature lookup keys associated with the subscription
-	"""
-	featureLookupKeys: [String!]
 	owner: Organization
 	events(
 		"""
@@ -32850,10 +32838,6 @@ type OrgSubscriptionHistory implements Node {
 	"""
 	stripeSubscriptionID: String
 	"""
-	the price of the product tier
-	"""
-	productPrice: Price
-	"""
 	the status of the subscription in stripe -- see https://docs.stripe.com/api/subscriptions/object#subscription_object-status
 	"""
 	stripeSubscriptionStatus: String
@@ -32873,14 +32857,6 @@ type OrgSubscriptionHistory implements Node {
 	number of days until there is a due payment
 	"""
 	daysUntilDue: String
-	"""
-	the features associated with the subscription
-	"""
-	features: [String!]
-	"""
-	the feature lookup keys associated with the subscription
-	"""
-	featureLookupKeys: [String!]
 }
 """
 A connection to a list of items.

--- a/internal/graphapi/generated/root_.generated.go
+++ b/internal/graphapi/generated/root_.generated.go
@@ -2938,13 +2938,10 @@ type ComplexityRoot struct {
 		DaysUntilDue             func(childComplexity int) int
 		Events                   func(childComplexity int, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy []*generated.EventOrder, where *generated.EventWhereInput) int
 		ExpiresAt                func(childComplexity int) int
-		FeatureLookupKeys        func(childComplexity int) int
-		Features                 func(childComplexity int) int
 		ID                       func(childComplexity int) int
 		ManagePaymentMethods     func(childComplexity int) int
 		Owner                    func(childComplexity int) int
 		OwnerID                  func(childComplexity int) int
-		ProductPrice             func(childComplexity int) int
 		StripeSubscriptionID     func(childComplexity int) int
 		StripeSubscriptionStatus func(childComplexity int) int
 		Tags                     func(childComplexity int) int
@@ -2970,13 +2967,10 @@ type ComplexityRoot struct {
 		CreatedBy                func(childComplexity int) int
 		DaysUntilDue             func(childComplexity int) int
 		ExpiresAt                func(childComplexity int) int
-		FeatureLookupKeys        func(childComplexity int) int
-		Features                 func(childComplexity int) int
 		HistoryTime              func(childComplexity int) int
 		ID                       func(childComplexity int) int
 		Operation                func(childComplexity int) int
 		OwnerID                  func(childComplexity int) int
-		ProductPrice             func(childComplexity int) int
 		Ref                      func(childComplexity int) int
 		StripeSubscriptionID     func(childComplexity int) int
 		StripeSubscriptionStatus func(childComplexity int) int
@@ -21175,20 +21169,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.OrgSubscription.ExpiresAt(childComplexity), true
 
-	case "OrgSubscription.featureLookupKeys":
-		if e.complexity.OrgSubscription.FeatureLookupKeys == nil {
-			break
-		}
-
-		return e.complexity.OrgSubscription.FeatureLookupKeys(childComplexity), true
-
-	case "OrgSubscription.features":
-		if e.complexity.OrgSubscription.Features == nil {
-			break
-		}
-
-		return e.complexity.OrgSubscription.Features(childComplexity), true
-
 	case "OrgSubscription.id":
 		if e.complexity.OrgSubscription.ID == nil {
 			break
@@ -21216,13 +21196,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.OrgSubscription.OwnerID(childComplexity), true
-
-	case "OrgSubscription.productPrice":
-		if e.complexity.OrgSubscription.ProductPrice == nil {
-			break
-		}
-
-		return e.complexity.OrgSubscription.ProductPrice(childComplexity), true
 
 	case "OrgSubscription.stripeSubscriptionID":
 		if e.complexity.OrgSubscription.StripeSubscriptionID == nil {
@@ -21336,20 +21309,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.OrgSubscriptionHistory.ExpiresAt(childComplexity), true
 
-	case "OrgSubscriptionHistory.featureLookupKeys":
-		if e.complexity.OrgSubscriptionHistory.FeatureLookupKeys == nil {
-			break
-		}
-
-		return e.complexity.OrgSubscriptionHistory.FeatureLookupKeys(childComplexity), true
-
-	case "OrgSubscriptionHistory.features":
-		if e.complexity.OrgSubscriptionHistory.Features == nil {
-			break
-		}
-
-		return e.complexity.OrgSubscriptionHistory.Features(childComplexity), true
-
 	case "OrgSubscriptionHistory.historyTime":
 		if e.complexity.OrgSubscriptionHistory.HistoryTime == nil {
 			break
@@ -21377,13 +21336,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.OrgSubscriptionHistory.OwnerID(childComplexity), true
-
-	case "OrgSubscriptionHistory.productPrice":
-		if e.complexity.OrgSubscriptionHistory.ProductPrice == nil {
-			break
-		}
-
-		return e.complexity.OrgSubscriptionHistory.ProductPrice(childComplexity), true
 
 	case "OrgSubscriptionHistory.ref":
 		if e.complexity.OrgSubscriptionHistory.Ref == nil {
@@ -66994,10 +66946,6 @@ type OrgSubscription implements Node {
   """
   stripeSubscriptionID: String
   """
-  the price of the product tier
-  """
-  productPrice: Price
-  """
   the status of the subscription in stripe -- see https://docs.stripe.com/api/subscriptions/object#subscription_object-status
   """
   stripeSubscriptionStatus: String
@@ -67017,14 +66965,6 @@ type OrgSubscription implements Node {
   number of days until there is a due payment
   """
   daysUntilDue: String
-  """
-  the features associated with the subscription
-  """
-  features: [String!]
-  """
-  the feature lookup keys associated with the subscription
-  """
-  featureLookupKeys: [String!]
   owner: Organization
   events(
     """
@@ -67110,10 +67050,6 @@ type OrgSubscriptionHistory implements Node {
   """
   stripeSubscriptionID: String
   """
-  the price of the product tier
-  """
-  productPrice: Price
-  """
   the status of the subscription in stripe -- see https://docs.stripe.com/api/subscriptions/object#subscription_object-status
   """
   stripeSubscriptionStatus: String
@@ -67133,14 +67069,6 @@ type OrgSubscriptionHistory implements Node {
   number of days until there is a due payment
   """
   daysUntilDue: String
-  """
-  the features associated with the subscription
-  """
-  features: [String!]
-  """
-  the feature lookup keys associated with the subscription
-  """
-  featureLookupKeys: [String!]
 }
 """
 A connection to a list of items.

--- a/internal/graphapi/generated/scalars.generated.go
+++ b/internal/graphapi/generated/scalars.generated.go
@@ -470,16 +470,6 @@ func (ec *executionContext) marshalOJobConfiguration2githubᚗcomᚋtheopenlane�
 	return v
 }
 
-func (ec *executionContext) unmarshalOPrice2githubᚗcomᚋtheopenlaneᚋcoreᚋpkgᚋmodelsᚐPrice(ctx context.Context, v any) (models.Price, error) {
-	var res models.Price
-	err := res.UnmarshalGQL(v)
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalOPrice2githubᚗcomᚋtheopenlaneᚋcoreᚋpkgᚋmodelsᚐPrice(ctx context.Context, sel ast.SelectionSet, v models.Price) graphql.Marshaler {
-	return v
-}
-
 func (ec *executionContext) unmarshalOReference2ᚕgithubᚗcomᚋtheopenlaneᚋcoreᚋpkgᚋmodelsᚐReferenceᚄ(ctx context.Context, v any) ([]models.Reference, error) {
 	if v == nil {
 		return nil, nil

--- a/internal/graphapi/query/adminsearch.graphql
+++ b/internal/graphapi/query/adminsearch.graphql
@@ -598,11 +598,8 @@ query AdminSearch($query: String!) {
           tags
           ownerID
           stripeSubscriptionID
-          productPrice
           stripeSubscriptionStatus
           daysUntilDue
-          features
-          featureLookupKeys
         }
       }
     }

--- a/internal/graphapi/query/organization.graphql
+++ b/internal/graphapi/query/organization.graphql
@@ -153,7 +153,6 @@ query GetAllOrganizations {
         orgSubscriptions {
           stripeSubscriptionStatus
           active
-          features
           id
         }
         createdAt
@@ -220,7 +219,6 @@ query GetOrganizationByID($organizationId: ID!) {
     orgSubscriptions {
       stripeSubscriptionStatus
       active
-      features
       id
     }
     controlCreators {
@@ -358,7 +356,6 @@ query GetOrganizations($where: OrganizationWhereInput) {
         orgSubscriptions {
           stripeSubscriptionStatus
           active
-          features
           id
         }
         createdAt
@@ -415,7 +412,6 @@ mutation UpdateOrganization($updateOrganizationId: ID!, $input: UpdateOrganizati
       orgSubscriptions {
         stripeSubscriptionStatus
         active
-        features
         id
       }
       programCreators {

--- a/internal/graphapi/query/orgsubscription.graphql
+++ b/internal/graphapi/query/orgsubscription.graphql
@@ -9,11 +9,8 @@ query GetAllOrgSubscriptions {
         createdBy
         daysUntilDue
         expiresAt
-        featureLookupKeys
-        features
         id
         ownerID
-        productPrice
         stripeSubscriptionID
         stripeSubscriptionStatus
         tags
@@ -31,11 +28,8 @@ query GetOrgSubscriptionByID($orgSubscriptionId: ID!) {
     createdBy
     daysUntilDue
     expiresAt
-    featureLookupKeys
-    features
     id
     ownerID
-    productPrice
     stripeSubscriptionStatus
     tags
     trialExpiresAt
@@ -53,11 +47,8 @@ query GetOrgSubscriptions($where: OrgSubscriptionWhereInput) {
         createdBy
         daysUntilDue
         expiresAt
-        featureLookupKeys
-        features
         id
         ownerID
-        productPrice
         stripeSubscriptionStatus
         tags
         trialExpiresAt

--- a/internal/graphapi/query/orgsubscriptionhistory.graphql
+++ b/internal/graphapi/query/orgsubscriptionhistory.graphql
@@ -1,5 +1,3 @@
-
-
 query GetAllOrgSubscriptionHistories {
   orgSubscriptionHistories {
     edges {
@@ -8,7 +6,6 @@ query GetAllOrgSubscriptionHistories {
         createdAt
         createdBy
         expiresAt
-        features
         historyTime
         id
         operation
@@ -32,7 +29,6 @@ query GetOrgSubscriptionHistories($where: OrgSubscriptionHistoryWhereInput) {
         createdAt
         createdBy
         expiresAt
-        features
         historyTime
         id
         operation

--- a/internal/graphapi/query/simple/orgsubscription.graphql
+++ b/internal/graphapi/query/simple/orgsubscription.graphql
@@ -16,11 +16,8 @@ query GetAllOrgSubscriptions {
         createdBy
         daysUntilDue
         expiresAt
-        featureLookupKeys
-        features
         id
         ownerID
-        productPrice
         stripeSubscriptionID
         stripeSubscriptionStatus
         tags
@@ -38,11 +35,8 @@ query GetOrgSubscriptionByID($orgSubscriptionId: ID!) {
     createdBy
     daysUntilDue
     expiresAt
-    featureLookupKeys
-    features
     id
     ownerID
-    productPrice
     stripeSubscriptionID
     stripeSubscriptionStatus
     tags
@@ -68,11 +62,8 @@ query GetOrgSubscriptions($first: Int, $last: Int, $where: OrgSubscriptionWhereI
         createdBy
         daysUntilDue
         expiresAt
-        featureLookupKeys
-        features
         id
         ownerID
-        productPrice
         stripeSubscriptionID
         stripeSubscriptionStatus
         tags

--- a/internal/graphapi/query/simple/orgsubscriptionhistory.graphql
+++ b/internal/graphapi/query/simple/orgsubscriptionhistory.graphql
@@ -16,13 +16,10 @@ query GetAllOrgSubscriptionHistories {
         createdBy
         daysUntilDue
         expiresAt
-        featureLookupKeys
-        features
         historyTime
         id
         operation
         ownerID
-        productPrice
         ref
         stripeSubscriptionID
         stripeSubscriptionStatus
@@ -51,13 +48,10 @@ query GetOrgSubscriptionHistories($first: Int, $last: Int, $where: OrgSubscripti
         createdBy
         daysUntilDue
         expiresAt
-        featureLookupKeys
-        features
         historyTime
         id
         operation
         ownerID
-        productPrice
         ref
         stripeSubscriptionID
         stripeSubscriptionStatus

--- a/internal/graphapi/schema/ent.graphql
+++ b/internal/graphapi/schema/ent.graphql
@@ -28320,10 +28320,6 @@ type OrgSubscription implements Node {
   """
   stripeSubscriptionID: String
   """
-  the price of the product tier
-  """
-  productPrice: Price
-  """
   the status of the subscription in stripe -- see https://docs.stripe.com/api/subscriptions/object#subscription_object-status
   """
   stripeSubscriptionStatus: String
@@ -28343,14 +28339,6 @@ type OrgSubscription implements Node {
   number of days until there is a due payment
   """
   daysUntilDue: String
-  """
-  the features associated with the subscription
-  """
-  features: [String!]
-  """
-  the feature lookup keys associated with the subscription
-  """
-  featureLookupKeys: [String!]
   owner: Organization
   events(
     """
@@ -28436,10 +28424,6 @@ type OrgSubscriptionHistory implements Node {
   """
   stripeSubscriptionID: String
   """
-  the price of the product tier
-  """
-  productPrice: Price
-  """
   the status of the subscription in stripe -- see https://docs.stripe.com/api/subscriptions/object#subscription_object-status
   """
   stripeSubscriptionStatus: String
@@ -28459,14 +28443,6 @@ type OrgSubscriptionHistory implements Node {
   number of days until there is a due payment
   """
   daysUntilDue: String
-  """
-  the features associated with the subscription
-  """
-  features: [String!]
-  """
-  the feature lookup keys associated with the subscription
-  """
-  featureLookupKeys: [String!]
 }
 """
 A connection to a list of items.

--- a/internal/graphapi/search.go
+++ b/internal/graphapi/search.go
@@ -1231,22 +1231,10 @@ func adminSearchOrgSubscriptions(ctx context.Context, query string, after *entgq
 					likeQuery := "%" + query + "%"
 					s.Where(sql.ExprP("(tags)::text LIKE $2", likeQuery)) // search by Tags
 				},
-				orgsubscription.OwnerIDContainsFold(query),              // search by OwnerID
-				orgsubscription.StripeSubscriptionIDContainsFold(query), // search by StripeSubscriptionID
-				func(s *sql.Selector) {
-					likeQuery := "%" + query + "%"
-					s.Where(sql.ExprP("(product_price)::text LIKE $5", likeQuery)) // search by ProductPrice
-				},
+				orgsubscription.OwnerIDContainsFold(query),                  // search by OwnerID
+				orgsubscription.StripeSubscriptionIDContainsFold(query),     // search by StripeSubscriptionID
 				orgsubscription.StripeSubscriptionStatusContainsFold(query), // search by StripeSubscriptionStatus
 				orgsubscription.DaysUntilDueContainsFold(query),             // search by DaysUntilDue
-				func(s *sql.Selector) {
-					likeQuery := "%" + query + "%"
-					s.Where(sql.ExprP("(features)::text LIKE $8", likeQuery)) // search by Features
-				},
-				func(s *sql.Selector) {
-					likeQuery := "%" + query + "%"
-					s.Where(sql.ExprP("(feature_lookup_keys)::text LIKE $9", likeQuery)) // search by FeatureLookupKeys
-				},
 			),
 		)
 

--- a/internal/graphapi/testclient/models.go
+++ b/internal/graphapi/testclient/models.go
@@ -18206,8 +18206,6 @@ type OrgSubscription struct {
 	OwnerID *string `json:"ownerID,omitempty"`
 	// the stripe subscription id
 	StripeSubscriptionID *string `json:"stripeSubscriptionID,omitempty"`
-	// the price of the product tier
-	ProductPrice *models.Price `json:"productPrice,omitempty"`
 	// the status of the subscription in stripe -- see https://docs.stripe.com/api/subscriptions/object#subscription_object-status
 	StripeSubscriptionStatus *string `json:"stripeSubscriptionStatus,omitempty"`
 	// indicates if the subscription is active
@@ -18217,11 +18215,7 @@ type OrgSubscription struct {
 	// the time the trial is set to expire
 	TrialExpiresAt *time.Time `json:"trialExpiresAt,omitempty"`
 	// number of days until there is a due payment
-	DaysUntilDue *string `json:"daysUntilDue,omitempty"`
-	// the features associated with the subscription
-	Features []string `json:"features,omitempty"`
-	// the feature lookup keys associated with the subscription
-	FeatureLookupKeys    []string         `json:"featureLookupKeys,omitempty"`
+	DaysUntilDue         *string          `json:"daysUntilDue,omitempty"`
 	Owner                *Organization    `json:"owner,omitempty"`
 	Events               *EventConnection `json:"events"`
 	ManagePaymentMethods *string          `json:"managePaymentMethods,omitempty"`
@@ -18262,8 +18256,6 @@ type OrgSubscriptionHistory struct {
 	OwnerID *string `json:"ownerID,omitempty"`
 	// the stripe subscription id
 	StripeSubscriptionID *string `json:"stripeSubscriptionID,omitempty"`
-	// the price of the product tier
-	ProductPrice *models.Price `json:"productPrice,omitempty"`
 	// the status of the subscription in stripe -- see https://docs.stripe.com/api/subscriptions/object#subscription_object-status
 	StripeSubscriptionStatus *string `json:"stripeSubscriptionStatus,omitempty"`
 	// indicates if the subscription is active
@@ -18274,10 +18266,6 @@ type OrgSubscriptionHistory struct {
 	TrialExpiresAt *time.Time `json:"trialExpiresAt,omitempty"`
 	// number of days until there is a due payment
 	DaysUntilDue *string `json:"daysUntilDue,omitempty"`
-	// the features associated with the subscription
-	Features []string `json:"features,omitempty"`
-	// the feature lookup keys associated with the subscription
-	FeatureLookupKeys []string `json:"featureLookupKeys,omitempty"`
 }
 
 func (OrgSubscriptionHistory) IsNode() {}

--- a/internal/httpserve/handlers/webhook.go
+++ b/internal/httpserve/handlers/webhook.go
@@ -376,20 +376,6 @@ func (h *Handler) syncOrgSubscriptionWithStripe(ctx context.Context, subscriptio
 		log.Debug().Str("subscription_id", orgSubscription.ID).Str("status", orgSubscription.StripeSubscriptionStatus).Msg("stripe subscription status changed")
 	}
 
-	if orgSubscription.ProductPrice != stripeOrgSubscription.ProductPrice {
-		productPriceCopy := stripeOrgSubscription.ProductPrice
-
-		productPriceCopy.Amount /= 100 // convert to dollars from cents
-
-		mutation.SetProductPrice(productPriceCopy)
-
-		mutation.SetProductPrice(stripeOrgSubscription.ProductPrice)
-
-		changed = true
-
-		log.Debug().Str("subscription_id", orgSubscription.ID).Str("price", orgSubscription.ProductPrice.String()).Msgf("product price changed")
-	}
-
 	if stripeOrgSubscription.TrialExpiresAt != nil && orgSubscription.TrialExpiresAt != stripeOrgSubscription.TrialExpiresAt {
 		mutation.SetTrialExpiresAt(*stripeOrgSubscription.TrialExpiresAt)
 

--- a/internal/httpserve/handlers/webhook.go
+++ b/internal/httpserve/handlers/webhook.go
@@ -316,12 +316,35 @@ func (h *Handler) handlePaymentMethodAdded(ctx context.Context, paymentMethod *s
 }
 
 // getOrgSubscription retrieves the OrgSubscription from the database based on the Stripe subscription ID
-func getOrgSubscription(ctx context.Context, subscriptionID string) (*ent.OrgSubscription, error) {
+func getOrgSubscription(ctx context.Context, subscriptionID string, customer *stripe.Customer) (*ent.OrgSubscription, error) {
 	allowCtx := contextx.With(ctx, auth.OrgSubscriptionContextKey{})
 
 	orgSubscription, err := transaction.FromContext(ctx).OrgSubscription.Query().
 		Where(orgsubscription.StripeSubscriptionID(subscriptionID)).Only(allowCtx)
 	if err != nil {
+		if ent.IsNotFound(err) {
+			// try by the metadata field as a fallback if customer is provided
+			if customer != nil && customer.Metadata != nil {
+				// first try org_subscription_id
+				if orgSubID, ok := customer.Metadata["org_subscription_id"]; ok && orgSubID != "" {
+					orgSubscription, err = transaction.FromContext(ctx).OrgSubscription.Query().
+						Where(orgsubscription.ID(orgSubID)).Only(allowCtx)
+					if err == nil {
+						return orgSubscription, nil
+					}
+				}
+
+				// fallback to organization_id
+				if orgID, ok := customer.Metadata["organization_id"]; ok && orgID != "" {
+					orgSubscription, err = transaction.FromContext(ctx).OrgSubscription.Query().
+						Where(orgsubscription.OwnerID(orgID), orgsubscription.DeletedAtIsNil()).Only(allowCtx)
+					if err == nil {
+						return orgSubscription, nil
+					}
+				}
+			}
+		}
+
 		log.Error().Err(err).Msg("failed to find org subscription")
 		return nil, err
 	}
@@ -332,7 +355,8 @@ func getOrgSubscription(ctx context.Context, subscriptionID string) (*ent.OrgSub
 // syncOrgSubscriptionWithStripe updates the internal OrgSubscription record with data from Stripe and
 // returns the owner (organization) ID of the OrgSubscription to be used for further operations if needed
 func (h *Handler) syncOrgSubscriptionWithStripe(ctx context.Context, subscription *stripe.Subscription, customer *stripe.Customer) (*string, error) {
-	orgSubscription, err := getOrgSubscription(ctx, subscription.ID)
+
+	orgSubscription, err := getOrgSubscription(ctx, subscription.ID, customer)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/httpserve/handlers/webhook.go
+++ b/internal/httpserve/handlers/webhook.go
@@ -362,7 +362,7 @@ func (h *Handler) syncOrgSubscriptionWithStripe(ctx context.Context, subscriptio
 	}
 
 	// map stripe data to internal OrgSubscription
-	stripeOrgSubscription := em.StripeSubscriptionToOrgSubscription(subscription, entitlements.MapStripeCustomer(customer))
+	stripeOrgSubscription := em.StripeSubscriptionToOrgSubscription(subscription)
 
 	// Check if any fields have changed before saving the updated OrgSubscription
 	changed := false

--- a/internal/httpserve/handlers/webhook_helpers.go
+++ b/internal/httpserve/handlers/webhook_helpers.go
@@ -24,7 +24,7 @@ import (
 // syncSubscriptionItemsWithStripe ensures OrgProduct, OrgPrice, and OrgModule
 // records exist and are updated based on the given Stripe subscription data.
 func (h *Handler) syncSubscriptionItemsWithStripe(ctx context.Context, subscriptionID string, items []*stripe.SubscriptionItem, subStatus stripe.SubscriptionStatus) error {
-	orgSub, err := getOrgSubscription(ctx, subscriptionID)
+	orgSub, err := getOrgSubscription(ctx, subscriptionID, nil)
 	if err != nil {
 		return err
 	}
@@ -196,7 +196,7 @@ func reconcileModules(ctx context.Context, orgSub *ent.OrgSubscription, currentM
 
 // removeAllModules drops all modules except the base one
 func (h *Handler) removeAllModules(ctx context.Context, subscriptionID string) error {
-	orgSub, err := getOrgSubscription(ctx, subscriptionID)
+	orgSub, err := getOrgSubscription(ctx, subscriptionID, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/entitlements/customers.go
+++ b/pkg/entitlements/customers.go
@@ -113,10 +113,6 @@ func (sc *StripeClient) CreateCustomerAndSubscription(ctx context.Context, o *Or
 
 	log.Debug().Str("customer_id", customer.ID).Str("subscription_id", subscription.ID).Msg("subscription created")
 
-	// if err := sc.retrieveFeatureLists(ctx, o); err != nil {
-	// 	return ErrCustomerNotFound
-	// }
-
 	_, err = sc.Client.V1Customers.Update(ctx, customer.ID, sc.UpdateCustomerWithOptions(
 		&stripe.CustomerUpdateParams{}, WithUpdateCustomerMetadata(map[string]string{"subscription_schedule_id": subscription.StripeSubscriptionScheduleID})))
 	if err != nil {
@@ -153,44 +149,6 @@ func (sc *StripeClient) FindOrCreateCustomer(ctx context.Context, o *Organizatio
 		log.Error().Err(ErrFoundMultipleCustomers).Str("organization_id", o.OrganizationID).Interface("customers", customers).Msg("found multiple customers, skipping all updates")
 		return ErrFoundMultipleCustomers
 	}
-}
-
-// retrieveFeatureLists retrieves the features for a customer
-func (sc *StripeClient) retrieveFeatureLists(ctx context.Context, o *OrganizationCustomer) error {
-	var feats, featNames []string
-
-	const maxRetries = 5
-
-	for i := range maxRetries {
-		var err error
-
-		feats, featNames, err = sc.retrieveActiveEntitlements(ctx, o.StripeCustomerID)
-		if err != nil {
-			return err
-		}
-
-		// if we have features, break out of the loop
-		if len(feats) > 0 {
-			log.Debug().Str("organization_id", o.OrganizationID).Str("customer_id", o.StripeCustomerID).Msg("features found for customer")
-
-			break
-		}
-
-		log.Debug().Str("organization_id", o.OrganizationID).Str("customer_id", o.StripeCustomerID).Msg("no features found for customer, retrying")
-
-		time.Sleep(time.Duration(i+1) * time.Second) // backoff retry
-	}
-
-	if len(feats) == 0 {
-		log.Warn().Str("customer_id", o.StripeCustomerID).Msg("no features found for customer")
-	}
-
-	log.Debug().Str("organization_id", o.OrganizationID).Strs("features", feats).Str("customer_id", o.StripeCustomerID).Msg("found features for customer")
-
-	o.Features = feats
-	o.FeatureNames = featNames
-
-	return nil
 }
 
 // GetCustomerByStripeID gets a customer by ID

--- a/pkg/entitlements/errors.go
+++ b/pkg/entitlements/errors.go
@@ -9,6 +9,8 @@ var (
 	ErrFoundMultipleCustomers = errors.New("found multiple customers with the same name")
 	// ErrMultipleSubscriptions = errors.New("multiple subscriptions found")
 	ErrMultipleSubscriptions = errors.New("multiple subscriptions found")
+	// ErrNoSubscriptions is returned when no subscriptions are found
+	ErrNoSubscriptions = errors.New("no subscriptions found")
 	// ErrCustomerNotFound is returned when a customer is not found
 	ErrCustomerNotFound = errors.New("customer not found")
 	// ErrCustomerLookupFailed is returned when a customer lookup fails
@@ -21,4 +23,6 @@ var (
 	ErrCustomerIDRequired = errors.New("customer ID is required")
 	// ErrMissingAPIKey is returned when the API key is missing
 	ErrMissingAPIKey = errors.New("missing API key")
+	// ErrNoSubscriptionItems is returned when no subscription items are found
+	ErrNoSubscriptionItems = errors.New("no subscription items found to create subscription")
 )

--- a/pkg/entitlements/mocks/stripe.go
+++ b/pkg/entitlements/mocks/stripe.go
@@ -1,3 +1,5 @@
+//go:build test
+
 package mocks
 
 import (

--- a/pkg/entitlements/mocks/stripe.go
+++ b/pkg/entitlements/mocks/stripe.go
@@ -1,5 +1,3 @@
-//go:build test
-
 package mocks
 
 import (

--- a/pkg/entitlements/subscriptions.go
+++ b/pkg/entitlements/subscriptions.go
@@ -138,29 +138,6 @@ func (sc *StripeClient) CreateSubscriptionScheduleFromSubs(ctx context.Context, 
 	return schedule, nil
 }
 
-// retrieveActiveEntitlements retrieves active entitlements for a customer
-func (sc *StripeClient) retrieveActiveEntitlements(ctx context.Context, customerID string) (feat []string, featNames []string, err error) {
-	params := &stripe.EntitlementsActiveEntitlementListParams{
-		Customer: stripe.String(customerID),
-		Expand:   []*string{stripe.String("data.feature")},
-	}
-
-	result := sc.Client.V1EntitlementsActiveEntitlements.List(ctx, params)
-
-	for feature, err := range result {
-		if err != nil {
-			log.Err(err).Msg("failed to list active entitlements")
-
-			return nil, nil, err
-		}
-
-		feat = append(feat, feature.LookupKey)
-		featNames = append(featNames, feature.Feature.Name)
-	}
-
-	return feat, featNames, nil
-}
-
 // MapStripeSubscription maps a stripe.Subscription to a "internal" subscription struct
 func (sc *StripeClient) MapStripeSubscription(ctx context.Context, subs *stripe.Subscription, sched *stripe.SubscriptionSchedule) *Subscription {
 	prices := []Price{}

--- a/pkg/entitlements/subscriptions.go
+++ b/pkg/entitlements/subscriptions.go
@@ -82,6 +82,10 @@ func (sc *StripeClient) CreateSubscriptionWithPrices(ctx context.Context, cust *
 		}
 	}
 
+	if len(items) == 0 {
+		return nil, ErrNoSubscriptionItems
+	}
+
 	params := &stripe.SubscriptionCreateParams{
 		Customer:        stripe.String(cust.ID),
 		Items:           items,

--- a/pkg/openlaneclient/graphclient.go
+++ b/pkg/openlaneclient/graphclient.go
@@ -42730,22 +42730,19 @@ func (t *GetAllOrgSubscriptions_OrgSubscriptions_PageInfo) GetStartCursor() *str
 }
 
 type GetAllOrgSubscriptions_OrgSubscriptions_Edges_Node struct {
-	Active                   bool          "json:\"active\" graphql:\"active\""
-	CreatedAt                *time.Time    "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy                *string       "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	DaysUntilDue             *string       "json:\"daysUntilDue,omitempty\" graphql:\"daysUntilDue\""
-	ExpiresAt                *time.Time    "json:\"expiresAt,omitempty\" graphql:\"expiresAt\""
-	FeatureLookupKeys        []string      "json:\"featureLookupKeys,omitempty\" graphql:\"featureLookupKeys\""
-	Features                 []string      "json:\"features,omitempty\" graphql:\"features\""
-	ID                       string        "json:\"id\" graphql:\"id\""
-	OwnerID                  *string       "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	ProductPrice             *models.Price "json:\"productPrice,omitempty\" graphql:\"productPrice\""
-	StripeSubscriptionID     *string       "json:\"stripeSubscriptionID,omitempty\" graphql:\"stripeSubscriptionID\""
-	StripeSubscriptionStatus *string       "json:\"stripeSubscriptionStatus,omitempty\" graphql:\"stripeSubscriptionStatus\""
-	Tags                     []string      "json:\"tags,omitempty\" graphql:\"tags\""
-	TrialExpiresAt           *time.Time    "json:\"trialExpiresAt,omitempty\" graphql:\"trialExpiresAt\""
-	UpdatedAt                *time.Time    "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy                *string       "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Active                   bool       "json:\"active\" graphql:\"active\""
+	CreatedAt                *time.Time "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy                *string    "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	DaysUntilDue             *string    "json:\"daysUntilDue,omitempty\" graphql:\"daysUntilDue\""
+	ExpiresAt                *time.Time "json:\"expiresAt,omitempty\" graphql:\"expiresAt\""
+	ID                       string     "json:\"id\" graphql:\"id\""
+	OwnerID                  *string    "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	StripeSubscriptionID     *string    "json:\"stripeSubscriptionID,omitempty\" graphql:\"stripeSubscriptionID\""
+	StripeSubscriptionStatus *string    "json:\"stripeSubscriptionStatus,omitempty\" graphql:\"stripeSubscriptionStatus\""
+	Tags                     []string   "json:\"tags,omitempty\" graphql:\"tags\""
+	TrialExpiresAt           *time.Time "json:\"trialExpiresAt,omitempty\" graphql:\"trialExpiresAt\""
+	UpdatedAt                *time.Time "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy                *string    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *GetAllOrgSubscriptions_OrgSubscriptions_Edges_Node) GetActive() bool {
@@ -42778,18 +42775,6 @@ func (t *GetAllOrgSubscriptions_OrgSubscriptions_Edges_Node) GetExpiresAt() *tim
 	}
 	return t.ExpiresAt
 }
-func (t *GetAllOrgSubscriptions_OrgSubscriptions_Edges_Node) GetFeatureLookupKeys() []string {
-	if t == nil {
-		t = &GetAllOrgSubscriptions_OrgSubscriptions_Edges_Node{}
-	}
-	return t.FeatureLookupKeys
-}
-func (t *GetAllOrgSubscriptions_OrgSubscriptions_Edges_Node) GetFeatures() []string {
-	if t == nil {
-		t = &GetAllOrgSubscriptions_OrgSubscriptions_Edges_Node{}
-	}
-	return t.Features
-}
 func (t *GetAllOrgSubscriptions_OrgSubscriptions_Edges_Node) GetID() string {
 	if t == nil {
 		t = &GetAllOrgSubscriptions_OrgSubscriptions_Edges_Node{}
@@ -42801,12 +42786,6 @@ func (t *GetAllOrgSubscriptions_OrgSubscriptions_Edges_Node) GetOwnerID() *strin
 		t = &GetAllOrgSubscriptions_OrgSubscriptions_Edges_Node{}
 	}
 	return t.OwnerID
-}
-func (t *GetAllOrgSubscriptions_OrgSubscriptions_Edges_Node) GetProductPrice() *models.Price {
-	if t == nil {
-		t = &GetAllOrgSubscriptions_OrgSubscriptions_Edges_Node{}
-	}
-	return t.ProductPrice
 }
 func (t *GetAllOrgSubscriptions_OrgSubscriptions_Edges_Node) GetStripeSubscriptionID() *string {
 	if t == nil {
@@ -42882,22 +42861,19 @@ func (t *GetAllOrgSubscriptions_OrgSubscriptions) GetTotalCount() int64 {
 }
 
 type GetOrgSubscriptionByID_OrgSubscription struct {
-	Active                   bool          "json:\"active\" graphql:\"active\""
-	CreatedAt                *time.Time    "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy                *string       "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	DaysUntilDue             *string       "json:\"daysUntilDue,omitempty\" graphql:\"daysUntilDue\""
-	ExpiresAt                *time.Time    "json:\"expiresAt,omitempty\" graphql:\"expiresAt\""
-	FeatureLookupKeys        []string      "json:\"featureLookupKeys,omitempty\" graphql:\"featureLookupKeys\""
-	Features                 []string      "json:\"features,omitempty\" graphql:\"features\""
-	ID                       string        "json:\"id\" graphql:\"id\""
-	OwnerID                  *string       "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	ProductPrice             *models.Price "json:\"productPrice,omitempty\" graphql:\"productPrice\""
-	StripeSubscriptionID     *string       "json:\"stripeSubscriptionID,omitempty\" graphql:\"stripeSubscriptionID\""
-	StripeSubscriptionStatus *string       "json:\"stripeSubscriptionStatus,omitempty\" graphql:\"stripeSubscriptionStatus\""
-	Tags                     []string      "json:\"tags,omitempty\" graphql:\"tags\""
-	TrialExpiresAt           *time.Time    "json:\"trialExpiresAt,omitempty\" graphql:\"trialExpiresAt\""
-	UpdatedAt                *time.Time    "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy                *string       "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Active                   bool       "json:\"active\" graphql:\"active\""
+	CreatedAt                *time.Time "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy                *string    "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	DaysUntilDue             *string    "json:\"daysUntilDue,omitempty\" graphql:\"daysUntilDue\""
+	ExpiresAt                *time.Time "json:\"expiresAt,omitempty\" graphql:\"expiresAt\""
+	ID                       string     "json:\"id\" graphql:\"id\""
+	OwnerID                  *string    "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	StripeSubscriptionID     *string    "json:\"stripeSubscriptionID,omitempty\" graphql:\"stripeSubscriptionID\""
+	StripeSubscriptionStatus *string    "json:\"stripeSubscriptionStatus,omitempty\" graphql:\"stripeSubscriptionStatus\""
+	Tags                     []string   "json:\"tags,omitempty\" graphql:\"tags\""
+	TrialExpiresAt           *time.Time "json:\"trialExpiresAt,omitempty\" graphql:\"trialExpiresAt\""
+	UpdatedAt                *time.Time "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy                *string    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *GetOrgSubscriptionByID_OrgSubscription) GetActive() bool {
@@ -42930,18 +42906,6 @@ func (t *GetOrgSubscriptionByID_OrgSubscription) GetExpiresAt() *time.Time {
 	}
 	return t.ExpiresAt
 }
-func (t *GetOrgSubscriptionByID_OrgSubscription) GetFeatureLookupKeys() []string {
-	if t == nil {
-		t = &GetOrgSubscriptionByID_OrgSubscription{}
-	}
-	return t.FeatureLookupKeys
-}
-func (t *GetOrgSubscriptionByID_OrgSubscription) GetFeatures() []string {
-	if t == nil {
-		t = &GetOrgSubscriptionByID_OrgSubscription{}
-	}
-	return t.Features
-}
 func (t *GetOrgSubscriptionByID_OrgSubscription) GetID() string {
 	if t == nil {
 		t = &GetOrgSubscriptionByID_OrgSubscription{}
@@ -42953,12 +42917,6 @@ func (t *GetOrgSubscriptionByID_OrgSubscription) GetOwnerID() *string {
 		t = &GetOrgSubscriptionByID_OrgSubscription{}
 	}
 	return t.OwnerID
-}
-func (t *GetOrgSubscriptionByID_OrgSubscription) GetProductPrice() *models.Price {
-	if t == nil {
-		t = &GetOrgSubscriptionByID_OrgSubscription{}
-	}
-	return t.ProductPrice
 }
 func (t *GetOrgSubscriptionByID_OrgSubscription) GetStripeSubscriptionID() *string {
 	if t == nil {
@@ -43030,22 +42988,19 @@ func (t *GetOrgSubscriptions_OrgSubscriptions_PageInfo) GetStartCursor() *string
 }
 
 type GetOrgSubscriptions_OrgSubscriptions_Edges_Node struct {
-	Active                   bool          "json:\"active\" graphql:\"active\""
-	CreatedAt                *time.Time    "json:\"createdAt,omitempty\" graphql:\"createdAt\""
-	CreatedBy                *string       "json:\"createdBy,omitempty\" graphql:\"createdBy\""
-	DaysUntilDue             *string       "json:\"daysUntilDue,omitempty\" graphql:\"daysUntilDue\""
-	ExpiresAt                *time.Time    "json:\"expiresAt,omitempty\" graphql:\"expiresAt\""
-	FeatureLookupKeys        []string      "json:\"featureLookupKeys,omitempty\" graphql:\"featureLookupKeys\""
-	Features                 []string      "json:\"features,omitempty\" graphql:\"features\""
-	ID                       string        "json:\"id\" graphql:\"id\""
-	OwnerID                  *string       "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	ProductPrice             *models.Price "json:\"productPrice,omitempty\" graphql:\"productPrice\""
-	StripeSubscriptionID     *string       "json:\"stripeSubscriptionID,omitempty\" graphql:\"stripeSubscriptionID\""
-	StripeSubscriptionStatus *string       "json:\"stripeSubscriptionStatus,omitempty\" graphql:\"stripeSubscriptionStatus\""
-	Tags                     []string      "json:\"tags,omitempty\" graphql:\"tags\""
-	TrialExpiresAt           *time.Time    "json:\"trialExpiresAt,omitempty\" graphql:\"trialExpiresAt\""
-	UpdatedAt                *time.Time    "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
-	UpdatedBy                *string       "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
+	Active                   bool       "json:\"active\" graphql:\"active\""
+	CreatedAt                *time.Time "json:\"createdAt,omitempty\" graphql:\"createdAt\""
+	CreatedBy                *string    "json:\"createdBy,omitempty\" graphql:\"createdBy\""
+	DaysUntilDue             *string    "json:\"daysUntilDue,omitempty\" graphql:\"daysUntilDue\""
+	ExpiresAt                *time.Time "json:\"expiresAt,omitempty\" graphql:\"expiresAt\""
+	ID                       string     "json:\"id\" graphql:\"id\""
+	OwnerID                  *string    "json:\"ownerID,omitempty\" graphql:\"ownerID\""
+	StripeSubscriptionID     *string    "json:\"stripeSubscriptionID,omitempty\" graphql:\"stripeSubscriptionID\""
+	StripeSubscriptionStatus *string    "json:\"stripeSubscriptionStatus,omitempty\" graphql:\"stripeSubscriptionStatus\""
+	Tags                     []string   "json:\"tags,omitempty\" graphql:\"tags\""
+	TrialExpiresAt           *time.Time "json:\"trialExpiresAt,omitempty\" graphql:\"trialExpiresAt\""
+	UpdatedAt                *time.Time "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
+	UpdatedBy                *string    "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
 func (t *GetOrgSubscriptions_OrgSubscriptions_Edges_Node) GetActive() bool {
@@ -43078,18 +43033,6 @@ func (t *GetOrgSubscriptions_OrgSubscriptions_Edges_Node) GetExpiresAt() *time.T
 	}
 	return t.ExpiresAt
 }
-func (t *GetOrgSubscriptions_OrgSubscriptions_Edges_Node) GetFeatureLookupKeys() []string {
-	if t == nil {
-		t = &GetOrgSubscriptions_OrgSubscriptions_Edges_Node{}
-	}
-	return t.FeatureLookupKeys
-}
-func (t *GetOrgSubscriptions_OrgSubscriptions_Edges_Node) GetFeatures() []string {
-	if t == nil {
-		t = &GetOrgSubscriptions_OrgSubscriptions_Edges_Node{}
-	}
-	return t.Features
-}
 func (t *GetOrgSubscriptions_OrgSubscriptions_Edges_Node) GetID() string {
 	if t == nil {
 		t = &GetOrgSubscriptions_OrgSubscriptions_Edges_Node{}
@@ -43101,12 +43044,6 @@ func (t *GetOrgSubscriptions_OrgSubscriptions_Edges_Node) GetOwnerID() *string {
 		t = &GetOrgSubscriptions_OrgSubscriptions_Edges_Node{}
 	}
 	return t.OwnerID
-}
-func (t *GetOrgSubscriptions_OrgSubscriptions_Edges_Node) GetProductPrice() *models.Price {
-	if t == nil {
-		t = &GetOrgSubscriptions_OrgSubscriptions_Edges_Node{}
-	}
-	return t.ProductPrice
 }
 func (t *GetOrgSubscriptions_OrgSubscriptions_Edges_Node) GetStripeSubscriptionID() *string {
 	if t == nil {
@@ -43219,13 +43156,10 @@ type GetAllOrgSubscriptionHistories_OrgSubscriptionHistories_Edges_Node struct {
 	CreatedBy                *string        "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	DaysUntilDue             *string        "json:\"daysUntilDue,omitempty\" graphql:\"daysUntilDue\""
 	ExpiresAt                *time.Time     "json:\"expiresAt,omitempty\" graphql:\"expiresAt\""
-	FeatureLookupKeys        []string       "json:\"featureLookupKeys,omitempty\" graphql:\"featureLookupKeys\""
-	Features                 []string       "json:\"features,omitempty\" graphql:\"features\""
 	HistoryTime              time.Time      "json:\"historyTime\" graphql:\"historyTime\""
 	ID                       string         "json:\"id\" graphql:\"id\""
 	Operation                history.OpType "json:\"operation\" graphql:\"operation\""
 	OwnerID                  *string        "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	ProductPrice             *models.Price  "json:\"productPrice,omitempty\" graphql:\"productPrice\""
 	Ref                      *string        "json:\"ref,omitempty\" graphql:\"ref\""
 	StripeSubscriptionID     *string        "json:\"stripeSubscriptionID,omitempty\" graphql:\"stripeSubscriptionID\""
 	StripeSubscriptionStatus *string        "json:\"stripeSubscriptionStatus,omitempty\" graphql:\"stripeSubscriptionStatus\""
@@ -43265,18 +43199,6 @@ func (t *GetAllOrgSubscriptionHistories_OrgSubscriptionHistories_Edges_Node) Get
 	}
 	return t.ExpiresAt
 }
-func (t *GetAllOrgSubscriptionHistories_OrgSubscriptionHistories_Edges_Node) GetFeatureLookupKeys() []string {
-	if t == nil {
-		t = &GetAllOrgSubscriptionHistories_OrgSubscriptionHistories_Edges_Node{}
-	}
-	return t.FeatureLookupKeys
-}
-func (t *GetAllOrgSubscriptionHistories_OrgSubscriptionHistories_Edges_Node) GetFeatures() []string {
-	if t == nil {
-		t = &GetAllOrgSubscriptionHistories_OrgSubscriptionHistories_Edges_Node{}
-	}
-	return t.Features
-}
 func (t *GetAllOrgSubscriptionHistories_OrgSubscriptionHistories_Edges_Node) GetHistoryTime() *time.Time {
 	if t == nil {
 		t = &GetAllOrgSubscriptionHistories_OrgSubscriptionHistories_Edges_Node{}
@@ -43300,12 +43222,6 @@ func (t *GetAllOrgSubscriptionHistories_OrgSubscriptionHistories_Edges_Node) Get
 		t = &GetAllOrgSubscriptionHistories_OrgSubscriptionHistories_Edges_Node{}
 	}
 	return t.OwnerID
-}
-func (t *GetAllOrgSubscriptionHistories_OrgSubscriptionHistories_Edges_Node) GetProductPrice() *models.Price {
-	if t == nil {
-		t = &GetAllOrgSubscriptionHistories_OrgSubscriptionHistories_Edges_Node{}
-	}
-	return t.ProductPrice
 }
 func (t *GetAllOrgSubscriptionHistories_OrgSubscriptionHistories_Edges_Node) GetRef() *string {
 	if t == nil {
@@ -43424,13 +43340,10 @@ type GetOrgSubscriptionHistories_OrgSubscriptionHistories_Edges_Node struct {
 	CreatedBy                *string        "json:\"createdBy,omitempty\" graphql:\"createdBy\""
 	DaysUntilDue             *string        "json:\"daysUntilDue,omitempty\" graphql:\"daysUntilDue\""
 	ExpiresAt                *time.Time     "json:\"expiresAt,omitempty\" graphql:\"expiresAt\""
-	FeatureLookupKeys        []string       "json:\"featureLookupKeys,omitempty\" graphql:\"featureLookupKeys\""
-	Features                 []string       "json:\"features,omitempty\" graphql:\"features\""
 	HistoryTime              time.Time      "json:\"historyTime\" graphql:\"historyTime\""
 	ID                       string         "json:\"id\" graphql:\"id\""
 	Operation                history.OpType "json:\"operation\" graphql:\"operation\""
 	OwnerID                  *string        "json:\"ownerID,omitempty\" graphql:\"ownerID\""
-	ProductPrice             *models.Price  "json:\"productPrice,omitempty\" graphql:\"productPrice\""
 	Ref                      *string        "json:\"ref,omitempty\" graphql:\"ref\""
 	StripeSubscriptionID     *string        "json:\"stripeSubscriptionID,omitempty\" graphql:\"stripeSubscriptionID\""
 	StripeSubscriptionStatus *string        "json:\"stripeSubscriptionStatus,omitempty\" graphql:\"stripeSubscriptionStatus\""
@@ -43470,18 +43383,6 @@ func (t *GetOrgSubscriptionHistories_OrgSubscriptionHistories_Edges_Node) GetExp
 	}
 	return t.ExpiresAt
 }
-func (t *GetOrgSubscriptionHistories_OrgSubscriptionHistories_Edges_Node) GetFeatureLookupKeys() []string {
-	if t == nil {
-		t = &GetOrgSubscriptionHistories_OrgSubscriptionHistories_Edges_Node{}
-	}
-	return t.FeatureLookupKeys
-}
-func (t *GetOrgSubscriptionHistories_OrgSubscriptionHistories_Edges_Node) GetFeatures() []string {
-	if t == nil {
-		t = &GetOrgSubscriptionHistories_OrgSubscriptionHistories_Edges_Node{}
-	}
-	return t.Features
-}
 func (t *GetOrgSubscriptionHistories_OrgSubscriptionHistories_Edges_Node) GetHistoryTime() *time.Time {
 	if t == nil {
 		t = &GetOrgSubscriptionHistories_OrgSubscriptionHistories_Edges_Node{}
@@ -43505,12 +43406,6 @@ func (t *GetOrgSubscriptionHistories_OrgSubscriptionHistories_Edges_Node) GetOwn
 		t = &GetOrgSubscriptionHistories_OrgSubscriptionHistories_Edges_Node{}
 	}
 	return t.OwnerID
-}
-func (t *GetOrgSubscriptionHistories_OrgSubscriptionHistories_Edges_Node) GetProductPrice() *models.Price {
-	if t == nil {
-		t = &GetOrgSubscriptionHistories_OrgSubscriptionHistories_Edges_Node{}
-	}
-	return t.ProductPrice
 }
 func (t *GetOrgSubscriptionHistories_OrgSubscriptionHistories_Edges_Node) GetRef() *string {
 	if t == nil {
@@ -97457,11 +97352,8 @@ const GetAllOrgSubscriptionsDocument = `query GetAllOrgSubscriptions {
 				createdBy
 				daysUntilDue
 				expiresAt
-				featureLookupKeys
-				features
 				id
 				ownerID
-				productPrice
 				stripeSubscriptionID
 				stripeSubscriptionStatus
 				tags
@@ -97496,11 +97388,8 @@ const GetOrgSubscriptionByIDDocument = `query GetOrgSubscriptionByID ($orgSubscr
 		createdBy
 		daysUntilDue
 		expiresAt
-		featureLookupKeys
-		features
 		id
 		ownerID
-		productPrice
 		stripeSubscriptionID
 		stripeSubscriptionStatus
 		tags
@@ -97544,11 +97433,8 @@ const GetOrgSubscriptionsDocument = `query GetOrgSubscriptions ($first: Int, $la
 				createdBy
 				daysUntilDue
 				expiresAt
-				featureLookupKeys
-				features
 				id
 				ownerID
-				productPrice
 				stripeSubscriptionID
 				stripeSubscriptionStatus
 				tags
@@ -97596,13 +97482,10 @@ const GetAllOrgSubscriptionHistoriesDocument = `query GetAllOrgSubscriptionHisto
 				createdBy
 				daysUntilDue
 				expiresAt
-				featureLookupKeys
-				features
 				historyTime
 				id
 				operation
 				ownerID
-				productPrice
 				ref
 				stripeSubscriptionID
 				stripeSubscriptionStatus
@@ -97647,13 +97530,10 @@ const GetOrgSubscriptionHistoriesDocument = `query GetOrgSubscriptionHistories (
 				createdBy
 				daysUntilDue
 				expiresAt
-				featureLookupKeys
-				features
 				historyTime
 				id
 				operation
 				ownerID
-				productPrice
 				ref
 				stripeSubscriptionID
 				stripeSubscriptionStatus

--- a/pkg/openlaneclient/models.go
+++ b/pkg/openlaneclient/models.go
@@ -18206,8 +18206,6 @@ type OrgSubscription struct {
 	OwnerID *string `json:"ownerID,omitempty"`
 	// the stripe subscription id
 	StripeSubscriptionID *string `json:"stripeSubscriptionID,omitempty"`
-	// the price of the product tier
-	ProductPrice *models.Price `json:"productPrice,omitempty"`
 	// the status of the subscription in stripe -- see https://docs.stripe.com/api/subscriptions/object#subscription_object-status
 	StripeSubscriptionStatus *string `json:"stripeSubscriptionStatus,omitempty"`
 	// indicates if the subscription is active
@@ -18217,11 +18215,7 @@ type OrgSubscription struct {
 	// the time the trial is set to expire
 	TrialExpiresAt *time.Time `json:"trialExpiresAt,omitempty"`
 	// number of days until there is a due payment
-	DaysUntilDue *string `json:"daysUntilDue,omitempty"`
-	// the features associated with the subscription
-	Features []string `json:"features,omitempty"`
-	// the feature lookup keys associated with the subscription
-	FeatureLookupKeys    []string         `json:"featureLookupKeys,omitempty"`
+	DaysUntilDue         *string          `json:"daysUntilDue,omitempty"`
 	Owner                *Organization    `json:"owner,omitempty"`
 	Events               *EventConnection `json:"events"`
 	ManagePaymentMethods *string          `json:"managePaymentMethods,omitempty"`
@@ -18262,8 +18256,6 @@ type OrgSubscriptionHistory struct {
 	OwnerID *string `json:"ownerID,omitempty"`
 	// the stripe subscription id
 	StripeSubscriptionID *string `json:"stripeSubscriptionID,omitempty"`
-	// the price of the product tier
-	ProductPrice *models.Price `json:"productPrice,omitempty"`
 	// the status of the subscription in stripe -- see https://docs.stripe.com/api/subscriptions/object#subscription_object-status
 	StripeSubscriptionStatus *string `json:"stripeSubscriptionStatus,omitempty"`
 	// indicates if the subscription is active
@@ -18274,10 +18266,6 @@ type OrgSubscriptionHistory struct {
 	TrialExpiresAt *time.Time `json:"trialExpiresAt,omitempty"`
 	// number of days until there is a due payment
 	DaysUntilDue *string `json:"daysUntilDue,omitempty"`
-	// the features associated with the subscription
-	Features []string `json:"features,omitempty"`
-	// the feature lookup keys associated with the subscription
-	FeatureLookupKeys []string `json:"featureLookupKeys,omitempty"`
 }
 
 func (OrgSubscriptionHistory) IsNode() {}


### PR DESCRIPTION
Reconciler:
- adds ability to only run for specific org ids instead of all orgs with diffs
- adds org name to output
- Excludes personal orgs from queries; these are no longer in stripe and so the diffs were showing extra orgs to fix that I wanted to bypass
- Adds additional logic to set the stripe customer id on the org schema if it wasn't already there
- Adds a new "createSubscription" that will create a trial subscription schedule when its missing completely based on the same logic that would happen on an org creation. In theory; this shouldn't be used much but needed it to reconcile a bunch of orgs in weird states
- Removes error on multiple prices, all orgs will will multiple prices now, but its no longer set on the org subscription

Events:
- fixes subscription cancellation when an org is deleted by looking at `Update` events using the `DeleteOrganization` resolver. These return a count of orgs delete in the ent.Value so we are pulling the id from the mutation.ID() for this event type
- Skips the soft delete interceptor when looking up the organization on delete because the org will have already been soft-deleted

Hooks:
- Moved the `createDefaultOrgModulesProductsPrices` to the `reconciler` package. At first I thought I could use the same function for creating completely missing subscriptions and couldn't have the functions in the hooks because of import cycles, however, I needed just the prices. Because this function and the new `GetDefaultPrices` is very similar logic I decided to just leave it in the `reconciler` package. 

Schemas:
- orgSubscription: Removed `product_price`, `features`, and `feature_lookup_keys`; these are no longer used and data was all over the place. We now use modules for features and prices are on each product, not on the subscription

Webhook:
- adds a fallback to looking up on stripe org subscription, that will look up based on our internal org sub id or organization id. This should fix a few remaining records that are in both stripe and our database, but the stripe org subscription id is missing so its not getting updated. 