### PR TITLE
bug: get metadata as backup from stripe sub, not customer data

### DIFF
--- a/internal/httpserve/handlers/webhook.go
+++ b/internal/httpserve/handlers/webhook.go
@@ -320,7 +320,7 @@ func getOrgSubscription(ctx context.Context, subscription *stripe.Subscription) 
 				// first try org_subscription_id
 				if orgSubID := entitlements.GetOrganizationSubscriptionIDFromMetadata(subscription.Metadata); orgSubID != "" {
 					orgSubscription, err = transaction.FromContext(ctx).OrgSubscription.Query().
-						Where(orgsubscription.ID(orgSubID)).Only(allowCtx)
+						Where(orgsubscription.ID(orgSubID), orgsubscription.DeletedAtIsNil()).Only(allowCtx)
 					if err == nil {
 						return orgSubscription, nil
 					}

--- a/internal/httpserve/handlers/webhook.go
+++ b/internal/httpserve/handlers/webhook.go
@@ -243,17 +243,12 @@ func (h *Handler) handleSubscriptionPaused(ctx context.Context, s *stripe.Subscr
 		return ErrSubscriberNotFound
 	}
 
-	customer, err := h.Entitlements.GetCustomerByStripeID(ctx, s.Customer.ID)
-	if err != nil {
-		return err
-	}
-
-	ownerID, err := h.syncOrgSubscriptionWithStripe(ctx, s, customer)
+	ownerID, err := h.syncOrgSubscriptionWithStripe(ctx, s)
 	if err != nil {
 		return
 	}
 
-	if err = h.removeAllModules(ctx, s.ID); err != nil {
+	if err = h.removeAllModules(ctx, s); err != nil {
 		return
 	}
 
@@ -273,17 +268,14 @@ func (h *Handler) handleSubscriptionUpdated(ctx context.Context, s *stripe.Subsc
 		return ErrSubscriberNotFound
 	}
 
-	customer, err := h.Entitlements.GetCustomerByStripeID(ctx, s.Customer.ID)
+	_, err := h.syncOrgSubscriptionWithStripe(ctx, s)
 	if err != nil {
+		log.Error().Err(err).Msg("failed to sync org subscription with stripe")
+
 		return err
 	}
 
-	_, err = h.syncOrgSubscriptionWithStripe(ctx, s, customer)
-	if err != nil {
-		return err
-	}
-
-	return h.syncSubscriptionItemsWithStripe(ctx, s.ID, s.Items.Data, s.Status)
+	return h.syncSubscriptionItemsWithStripe(ctx, s, s.Items.Data, s.Status)
 }
 
 // handleTrialWillEnd handles trial will end events, currently just calls handleSubscriptionUpdated
@@ -316,17 +308,17 @@ func (h *Handler) handlePaymentMethodAdded(ctx context.Context, paymentMethod *s
 }
 
 // getOrgSubscription retrieves the OrgSubscription from the database based on the Stripe subscription ID
-func getOrgSubscription(ctx context.Context, subscriptionID string, customer *stripe.Customer) (*ent.OrgSubscription, error) {
+func getOrgSubscription(ctx context.Context, subscription *stripe.Subscription) (*ent.OrgSubscription, error) {
 	allowCtx := contextx.With(ctx, auth.OrgSubscriptionContextKey{})
 
 	orgSubscription, err := transaction.FromContext(ctx).OrgSubscription.Query().
-		Where(orgsubscription.StripeSubscriptionID(subscriptionID)).Only(allowCtx)
+		Where(orgsubscription.StripeSubscriptionID(subscription.ID)).Only(allowCtx)
 	if err != nil {
 		if ent.IsNotFound(err) {
 			// try by the metadata field as a fallback if customer is provided
-			if customer != nil && customer.Metadata != nil {
+			if subscription != nil && subscription.Metadata != nil {
 				// first try org_subscription_id
-				if orgSubID, ok := customer.Metadata["org_subscription_id"]; ok && orgSubID != "" {
+				if orgSubID, ok := subscription.Metadata["org_subscription_id"]; ok && orgSubID != "" {
 					orgSubscription, err = transaction.FromContext(ctx).OrgSubscription.Query().
 						Where(orgsubscription.ID(orgSubID)).Only(allowCtx)
 					if err == nil {
@@ -335,7 +327,7 @@ func getOrgSubscription(ctx context.Context, subscriptionID string, customer *st
 				}
 
 				// fallback to organization_id
-				if orgID, ok := customer.Metadata["organization_id"]; ok && orgID != "" {
+				if orgID, ok := subscription.Metadata["organization_id"]; ok && orgID != "" {
 					orgSubscription, err = transaction.FromContext(ctx).OrgSubscription.Query().
 						Where(orgsubscription.OwnerID(orgID), orgsubscription.DeletedAtIsNil()).Only(allowCtx)
 					if err == nil {
@@ -343,6 +335,8 @@ func getOrgSubscription(ctx context.Context, subscriptionID string, customer *st
 					}
 				}
 			}
+
+			log.Warn().Str("subscription_id", subscription.ID).Msg("org subscription not found and no metadata to fallback on")
 		}
 
 		log.Error().Err(err).Msg("failed to find org subscription")
@@ -354,9 +348,9 @@ func getOrgSubscription(ctx context.Context, subscriptionID string, customer *st
 
 // syncOrgSubscriptionWithStripe updates the internal OrgSubscription record with data from Stripe and
 // returns the owner (organization) ID of the OrgSubscription to be used for further operations if needed
-func (h *Handler) syncOrgSubscriptionWithStripe(ctx context.Context, subscription *stripe.Subscription, customer *stripe.Customer) (*string, error) {
+func (h *Handler) syncOrgSubscriptionWithStripe(ctx context.Context, subscription *stripe.Subscription) (*string, error) {
 
-	orgSubscription, err := getOrgSubscription(ctx, subscription.ID, customer)
+	orgSubscription, err := getOrgSubscription(ctx, subscription)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/httpserve/handlers/webhook.go
+++ b/internal/httpserve/handlers/webhook.go
@@ -318,7 +318,7 @@ func getOrgSubscription(ctx context.Context, subscription *stripe.Subscription) 
 			// try by the metadata field as a fallback if customer is provided
 			if subscription != nil && subscription.Metadata != nil {
 				// first try org_subscription_id
-				if orgSubID, ok := subscription.Metadata["org_subscription_id"]; ok && orgSubID != "" {
+				if orgSubID := entitlements.GetOrganizationSubscriptionIDFromMetadata(subscription.Metadata); orgSubID != "" {
 					orgSubscription, err = transaction.FromContext(ctx).OrgSubscription.Query().
 						Where(orgsubscription.ID(orgSubID)).Only(allowCtx)
 					if err == nil {
@@ -327,7 +327,7 @@ func getOrgSubscription(ctx context.Context, subscription *stripe.Subscription) 
 				}
 
 				// fallback to organization_id
-				if orgID, ok := subscription.Metadata["organization_id"]; ok && orgID != "" {
+				if orgID := entitlements.GetOrganizationIDFromMetadata(subscription.Metadata); orgID != "" {
 					orgSubscription, err = transaction.FromContext(ctx).OrgSubscription.Query().
 						Where(orgsubscription.OwnerID(orgID), orgsubscription.DeletedAtIsNil()).Only(allowCtx)
 					if err == nil {

--- a/internal/httpserve/handlers/webhook_helpers.go
+++ b/internal/httpserve/handlers/webhook_helpers.go
@@ -23,8 +23,8 @@ import (
 
 // syncSubscriptionItemsWithStripe ensures OrgProduct, OrgPrice, and OrgModule
 // records exist and are updated based on the given Stripe subscription data.
-func (h *Handler) syncSubscriptionItemsWithStripe(ctx context.Context, subscriptionID string, items []*stripe.SubscriptionItem, subStatus stripe.SubscriptionStatus) error {
-	orgSub, err := getOrgSubscription(ctx, subscriptionID, nil)
+func (h *Handler) syncSubscriptionItemsWithStripe(ctx context.Context, subscription *stripe.Subscription, items []*stripe.SubscriptionItem, subStatus stripe.SubscriptionStatus) error {
+	orgSub, err := getOrgSubscription(ctx, subscription)
 	if err != nil {
 		return err
 	}
@@ -195,8 +195,8 @@ func reconcileModules(ctx context.Context, orgSub *ent.OrgSubscription, currentM
 }
 
 // removeAllModules drops all modules except the base one
-func (h *Handler) removeAllModules(ctx context.Context, subscriptionID string) error {
-	orgSub, err := getOrgSubscription(ctx, subscriptionID, nil)
+func (h *Handler) removeAllModules(ctx context.Context, subscription *stripe.Subscription) error {
+	orgSub, err := getOrgSubscription(ctx, subscription)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
confirmed this data is in the stripe event data, but looks like it wasn't on the customer. We don't actually need the customer here for anything else because of other delete functions so was able to skip the extra calls to customer as well. 