### PR TITLE
set gcflags for non-prod go commands

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -250,7 +250,7 @@ tasks:
     desc: runs golangci-lint, the most annoying opinionated linter ever, for CI
     ## do not use --fix in CI
     cmds:
-      - golangci-lint run --config=.golangci.yaml --verbose --concurrency 8 --print-resources-usage --new
+      - golangci-lint run --config=.golangci.yaml --verbose --concurrency 8 --print-resources-usage --new-from-rev=HEAD~
 
   go:test:
     desc: runs and outputs results of created go tests


### PR DESCRIPTION
- adds `-gcflags=all=-l` to all non-prod build go commands to speed up compile + binary size
- updates linter to use `--new-from-rev=HEAD~` for ci runs