### PR TITLE
Create trust center by default when module is enabled in stripe

### DIFF
--- a/internal/ent/hooks/errors.go
+++ b/internal/ent/hooks/errors.go
@@ -83,6 +83,8 @@ var (
 	ErrSSONotEnforceable = errors.New("you cannot enforce sso without testing the connection works correctly")
 	// ErrUnableToDetermineEventID is returned when we cannot determine the event ID for an event
 	ErrUnableToDetermineEventID = errors.New("unable to determine event ID")
+	// ErrNotSingularTrustCenter is returned when an org is trying to create multiple trust centers
+	ErrNotSingularTrustCenter = errors.New("you can only create/manage one trust center at a time")
 )
 
 // IsUniqueConstraintError reports if the error resulted from a DB uniqueness constraint violation.

--- a/internal/ent/hooks/orgownedtuples.go
+++ b/internal/ent/hooks/orgownedtuples.go
@@ -8,7 +8,7 @@ import (
 	"github.com/theopenlane/iam/auth"
 	"github.com/theopenlane/iam/fgax"
 
-	"github.com/theopenlane/core/internal/ent/generated"
+	"github.com/theopenlane/core/internal/ent/privacy/utils"
 )
 
 // OrgOwnedTuplesHookWithAdmin is a hook that adds organization owned tuples for the object being created
@@ -73,7 +73,7 @@ func hookOrgOwnedTuples(includeAdminRelation bool) ent.Hook {
 
 			// write the tuples to the authz service
 			if len(addTuples) != 0 {
-				if _, err := generated.FromContext(ctx).Authz.WriteTupleKeys(ctx, addTuples, nil); err != nil {
+				if _, err := utils.AuthzClientFromContext(ctx).WriteTupleKeys(ctx, addTuples, nil); err != nil {
 					return nil, err
 				}
 			}

--- a/internal/ent/hooks/trustcenter.go
+++ b/internal/ent/hooks/trustcenter.go
@@ -12,6 +12,7 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/hook"
 	"github.com/theopenlane/core/internal/ent/generated/organization"
+	"github.com/theopenlane/core/internal/ent/generated/trustcenter"
 	"github.com/theopenlane/iam/auth"
 	"github.com/theopenlane/iam/fgax"
 )
@@ -30,7 +31,9 @@ func HookTrustCenter() ent.Hook {
 				return nil, err
 			}
 
-			exists, err := m.Client().TrustCenter.Query().Exist(ctx)
+			exists, err := m.Client().TrustCenter.Query().
+				Where(trustcenter.OwnerID(orgID)).
+				Exist(ctx)
 			if err != nil {
 				return nil, err
 			}
@@ -95,7 +98,7 @@ func HookTrustCenter() ent.Hook {
 			})
 
 			if _, err := m.Authz.WriteTupleKeys(ctx, append(wildcardTuples, systemTuple), nil); err != nil {
-				return ctx, fmt.Errorf("failed to create file access permissions: %w", err)
+				return nil, fmt.Errorf("failed to create file access permissions: %w", err)
 			}
 
 			return trustCenter, nil

--- a/internal/ent/hooks/trustcenter.go
+++ b/internal/ent/hooks/trustcenter.go
@@ -12,7 +12,6 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/hook"
 	"github.com/theopenlane/core/internal/ent/generated/organization"
-	"github.com/theopenlane/core/internal/ent/generated/trustcenter"
 	"github.com/theopenlane/iam/auth"
 	"github.com/theopenlane/iam/fgax"
 )
@@ -32,7 +31,6 @@ func HookTrustCenter() ent.Hook {
 			}
 
 			exists, err := m.Client().TrustCenter.Query().
-				Where(trustcenter.OwnerID(orgID)).
 				Exist(ctx)
 			if err != nil {
 				return nil, err

--- a/internal/graphapi/trustcenter_test.go
+++ b/internal/graphapi/trustcenter_test.go
@@ -270,7 +270,7 @@ func TestMutationCreateTrustCenter(t *testing.T) {
 			request:     testclient.CreateTrustCenterInput{},
 			client:      suite.client.api,
 			ctx:         testUser1.UserCtx,
-			expectedErr: "trustcenter already exists", // This will be the error when trying to create a duplicate
+			expectedErr: "one trust center at a time",
 		},
 	}
 


### PR DESCRIPTION
- **improve error message for duplicated trust centers**
- **create trustcenter on webhook and make sure there can only be one at any given time**
- **fix context**
