### PR TITLE
fix: add modules to claims on refresh

### DIFF
--- a/internal/httpserve/handlers/accountfeatures_test.go
+++ b/internal/httpserve/handlers/accountfeatures_test.go
@@ -31,7 +31,7 @@ func (suite *HandlerTestSuite) TestAccountFeaturesHandler() {
 		featuresExpected = append(featuresExpected, m.String())
 	}
 
-	suite.enableModules(testUser1.UserCtx, testUser1.ID, testUser1.OrganizationID, modulesEnabled)
+	suite.enableModules(testUser1.ID, testUser1.OrganizationID, modulesEnabled)
 
 	testCases := []struct {
 		name             string

--- a/internal/httpserve/handlers/invite_test.go
+++ b/internal/httpserve/handlers/invite_test.go
@@ -62,7 +62,7 @@ func (suite *HandlerTestSuite) TestOrgInviteAcceptHandler() {
 
 	recipientCtx := auth.NewTestContextWithOrgID(recipient.ID, userSetting.Edges.DefaultOrg.ID)
 
-	suite.enableModules(recipientCtx, recipient.ID, userSetting.Edges.DefaultOrg.ID,
+	suite.enableModules(recipient.ID, userSetting.Edges.DefaultOrg.ID,
 		[]models.OrgModule{models.CatalogBaseModule})
 
 	testCases := []struct {
@@ -231,7 +231,7 @@ func (suite *HandlerTestSuite) TestOrgInviteAcceptHandler_ExistingMemberNoReInvi
 
 	recipientCtx := auth.NewTestContextWithOrgID(recipient.ID, userSetting.Edges.DefaultOrg.ID)
 
-	suite.enableModules(recipientCtx, recipient.ID, userSetting.Edges.DefaultOrg.ID,
+	suite.enableModules(recipient.ID, userSetting.Edges.DefaultOrg.ID,
 		[]models.OrgModule{models.CatalogBaseModule})
 
 	// invite user to org

--- a/internal/httpserve/handlers/seed_test.go
+++ b/internal/httpserve/handlers/seed_test.go
@@ -138,7 +138,7 @@ func (suite *HandlerTestSuite) userBuilderWithInput(ctx context.Context, input *
 	return testUser
 }
 
-func (suite *HandlerTestSuite) enableModules(_ context.Context, userID, orgID string, features []models.OrgModule) {
+func (suite *HandlerTestSuite) enableModules(userID, orgID string, features []models.OrgModule) {
 	// default to all modules if none provided
 	if len(features) == 0 {
 		features = models.AllOrgModules


### PR DESCRIPTION
- repulls modules on refresh of the JWT and returns on the new JWT