### PR TITLE
bug: fix taskfile for correct commands on impersonation + target user get

### DIFF
--- a/cmd/cli/Taskfile.yaml
+++ b/cmd/cli/Taskfile.yaml
@@ -210,19 +210,19 @@ tasks:
   impersonation:target:setup:
     desc: create target users for impersonation testing
     cmds:
-      - task: user:register
+      - task: verifyuser
         vars:
           EMAIL_ADDRESS: "target1@example.com"
-      - task: user:login
+      - task: login
         vars:
           EMAIL_ADDRESS: "target1@example.com"
       - task: org:create
         vars:
           ORG_NAME: "target1-org"
-      - task: user:register
+      - task: verifyuser
         vars:
           EMAIL_ADDRESS: "target2@example.com"
-      - task: user:login
+      - task: login
         vars:
           EMAIL_ADDRESS: "target2@example.com"
       - task: org:create
@@ -234,7 +234,7 @@ tasks:
     env:
       CORE_PASSWORD: mattisthebest1234
     cmds:
-      - task: user:login
+      - task: login
         vars:
           EMAIL_ADDRESS: "{{ .ADMIN_USER_EMAIL }}"
       - go run -tags cli main.go user get -z json | jq -r '.users.edges[] | "  " + .node.id + " - " + .node.email

--- a/cmd/cli/Taskfile.yaml
+++ b/cmd/cli/Taskfile.yaml
@@ -237,7 +237,7 @@ tasks:
       - task: login
         vars:
           EMAIL_ADDRESS: "{{ .ADMIN_USER_EMAIL }}"
-      - go run -tags cli main.go user get -z json | jq -r '.users.edges[] | "  " + .node.id + " - " + .node.email
+      - go run -tags cli main.go user get -s=false -z json | jq -r '.users.edges[] | "  " + .node.id + " - " + .node.email'
 
   # === Testing Utilities ===
   test:connection:

--- a/cmd/cli/Taskfile.yaml
+++ b/cmd/cli/Taskfile.yaml
@@ -98,8 +98,8 @@ tasks:
   user:setup:
     desc: complete user setup with default privileges
     cmds:
-      - task: user:register
-      - task: user:login
+      - task: verifyuser
+      - task: login
       - task: org:create
       - task: token:create
 

--- a/internal/ent/interceptors/user.go
+++ b/internal/ent/interceptors/user.go
@@ -29,6 +29,11 @@ func TraverseUser() ent.Interceptor {
 			return nil
 		}
 
+		// allow system admins to see all users
+		if auth.IsSystemAdminFromContext(ctx) {
+			return nil
+		}
+
 		// allow users to be created without filtering
 		rootFieldCtx := graphql.GetRootFieldContext(ctx)
 		if rootFieldCtx != nil && rootFieldCtx.Object == "createUser" {

--- a/internal/httpserve/handlers/impersonation.go
+++ b/internal/httpserve/handlers/impersonation.go
@@ -11,6 +11,7 @@ import (
 	"github.com/theopenlane/iam/tokens"
 
 	"github.com/theopenlane/core/internal/ent/generated"
+	"github.com/theopenlane/core/internal/ent/generated/privacy"
 	models "github.com/theopenlane/core/pkg/openapi"
 	"github.com/theopenlane/utils/rout"
 )
@@ -206,7 +207,8 @@ func (h *Handler) validateImpersonationPermissions(currentUser *auth.Authenticat
 // getTargetUser retrieves information about the target user and validates organization access
 func (h *Handler) getTargetUser(ctx context.Context, userID string, orgID string) (*generated.User, error) {
 	// First get the user
-	user, err := h.DBClient.User.Get(ctx, userID)
+	allowCtx := privacy.DecisionContext(ctx, privacy.Allow)
+	user, err := h.DBClient.User.Get(allowCtx, userID)
 	if err != nil {
 		if generated.IsNotFound(err) {
 			return nil, ErrTargetUserNotFound

--- a/internal/httpserve/handlers/impersonation.go
+++ b/internal/httpserve/handlers/impersonation.go
@@ -11,7 +11,6 @@ import (
 	"github.com/theopenlane/iam/tokens"
 
 	"github.com/theopenlane/core/internal/ent/generated"
-	"github.com/theopenlane/core/internal/ent/generated/privacy"
 	models "github.com/theopenlane/core/pkg/openapi"
 	"github.com/theopenlane/utils/rout"
 )
@@ -207,8 +206,7 @@ func (h *Handler) validateImpersonationPermissions(currentUser *auth.Authenticat
 // getTargetUser retrieves information about the target user and validates organization access
 func (h *Handler) getTargetUser(ctx context.Context, userID string, orgID string) (*generated.User, error) {
 	// First get the user
-	allowCtx := privacy.DecisionContext(ctx, privacy.Allow)
-	user, err := h.DBClient.User.Get(allowCtx, userID)
+	user, err := h.DBClient.User.Get(ctx, userID)
 	if err != nil {
 		if generated.IsNotFound(err) {
 			return nil, ErrTargetUserNotFound


### PR DESCRIPTION
fixes a `target user not found error`:

```
curl -H 'Content-Type: application/json' -H "Authorization: Bearer tolp_REDACTED" http://localhost:17608/v1/impersonation/start -X POST -d '{"target_user_id":"01K713329YR7GT7VKXAV0ES9EN", "type": "job", "reason": "test mitb impersonation", "organization_id":"01K71333QN5VYD3HRDEJPMNEHW"}'
{"success":true,"token":"REDCATED","expires_at":"2025-10-08T00:17:39.340306-06:00","session_id":"01K7141VKSTAHQJYJZ17KP5EZ0","message":"Impersonation session started successfully"}
```

Fixes `list` command too:
```
task  cli:impersonation:target:list                                                         
task: [cli:login:creds] go run -tags cli main.go login -u admin@admin.theopenlane.io

Authentication Successful!
auth tokens successfully stored in keychain
task: [cli:impersonation:target:list] go run -tags cli main.go user get -s=false -z json | jq -r '.users.edges[] | "  " + .node.id + " - " + .node.email'
  01K71342VAM56G50GTECV6NA62 - admin@admin.theopenlane.io
  01K71334D0M03A40802FAAFPW3 - target2@example.com
  01K713329YR7GT7VKXAV0ES9EN - target1@example.com
  ```