### PR TITLE
feat: autoset allowed domains based on email, set autojoin true

### DIFF
--- a/internal/ent/hooks/organization.go
+++ b/internal/ent/hooks/organization.go
@@ -8,6 +8,7 @@ import (
 
 	"entgo.io/ent"
 	"github.com/rs/zerolog"
+	"github.com/samber/lo"
 	"github.com/stripe/stripe-go/v82"
 
 	"github.com/theopenlane/iam/auth"
@@ -454,6 +455,13 @@ func defaultOrganizationSettings(ctx context.Context, m *generated.OrganizationM
 		billingContact := user.FirstName + " " + user.LastName
 		input.BillingEmail = &user.Email
 		input.BillingContact = &billingContact
+
+		// automatically add the user's email domain to the allowed email domains
+		// and enable auto-join for matching domains
+		emailDomain := strings.SplitAfter(user.Email, "@")[1]
+
+		input.AllowedEmailDomains = []string{emailDomain}
+		input.AllowMatchingDomainsAutojoin = lo.ToPtr(true)
 	}
 
 	organizationSetting, err := m.Client().OrganizationSetting.Create().SetInput(input).Save(ctx)

--- a/internal/graphapi/models_test.go
+++ b/internal/graphapi/models_test.go
@@ -541,7 +541,8 @@ func (u *UserBuilder) MustNew(ctx context.Context, t *testing.T) *ent.User {
 	}
 
 	if u.Email == "" {
-		u.Email = gofakeit.Email()
+		// ensure email has a valid domain for email verification tests
+		u.Email = strings.ToLower(fmt.Sprintf("%s.%s.%s@%s", u.FirstName, u.LastName, ulids.New().String(), "theopenlane.io"))
 	}
 
 	if u.Password == "" {

--- a/internal/graphapi/models_test.go
+++ b/internal/graphapi/models_test.go
@@ -676,7 +676,7 @@ func (i *InviteBuilder) MustNew(ctx context.Context, t *testing.T) *ent.Invite {
 	rec := i.Recipient
 
 	if rec == "" {
-		rec = gofakeit.Email()
+		rec = strings.ToLower(fmt.Sprintf("%s@%s", ulids.New().String(), "theopenlane.io"))
 	}
 
 	inviteQuery := i.client.db.Invite.Create().

--- a/internal/graphapi/organization_test.go
+++ b/internal/graphapi/organization_test.go
@@ -217,8 +217,9 @@ func TestMutationCreateOrganization(t *testing.T) {
 				ContentType: avatarFile.ContentType,
 			},
 			settings: &testclient.CreateOrganizationSettingInput{
-				Domains:             []string{"meow.theopenlane.io"},
-				AllowedEmailDomains: []string{"theopenlane.io"},
+				Domains:                      []string{"meow.theopenlane.io"},
+				AllowedEmailDomains:          []string{"theopenlane.io"},
+				AllowMatchingDomainsAutojoin: lo.ToPtr(true),
 				BillingAddress: &models.Address{
 					Line1:      gofakeit.StreetNumber() + " " + gofakeit.Street(),
 					City:       gofakeit.City(),
@@ -498,6 +499,10 @@ func TestMutationCreateOrganization(t *testing.T) {
 					assert.Check(t, is.Equal(tc.settings.BillingAddress.PostalCode, resp.CreateOrganization.Organization.Setting.BillingAddress.PostalCode))
 					assert.Check(t, is.Equal(tc.settings.BillingAddress.Country, resp.CreateOrganization.Organization.Setting.BillingAddress.Country))
 				}
+
+				// ensure the allowed email domains is set properly
+				assert.Check(t, is.Contains(resp.CreateOrganization.Organization.Setting.AllowedEmailDomains, userResp.User.Email[strings.Index(userResp.User.Email, "@")+1:]))
+				assert.Check(t, is.Equal(true, *resp.CreateOrganization.Organization.Setting.AllowMatchingDomainsAutojoin))
 			}
 
 			// ensure entity types are created

--- a/internal/graphapi/query/organization.graphql
+++ b/internal/graphapi/query/organization.graphql
@@ -17,6 +17,7 @@ mutation CreateOrganization($input: CreateOrganizationInput!, $avatarFile: Uploa
       setting {
         id
         allowedEmailDomains
+        allowMatchingDomainsAutojoin
         createdAt
         updatedAt
         createdBy
@@ -59,6 +60,7 @@ mutation CreateOrganizationWithMembers($organizationInput: CreateOrganizationInp
       setting {
         id
         allowedEmailDomains
+        allowMatchingDomainsAutojoin
         createdAt
         updatedAt
         createdBy
@@ -137,6 +139,7 @@ query GetAllOrganizations {
         setting {
           id
           allowedEmailDomains
+          allowMatchingDomainsAutojoin
           createdAt
           updatedAt
           createdBy
@@ -203,6 +206,7 @@ query GetOrganizationByID($organizationId: ID!) {
     setting {
       id
       allowedEmailDomains
+      allowMatchingDomainsAutojoin
       createdAt
       updatedAt
       createdBy
@@ -345,6 +349,7 @@ query GetOrganizations($where: OrganizationWhereInput) {
         setting {
           id
           allowedEmailDomains
+          allowMatchingDomainsAutojoin
           domains
           billingContact
           billingEmail
@@ -396,6 +401,7 @@ mutation UpdateOrganization($updateOrganizationId: ID!, $input: UpdateOrganizati
       setting {
         id
         allowedEmailDomains
+        allowMatchingDomainsAutojoin
         createdAt
         updatedAt
         createdBy

--- a/internal/graphapi/query/organizationsetting.graphql
+++ b/internal/graphapi/query/organizationsetting.graphql
@@ -3,6 +3,7 @@ query GetAllOrganizationSettings {
     edges {
       node {
         allowedEmailDomains
+        allowMatchingDomainsAutojoin
         billingAddress
         billingContact
         billingEmail
@@ -36,6 +37,7 @@ query GetAllOrganizationSettings {
 query GetOrganizationSettingByID($organizationSettingId: ID!) {
   organizationSetting(id: $organizationSettingId) {
     allowedEmailDomains
+    allowMatchingDomainsAutojoin
     billingAddress
     billingContact
     billingEmail
@@ -69,6 +71,7 @@ query GetOrganizationSettings($where: OrganizationSettingWhereInput!) {
     edges {
       node {
         allowedEmailDomains
+        allowMatchingDomainsAutojoin
         billingAddress
         billingContact
         billingEmail
@@ -103,6 +106,7 @@ mutation UpdateOrganizationSetting($updateOrganizationSettingId: ID!, $input: Up
   updateOrganizationSetting(id: $updateOrganizationSettingId, input: $input) {
     organizationSetting {
       allowedEmailDomains
+      allowMatchingDomainsAutojoin
       billingAddress
       billingContact
       billingEmail

--- a/internal/graphapi/query/simple/organizationsetting.graphql
+++ b/internal/graphapi/query/simple/organizationsetting.graphql
@@ -3,6 +3,7 @@ mutation CreateBulkCSVOrganizationSetting($input: Upload!) {
   createBulkCSVOrganizationSetting(input: $input) {
     organizationSettings {
       allowedEmailDomains
+      allowMatchingDomainsAutojoin
       billingAddress
       billingContact
       billingEmail
@@ -35,6 +36,7 @@ mutation CreateBulkOrganizationSetting($input: [CreateOrganizationSettingInput!]
   createBulkOrganizationSetting(input: $input) {
     organizationSettings {
       allowedEmailDomains
+      allowMatchingDomainsAutojoin
       billingAddress
       billingContact
       billingEmail
@@ -67,6 +69,7 @@ mutation CreateOrganizationSetting($input: CreateOrganizationSettingInput!) {
   createOrganizationSetting(input: $input) {
     organizationSetting {
       allowedEmailDomains
+      allowMatchingDomainsAutojoin
       billingAddress
       billingContact
       billingEmail
@@ -113,6 +116,7 @@ query GetAllOrganizationSettings {
     edges {
       node {
         allowedEmailDomains
+        allowMatchingDomainsAutojoin
         billingAddress
         billingContact
         billingEmail
@@ -144,6 +148,7 @@ query GetAllOrganizationSettings {
 query GetOrganizationSettingByID($organizationSettingId: ID!) {
   organizationSetting(id: $organizationSettingId) {
     allowedEmailDomains
+    allowMatchingDomainsAutojoin
     billingAddress
     billingContact
     billingEmail
@@ -183,6 +188,7 @@ query GetOrganizationSettings($first: Int, $last: Int, $where: OrganizationSetti
     edges {
       node {
         allowedEmailDomains
+        allowMatchingDomainsAutojoin
         billingAddress
         billingContact
         billingEmail
@@ -215,6 +221,7 @@ mutation UpdateOrganizationSetting($updateOrganizationSettingId: ID!, $input: Up
   updateOrganizationSetting(id: $updateOrganizationSettingId, input: $input) {
     organizationSetting {
       allowedEmailDomains
+      allowMatchingDomainsAutojoin
       billingAddress
       billingContact
       billingEmail

--- a/pkg/openlaneclient/graphclient.go
+++ b/pkg/openlaneclient/graphclient.go
@@ -39823,6 +39823,7 @@ func (t *GetOrganizationHistories_OrganizationHistories) GetTotalCount() int64 {
 }
 
 type CreateBulkCSVOrganizationSetting_CreateBulkCSVOrganizationSetting_OrganizationSettings struct {
+	AllowMatchingDomainsAutojoin     *bool              "json:\"allowMatchingDomainsAutojoin,omitempty\" graphql:\"allowMatchingDomainsAutojoin\""
 	AllowedEmailDomains              []string           "json:\"allowedEmailDomains,omitempty\" graphql:\"allowedEmailDomains\""
 	BillingAddress                   *models.Address    "json:\"billingAddress,omitempty\" graphql:\"billingAddress\""
 	BillingContact                   *string            "json:\"billingContact,omitempty\" graphql:\"billingContact\""
@@ -39850,6 +39851,12 @@ type CreateBulkCSVOrganizationSetting_CreateBulkCSVOrganizationSetting_Organizat
 	UpdatedBy                        *string            "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
+func (t *CreateBulkCSVOrganizationSetting_CreateBulkCSVOrganizationSetting_OrganizationSettings) GetAllowMatchingDomainsAutojoin() *bool {
+	if t == nil {
+		t = &CreateBulkCSVOrganizationSetting_CreateBulkCSVOrganizationSetting_OrganizationSettings{}
+	}
+	return t.AllowMatchingDomainsAutojoin
+}
 func (t *CreateBulkCSVOrganizationSetting_CreateBulkCSVOrganizationSetting_OrganizationSettings) GetAllowedEmailDomains() []string {
 	if t == nil {
 		t = &CreateBulkCSVOrganizationSetting_CreateBulkCSVOrganizationSetting_OrganizationSettings{}
@@ -40013,6 +40020,7 @@ func (t *CreateBulkCSVOrganizationSetting_CreateBulkCSVOrganizationSetting) GetO
 }
 
 type CreateBulkOrganizationSetting_CreateBulkOrganizationSetting_OrganizationSettings struct {
+	AllowMatchingDomainsAutojoin     *bool              "json:\"allowMatchingDomainsAutojoin,omitempty\" graphql:\"allowMatchingDomainsAutojoin\""
 	AllowedEmailDomains              []string           "json:\"allowedEmailDomains,omitempty\" graphql:\"allowedEmailDomains\""
 	BillingAddress                   *models.Address    "json:\"billingAddress,omitempty\" graphql:\"billingAddress\""
 	BillingContact                   *string            "json:\"billingContact,omitempty\" graphql:\"billingContact\""
@@ -40040,6 +40048,12 @@ type CreateBulkOrganizationSetting_CreateBulkOrganizationSetting_OrganizationSet
 	UpdatedBy                        *string            "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
+func (t *CreateBulkOrganizationSetting_CreateBulkOrganizationSetting_OrganizationSettings) GetAllowMatchingDomainsAutojoin() *bool {
+	if t == nil {
+		t = &CreateBulkOrganizationSetting_CreateBulkOrganizationSetting_OrganizationSettings{}
+	}
+	return t.AllowMatchingDomainsAutojoin
+}
 func (t *CreateBulkOrganizationSetting_CreateBulkOrganizationSetting_OrganizationSettings) GetAllowedEmailDomains() []string {
 	if t == nil {
 		t = &CreateBulkOrganizationSetting_CreateBulkOrganizationSetting_OrganizationSettings{}
@@ -40203,6 +40217,7 @@ func (t *CreateBulkOrganizationSetting_CreateBulkOrganizationSetting) GetOrganiz
 }
 
 type CreateOrganizationSetting_CreateOrganizationSetting_OrganizationSetting struct {
+	AllowMatchingDomainsAutojoin     *bool              "json:\"allowMatchingDomainsAutojoin,omitempty\" graphql:\"allowMatchingDomainsAutojoin\""
 	AllowedEmailDomains              []string           "json:\"allowedEmailDomains,omitempty\" graphql:\"allowedEmailDomains\""
 	BillingAddress                   *models.Address    "json:\"billingAddress,omitempty\" graphql:\"billingAddress\""
 	BillingContact                   *string            "json:\"billingContact,omitempty\" graphql:\"billingContact\""
@@ -40230,6 +40245,12 @@ type CreateOrganizationSetting_CreateOrganizationSetting_OrganizationSetting str
 	UpdatedBy                        *string            "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
+func (t *CreateOrganizationSetting_CreateOrganizationSetting_OrganizationSetting) GetAllowMatchingDomainsAutojoin() *bool {
+	if t == nil {
+		t = &CreateOrganizationSetting_CreateOrganizationSetting_OrganizationSetting{}
+	}
+	return t.AllowMatchingDomainsAutojoin
+}
 func (t *CreateOrganizationSetting_CreateOrganizationSetting_OrganizationSetting) GetAllowedEmailDomains() []string {
 	if t == nil {
 		t = &CreateOrganizationSetting_CreateOrganizationSetting_OrganizationSetting{}
@@ -40436,6 +40457,7 @@ func (t *GetAllOrganizationSettings_OrganizationSettings_PageInfo) GetStartCurso
 }
 
 type GetAllOrganizationSettings_OrganizationSettings_Edges_Node struct {
+	AllowMatchingDomainsAutojoin     *bool              "json:\"allowMatchingDomainsAutojoin,omitempty\" graphql:\"allowMatchingDomainsAutojoin\""
 	AllowedEmailDomains              []string           "json:\"allowedEmailDomains,omitempty\" graphql:\"allowedEmailDomains\""
 	BillingAddress                   *models.Address    "json:\"billingAddress,omitempty\" graphql:\"billingAddress\""
 	BillingContact                   *string            "json:\"billingContact,omitempty\" graphql:\"billingContact\""
@@ -40463,6 +40485,12 @@ type GetAllOrganizationSettings_OrganizationSettings_Edges_Node struct {
 	UpdatedBy                        *string            "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
+func (t *GetAllOrganizationSettings_OrganizationSettings_Edges_Node) GetAllowMatchingDomainsAutojoin() *bool {
+	if t == nil {
+		t = &GetAllOrganizationSettings_OrganizationSettings_Edges_Node{}
+	}
+	return t.AllowMatchingDomainsAutojoin
+}
 func (t *GetAllOrganizationSettings_OrganizationSettings_Edges_Node) GetAllowedEmailDomains() []string {
 	if t == nil {
 		t = &GetAllOrganizationSettings_OrganizationSettings_Edges_Node{}
@@ -40651,6 +40679,7 @@ func (t *GetAllOrganizationSettings_OrganizationSettings) GetTotalCount() int64 
 }
 
 type GetOrganizationSettingByID_OrganizationSetting struct {
+	AllowMatchingDomainsAutojoin     *bool              "json:\"allowMatchingDomainsAutojoin,omitempty\" graphql:\"allowMatchingDomainsAutojoin\""
 	AllowedEmailDomains              []string           "json:\"allowedEmailDomains,omitempty\" graphql:\"allowedEmailDomains\""
 	BillingAddress                   *models.Address    "json:\"billingAddress,omitempty\" graphql:\"billingAddress\""
 	BillingContact                   *string            "json:\"billingContact,omitempty\" graphql:\"billingContact\""
@@ -40678,6 +40707,12 @@ type GetOrganizationSettingByID_OrganizationSetting struct {
 	UpdatedBy                        *string            "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
+func (t *GetOrganizationSettingByID_OrganizationSetting) GetAllowMatchingDomainsAutojoin() *bool {
+	if t == nil {
+		t = &GetOrganizationSettingByID_OrganizationSetting{}
+	}
+	return t.AllowMatchingDomainsAutojoin
+}
 func (t *GetOrganizationSettingByID_OrganizationSetting) GetAllowedEmailDomains() []string {
 	if t == nil {
 		t = &GetOrganizationSettingByID_OrganizationSetting{}
@@ -40862,6 +40897,7 @@ func (t *GetOrganizationSettings_OrganizationSettings_PageInfo) GetStartCursor()
 }
 
 type GetOrganizationSettings_OrganizationSettings_Edges_Node struct {
+	AllowMatchingDomainsAutojoin     *bool              "json:\"allowMatchingDomainsAutojoin,omitempty\" graphql:\"allowMatchingDomainsAutojoin\""
 	AllowedEmailDomains              []string           "json:\"allowedEmailDomains,omitempty\" graphql:\"allowedEmailDomains\""
 	BillingAddress                   *models.Address    "json:\"billingAddress,omitempty\" graphql:\"billingAddress\""
 	BillingContact                   *string            "json:\"billingContact,omitempty\" graphql:\"billingContact\""
@@ -40889,6 +40925,12 @@ type GetOrganizationSettings_OrganizationSettings_Edges_Node struct {
 	UpdatedBy                        *string            "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
+func (t *GetOrganizationSettings_OrganizationSettings_Edges_Node) GetAllowMatchingDomainsAutojoin() *bool {
+	if t == nil {
+		t = &GetOrganizationSettings_OrganizationSettings_Edges_Node{}
+	}
+	return t.AllowMatchingDomainsAutojoin
+}
 func (t *GetOrganizationSettings_OrganizationSettings_Edges_Node) GetAllowedEmailDomains() []string {
 	if t == nil {
 		t = &GetOrganizationSettings_OrganizationSettings_Edges_Node{}
@@ -41077,6 +41119,7 @@ func (t *GetOrganizationSettings_OrganizationSettings) GetTotalCount() int64 {
 }
 
 type UpdateOrganizationSetting_UpdateOrganizationSetting_OrganizationSetting struct {
+	AllowMatchingDomainsAutojoin     *bool              "json:\"allowMatchingDomainsAutojoin,omitempty\" graphql:\"allowMatchingDomainsAutojoin\""
 	AllowedEmailDomains              []string           "json:\"allowedEmailDomains,omitempty\" graphql:\"allowedEmailDomains\""
 	BillingAddress                   *models.Address    "json:\"billingAddress,omitempty\" graphql:\"billingAddress\""
 	BillingContact                   *string            "json:\"billingContact,omitempty\" graphql:\"billingContact\""
@@ -41104,6 +41147,12 @@ type UpdateOrganizationSetting_UpdateOrganizationSetting_OrganizationSetting str
 	UpdatedBy                        *string            "json:\"updatedBy,omitempty\" graphql:\"updatedBy\""
 }
 
+func (t *UpdateOrganizationSetting_UpdateOrganizationSetting_OrganizationSetting) GetAllowMatchingDomainsAutojoin() *bool {
+	if t == nil {
+		t = &UpdateOrganizationSetting_UpdateOrganizationSetting_OrganizationSetting{}
+	}
+	return t.AllowMatchingDomainsAutojoin
+}
 func (t *UpdateOrganizationSetting_UpdateOrganizationSetting_OrganizationSetting) GetAllowedEmailDomains() []string {
 	if t == nil {
 		t = &UpdateOrganizationSetting_UpdateOrganizationSetting_OrganizationSetting{}
@@ -96465,6 +96514,7 @@ const CreateBulkCSVOrganizationSettingDocument = `mutation CreateBulkCSVOrganiza
 	createBulkCSVOrganizationSetting(input: $input) {
 		organizationSettings {
 			allowedEmailDomains
+			allowMatchingDomainsAutojoin
 			billingAddress
 			billingContact
 			billingEmail
@@ -96515,6 +96565,7 @@ const CreateBulkOrganizationSettingDocument = `mutation CreateBulkOrganizationSe
 	createBulkOrganizationSetting(input: $input) {
 		organizationSettings {
 			allowedEmailDomains
+			allowMatchingDomainsAutojoin
 			billingAddress
 			billingContact
 			billingEmail
@@ -96565,6 +96616,7 @@ const CreateOrganizationSettingDocument = `mutation CreateOrganizationSetting ($
 	createOrganizationSetting(input: $input) {
 		organizationSetting {
 			allowedEmailDomains
+			allowMatchingDomainsAutojoin
 			billingAddress
 			billingContact
 			billingEmail
@@ -96647,6 +96699,7 @@ const GetAllOrganizationSettingsDocument = `query GetAllOrganizationSettings {
 		edges {
 			node {
 				allowedEmailDomains
+				allowMatchingDomainsAutojoin
 				billingAddress
 				billingContact
 				billingEmail
@@ -96695,6 +96748,7 @@ func (c *Client) GetAllOrganizationSettings(ctx context.Context, interceptors ..
 const GetOrganizationSettingByIDDocument = `query GetOrganizationSettingByID ($organizationSettingId: ID!) {
 	organizationSetting(id: $organizationSettingId) {
 		allowedEmailDomains
+		allowMatchingDomainsAutojoin
 		billingAddress
 		billingContact
 		billingEmail
@@ -96752,6 +96806,7 @@ const GetOrganizationSettingsDocument = `query GetOrganizationSettings ($first: 
 		edges {
 			node {
 				allowedEmailDomains
+				allowMatchingDomainsAutojoin
 				billingAddress
 				billingContact
 				billingEmail
@@ -96805,6 +96860,7 @@ const UpdateOrganizationSettingDocument = `mutation UpdateOrganizationSetting ($
 	updateOrganizationSetting(id: $updateOrganizationSettingId, input: $input) {
 		organizationSetting {
 			allowedEmailDomains
+			allowMatchingDomainsAutojoin
 			billingAddress
 			billingContact
 			billingEmail


### PR DESCRIPTION
updates the `defaultOrganizationSettings` to auto set the the following fields:
- `AllowedEmailDomains` to the email domain of the user creating the organization
- `AllowMatchingDomainsAutojoin=true`

