### PR TITLE
skip index on soft delete for org owner when no deleted_at

### DIFF
--- a/internal/ent/schema/defaults.go
+++ b/internal/ent/schema/defaults.go
@@ -78,6 +78,16 @@ func (m mixinConfig) getMixins(schema ent.Interface) []ent.Mixin {
 
 	if !m.excludeSoftDelete {
 		mixins = append(mixins, mixin.SoftDeleteMixin{})
+	} else {
+		for i, mixin := range m.additionalMixins {
+			if _, ok := mixin.(ObjectOwnedMixin); ok {
+				// if the ObjectOwnedMixin is present, set the SkipDeletedAt field
+				if o, ok := mixin.(ObjectOwnedMixin); ok {
+					o.SkipDeletedAt = true
+					m.additionalMixins[i] = o
+				}
+			}
+		}
 	}
 
 	// always include the IDMixin, if a prefix is provided it will be used

--- a/internal/ent/schema/mixin_objectowned.go
+++ b/internal/ent/schema/mixin_objectowned.go
@@ -68,6 +68,8 @@ type ObjectOwnedMixin struct {
 	UseListObjectsFilter bool
 	// OwnerFieldName is the field name for the owner, defaults to "owner_id"
 	OwnerFieldName string
+	// SkipDeletedAt indicates if the schema has not included the soft delete mixin
+	SkipDeletedAt bool
 }
 
 type HookFunc func(o ObjectOwnedMixin) ent.Hook
@@ -210,7 +212,7 @@ func withSkipFilterInterceptor(mode interceptors.SkipMode) objectOwnedOption {
 // Indexes of the ObjectOwnedMixin
 func (o ObjectOwnedMixin) Indexes() []ent.Index {
 	// add the organization owner index if the flag is set or the field name is included
-	if o.IncludeOrganizationOwner || slices.Contains(o.FieldNames, o.OwnerFieldName) {
+	if !o.SkipDeletedAt && (o.IncludeOrganizationOwner || slices.Contains(o.FieldNames, o.OwnerFieldName)) {
 		return []ent.Index{
 			index.Fields(o.OwnerFieldName).
 				Annotations(entsql.IndexWhere("deleted_at is NULL")),


### PR DESCRIPTION
when excluding soft deletes on a schema with org owner, it would fail because there was an index auto-created with `deleted_at` but the column doesn't exists. This will auto-set a flag to skip the index when the combination exists on the schema