### PR TITLE
Replace utils/slice with samber/lo

### DIFF
--- a/internal/ent/hooks/apitoken.go
+++ b/internal/ent/hooks/apitoken.go
@@ -6,10 +6,10 @@ import (
 
 	"entgo.io/ent"
 	"github.com/rs/zerolog"
+	"github.com/samber/lo"
 	"github.com/theopenlane/iam/fgax"
 
 	"github.com/theopenlane/iam/auth"
-	sliceutil "github.com/theopenlane/utils/slice"
 
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/hook"
@@ -180,7 +180,7 @@ func getNewScopes(ctx context.Context, m *generated.APITokenMutation) ([]string,
 	var newScopes []string
 
 	for _, scope := range scopes {
-		if !sliceutil.Contains(oldScopes, scope) {
+		if !lo.Contains(oldScopes, scope) {
 			newScopes = append(newScopes, scope)
 		}
 	}

--- a/internal/graphapi/helpers.go
+++ b/internal/graphapi/helpers.go
@@ -18,7 +18,6 @@ import (
 	"github.com/theopenlane/gqlgen-plugins/graphutils"
 	"github.com/theopenlane/iam/auth"
 	"github.com/theopenlane/utils/rout"
-	sliceutil "github.com/theopenlane/utils/slice"
 
 	ent "github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/privacy/rule"
@@ -341,7 +340,7 @@ func setOrgFromInputInContext(ctx context.Context, inputOrgID *string) error {
 		return err
 	}
 
-	if !sliceutil.Contains(orgIDs, *inputOrgID) {
+	if !lo.Contains(orgIDs, *inputOrgID) {
 		return fmt.Errorf("%w: organization id %s not found in the authenticated organizations", rout.ErrBadRequest, *inputOrgID)
 	}
 

--- a/internal/httpserve/handlers/accountfeatures.go
+++ b/internal/httpserve/handlers/accountfeatures.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"github.com/samber/lo"
 	echo "github.com/theopenlane/echox"
 
 	"github.com/theopenlane/utils/rout"
@@ -13,8 +14,6 @@ import (
 
 	"github.com/theopenlane/core/internal/ent/privacy/rule"
 	models "github.com/theopenlane/core/pkg/openapi"
-
-	sliceutil "github.com/theopenlane/utils/slice"
 )
 
 // AccountFeaturesHandler lists all features the authenticated user has access to in relation to an organization
@@ -66,7 +65,7 @@ func (h *Handler) AccountFeaturesHandler(ctx echo.Context, openapi *OpenAPIConte
 func (h *Handler) getOrganizationID(id string, au *auth.AuthenticatedUser) (string, error) {
 	// if an ID is provided, check if the authenticated user has access to it
 	if id != "" {
-		if !sliceutil.Contains(au.OrganizationIDs, id) {
+		if !lo.Contains(au.OrganizationIDs, id) {
 			return "", ErrInvalidInput
 		}
 


### PR DESCRIPTION
Function signatures are identical; upstream maintained library that we use frequently > weird fork of parts of the library