### PR TITLE
Add support for regular authenticated users to submit questionnaires too

### DIFF
--- a/pkg/openapi/models.go
+++ b/pkg/openapi/models.go
@@ -1768,7 +1768,8 @@ var ExampleGetQuestionnaireResponse = GetQuestionnaireResponse{
 
 // SubmitQuestionnaireRequest is the request to submit questionnaire response data
 type SubmitQuestionnaireRequest struct {
-	Data map[string]any `json:"data" binding:"required"`
+	AssessmentID string         `json:"assessment_id,omitempty"`
+	Data         map[string]any `json:"data" binding:"required"`
 }
 
 // ExampleSubmitQuestionnaireRequest is an example questionnaire submission request for OpenAPI documentation


### PR DESCRIPTION
submission can now be done by either:

- an authenticated user in the dashboard 
- anon user with a jwt
