### PR TITLE
fix: presigned url returning wrong content type

### DIFF
--- a/pkg/objects/storage/providers/r2/provider.go
+++ b/pkg/objects/storage/providers/r2/provider.go
@@ -255,7 +255,7 @@ func (p *Provider) GetPresignedURL(ctx context.Context, file *storagetypes.File,
 	presignURL, err := p.presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
 		Bucket:                     aws.String(p.options.Bucket),
 		Key:                        aws.String(file.Key),
-		ResponseContentType:        aws.String("application/octet-stream"),
+		ResponseContentType:        aws.String(file.ContentType),
 		ResponseContentDisposition: aws.String("attachment"),
 	}, func(s3opts *s3.PresignOptions) {
 		s3opts.Expires = expires

--- a/pkg/objects/storage/providers/s3/provider.go
+++ b/pkg/objects/storage/providers/s3/provider.go
@@ -345,8 +345,8 @@ func (p *Provider) GetPresignedURL(ctx context.Context, file *storagetypes.File,
 	presignURL, err := p.presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
 		Bucket:                     aws.String(file.Bucket),
 		Key:                        aws.String(file.Key),
-		ResponseContentType:        lo.ToPtr("application/octet-stream"),
-		ResponseContentDisposition: lo.ToPtr("attachment"),
+		ResponseContentType:        aws.String(file.ContentType),
+		ResponseContentDisposition: aws.String("attachment"),
 	}, func(s3opts *s3.PresignOptions) {
 		s3opts.Expires = opts.Duration
 		s3opts.ClientOptions = []func(*s3.Options){

--- a/pkg/objects/storage/providers/s3/provider_test.go
+++ b/pkg/objects/storage/providers/s3/provider_test.go
@@ -313,8 +313,9 @@ func TestS3ProviderPresignURLProxyDisabled(t *testing.T) {
 
 	url, err := provider.GetPresignedURL(ctx, &storagetypes.File{
 		FileMetadata: storagetypes.FileMetadata{
-			Bucket: minioBucket,
-			Key:    "folder/object.txt",
+			Bucket:      minioBucket,
+			Key:         "folder/object.txt",
+			ContentType: "text/plain",
 		},
 	}, &storagetypes.PresignedURLOptions{Duration: time.Minute})
 	require.NoError(t, err)
@@ -323,6 +324,7 @@ func TestS3ProviderPresignURLProxyDisabled(t *testing.T) {
 	require.Contains(t, url, "X-Amz-Credential=", "URL should contain AWS credentials")
 	require.Contains(t, url, "X-Amz-Signature=", "URL should contain AWS signature")
 	require.Contains(t, url, "folder/object.txt", "URL should contain object key")
+	require.Contains(t, url, "response-content-type=text%2Fplain", "URL should contain response content type")
 
 	resp, err := http.Get(url)
 	require.NoError(t, err)


### PR DESCRIPTION
tested locally with s3 evidence files + trust center customer logos, fixes rendering of images and does not break downloads of files