### PR TITLE
fix: go-client dep, softfail

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -731,4 +731,6 @@ steps:
               config: "file://db/atlas.hcl"
       - label: ":go: go-client schema update"
         trigger: go-client
+        depends_on: "apollo-publish-schema"
         if: build.tag != null
+        soft_fail: true


### PR DESCRIPTION
dont fail core pipeline if go-client fails, also ensure it runs after the new schema is published with a dep