### PR TITLE
don't error on creating tag definitions for now

### DIFF
--- a/internal/ent/hooks/tags.go
+++ b/internal/ent/hooks/tags.go
@@ -56,7 +56,7 @@ func HookTags() ent.Hook {
 					if err := mut.Client().TagDefinition.Create().
 						SetInput(input).
 						Exec(ctx); err != nil {
-						return nil, err
+						log.Warn().Err(err).Str("tag", tag).Msg("error creating tag definition")
 					}
 				} else if err != nil {
 					log.Warn().Err(err).Msg("error querying tag definitions, skipping org tag creation")


### PR DESCRIPTION
I noticed a clone of controls failed in the logs due to tag constraints. Going to switch this to a warn and keep going for now until I can debug. 