### PR TITLE
Local smtp with mailhog

### DIFF
--- a/docker/Taskfile.yaml
+++ b/docker/Taskfile.yaml
@@ -206,3 +206,29 @@ tasks:
     cmds:
       - task: windmill
       - task: windmill:open
+
+  mailhog:
+    dir: ..
+    desc: brings up the compose environment for mailhog
+    cmds:
+      - "docker compose -f ./docker/docker-compose-mailhog.yml up -d"
+
+  mailhog:down:
+    dir: ..
+    desc: brings the mailhog compose environment down
+    cmds:
+      - docker compose down
+
+  mailhog:open:
+    dir: ..
+    desc: opens the mailhog web interface in a browser
+    cmds:
+      - 'open "http://localhost:9225"'
+
+  mailhog:up:
+    dir: ..
+    desc: brings the mailhog compose environment up and opens the web interface
+    aliases: [mailhogup]
+    cmds:
+      - task: mailhog
+      - task: mailhog:open

--- a/docker/docker-compose-mailhog.yml
+++ b/docker/docker-compose-mailhog.yml
@@ -1,0 +1,9 @@
+services:
+  mailhog:
+    image: mailhog/mailhog
+    restart: always
+    ports:
+      - "9125:1025"
+      - "9225:8025"
+    networks:
+      - default


### PR DESCRIPTION
This sets up [mailhog](https://github.com/mailhog/MailHog) so smtp can be used locally 
and email previews actually seen. Without having to dig into riverboat's log or 
use resend dev mode that would open up files around


port would be `localhost:9125`, any username + password should work just fine.

- `task docker:mailhog` to start the docker compose service
- `task docker:mailhog:open`: opens up the UI to view the emails being sent
- `task:docker:mailhog:up` to do step 1 and 2 together
- `task:docker:mailhog:down`
