### PR TITLE
Handle special characters for managed group names for users

### DIFF
--- a/internal/ent/validator/specialcharacter.go
+++ b/internal/ent/validator/specialcharacter.go
@@ -7,13 +7,16 @@ import (
 	"github.com/theopenlane/utils/rout"
 )
 
+// InvalidChars is a list of characters not allowed to be used
+// as part of a name/title
+const InvalidChars = "!@#$%^*()+{}|:\"<>?`=[]\\;'/~"
+
 // SpecialCharValidator validates a name field for special characters
 // returns an error if the name contains special characters.
 // Only hyphens, underscores, periods, commas, and ampersands are allowed
 func SpecialCharValidator(name string) error {
-	invalidChars := "!@#$%^*()+{}|:\"<>?`=[]\\;'/~"
 
-	if strings.ContainsAny(name, invalidChars) {
+	if strings.ContainsAny(name, InvalidChars) {
 		return fmt.Errorf("%w, field cannot contain special characters", rout.InvalidField("name"))
 	}
 

--- a/internal/graphapi/group_test.go
+++ b/internal/graphapi/group_test.go
@@ -10,11 +10,12 @@ import (
 
 	"github.com/brianvoe/gofakeit/v7"
 	"github.com/samber/lo"
+	"github.com/theopenlane/iam/auth"
+	"github.com/theopenlane/utils/ulids"
+
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/graphapi/testclient"
 	"github.com/theopenlane/core/pkg/enums"
-	"github.com/theopenlane/iam/auth"
-	"github.com/theopenlane/utils/ulids"
 )
 
 func TestQueryGroup(t *testing.T) {
@@ -278,6 +279,15 @@ func TestMutationCreateGroup(t *testing.T) {
 			description: gofakeit.HipsterSentence(),
 			client:      suite.client.api,
 			ctx:         testUser1.UserCtx,
+		},
+		{
+			name:        "invalid group name",
+			groupName:   name + "!@",
+			displayName: gofakeit.LetterN(50),
+			description: gofakeit.HipsterSentence(),
+			client:      suite.client.api,
+			ctx:         testUser1.UserCtx,
+			errorMsg:    "field cannot contain special character",
 		},
 		{
 			name:        "duplicate group name, case insensitive",

--- a/internal/graphapi/orgmembers_test.go
+++ b/internal/graphapi/orgmembers_test.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"testing"
 
+	"github.com/theopenlane/iam/auth"
+	"github.com/theopenlane/utils/ulids"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
 	"github.com/theopenlane/core/internal/ent/hooks"
 	"github.com/theopenlane/core/internal/graphapi/testclient"
 	"github.com/theopenlane/core/pkg/enums"
-	"github.com/theopenlane/iam/auth"
-	"github.com/theopenlane/utils/ulids"
-	"gotest.tools/v3/assert"
-	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestQueryOrgMembers(t *testing.T) {
@@ -190,6 +191,7 @@ func TestMutationCreateOrgMembers(t *testing.T) {
 
 	user1 := (&UserBuilder{client: suite.client}).MustNew(testUser.UserCtx, t)
 	user2 := (&UserBuilder{client: suite.client}).MustNew(testUser.UserCtx, t)
+	user3 := (&UserBuilder{client: suite.client, Email: "mitb2@anderson.io", FirstName: "FirstName!@"}).MustNew(testUser.UserCtx, t)
 
 	userWithValidDomain := (&UserBuilder{client: suite.client, Email: "matt@anderson.net"}).MustNew(testUser.UserCtx, t)
 	userWithInvalidDomain := (&UserBuilder{client: suite.client, Email: "mitb@example.com"}).MustNew(testUser.UserCtx, t)
@@ -216,6 +218,14 @@ func TestMutationCreateOrgMembers(t *testing.T) {
 			name:   "happy path, add member",
 			orgID:  orgWithRestrictions.ID,
 			userID: userWithValidDomain.ID,
+			ctx:    otherOrgCtx,
+			role:   enums.RoleMember,
+		},
+		{
+			// it will be a managed group so it passes
+			name:   "happy path, add member with invalid name",
+			orgID:  orgWithRestrictions.ID,
+			userID: user3.ID,
 			ctx:    otherOrgCtx,
 			role:   enums.RoleMember,
 		},


### PR DESCRIPTION
these are autogenerated from users' name and there might be special characters in the name, so strip them off if need be