### PR TITLE
Auto-configure provider for DevMode functionality in Object Storage

### DIFF
--- a/config/config-dev.example.yaml
+++ b/config/config-dev.example.yaml
@@ -154,7 +154,7 @@ entConfig:
     onsuccessscript: ""
 
 objectstorage:
-  devmode: true
+  devmode: true # when enabled, a local disk storage provider is automatically configured and other providers are ignored
   enabled: true
   providers:
       disk:

--- a/config/helm-values.yaml
+++ b/config/helm-values.yaml
@@ -451,7 +451,7 @@ coreConfiguration:
     maxsizemb: 0  # @schema type:integer
     # -- MaxMemoryMB is the maximum memory to use for file uploads in MB
     maxmemorymb: 0  # @schema type:integer
-    # -- DevMode enables simple file upload handling for local development and testing
+    # -- DevMode automatically configures a local disk storage provider (and ensures directories exist) and ignores other provider configs
     devmode: false  # @schema type:boolean; default:false
     # -- Providers contains configuration for each storage provider
     providers:

--- a/internal/httpserve/serveropts/option.go
+++ b/internal/httpserve/serveropts/option.go
@@ -476,13 +476,6 @@ func WithObjectStorage() ServerOption {
 		s.Config.StorageService = storageService
 		s.Config.Handler.ObjectStore = storageService
 
-		errs := validators.ValidateConfiguredStorageProviders(context.Background(), cfg)
-		if len(errs) > 0 {
-			for _, err := range errs {
-				log.Warn().Err(err).Msg("object storage validation warning")
-			}
-		}
-
 		// Strict availability check for providers with ensureAvailable=true
 		strictErrs := validators.ValidateAvailabilityByProvider(context.Background(), cfg)
 		if len(strictErrs) > 0 {

--- a/internal/objects/resolver/providers.go
+++ b/internal/objects/resolver/providers.go
@@ -54,8 +54,6 @@ func providerOptionsFromConfig(provider storage.ProviderType, config storage.Pro
 		providerCfg = config.Providers.S3
 	case storage.R2Provider:
 		providerCfg = config.Providers.CloudflareR2
-	case storage.GCSProvider:
-		providerCfg = config.Providers.GCS
 	case storage.DiskProvider:
 		providerCfg = config.Providers.Disk
 	case storage.DatabaseProvider:
@@ -104,7 +102,7 @@ func providerOptionsFromConfig(provider storage.ProviderType, config storage.Pro
 		if providerCfg.Endpoint != "" {
 			options.Apply(storage.WithEndpoint(providerCfg.Endpoint))
 		}
-	case storage.R2Provider, storage.GCSProvider:
+	case storage.R2Provider:
 		if providerCfg.Bucket != "" {
 			options.Apply(storage.WithBucket(providerCfg.Bucket))
 		}

--- a/internal/objects/resolver/rules_test.go
+++ b/internal/objects/resolver/rules_test.go
@@ -41,7 +41,8 @@ func TestConfigureProviderRulesDevMode(t *testing.T) {
 	config := storage.ProviderConfig{
 		DevMode: true,
 		Providers: storage.Providers{
-			Disk: storage.ProviderConfigs{Enabled: true},
+			// we build the disk provider even if disabled to ensure dev mode works - so test ensures the builder still constructs
+			Disk: storage.ProviderConfigs{Enabled: false},
 		},
 	}
 
@@ -280,7 +281,7 @@ func TestHandleDevModeOptionClone(t *testing.T) {
 		WithProviderConfig(storage.ProviderConfig{
 			DevMode: true,
 			Providers: storage.Providers{
-				Disk: storage.ProviderConfigs{Enabled: true},
+				Disk: storage.ProviderConfigs{Enabled: false},
 			},
 		}),
 		WithProviderBuilders(providerBuilders{

--- a/jsonschema/api-docs.md
+++ b/jsonschema/api-docs.md
@@ -1366,7 +1366,7 @@ ProviderConfig contains configuration for object storage providers
 |[**keys**](#objectstoragekeys)|`string[]`|||
 |**maxsizemb**|`integer`|MaxSizeMB is the maximum file size allowed in MB<br/>||
 |**maxmemorymb**|`integer`|MaxMemoryMB is the maximum memory to use for file uploads in MB<br/>||
-|**devmode**|`boolean`|DevMode enables simple file upload handling for local development and testing<br/>||
+|**devmode**|`boolean`|DevMode automatically configures a local disk storage provider (and ensures directories exist) and ignores other provider configs<br/>||
 |[**providers**](#objectstorageproviders)|`object`|||
 
 **Additional Properties:** not allowed  

--- a/jsonschema/core.config.json
+++ b/jsonschema/core.config.json
@@ -1296,7 +1296,7 @@
         },
         "devmode": {
           "type": "boolean",
-          "description": "DevMode enables simple file upload handling for local development and testing"
+          "description": "DevMode automatically configures a local disk storage provider (and ensures directories exist) and ignores other provider configs"
         },
         "providers": {
           "$ref": "#/$defs/storage.Providers",

--- a/pkg/objects/storage/types.go
+++ b/pkg/objects/storage/types.go
@@ -93,7 +93,7 @@ type ProviderConfig struct {
 	MaxSizeMB int64 `json:"maxsizemb" koanf:"maxsizemb"`
 	// MaxMemoryMB is the maximum memory to use for file uploads in MB
 	MaxMemoryMB int64 `json:"maxmemorymb" koanf:"maxmemorymb"`
-	// DevMode enables simple file upload handling for local development and testing
+	// DevMode automatically configures a local disk storage provider (and ensures directories exist) and ignores other provider configs
 	DevMode bool `json:"devmode" koanf:"devmode" default:"false"`
 	// Providers contains configuration for each storage provider
 	Providers Providers `json:"providers" koanf:"providers"`


### PR DESCRIPTION
- sets all `devMode` options needed when enabled for fully functional setup
- ignores other storage provider options (including disk) even if configured
- adds `devMode` check into the existing ensure provider availability checks 
- Removes redundant / unneeded GCS provider, and collapses duplicate function(s) for the checks; removes unneeded call in serverOpts
- more descriptive comments regarding the bool's behavior
- updates tests to ensure Disk Provider configuration is ignored, but disk provider is initialized with the correct configuration