### PR TITLE
fix: fk constraint due to setting org membership id instead of user id

### DIFF
--- a/pkg/slateparser/slate_parser.go
+++ b/pkg/slateparser/slate_parser.go
@@ -106,10 +106,10 @@ func GetNewMentions(oldText string, newText string, objectType string, objectID 
 	return result
 }
 
-// ExtractMentionedUserIDs extracts just the user IDs from a mention map.
-// It validates that each UserID is a valid ULID and skips invalid ones.
-func ExtractMentionedUserIDs(mentions map[string]Mention) []string {
-	userIDs := make([]string, 0, len(mentions))
+// ExtractMentionedOrgMemberIDs extracts just the org membership IDs from a mention map.
+// It validates that each ID is a valid ULID and skips invalid ones.
+func ExtractMentionedOrgMemberIDs(mentions map[string]Mention) []string {
+	omIDs := make([]string, 0, len(mentions))
 	seen := make(map[string]bool)
 
 	for _, mention := range mentions {
@@ -120,12 +120,12 @@ func ExtractMentionedUserIDs(mentions map[string]Mention) []string {
 
 		// Deduplicate in case the same user is mentioned multiple times
 		if !seen[mention.UserID] {
-			userIDs = append(userIDs, mention.UserID)
+			omIDs = append(omIDs, mention.UserID)
 			seen[mention.UserID] = true
 		}
 	}
 
-	return userIDs
+	return omIDs
 }
 
 // IsValidSlateText checks if the text contains valid Slate formatted content

--- a/pkg/slateparser/slate_parser_test.go
+++ b/pkg/slateparser/slate_parser_test.go
@@ -204,7 +204,7 @@ func TestExtractMentionedUserIDs(t *testing.T) {
 		},
 	}
 
-	userIDs := ExtractMentionedUserIDs(mentions)
+	userIDs := ExtractMentionedOrgMemberIDs(mentions)
 
 	assert.Equal(t, 2, len(userIDs), "should have 2 unique valid user IDs")
 	assert.Contains(t, userIDs, validUserID1)


### PR DESCRIPTION
Another one, this time it was because the id in the slate data is the org membership id, and we need to pass the user id