### PR TITLE
fix: auto-join was silently failing 

### DIFF
--- a/internal/ent/hooks/orgmembers.go
+++ b/internal/ent/hooks/orgmembers.go
@@ -290,6 +290,7 @@ func createUserManagedGroup(ctx context.Context, m *generated.OrgMembershipMutat
 		Save(allowCtx)
 	if err != nil {
 		zerolog.Ctx(allowCtx).Error().Err(err).Msg("error creating user managed group")
+
 		return err
 	}
 

--- a/internal/ent/hooks/usersettings.go
+++ b/internal/ent/hooks/usersettings.go
@@ -202,6 +202,7 @@ func autoJoinOrganizationsForUser(ctx context.Context, dbClient *generated.Clien
 		return err
 	}
 
+	lastOrgID := ""
 	for _, org := range orgs {
 		// check if user is already a member
 		exists, err := dbClient.OrgMembership.Query().
@@ -228,15 +229,38 @@ func autoJoinOrganizationsForUser(ctx context.Context, dbClient *generated.Clien
 			Role:           &defaultRole,
 		}
 
+		// add organization to the context for auto-join
+		ctx = auth.WithAuthenticatedUser(ctx, &auth.AuthenticatedUser{
+			SubjectID:       user.ID,
+			SubjectEmail:    user.Email,
+			OrganizationID:  org.ID,
+			OrganizationIDs: []string{org.ID},
+		})
+
 		if err := dbClient.OrgMembership.Create().
 			SetInput(input).
 			Exec(ctx); err != nil {
 			zerolog.Ctx(ctx).Error().Err(err).Msg("unable to auto-join user to organization")
 
-			continue
+			// swallowing this error means some transactions are not rolled back and you can end up in a partial membership state
+			return err
 		}
 
-		zerolog.Ctx(ctx).Debug().Str("user_id", user.ID).Str("org_id", org.ID).Str("domain", userDomain).Msg("user auto-joined organization based on email domain match")
+		zerolog.Ctx(ctx).Info().Str("user_id", user.ID).Str("org_id", org.ID).Str("domain", userDomain).Msg("user auto-joined organization based on email domain match")
+
+		lastOrgID = org.ID
+	}
+
+	if lastOrgID != "" {
+		// set the user's default organization to the last one they were added to
+		if _, err := dbClient.UserSetting.Update().
+			Where(usersetting.UserID(user.ID), usersetting.DeletedAtIsNil()).
+			SetDefaultOrgID(lastOrgID).
+			Save(ctx); err != nil {
+			zerolog.Ctx(ctx).Error().Err(err).Msg("unable to update user's default organization after auto-join")
+
+			return err
+		}
 	}
 
 	return nil

--- a/internal/httpserve/handlers/ent.go
+++ b/internal/httpserve/handlers/ent.go
@@ -451,6 +451,14 @@ func (h *Handler) CheckAndCreateUser(ctx context.Context, name, email string, pr
 				return nil, err
 			}
 
+			// pull latest user settings to ensure any hook updates are included
+			entUser.Edges.Setting, err = entUser.QuerySetting().Only(ctx)
+			if err != nil {
+				log.Error().Err(err).Msg("error fetching user settings")
+
+				return nil, err
+			}
+
 			// return newly created user
 			return entUser, nil
 		}


### PR DESCRIPTION
resolves: ISS-794

- fixes issue with org member being added but group membership creating, and because of the `continue` the failure wouldn't be rolled back, resulting in the user only half-added to the organization
- fixes so that the default org is set and returned so the user lands in the auto-joined org