### PR TITLE
un-skip apollo linter

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -398,7 +398,7 @@ steps:
               step: lint
       - label: ":graphql: lint graphql schema"
         key: "apollo-lint-schema"
-        skip: "true" # skip until plugin is fixed
+        skip: "false" # skip until plugin is fixed
         soft_fail:
           - exit_status: 1
         cancel_on_build_failing: true

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -398,7 +398,7 @@ steps:
               step: lint
       - label: ":graphql: lint graphql schema"
         key: "apollo-lint-schema"
-        skip: "false" # skip until plugin is fixed
+        skip: "false"
         soft_fail:
           - exit_status: 1
         cancel_on_build_failing: true


### PR DESCRIPTION
I can't remember how this was broken before just that "it was always failing"; looks to pass now so turning it back on to see what happens