### PR TITLE
bug: set storage region, use for retreival

### DIFF
--- a/internal/ent/hooks/file.go
+++ b/internal/ent/hooks/file.go
@@ -61,6 +61,7 @@ func HookFileDelete() ent.Hook {
 						file.FieldPersistedFileSize,
 						file.FieldMetadata,
 						file.FieldStorageVolume,
+						file.FieldStorageRegion,
 					).All(ctx)
 				if err != nil {
 					return nil, err
@@ -78,6 +79,8 @@ func HookFileDelete() ent.Hook {
 								Key:           f.StoragePath,
 								ContentType:   f.DetectedContentType,
 								Size:          f.PersistedFileSize,
+								Bucket:        f.StorageVolume,
+								Region:        f.StorageRegion,
 								ProviderHints: &storagetypes.ProviderHints{},
 							},
 						}

--- a/internal/ent/interceptors/file.go
+++ b/internal/ent/interceptors/file.go
@@ -135,6 +135,7 @@ func setPresignedURL(ctx context.Context, file *generated.File, q *generated.Fil
 		FileMetadata: storagetypes.FileMetadata{
 			Key:          file.StoragePath,
 			Bucket:       file.StorageVolume,
+			Region:       file.StorageRegion,
 			ContentType:  file.DetectedContentType,
 			Size:         file.PersistedFileSize,
 			ProviderType: storagetypes.ProviderType(file.StorageProvider),

--- a/internal/graphapi/file_test.go
+++ b/internal/graphapi/file_test.go
@@ -152,6 +152,9 @@ func TestQueryFile(t *testing.T) {
 			assert.Assert(t, resp != nil)
 
 			assert.Check(t, is.Equal(tc.queryID, resp.File.ID))
+			assert.Check(t, resp.File.StoragePath != nil)
+			assert.Check(t, resp.File.StorageProvider != nil)
+			assert.Check(t, resp.File.StorageRegion != nil)
 		})
 	}
 

--- a/internal/objects/store/persistence.go
+++ b/internal/objects/store/persistence.go
@@ -35,6 +35,7 @@ func UpdateFileWithStorageMetadata(ctx context.Context, entFile *ent.File, fileD
 		SetURI(fileData.FileMetadata.FullURI).
 		SetStoragePath(fileData.Key).
 		SetStorageVolume(fileData.Bucket).
+		SetStorageRegion(fileData.Region).
 		SetStorageProvider(string(fileData.ProviderType))
 
 	if len(fileData.Metadata) > 0 {

--- a/pkg/objects/storage/providers/database/provider.go
+++ b/pkg/objects/storage/providers/database/provider.go
@@ -98,6 +98,7 @@ func (p *Provider) Download(ctx context.Context, fileRef *storagetypes.File, _ *
 		FileMetadata: storagetypes.FileMetadata{
 			Key:          fileID,
 			Bucket:       p.bucket(),
+			Region:       p.options.Region,
 			ContentType:  record.DetectedContentType,
 			Name:         record.ProvidedFileName,
 			ProviderType: storagetypes.DatabaseProvider,

--- a/pkg/objects/storage/providers/disk/provider.go
+++ b/pkg/objects/storage/providers/disk/provider.go
@@ -103,6 +103,7 @@ func (p *Provider) Upload(_ context.Context, reader io.Reader, opts *storagetype
 			Size:         size,
 			Folder:       filepath.ToSlash(opts.FolderDestination),
 			Bucket:       p.options.Bucket,
+			Region:       p.options.Region,
 			ContentType:  opts.ContentType,
 			ProviderType: storagetypes.DiskProvider,
 			FullURI:      fmt.Sprintf("%s%s", p.Scheme, filepath.ToSlash(targetPath)),
@@ -129,7 +130,12 @@ func (p *Provider) Download(_ context.Context, file *storagetypes.File, _ *stora
 
 // Delete implements storagetypes.Provider
 func (p *Provider) Delete(_ context.Context, file *storagetypes.File, _ *storagetypes.DeleteFileOptions) error {
-	err := os.Remove(filepath.Join(p.options.Bucket, file.Key))
+	bucket := file.Bucket
+	if bucket == "" {
+		bucket = p.options.Bucket
+	}
+
+	err := os.Remove(filepath.Join(bucket, file.Key))
 	if os.IsNotExist(err) {
 		metrics.RecordStorageDelete(string(storagetypes.DiskProvider))
 		return nil

--- a/pkg/objects/storage/providers/r2/provider.go
+++ b/pkg/objects/storage/providers/r2/provider.go
@@ -173,6 +173,7 @@ func (p *Provider) Upload(ctx context.Context, reader io.Reader, opts *storagety
 			Size:         size,
 			Folder:       opts.FolderDestination,
 			Bucket:       p.options.Bucket,
+			Region:       p.options.Region,
 			ContentType:  opts.ContentType,
 			ProviderType: storagetypes.R2Provider,
 			FullURI:      fmt.Sprintf("r2://%s/%s", p.options.Bucket, objectKey),
@@ -212,8 +213,13 @@ func (p *Provider) Download(ctx context.Context, file *storagetypes.File, _ *sto
 
 // Delete implements storagetypes.Provider
 func (p *Provider) Delete(ctx context.Context, file *storagetypes.File, _ *storagetypes.DeleteFileOptions) error {
+	bucket := file.Bucket
+	if bucket == "" {
+		bucket = p.options.Bucket
+	}
+
 	_, err := p.client.DeleteObject(ctx, &s3.DeleteObjectInput{
-		Bucket: aws.String(p.options.Bucket),
+		Bucket: aws.String(bucket),
 		Key:    aws.String(file.Key),
 	})
 	if err != nil {

--- a/pkg/objects/storage/service.go
+++ b/pkg/objects/storage/service.go
@@ -75,6 +75,7 @@ func (s *ObjectService) Upload(ctx context.Context, provider Provider, reader io
 		FileMetadata: FileMetadata{
 			Key:           opts.Key,
 			Bucket:        opts.Bucket,
+			Region:        opts.Region,
 			ProviderHints: opts.ProviderHints,
 		},
 	}
@@ -95,6 +96,7 @@ func (s *ObjectService) Upload(ctx context.Context, provider Provider, reader io
 		ContentType:   metadata.ContentType,
 		Folder:        metadata.Folder,
 		Bucket:        metadata.Bucket,
+		Region:        metadata.Region,
 		FullURI:       metadata.FullURI,
 		ProviderType:  metadata.ProviderType,
 		PresignedURL:  metadata.PresignedURL,
@@ -114,6 +116,11 @@ func (s *ObjectService) Upload(ctx context.Context, provider Provider, reader io
 	if fileMetadata.Bucket == "" {
 		fileMetadata.Bucket = storageOpts.Bucket
 	}
+
+	if fileMetadata.Region == "" {
+		fileMetadata.Region = storageOpts.Region
+	}
+
 	if fileMetadata.ProviderType == "" {
 		fileMetadata.ProviderType = provider.ProviderType()
 	}

--- a/pkg/objects/storage/types/provider.go
+++ b/pkg/objects/storage/types/provider.go
@@ -141,6 +141,8 @@ type FileMetadata struct {
 	Key string `json:"key"`
 	// Bucket is the bucket where the file is stored
 	Bucket string `json:"bucket,omitempty"`
+	// Region is the region where the file is stored
+	Region string `json:"region,omitempty"`
 	// Folder is the folder/path within the bucket the file is stored
 	Folder string `json:"folder,omitempty"`
 	// FullURI is the full URI to access the file which would include the storage scheme, e.g. s3://bucket/folder/file


### PR DESCRIPTION
We currently retrieve objects from s3 based on the region and bucket in the config, which will break if those change. This will now use the `StorageRegion` set on the object, and fallback to the config region if it is not set, same for bucket. This also fixes an issue where we weren't actually setting the region in the database and adds a corresponding test. 

First two were from before the fix, second two after:

```
core=# select id, storage_region, storage_provider from files;
-[ RECORD 1 ]----+---------------------------
id               | 01K82JFAEWR97KJJKFJZQX9ABX
storage_region   | 
storage_provider | s3
-[ RECORD 2 ]----+---------------------------
id               | 01K82KDVN2QNEMVA6HY51YK7YR
storage_region   | 
storage_provider | s3
-[ RECORD 3 ]----+---------------------------
id               | 01K82KSS5QHPV76ZEFQQEQGH8P
storage_region   | us-east-2
storage_provider | s3
-[ RECORD 4 ]----+---------------------------
id               | 01K82M2SYK978JYRRWBG80Y89Y
storage_region   | us-west-2
storage_provider | s3
```

Tested with evidence locally as well, and then switched region + bucket and was still able to retrieve the older files. 