### PR TITLE
delete pirsch domain job

### DIFF
--- a/pkg/corejobs/delete_pirsch_domain.go
+++ b/pkg/corejobs/delete_pirsch_domain.go
@@ -1,0 +1,66 @@
+package corejobs
+
+import (
+	"context"
+
+	"github.com/riverqueue/river"
+	"github.com/rs/zerolog/log"
+
+	"github.com/theopenlane/core/pkg/corejobs/internal/pirsch"
+)
+
+// DeletePirschDomainArgs for the worker to delete a Pirsch domain
+type DeletePirschDomainArgs struct {
+	// PirschDomainID is the ID of the Pirsch domain to delete
+	PirschDomainID string `json:"pirsch_domain_id"`
+}
+
+// Kind satisfies the river.Job interface
+func (DeletePirschDomainArgs) Kind() string { return "delete_pirsch_domain" }
+
+// DeletePirschDomainWorker deletes a domain from Pirsch
+type DeletePirschDomainWorker struct {
+	river.WorkerDefaults[DeletePirschDomainArgs]
+
+	Config PirschDomainConfig `koanf:"config" json:"config" jsonschema:"description=the configuration for pirsch domain deletion"`
+
+	pirschClient pirsch.Client
+}
+
+// WithPirschClient sets the Pirsch client for the worker
+// and returns the worker for method chaining
+func (w *DeletePirschDomainWorker) WithPirschClient(cl pirsch.Client) *DeletePirschDomainWorker {
+	w.pirschClient = cl
+	return w
+}
+
+// Work satisfies the river.Worker interface for the delete pirsch domain worker
+// it deletes a domain from Pirsch
+func (w *DeletePirschDomainWorker) Work(ctx context.Context, job *river.Job[DeletePirschDomainArgs]) error {
+	log.Info().
+		Str("pirsch_domain_id", job.Args.PirschDomainID).
+		Msg("deleting pirsch domain")
+
+	if job.Args.PirschDomainID == "" {
+		return newMissingRequiredArg("pirsch_domain_id", DeletePirschDomainArgs{}.Kind())
+	}
+
+	if w.pirschClient == nil {
+		w.pirschClient = pirsch.NewClient(w.Config.PirschClientID, w.Config.PirschClientSecret)
+	}
+
+	// Delete the domain from Pirsch
+	if err := w.pirschClient.DeleteDomain(ctx, job.Args.PirschDomainID); err != nil {
+		log.Error().
+			Err(err).
+			Str("pirsch_domain_id", job.Args.PirschDomainID).
+			Msg("failed to delete pirsch domain")
+		return err
+	}
+
+	log.Info().
+		Str("pirsch_domain_id", job.Args.PirschDomainID).
+		Msg("successfully deleted pirsch domain")
+
+	return nil
+}

--- a/pkg/corejobs/delete_pirsch_domain_test.go
+++ b/pkg/corejobs/delete_pirsch_domain_test.go
@@ -1,0 +1,81 @@
+package corejobs_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/riverqueue/river"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/theopenlane/core/pkg/corejobs"
+
+	pirschmocks "github.com/theopenlane/core/pkg/corejobs/internal/pirsch/mocks"
+)
+
+func TestDeletePirschDomainWorker(t *testing.T) {
+	t.Parallel()
+
+	pirschDomainID := "pirsch123"
+
+	testCases := []struct {
+		name              string
+		pirschDomainID    string
+		expectDeleteCall  bool
+		deleteDomainError error
+		expectedError     string
+	}{
+		{
+			name:             "happy path",
+			pirschDomainID:   pirschDomainID,
+			expectDeleteCall: true,
+		},
+		{
+			name:          "missing pirsch domain id",
+			pirschDomainID: "",
+			expectedError: "pirsch_domain_id is required for the delete_pirsch_domain job",
+		},
+		{
+			name:              "delete domain fails",
+			pirschDomainID:    pirschDomainID,
+			expectDeleteCall:  true,
+			deleteDomainError: ErrTest,
+			expectedError:     "test error",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			pirschMock := pirschmocks.NewMockClient(t)
+
+			if tc.expectDeleteCall {
+				pirschMock.EXPECT().DeleteDomain(mock.Anything, tc.pirschDomainID).Return(tc.deleteDomainError)
+			}
+
+			worker := &corejobs.DeletePirschDomainWorker{
+				Config: corejobs.PirschDomainConfig{
+					PirschClientID:     "test_client_id",
+					PirschClientSecret: "test_client_secret",
+				},
+			}
+
+			worker.WithPirschClient(pirschMock)
+
+			err := worker.Work(ctx, &river.Job[corejobs.DeletePirschDomainArgs]{Args: corejobs.DeletePirschDomainArgs{
+				PirschDomainID: tc.pirschDomainID,
+			}})
+
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if !tc.expectDeleteCall {
+				pirschMock.AssertNotCalled(t, "DeleteDomain")
+			}
+		})
+	}
+}


### PR DESCRIPTION
river job for deleting pirsch domains.

This will get triggered on the custom domain delete hook.