### PR TITLE
fix bug where watermark cannot be updated for orgs [Do not merge for now ]

### DIFF
--- a/internal/objects/service.go
+++ b/internal/objects/service.go
@@ -6,12 +6,13 @@ import (
 	"io"
 	"time"
 
+	"github.com/theopenlane/eddy"
+	"github.com/theopenlane/iam/auth"
+
 	"github.com/theopenlane/core/pkg/logx"
 	pkgobjects "github.com/theopenlane/core/pkg/objects"
 	"github.com/theopenlane/core/pkg/objects/storage"
 	storagetypes "github.com/theopenlane/core/pkg/objects/storage/types"
-	"github.com/theopenlane/eddy"
-	"github.com/theopenlane/iam/auth"
 )
 
 // ProviderCacheKey implements eddy.CacheKey for provider caching
@@ -161,10 +162,7 @@ func (s *Service) resolveUploadProvider(ctx context.Context, opts *storage.Uploa
 	}
 
 	// Get organization ID from auth context
-	orgID, err := auth.GetOrganizationIDFromContext(ctx)
-	if err != nil || orgID == "" {
-		return nil, ErrNoOrganizationID
-	}
+	orgID, _ := auth.GetOrganizationIDFromContext(ctx)
 
 	cacheKey := ProviderCacheKey{
 		TenantID:        orgID,

--- a/internal/objects/service_test.go
+++ b/internal/objects/service_test.go
@@ -10,12 +10,13 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/mo"
 
-	pkgobjects "github.com/theopenlane/core/pkg/objects"
-	"github.com/theopenlane/core/pkg/objects/storage"
-	storagetypes "github.com/theopenlane/core/pkg/objects/storage/types"
 	"github.com/theopenlane/eddy"
 	"github.com/theopenlane/iam/auth"
 	"github.com/theopenlane/utils/contextx"
+
+	pkgobjects "github.com/theopenlane/core/pkg/objects"
+	"github.com/theopenlane/core/pkg/objects/storage"
+	storagetypes "github.com/theopenlane/core/pkg/objects/storage/types"
 )
 
 type fakeProvider struct {
@@ -191,30 +192,6 @@ func TestServiceResolveUploadProviderErrors(t *testing.T) {
 
 	if _, err := service.resolveUploadProvider(ctx, &storage.UploadOptions{}); !errors.Is(err, ErrProviderResolutionFailed) {
 		t.Fatalf("expected ErrProviderResolutionFailed when builder missing, got %v", err)
-	}
-
-	builder := &eddy.BuilderFunc[storage.Provider, storage.ProviderCredentials, *storage.ProviderOptions]{
-		Type: "fake",
-		Func: func(context.Context, storage.ProviderCredentials, *storage.ProviderOptions) (storage.Provider, error) {
-			return &fakeProvider{id: "fake"}, nil
-		},
-	}
-
-	resolverNoOrg := eddy.NewResolver[storage.Provider, storage.ProviderCredentials, *storage.ProviderOptions]()
-	resolverNoOrg.AddRule(&eddy.RuleFunc[storage.Provider, storage.ProviderCredentials, *storage.ProviderOptions]{
-		EvaluateFunc: func(context.Context) mo.Option[eddy.Result[storage.Provider, storage.ProviderCredentials, *storage.ProviderOptions]] {
-			return mo.Some(eddy.Result[storage.Provider, storage.ProviderCredentials, *storage.ProviderOptions]{
-				Builder: builder,
-				Output:  storage.ProviderCredentials{},
-				Config:  storage.NewProviderOptions(),
-			})
-		},
-	})
-
-	service.resolver = resolverNoOrg
-
-	if _, err := service.resolveUploadProvider(context.Background(), &storage.UploadOptions{}); !errors.Is(err, ErrNoOrganizationID) {
-		t.Fatalf("expected ErrNoOrganizationID, got %v", err)
 	}
 }
 


### PR DESCRIPTION
 `OrganizationID` would not be provided in the cases of using a pat, and as such the cache key will never be set. This
is a also wrong check here as other usages of the `ProviderCacheKey` ignores the `err` and only set the cache key for the org if the org exists ( should not be a destructive action ).  

e.g https://github.com/theopenlane/core/blob/0f949492955b3bd9f84b5298718b237215eb936c/internal/objects/service.go#L193-L197
