### PR TITLE
trust center re-auth email

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	github.com/theopenlane/beacon v0.2.0
 	github.com/theopenlane/echo-prometheus v0.1.0
 	github.com/theopenlane/echox v0.2.4
-	github.com/theopenlane/emailtemplates v0.2.5
+	github.com/theopenlane/emailtemplates v0.2.6
 	github.com/theopenlane/entx v0.15.0
 	github.com/theopenlane/gqlgen-plugins v0.9.1
 	github.com/theopenlane/httpsling v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -649,6 +649,8 @@ github.com/theopenlane/echox v0.2.4 h1:bocz1Dfs7d2fkNa8foQqdmeTtkMTQNwe1v20bIGID
 github.com/theopenlane/echox v0.2.4/go.mod h1:0cPOHe4SSQHmqP0/n2LsIEzRSogkxSX653bE+PIOVZ8=
 github.com/theopenlane/emailtemplates v0.2.5 h1:Kp7wuxctBWaLaj1tlOonw2yAwU+xyTL+nAtm4OSWNNQ=
 github.com/theopenlane/emailtemplates v0.2.5/go.mod h1:nLNXcp1fj53qUA5akgJpl/3ovERORr4sSZoa6lA5Vso=
+github.com/theopenlane/emailtemplates v0.2.6 h1:CF4KJocdETeELLP7+l3/UleRexwb/bgXPEtARodWNHA=
+github.com/theopenlane/emailtemplates v0.2.6/go.mod h1:nLNXcp1fj53qUA5akgJpl/3ovERORr4sSZoa6lA5Vso=
 github.com/theopenlane/entx v0.15.0 h1:g7C0PaLKv3RUN24usjpWyK3HScO8vOXVn8BSlNQQ41o=
 github.com/theopenlane/entx v0.15.0/go.mod h1:YsSrNyon63exbXoNIwEUCx4iTQMfDFYiNlaj9RfxZaU=
 github.com/theopenlane/gqlgen-plugins v0.9.1 h1:+7ECHAMNo42wW2ySD96WXp4amWsPom6OtIJcAiD8vRE=


### PR DESCRIPTION
Send a new auth token to the user if they have already signed the trust center NDA.
