### PR TITLE
Bug: object storage upload with API tokens

### DIFF
--- a/internal/graphapi/common/helpers_test.go
+++ b/internal/graphapi/common/helpers_test.go
@@ -1,6 +1,7 @@
 package common //nolint:revive
 
 import (
+	"context"
 	"testing"
 
 	"github.com/99designs/gqlgen/graphql"
@@ -11,6 +12,8 @@ import (
 
 	"github.com/theopenlane/core/internal/ent/generated"
 	pkgobjects "github.com/theopenlane/core/pkg/objects"
+	"github.com/theopenlane/iam/auth"
+	"github.com/theopenlane/utils/ulids"
 )
 
 func TestStripOperation(t *testing.T) {
@@ -384,6 +387,94 @@ func TestIsEmpty(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := IsEmpty(tt.input)
 			assert.Check(t, is.Equal(tt.expected, result))
+		})
+	}
+}
+
+func TestSetOrganizationForUploads(t *testing.T) {
+	t.Parallel()
+
+	primaryOrg := ulids.New().String()
+	secondaryOrg := ulids.New().String()
+
+	tests := []struct {
+		name        string
+		authUser    *auth.AuthenticatedUser
+		variables   map[string]any
+		inputKey    string
+		expectedOrg string
+		expectedErr error
+	}{
+		{
+			name: "Org already set in context",
+			authUser: &auth.AuthenticatedUser{
+				OrganizationID:     primaryOrg,
+				AuthenticationType: auth.PATAuthentication,
+			},
+			variables:   map[string]any{},
+			inputKey:    "input",
+			expectedOrg: primaryOrg,
+		},
+		{
+			name: "PAT requires explicit owner",
+			authUser: &auth.AuthenticatedUser{
+				OrganizationIDs:    []string{primaryOrg, secondaryOrg},
+				AuthenticationType: auth.PATAuthentication,
+			},
+			variables: map[string]any{
+				"input": map[string]any{
+					"ownerID": primaryOrg,
+				},
+			},
+			inputKey:    "input",
+			expectedOrg: primaryOrg,
+		},
+		{
+			name: "PAT missing owner errors",
+			authUser: &auth.AuthenticatedUser{
+				OrganizationIDs:    []string{primaryOrg, secondaryOrg},
+				AuthenticationType: auth.PATAuthentication,
+			},
+			variables:   nil,
+			inputKey:    "input",
+			expectedErr: ErrNoOrganizationID,
+		},
+		{
+			name: "Non-PAT single authorized org fallback",
+			authUser: &auth.AuthenticatedUser{
+				OrganizationIDs:    []string{primaryOrg},
+				AuthenticationType: auth.APITokenAuthentication,
+			},
+			variables:   nil,
+			inputKey:    "input",
+			expectedOrg: primaryOrg,
+		},
+		{
+			name: "Non-PAT multiple orgs require owner input",
+			authUser: &auth.AuthenticatedUser{
+				OrganizationIDs:    []string{primaryOrg, secondaryOrg},
+				AuthenticationType: auth.APITokenAuthentication,
+			},
+			variables:   nil,
+			inputKey:    "input",
+			expectedErr: ErrNoOrganizationID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := auth.WithAuthenticatedUser(context.Background(), tt.authUser)
+
+			err := setOrganizationForUploads(ctx, tt.variables, tt.inputKey)
+			if tt.expectedErr != nil {
+				assert.ErrorIs(t, err, tt.expectedErr)
+				return
+			}
+
+			assert.NilError(t, err)
+			orgID, err := auth.GetOrganizationIDFromContext(ctx)
+			assert.NilError(t, err)
+			assert.Check(t, is.Equal(tt.expectedOrg, orgID))
 		})
 	}
 }

--- a/internal/objects/store/persistence.go
+++ b/internal/objects/store/persistence.go
@@ -130,8 +130,14 @@ func getOrgOwnerID(ctx context.Context, f pkgobjects.File) (string, error) {
 		return "", err
 	}
 
-	if !au.IsSystemAdmin && au.OrganizationID != "" {
-		return au.OrganizationID, nil
+	if !au.IsSystemAdmin {
+		if au.OrganizationID != "" {
+			return au.OrganizationID, nil
+		}
+
+		if len(au.OrganizationIDs) == 1 {
+			return au.OrganizationIDs[0], nil
+		}
 	}
 
 	// derive table name from correlated object type using snake_case to match DB naming

--- a/internal/objects/store/persistence_test.go
+++ b/internal/objects/store/persistence_test.go
@@ -1,0 +1,27 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+
+	"github.com/theopenlane/core/pkg/objects"
+	"github.com/theopenlane/iam/auth"
+	"github.com/theopenlane/utils/ulids"
+)
+
+func TestGetOrgOwnerIDUsesSingleAuthorizedOrg(t *testing.T) {
+	t.Parallel()
+
+	orgID := ulids.New().String()
+
+	ctx := auth.WithAuthenticatedUser(context.Background(), &auth.AuthenticatedUser{
+		OrganizationIDs: []string{orgID},
+	})
+
+	id, err := getOrgOwnerID(ctx, objects.File{})
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(orgID, id))
+}


### PR DESCRIPTION
Updates the `injectFileUploader` to set organization ID if its provided as an input key (e.g. when being used with a PAT that's authorized for multiple organizations) and updates persistence store to return a valid organization ID for non-system admin users. 