### PR TITLE
added validation function to validate filters of export_type Closes Issue #1345

### DIFF
--- a/internal/ent/validator/graphql_filter_validator.go
+++ b/internal/ent/validator/graphql_filter_validator.go
@@ -1,0 +1,26 @@
+package validator
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/theopenlane/core/pkg/enums"
+)
+
+// ValidateExportType checks if the provided export_type is valid.
+func ValidateExportType(filter string, exportType enums.ExportType) error {
+	if filter == "" {
+		return nil
+	}
+
+	// Get all allowed values for the enum
+	validValues := exportType.Values()
+
+	for _, v := range validValues {
+		if strings.ToUpper(filter) == v {
+			return nil // valid
+		}
+	}
+
+	return fmt.Errorf("invalid export_type '%s', must be one of %v", filter, validValues)
+}

--- a/internal/ent/validator/graphql_filter_validator_test.go
+++ b/internal/ent/validator/graphql_filter_validator_test.go
@@ -1,0 +1,45 @@
+package validator_test
+
+import (
+	"testing"
+
+	"github.com/theopenlane/core/internal/ent/validator"
+	"github.com/theopenlane/core/pkg/enums"
+)
+
+func TestValidateExportType(t *testing.T) {
+	tests := []struct {
+		name       string
+		filter     string
+		exportType enums.ExportType
+		wantErr    bool
+	}{
+		{
+			name:       "valid export type",
+			filter:     "TASK",
+			exportType: enums.ExportTypeTask,
+			wantErr:    false,
+		},
+		{
+			name:       "invalid export type",
+			filter:     "INVALID_TYPE",
+			exportType: enums.ExportTypeTask,
+			wantErr:    true,
+		},
+		{
+			name:       "null filter",
+			filter:     "",
+			exportType: enums.ExportTypeTask,
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validator.ValidateExportType(tt.filter, tt.exportType)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateExportType() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Export Filter Validator Closes #1345 

**Function:** `ValidateExportType`

This function validates the `filters` string provided for an export request against the allowed values of a given `export_type`. If the filter is empty, it passes validation. Otherwise, it ensures that the filter conforms to the allowed export type values.

**Unit Test:** `TestValidateExportType`

The unit test verifies the `ValidateExportType` function using two cases:
1. **Valid Input:** A filter string that conforms to one of the allowed export type values passes without error.
2. **Invalid Input:** A filter string that does not match any allowed export type value returns an appropriate error.

The tests ensure both correct validation behavior and proper error handling.
