### PR TITLE
Doc: Fix typos in Readme.md documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ We have additionally open-sourced the [Openlane UI](https://github.com/theopenla
 
 ## Features
 
-At it's core, this repo is a collection of services built on top of an entity
+At its core, this repo is a collection of services built on top of an entity
 framework which allows us to:
 
 - Model database schemas as graph structures


### PR DESCRIPTION
Hi, while reading the readme documentation, I came across some typos and fixed it.

- At it's core → At its core