### PR TITLE
make the font enums more graphql friendly

### DIFF
--- a/internal/ent/generated/migrate/schema.go
+++ b/internal/ent/generated/migrate/schema.go
@@ -5177,7 +5177,7 @@ var (
 		{Name: "opacity", Type: field.TypeFloat64, Nullable: true, Default: 0.3},
 		{Name: "rotation", Type: field.TypeFloat64, Nullable: true, Default: 45},
 		{Name: "color", Type: field.TypeString, Nullable: true, Default: "#808080"},
-		{Name: "font", Type: field.TypeEnum, Nullable: true, Enums: []string{"arial", "helvetica", "times", "times new roman", "georgia", "verdana", "courier", "courier new", "trebuchet ms", "comic sans ms", "impact", "palatino", "garamond", "bookman", "avant garde"}, Default: "arial"},
+		{Name: "font", Type: field.TypeEnum, Nullable: true, Enums: []string{"arial", "helvetica", "times", "times_new_roman", "georgia", "verdana", "courier", "courier_new", "trebuchet_ms", "comic_sans_ms", "impact", "palatino", "garamond", "bookman", "avant_garde"}, Default: "arial"},
 		{Name: "owner_id", Type: field.TypeString, Nullable: true},
 		{Name: "logo_id", Type: field.TypeString, Nullable: true},
 	}
@@ -5239,7 +5239,7 @@ var (
 		{Name: "opacity", Type: field.TypeFloat64, Nullable: true, Default: 0.3},
 		{Name: "rotation", Type: field.TypeFloat64, Nullable: true, Default: 45},
 		{Name: "color", Type: field.TypeString, Nullable: true, Default: "#808080"},
-		{Name: "font", Type: field.TypeEnum, Nullable: true, Enums: []string{"arial", "helvetica", "times", "times new roman", "georgia", "verdana", "courier", "courier new", "trebuchet ms", "comic sans ms", "impact", "palatino", "garamond", "bookman", "avant garde"}, Default: "arial"},
+		{Name: "font", Type: field.TypeEnum, Nullable: true, Enums: []string{"arial", "helvetica", "times", "times_new_roman", "georgia", "verdana", "courier", "courier_new", "trebuchet_ms", "comic_sans_ms", "impact", "palatino", "garamond", "bookman", "avant_garde"}, Default: "arial"},
 	}
 	// TrustCenterWatermarkConfigHistoryTable holds the schema information for the "trust_center_watermark_config_history" table.
 	TrustCenterWatermarkConfigHistoryTable = &schema.Table{

--- a/internal/ent/generated/trustcenterwatermarkconfig/trustcenterwatermarkconfig.go
+++ b/internal/ent/generated/trustcenterwatermarkconfig/trustcenterwatermarkconfig.go
@@ -153,7 +153,7 @@ const DefaultFont enums.Font = "arial"
 // FontValidator is a validator for the "font" field enum values. It is called by the builders before save.
 func FontValidator(f enums.Font) error {
 	switch f.String() {
-	case "arial", "helvetica", "times", "times new roman", "georgia", "verdana", "courier", "courier new", "trebuchet ms", "comic sans ms", "impact", "palatino", "garamond", "bookman", "avant garde":
+	case "arial", "helvetica", "times", "times_new_roman", "georgia", "verdana", "courier", "courier_new", "trebuchet_ms", "comic_sans_ms", "impact", "palatino", "garamond", "bookman", "avant_garde":
 		return nil
 	default:
 		return fmt.Errorf("trustcenterwatermarkconfig: invalid enum value for font field: %q", f)

--- a/internal/ent/generated/trustcenterwatermarkconfighistory/trustcenterwatermarkconfighistory.go
+++ b/internal/ent/generated/trustcenterwatermarkconfighistory/trustcenterwatermarkconfighistory.go
@@ -135,7 +135,7 @@ const DefaultFont enums.Font = "arial"
 // FontValidator is a validator for the "font" field enum values. It is called by the builders before save.
 func FontValidator(f enums.Font) error {
 	switch f.String() {
-	case "arial", "helvetica", "times", "times new roman", "georgia", "verdana", "courier", "courier new", "trebuchet ms", "comic sans ms", "impact", "palatino", "garamond", "bookman", "avant garde":
+	case "arial", "helvetica", "times", "times_new_roman", "georgia", "verdana", "courier", "courier_new", "trebuchet_ms", "comic_sans_ms", "impact", "palatino", "garamond", "bookman", "avant_garde":
 		return nil
 	default:
 		return fmt.Errorf("trustcenterwatermarkconfighistory: invalid enum value for font field: %q", f)

--- a/internal/graphapi/clientschema/schema.graphql
+++ b/internal/graphapi/clientschema/schema.graphql
@@ -60872,25 +60872,18 @@ enum TrustCenterWatermarkConfigFont @goModel(model: "github.com/theopenlane/core
 	arial
 	helvetica
 	times
-	times
-	new
-	roman
+	times_new_roman
 	georgia
 	verdana
 	courier
-	courier
-	new
-	trebuchet
-	ms
-	comic
-	sans
-	ms
+	courier_new
+	trebuchet_ms
+	comic_sans_ms
 	impact
 	palatino
 	garamond
 	bookman
-	avant
-	garde
+	avant_garde
 }
 type TrustCenterWatermarkConfigHistory implements Node {
 	id: ID!
@@ -60975,25 +60968,18 @@ enum TrustCenterWatermarkConfigHistoryFont @goModel(model: "github.com/theopenla
 	arial
 	helvetica
 	times
-	times
-	new
-	roman
+	times_new_roman
 	georgia
 	verdana
 	courier
-	courier
-	new
-	trebuchet
-	ms
-	comic
-	sans
-	ms
+	courier_new
+	trebuchet_ms
+	comic_sans_ms
 	impact
 	palatino
 	garamond
 	bookman
-	avant
-	garde
+	avant_garde
 }
 """
 TrustCenterWatermarkConfigHistoryOpType is enum for the field operation

--- a/internal/graphapi/generated/root_.generated.go
+++ b/internal/graphapi/generated/root_.generated.go
@@ -90807,18 +90807,18 @@ enum TrustCenterWatermarkConfigFont @goModel(model: "github.com/theopenlane/core
   arial
   helvetica
   times
-  times new roman
+  times_new_roman
   georgia
   verdana
   courier
-  courier new
-  trebuchet ms
-  comic sans ms
+  courier_new
+  trebuchet_ms
+  comic_sans_ms
   impact
   palatino
   garamond
   bookman
-  avant garde
+  avant_garde
 }
 type TrustCenterWatermarkConfigHistory implements Node {
   id: ID!
@@ -90903,18 +90903,18 @@ enum TrustCenterWatermarkConfigHistoryFont @goModel(model: "github.com/theopenla
   arial
   helvetica
   times
-  times new roman
+  times_new_roman
   georgia
   verdana
   courier
-  courier new
-  trebuchet ms
-  comic sans ms
+  courier_new
+  trebuchet_ms
+  comic_sans_ms
   impact
   palatino
   garamond
   bookman
-  avant garde
+  avant_garde
 }
 """
 TrustCenterWatermarkConfigHistoryOpType is enum for the field operation

--- a/internal/graphapi/schema/ent.graphql
+++ b/internal/graphapi/schema/ent.graphql
@@ -52133,18 +52133,18 @@ enum TrustCenterWatermarkConfigFont @goModel(model: "github.com/theopenlane/core
   arial
   helvetica
   times
-  times new roman
+  times_new_roman
   georgia
   verdana
   courier
-  courier new
-  trebuchet ms
-  comic sans ms
+  courier_new
+  trebuchet_ms
+  comic_sans_ms
   impact
   palatino
   garamond
   bookman
-  avant garde
+  avant_garde
 }
 type TrustCenterWatermarkConfigHistory implements Node {
   id: ID!
@@ -52229,18 +52229,18 @@ enum TrustCenterWatermarkConfigHistoryFont @goModel(model: "github.com/theopenla
   arial
   helvetica
   times
-  times new roman
+  times_new_roman
   georgia
   verdana
   courier
-  courier new
-  trebuchet ms
-  comic sans ms
+  courier_new
+  trebuchet_ms
+  comic_sans_ms
   impact
   palatino
   garamond
   bookman
-  avant garde
+  avant_garde
 }
 """
 TrustCenterWatermarkConfigHistoryOpType is enum for the field operation

--- a/pkg/enums/font.go
+++ b/pkg/enums/font.go
@@ -17,7 +17,7 @@ var (
 	// FontTimes represents the Times font
 	FontTimes Font = "times"
 	// FontTimesNewRoman represents the Times New Roman font
-	FontTimesNewRoman Font = "times new roman"
+	FontTimesNewRoman Font = "times_new_roman"
 	// FontGeorgia represents the Georgia font
 	FontGeorgia Font = "georgia"
 	// FontVerdana represents the Verdana font
@@ -25,11 +25,11 @@ var (
 	// FontCourier represents the Courier font
 	FontCourier Font = "courier"
 	// FontCourierNew represents the Courier New font
-	FontCourierNew Font = "courier new"
+	FontCourierNew Font = "courier_new"
 	// FontTrebuchetMS represents the Trebuchet MS font
-	FontTrebuchetMS Font = "trebuchet ms"
+	FontTrebuchetMS Font = "trebuchet_ms"
 	// FontComicSansMS represents the Comic Sans MS font
-	FontComicSansMS Font = "comic sans ms"
+	FontComicSansMS Font = "comic_sans_ms"
 	// FontImpact represents the Impact font
 	FontImpact Font = "impact"
 	// FontPalatino represents the Palatino font
@@ -39,7 +39,7 @@ var (
 	// FontBookman represents the Bookman font
 	FontBookman Font = "bookman"
 	// FontAvantGarde represents the Avant Garde font
-	FontAvantGarde Font = "avant garde"
+	FontAvantGarde Font = "avant_garde"
 	// FontInvalid indicates that the font is invalid
 	FontInvalid Font = "FONT_INVALID"
 )


### PR DESCRIPTION
totes makes sense that graphql doesn't like the spaces, but wish it would just fail lol.
