### PR TITLE
Revert "chore(deps): update sigstore/cosign-installer action to v4"

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@8e94d75ddd33f69f691467e42275782e4bfefe84 # v0.20.9
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.0.0
+        uses: sigstore/cosign-installer@v3.10.0
       - name: Run GoReleaser
         id: run-goreleaser
         uses: goreleaser/goreleaser-action@v6


### PR DESCRIPTION
Reverts theopenlane/core#1397 this includes breaking changes that need to be updated in goreleaser before we can use this version

```
│ sign: cosign failed: exit status 1: Error: must provide --bundle with --signing-config or --use-signing-config │ error during command execution: must provide --bundle with --signing-config or --use-signing-config
```