### PR TITLE
Prevent deletion of standard if linked to trustcenter or control

### DIFF
--- a/internal/graphapi/control_test.go
+++ b/internal/graphapi/control_test.go
@@ -2400,9 +2400,9 @@ func TestQueryControlGroupsByCategory(t *testing.T) {
 		})
 	}
 
-	// cleanup created controls
-	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: standard.ID}).MustDelete(user1.UserCtx, t)
+	// cleanup created controls first, then standard
 	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: []string{control1.ID, control2.ID, control3.ID, control4.ID, control5.ID, control6.ID, control7.ID, control8.ID}}).MustDelete(user1.UserCtx, t)
+	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: standard.ID}).MustDelete(user1.UserCtx, t)
 }
 
 func TestMutationUpdateBulkControl(t *testing.T) {

--- a/internal/graphapi/standard_test.go
+++ b/internal/graphapi/standard_test.go
@@ -166,6 +166,7 @@ func TestQueryStandard(t *testing.T) {
 		})
 	}
 
+	(&Cleanup[*generated.ControlDeleteOne]{client: suite.client.db.Control, IDs: controlIDs}).MustDelete(systemAdminUser.UserCtx, t)
 	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, IDs: []string{publicStandard.ID, notPublicStandard.ID}}).MustDelete(systemAdminUser.UserCtx, t)
 	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, ID: orgOwnedStandard.ID}).MustDelete(testUser1.UserCtx, t)
 }
@@ -267,7 +268,7 @@ func TestQueryStandards(t *testing.T) {
 		})
 	}
 
-	systemOwnedIDs := notPublicStandardIDs
+	systemOwnedIDs := append(notPublicStandardIDs, publicStandardIDs...)
 
 	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, IDs: systemOwnedIDs}).MustDelete(systemAdminUser.UserCtx, t)
 	(&Cleanup[*generated.StandardDeleteOne]{client: suite.client.db.Standard, IDs: orgOwnedStandardIDs}).MustDelete(testUser1.UserCtx, t)


### PR DESCRIPTION
always block deletions if used by trustcenter compliance schema but for controls, we should 
only care if it is not a system owned standard before we check if it is being used by other controls.