### PR TITLE
Workflow Test Isolation fixes

### DIFF
--- a/internal/workflows/engine/approval_concurrency_test.go
+++ b/internal/workflows/engine/approval_concurrency_test.go
@@ -23,7 +23,8 @@ import (
 // not multiple times.
 //
 // Workflow Definition (Plain English):
-//   "Require 2 approvals before changing Control.status"
+//
+//	"Require 2 approvals before changing Control.status"
 //
 // Test Flow:
 //  1. Triggers an approval workflow requiring 2 approvers
@@ -35,12 +36,11 @@ import (
 //  7. Counts INSTANCE_COMPLETED events - must be exactly 1 (not 2)
 //
 // Why This Matters:
-//   In a distributed system, concurrent approvals could race to resume the workflow. The
-//   engine must ensure idempotent completion handling to prevent duplicate side effects
-//   (e.g., double-applying the proposal, sending duplicate notifications).
+//
+//	In a distributed system, concurrent approvals could race to resume the workflow. The
+//	engine must ensure idempotent completion handling to prevent duplicate side effects
+//	(e.g., double-applying the proposal, sending duplicate notifications).
 func (s *WorkflowEngineTestSuite) TestApprovalFlowConcurrentApprovalsResumesOnce() {
-	s.ClearWorkflowDefinitions()
-
 	approver1ID, orgID, userCtx := s.SetupTestUser()
 	approver2ID, approver2Ctx := s.CreateTestUserInOrg(orgID, enums.RoleMember)
 
@@ -128,6 +128,9 @@ func (s *WorkflowEngineTestSuite) TestApprovalFlowConcurrentApprovalsResumesOnce
 		s.Require().NoError(err)
 	}
 
+	// Wait for async event processing to complete before checking state
+	s.WaitForEvents()
+
 	proposal, err := s.client.WorkflowProposal.Get(userCtx, instance.WorkflowProposalID)
 	s.Require().NoError(err)
 	s.Equal(enums.WorkflowProposalStateApplied, proposal.State)
@@ -161,8 +164,9 @@ func (s *WorkflowEngineTestSuite) TestApprovalFlowConcurrentApprovalsResumesOnce
 // generate duplicate completion events.
 //
 // Workflow Definition (Plain English):
-//   "Require 1 approval (out of 2 possible approvers) before changing Control.status"
-//   RequiredCount = 1, but 2 approvers are assigned
+//
+//	"Require 1 approval (out of 2 possible approvers) before changing Control.status"
+//	RequiredCount = 1, but 2 approvers are assigned
 //
 // Test Flow:
 //  1. Triggers an approval workflow with 2 approvers but only 1 required
@@ -173,11 +177,10 @@ func (s *WorkflowEngineTestSuite) TestApprovalFlowConcurrentApprovalsResumesOnce
 //  6. Verifies the Control.status is still the correctly applied value
 //
 // Why This Matters:
-//   Users may approve workflows that have already completed. The engine must handle these
-//   "late" approvals gracefully without re-applying changes or corrupting workflow state.
+//
+//	Users may approve workflows that have already completed. The engine must handle these
+//	"late" approvals gracefully without re-applying changes or corrupting workflow state.
 func (s *WorkflowEngineTestSuite) TestApprovalFlowLateApprovalDoesNotReapply() {
-	s.ClearWorkflowDefinitions()
-
 	approver1ID, orgID, userCtx := s.SetupTestUser()
 	approver2ID, approver2Ctx := s.CreateTestUserInOrg(orgID, enums.RoleMember)
 
@@ -228,6 +231,8 @@ func (s *WorkflowEngineTestSuite) TestApprovalFlowLateApprovalDoesNotReapply() {
 	s.Require().NoError(err)
 	s.Require().NotNil(instance)
 
+	s.WaitForEvents()
+
 	assignments, err := s.client.WorkflowAssignment.Query().
 		Where(workflowassignment.WorkflowInstanceIDEQ(instance.ID)).
 		All(userCtx)
@@ -249,6 +254,8 @@ func (s *WorkflowEngineTestSuite) TestApprovalFlowLateApprovalDoesNotReapply() {
 	err = wfEngine.CompleteAssignment(userCtx, assignmentsByUser[approver1ID].ID, enums.WorkflowAssignmentStatusApproved, nil, nil)
 	s.Require().NoError(err)
 
+	s.WaitForEvents()
+
 	eventsBefore, err := s.client.WorkflowEvent.Query().
 		Where(workflowevent.WorkflowInstanceIDEQ(instance.ID)).
 		All(userCtx)
@@ -264,6 +271,8 @@ func (s *WorkflowEngineTestSuite) TestApprovalFlowLateApprovalDoesNotReapply() {
 
 	err = wfEngine.CompleteAssignment(approver2Ctx, assignmentsByUser[approver2ID].ID, enums.WorkflowAssignmentStatusApproved, nil, nil)
 	s.Require().NoError(err)
+
+	s.WaitForEvents()
 
 	eventsAfter, err := s.client.WorkflowEvent.Query().
 		Where(workflowevent.WorkflowInstanceIDEQ(instance.ID)).
@@ -294,10 +303,11 @@ func (s *WorkflowEngineTestSuite) TestApprovalFlowLateApprovalDoesNotReapply() {
 // workflow completes. Completing one action does not resume execution until all are done.
 //
 // Workflow Definition (Plain English):
-//   Actions:
-//     1. "Approval A" - requires User1 to approve "status" field changes
-//     2. "Approval B" - requires User2 to approve "reference_id" field changes
-//   Both actions have when="true" (always execute)
+//
+//	Actions:
+//	  1. "Approval A" - requires User1 to approve "status" field changes
+//	  2. "Approval B" - requires User2 to approve "reference_id" field changes
+//	Both actions have when="true" (always execute)
 //
 // Test Flow:
 //  1. Triggers a workflow with two independent approval actions
@@ -310,11 +320,10 @@ func (s *WorkflowEngineTestSuite) TestApprovalFlowLateApprovalDoesNotReapply() {
 //  8. Verifies the proposal was APPLIED
 //
 // Why This Matters:
-//   Complex workflows may require multiple independent sign-offs. The engine must gate
-//   completion until ALL required approval actions are resolved, not just the first one.
+//
+//	Complex workflows may require multiple independent sign-offs. The engine must gate
+//	completion until ALL required approval actions are resolved, not just the first one.
 func (s *WorkflowEngineTestSuite) TestConcurrentApprovalActionsGateUntilAllSatisfied() {
-	s.ClearWorkflowDefinitions()
-
 	approver1ID, orgID, userCtx := s.SetupTestUser()
 	approver2ID, approver2Ctx := s.CreateTestUserInOrg(orgID, enums.RoleMember)
 
@@ -396,6 +405,8 @@ func (s *WorkflowEngineTestSuite) TestConcurrentApprovalActionsGateUntilAllSatis
 	s.Require().NoError(err)
 	s.Require().NotNil(instance)
 
+	s.WaitForEvents()
+
 	assignments, err := s.client.WorkflowAssignment.Query().
 		Where(workflowassignment.WorkflowInstanceIDEQ(instance.ID)).
 		All(userCtx)
@@ -418,6 +429,8 @@ func (s *WorkflowEngineTestSuite) TestConcurrentApprovalActionsGateUntilAllSatis
 	err = wfEngine.CompleteAssignment(approver2Ctx, assignmentB.ID, enums.WorkflowAssignmentStatusApproved, nil, nil)
 	s.Require().NoError(err)
 
+	s.WaitForEvents()
+
 	updatedInstance, err := s.client.WorkflowInstance.Get(userCtx, instance.ID)
 	s.Require().NoError(err)
 	s.Equal(enums.WorkflowInstanceStatePaused, updatedInstance.State)
@@ -434,6 +447,8 @@ func (s *WorkflowEngineTestSuite) TestConcurrentApprovalActionsGateUntilAllSatis
 
 	err = wfEngine.CompleteAssignment(userCtx, assignmentA.ID, enums.WorkflowAssignmentStatusApproved, nil, nil)
 	s.Require().NoError(err)
+
+	s.WaitForEvents()
 
 	updatedInstance, err = s.client.WorkflowInstance.Get(userCtx, instance.ID)
 	s.Require().NoError(err)

--- a/internal/workflows/engine/approval_flow_test.go
+++ b/internal/workflows/engine/approval_flow_test.go
@@ -64,7 +64,6 @@ func hasSkippedAction(events []*generated.WorkflowEvent) bool {
 //   Ensures the quorum mechanism prevents premature application of changes and only
 //   applies them when the required number of approvals is reached.
 func (s *WorkflowEngineTestSuite) TestApprovalFlowQuorumAppliesProposal() {
-	s.ClearWorkflowDefinitions()
 
 	approver1ID, orgID, userCtx := s.SetupTestUser()
 	approver2ID, approver2Ctx := s.CreateTestUserInOrg(orgID, enums.RoleMember)
@@ -200,7 +199,6 @@ func (s *WorkflowEngineTestSuite) TestApprovalFlowQuorumAppliesProposal() {
 //   Demonstrates that "required=false" workflows provide a "first approval wins" behavior,
 //   useful for notification-style approvals where acknowledgment is sufficient.
 func (s *WorkflowEngineTestSuite) TestApprovalFlowOptionalQuorumProceedsEarly() {
-	s.ClearWorkflowDefinitions()
 
 	approver1ID, orgID, userCtx := s.SetupTestUser()
 	approver2ID, _ := s.CreateTestUserInOrg(orgID, enums.RoleMember)
@@ -325,7 +323,6 @@ func (s *WorkflowEngineTestSuite) TestApprovalFlowOptionalQuorumProceedsEarly() 
 //   Field clearing is a distinct operation from field setting. This ensures the workflow
 //   system correctly handles "clear" mutations and stages them as null values in proposals.
 func (s *WorkflowEngineTestSuite) TestApprovalStagingCapturesClearedField() {
-	s.ClearWorkflowDefinitions()
 
 	userID, orgID, _ := s.SetupTestUser()
 	seedCtx := s.SeedContext(userID, orgID)
@@ -442,7 +439,6 @@ func (s *WorkflowEngineTestSuite) TestApprovalStagingCapturesClearedField() {
 //   a workflow should fire. The proposed changes are captured separately in the proposal.
 //   This prevents circular logic where the proposed value would affect trigger evaluation.
 func (s *WorkflowEngineTestSuite) TestApprovalTriggerExpressionUsesCurrentObjectState() {
-	s.ClearWorkflowDefinitions()
 
 	userID, orgID, _ := s.SetupTestUser()
 	seedCtx := s.SeedContext(userID, orgID)
@@ -557,7 +553,6 @@ func (s *WorkflowEngineTestSuite) TestApprovalTriggerExpressionUsesCurrentObject
 //   Empty target resolution should not block changes indefinitely. When no one CAN approve,
 //   the system auto-applies to prevent deadlock situations.
 func (s *WorkflowEngineTestSuite) TestApprovalNoTargetsAutoApplies() {
-	s.ClearWorkflowDefinitions()
 
 	userID, orgID, _ := s.SetupTestUser()
 	seedCtx := s.SeedContext(userID, orgID)
@@ -675,7 +670,6 @@ func (s *WorkflowEngineTestSuite) TestApprovalNoTargetsAutoApplies() {
 //   fields alongside eligible ones, we cannot partially stage it. The entire mutation must
 //   be rejected to maintain data integrity and prevent unexpected partial updates.
 func (s *WorkflowEngineTestSuite) TestApprovalHookRejectsIneligibleFields() {
-	s.ClearWorkflowDefinitions()
 
 	userID, orgID, _ := s.SetupTestUser()
 	seedCtx := s.SeedContext(userID, orgID)
@@ -742,7 +736,6 @@ func (s *WorkflowEngineTestSuite) TestApprovalHookRejectsIneligibleFields() {
 //   Multiple teams or compliance requirements may have overlapping approval workflows.
 //   All matching workflows must execute to ensure complete policy enforcement.
 func (s *WorkflowEngineTestSuite) TestApprovalHookCreatesInstancesForAllMatchingDefinitions() {
-	s.ClearWorkflowDefinitions()
 
 	userID, orgID, _ := s.SetupTestUser()
 	seedCtx := s.SeedContext(userID, orgID)
@@ -828,7 +821,6 @@ func (s *WorkflowEngineTestSuite) TestApprovalHookCreatesInstancesForAllMatching
 //   Access to proposed_changes allows conditional logic based on the intended change, not just
 //   the current state.
 func (s *WorkflowEngineTestSuite) TestApprovalActionWhenUsesProposedChanges() {
-	s.ClearWorkflowDefinitions()
 
 	userID, orgID, _ := s.SetupTestUser()
 	seedCtx := s.SeedContext(userID, orgID)
@@ -939,7 +931,6 @@ func (s *WorkflowEngineTestSuite) TestApprovalActionWhenUsesProposedChanges() {
 //   Demonstrates that "when" expressions can selectively skip approval requirements based on
 //   the actual proposed values, enabling value-based routing of changes.
 func (s *WorkflowEngineTestSuite) TestApprovalActionWhenSkipsWhenProposedChangesDoNotMatch() {
-	s.ClearWorkflowDefinitions()
 
 	userID, orgID, _ := s.SetupTestUser()
 	seedCtx := s.SeedContext(userID, orgID)
@@ -1050,7 +1041,6 @@ func (s *WorkflowEngineTestSuite) TestApprovalActionWhenSkipsWhenProposedChanges
 //   Skipped approval actions should not block the workflow. The engine must recognize that
 //   a skipped action contributes zero pending work and advance to subsequent actions.
 func (s *WorkflowEngineTestSuite) TestSkippedApprovalActionAdvancesWorkflow() {
-	s.ClearWorkflowDefinitions()
 
 	userID, orgID, userCtx := s.SetupTestUser()
 
@@ -1129,6 +1119,8 @@ func (s *WorkflowEngineTestSuite) TestSkippedApprovalActionAdvancesWorkflow() {
 	s.Require().NoError(err)
 	s.Require().NotNil(instance)
 
+	s.WaitForEvents()
+
 	assignments, err := s.client.WorkflowAssignment.Query().
 		Where(workflowassignment.WorkflowInstanceIDEQ(instance.ID)).
 		All(userCtx)
@@ -1167,7 +1159,6 @@ func (s *WorkflowEngineTestSuite) TestSkippedApprovalActionAdvancesWorkflow() {
 //   modified after approval, the previous approval is no longer valid for the new content.
 //   This maintains approval integrity and prevents bait-and-switch scenarios.
 func (s *WorkflowEngineTestSuite) TestApprovalFlowEditSubmittedProposalInvalidatesApprovals() {
-	s.ClearWorkflowDefinitions()
 
 	userID, orgID, userCtx := s.SetupTestUser()
 	seedCtx := s.SeedContext(userID, orgID)
@@ -1305,7 +1296,6 @@ func (s *WorkflowEngineTestSuite) TestApprovalFlowEditSubmittedProposalInvalidat
 //   entity types) can have their own approval workflows for sensitive field changes like
 //   policy content modifications.
 func (s *WorkflowEngineTestSuite) TestInternalPolicyDetailsApprovalFlow() {
-	s.ClearWorkflowDefinitions()
 
 	userID, orgID, _ := s.SetupTestUser()
 	seedCtx := s.SeedContext(userID, orgID)
@@ -1368,6 +1358,9 @@ func (s *WorkflowEngineTestSuite) TestInternalPolicyDetailsApprovalFlow() {
 		Save(seedCtx)
 	s.Require().NoError(err)
 
+	// Wait for async event processing to complete
+	s.WaitForEvents()
+
 	// Original content should be unchanged (mutation was intercepted)
 	s.Equal(initialContent, updated.Details)
 
@@ -1402,6 +1395,8 @@ func (s *WorkflowEngineTestSuite) TestInternalPolicyDetailsApprovalFlow() {
 	})
 	s.Require().NoError(err)
 
+	s.WaitForEvents()
+
 	// Verify assignment was created
 	assignments, err := s.client.WorkflowAssignment.Query().
 		Where(workflowassignment.WorkflowInstanceIDEQ(instance.ID)).
@@ -1413,6 +1408,8 @@ func (s *WorkflowEngineTestSuite) TestInternalPolicyDetailsApprovalFlow() {
 	// Complete the approval
 	err = wfEngine.CompleteAssignment(seedCtx, assignments[0].ID, enums.WorkflowAssignmentStatusApproved, nil, nil)
 	s.Require().NoError(err)
+
+	s.WaitForEvents()
 
 	// Verify proposal is applied and content is updated
 	appliedProposal, err := s.client.WorkflowProposal.Get(seedCtx, proposal.ID)
@@ -1446,8 +1443,6 @@ func (s *WorkflowEngineTestSuite) TestInternalPolicyDetailsApprovalFlow() {
 //   Actions can be conditionally executed based on trigger context. This enables workflows
 //   that only fire certain actions when specific edges change, providing fine-grained control.
 func (s *WorkflowEngineTestSuite) TestActionWhenExpressionUsesTriggerContext() {
-	s.ClearWorkflowDefinitions()
-
 	_, orgID, userCtx := s.SetupTestUser()
 
 	wfEngine := s.Engine()
@@ -1473,19 +1468,20 @@ func (s *WorkflowEngineTestSuite) TestActionWhenExpressionUsesTriggerContext() {
 		Save(userCtx)
 	s.Require().NoError(err)
 
-	control, err := s.client.Control.Create().
-		SetRefCode("CTL-WHEN-" + ulid.Make().String()).
-		SetOwnerID(orgID).
-		SetReferenceID("REF-WHEN-" + ulid.Make().String()).
-		Save(userCtx)
-	s.Require().NoError(err)
-
-	obj := &workflows.Object{
-		ID:   control.ID,
-		Type: enums.WorkflowObjectTypeControl,
-	}
-
 	s.Run("when expression true executes", func() {
+		// Each subtest uses its own control to avoid duplicate instance guards
+		control, err := s.client.Control.Create().
+			SetRefCode("CTL-WHEN-TRUE-" + ulid.Make().String()).
+			SetOwnerID(orgID).
+			SetReferenceID("REF-WHEN-TRUE-" + ulid.Make().String()).
+			Save(userCtx)
+		s.Require().NoError(err)
+
+		obj := &workflows.Object{
+			ID:   control.ID,
+			Type: enums.WorkflowObjectTypeControl,
+		}
+
 		instance, err := wfEngine.TriggerWorkflow(userCtx, def, obj, engine.TriggerInput{
 			EventType:     "UPDATE",
 			ChangedFields: []string{"reference_id"},
@@ -1495,6 +1491,8 @@ func (s *WorkflowEngineTestSuite) TestActionWhenExpressionUsesTriggerContext() {
 		s.Require().NoError(err)
 		s.Require().NotNil(instance)
 
+		s.WaitForEvents()
+
 		events, err := s.client.WorkflowEvent.Query().
 			Where(workflowevent.WorkflowInstanceIDEQ(instance.ID)).
 			All(userCtx)
@@ -1503,6 +1501,19 @@ func (s *WorkflowEngineTestSuite) TestActionWhenExpressionUsesTriggerContext() {
 	})
 
 	s.Run("when expression false skips", func() {
+		// Each subtest uses its own control to avoid duplicate instance guards
+		control, err := s.client.Control.Create().
+			SetRefCode("CTL-WHEN-FALSE-" + ulid.Make().String()).
+			SetOwnerID(orgID).
+			SetReferenceID("REF-WHEN-FALSE-" + ulid.Make().String()).
+			Save(userCtx)
+		s.Require().NoError(err)
+
+		obj := &workflows.Object{
+			ID:   control.ID,
+			Type: enums.WorkflowObjectTypeControl,
+		}
+
 		instance, err := wfEngine.TriggerWorkflow(userCtx, def, obj, engine.TriggerInput{
 			EventType:     "UPDATE",
 			ChangedFields: []string{"reference_id"},
@@ -1511,6 +1522,8 @@ func (s *WorkflowEngineTestSuite) TestActionWhenExpressionUsesTriggerContext() {
 		})
 		s.Require().NoError(err)
 		s.Require().NotNil(instance)
+
+		s.WaitForEvents()
 
 		events, err := s.client.WorkflowEvent.Query().
 			Where(workflowevent.WorkflowInstanceIDEQ(instance.ID)).

--- a/internal/workflows/engine/emit_reconciler_test.go
+++ b/internal/workflows/engine/emit_reconciler_test.go
@@ -60,11 +60,10 @@ func (s *WorkflowEngineTestSuite) clearEmitFailedEvents(ctx context.Context) {
 //     - LastError: The error message from the failed emit
 //
 // Why This Matters:
-//   Emit failures should not be silently lost. Recording them enables monitoring, alerting,
-//   and automated recovery through the reconciliation process.
+//
+//	Emit failures should not be silently lost. Recording them enables monitoring, alerting,
+//	and automated recovery through the reconciliation process.
 func (s *WorkflowEngineTestSuite) TestEmitFailureRecorded() {
-	s.ClearWorkflowDefinitions()
-
 	_, orgID, userCtx := s.SetupTestUser()
 	s.clearEmitFailedEvents(userCtx)
 	def := s.CreateTestWorkflowDefinition(userCtx, orgID)
@@ -128,11 +127,10 @@ func (s *WorkflowEngineTestSuite) TestEmitFailureRecorded() {
 //  7. Verifies the workflow instance eventually completed (event processed)
 //
 // Why This Matters:
-//   The reconciliation process enables self-healing. When infrastructure recovers, the
-//   reconciler can retry failed emissions without losing workflow progress.
+//
+//	The reconciliation process enables self-healing. When infrastructure recovers, the
+//	reconciler can retry failed emissions without losing workflow progress.
 func (s *WorkflowEngineTestSuite) TestReconcileEmitFailureRecovers() {
-	s.ClearWorkflowDefinitions()
-
 	_, orgID, userCtx := s.SetupTestUser()
 	s.clearEmitFailedEvents(userCtx)
 	def := s.CreateTestWorkflowDefinition(userCtx, orgID)
@@ -200,12 +198,11 @@ func (s *WorkflowEngineTestSuite) TestReconcileEmitFailureRecovers() {
 //     - Workflow instance marked as FAILED
 //
 // Why This Matters:
-//   Infinite retries could waste resources on permanently broken workflows. After max
-//   attempts, the system must give up gracefully, mark the failure as terminal, and
-//   fail the workflow instance for human investigation.
+//
+//	Infinite retries could waste resources on permanently broken workflows. After max
+//	attempts, the system must give up gracefully, mark the failure as terminal, and
+//	fail the workflow instance for human investigation.
 func (s *WorkflowEngineTestSuite) TestReconcileEmitFailureTerminalAfterMaxAttempts() {
-	s.ClearWorkflowDefinitions()
-
 	_, orgID, userCtx := s.SetupTestUser()
 	s.clearEmitFailedEvents(userCtx)
 	def := s.CreateTestWorkflowDefinition(userCtx, orgID)

--- a/internal/workflows/engine/examples_test.go
+++ b/internal/workflows/engine/examples_test.go
@@ -28,31 +28,30 @@ import (
 // Based on: conditional-approval.json, webhook-notification.json
 //
 // Test Scenarios:
-//   Subtest "condition passes when object field matches":
-//     Workflow: Trigger when Control.status == "APPROVED"
-//     Object has status = APPROVED -> Condition passes
 //
-//   Subtest "condition fails when object field does not match":
-//     Workflow: Trigger when Control.status == "APPROVED"
-//     Object has status = NOT_IMPLEMENTED -> Condition fails
+//	Subtest "condition passes when object field matches":
+//	  Workflow: Trigger when Control.status == "APPROVED"
+//	  Object has status = APPROVED -> Condition passes
 //
-//   Subtest "condition with category field check":
-//     Workflow: Trigger when Control.category == "Technical" AND 'status' in changed_fields
-//     Tests both object field evaluation AND trigger context in conditions
+//	Subtest "condition fails when object field does not match":
+//	  Workflow: Trigger when Control.status == "APPROVED"
+//	  Object has status = NOT_IMPLEMENTED -> Condition fails
+//
+//	Subtest "condition with category field check":
+//	  Workflow: Trigger when Control.category == "Technical" AND 'status' in changed_fields
+//	  Tests both object field evaluation AND trigger context in conditions
 //
 // Why This Matters:
-//   Conditions allow workflows to be more selective about when they execute. A workflow
-//   might only fire when an object reaches a certain state, preventing unnecessary
-//   workflow instances for irrelevant changes.
+//
+//	Conditions allow workflows to be more selective about when they execute. A workflow
+//	might only fire when an object reaches a certain state, preventing unnecessary
+//	workflow instances for irrelevant changes.
 func (s *WorkflowEngineTestSuite) TestObjectFieldCondition() {
-	s.ClearWorkflowDefinitions()
-
 	_, orgID, userCtx := s.SetupTestUser()
 
 	wfEngine := s.Engine()
 
 	s.Run("condition passes when object field matches", func() {
-		s.ClearWorkflowDefinitions()
 
 		def, err := s.client.WorkflowDefinition.Create().
 			SetName("Object Field Condition " + ulid.Make().String()).
@@ -98,8 +97,6 @@ func (s *WorkflowEngineTestSuite) TestObjectFieldCondition() {
 	})
 
 	s.Run("condition fails when object field does not match", func() {
-		s.ClearWorkflowDefinitions()
-
 		def, err := s.client.WorkflowDefinition.Create().
 			SetName("Object Field Condition Fail " + ulid.Make().String()).
 			SetWorkflowKind(enums.WorkflowKindNotification).
@@ -144,8 +141,6 @@ func (s *WorkflowEngineTestSuite) TestObjectFieldCondition() {
 	})
 
 	s.Run("condition with category field check", func() {
-		s.ClearWorkflowDefinitions()
-
 		def, err := s.client.WorkflowDefinition.Create().
 			SetName("Category Condition " + ulid.Make().String()).
 			SetWorkflowKind(enums.WorkflowKindApproval).
@@ -213,8 +208,9 @@ func (s *WorkflowEngineTestSuite) TestObjectFieldCondition() {
 // Based on: webhook-notification.json
 //
 // Workflow Definition (Plain English):
-//   "When Control.status changes, send a webhook notification"
-//   WorkflowKind = NOTIFICATION (not APPROVAL)
+//
+//	"When Control.status changes, send a webhook notification"
+//	WorkflowKind = NOTIFICATION (not APPROVAL)
 //
 // Test Flow:
 //  1. Creates a NOTIFICATION workflow with a webhook action
@@ -225,18 +221,16 @@ func (s *WorkflowEngineTestSuite) TestObjectFieldCondition() {
 //  6. Confirms zero approval assignments were created
 //
 // Why This Matters:
-//   NOTIFICATION workflows are distinct from APPROVAL workflows. They execute their actions
-//   immediately and complete, without pausing for human interaction. This is useful for
-//   automated notifications, audit logging, and integrations.
+//
+//	NOTIFICATION workflows are distinct from APPROVAL workflows. They execute their actions
+//	immediately and complete, without pausing for human interaction. This is useful for
+//	automated notifications, audit logging, and integrations.
 func (s *WorkflowEngineTestSuite) TestNotificationWorkflowKind() {
-	s.ClearWorkflowDefinitions()
-
 	_, orgID, userCtx := s.SetupTestUser()
 
 	wfEngine := s.Engine()
 
 	s.Run("notification workflow triggers and completes without approval", func() {
-		s.ClearWorkflowDefinitions()
 
 		webhookCalled := make(chan struct{}, 1)
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -315,30 +309,31 @@ func (s *WorkflowEngineTestSuite) TestNotificationWorkflowKind() {
 // Based on: multi-step-approval.json
 //
 // Workflow Definition (Plain English):
-//   Actions:
-//     1. "Technical Review" approval (when: 'category' in changed_fields) - targets User1
-//     2. "Compliance Review" approval (when: 'status' in changed_fields) - targets User2
+//
+//	Actions:
+//	  1. "Technical Review" approval (when: 'category' in changed_fields) - targets User1
+//	  2. "Compliance Review" approval (when: 'status' in changed_fields) - targets User2
 //
 // Test Scenarios:
-//   Subtest "only category approval when category changes":
-//     - Changed fields: ["category"]
-//     - Expected: Only Technical Review assignment created
 //
-//   Subtest "only status approval when status changes":
-//     - Changed fields: ["status"]
-//     - Expected: Only Compliance Review assignment created
+//	Subtest "only category approval when category changes":
+//	  - Changed fields: ["category"]
+//	  - Expected: Only Technical Review assignment created
 //
-//   Subtest "both approvals when both fields change":
-//     - Changed fields: ["category", "status"]
-//     - Expected: Both Technical Review AND Compliance Review assignments created
+//	Subtest "only status approval when status changes":
+//	  - Changed fields: ["status"]
+//	  - Expected: Only Compliance Review assignment created
+//
+//	Subtest "both approvals when both fields change":
+//	  - Changed fields: ["category", "status"]
+//	  - Expected: Both Technical Review AND Compliance Review assignments created
 //
 // Why This Matters:
-//   Complex approval workflows may require different approvers for different field changes.
-//   Using "when" clauses on actions allows a single workflow definition to route approvals
-//   based on what actually changed.
+//
+//	Complex approval workflows may require different approvers for different field changes.
+//	Using "when" clauses on actions allows a single workflow definition to route approvals
+//	based on what actually changed.
 func (s *WorkflowEngineTestSuite) TestMultiStepParallelApprovals() {
-	s.ClearWorkflowDefinitions()
-
 	userID, orgID, userCtx := s.SetupTestUser()
 	user2ID, _ := s.CreateTestUserInOrg(orgID, enums.RoleMember)
 
@@ -371,7 +366,6 @@ func (s *WorkflowEngineTestSuite) TestMultiStepParallelApprovals() {
 	s.Require().NoError(err)
 
 	s.Run("only category approval when category changes", func() {
-		s.ClearWorkflowDefinitions()
 
 		def, err := s.client.WorkflowDefinition.Create().
 			SetName("Multi-Step Approval " + ulid.Make().String()).
@@ -423,6 +417,8 @@ func (s *WorkflowEngineTestSuite) TestMultiStepParallelApprovals() {
 		s.Require().NoError(err)
 		s.Require().NotNil(instance)
 
+		s.WaitForEvents()
+
 		assignments, err := s.client.WorkflowAssignment.Query().
 			Where(workflowassignment.WorkflowInstanceIDEQ(instance.ID)).
 			All(userCtx)
@@ -432,8 +428,6 @@ func (s *WorkflowEngineTestSuite) TestMultiStepParallelApprovals() {
 	})
 
 	s.Run("only status approval when status changes", func() {
-		s.ClearWorkflowDefinitions()
-
 		def, err := s.client.WorkflowDefinition.Create().
 			SetName("Multi-Step Approval Status " + ulid.Make().String()).
 			SetWorkflowKind(enums.WorkflowKindApproval).
@@ -484,6 +478,8 @@ func (s *WorkflowEngineTestSuite) TestMultiStepParallelApprovals() {
 		s.Require().NoError(err)
 		s.Require().NotNil(instance)
 
+		s.WaitForEvents()
+
 		assignments, err := s.client.WorkflowAssignment.Query().
 			Where(workflowassignment.WorkflowInstanceIDEQ(instance.ID)).
 			All(userCtx)
@@ -493,8 +489,6 @@ func (s *WorkflowEngineTestSuite) TestMultiStepParallelApprovals() {
 	})
 
 	s.Run("both approvals when both fields change", func() {
-		s.ClearWorkflowDefinitions()
-
 		def, err := s.client.WorkflowDefinition.Create().
 			SetName("Multi-Step Approval Both " + ulid.Make().String()).
 			SetWorkflowKind(enums.WorkflowKindApproval).
@@ -545,6 +539,8 @@ func (s *WorkflowEngineTestSuite) TestMultiStepParallelApprovals() {
 		s.Require().NoError(err)
 		s.Require().NotNil(instance)
 
+		s.WaitForEvents()
+
 		assignments, err := s.client.WorkflowAssignment.Query().
 			Where(workflowassignment.WorkflowInstanceIDEQ(instance.ID)).
 			All(userCtx)
@@ -566,29 +562,30 @@ func (s *WorkflowEngineTestSuite) TestMultiStepParallelApprovals() {
 // Based on: multi-approver-with-quorum-notifications.json, approval-with-notifications.json
 //
 // Workflow Definition (Plain English):
-//   Actions:
-//     1. "Team Review" approval (requires 2 approvers)
-//     2. "First Approval Received" notification (when: approved == 1 && pending > 0)
-//     3. "Quorum Reached" notification (when: approved >= 2)
-//     4. "Request Rejected" notification (when: rejected > 0)
+//
+//	Actions:
+//	  1. "Team Review" approval (requires 2 approvers)
+//	  2. "First Approval Received" notification (when: approved == 1 && pending > 0)
+//	  3. "Quorum Reached" notification (when: approved >= 2)
+//	  4. "Request Rejected" notification (when: rejected > 0)
 //
 // Test Scenarios:
-//   Subtest "first approval triggers partial notification":
-//     - First approver approves
-//     - Expected: "First Approval Received" notification fires (1 approved, 1 pending)
-//     - Workflow remains PAUSED (quorum not met)
 //
-//   Subtest "rejection triggers rejection notification":
-//     - One approver rejects
-//     - Expected: "Request Rejected" notification fires
+//	Subtest "first approval triggers partial notification":
+//	  - First approver approves
+//	  - Expected: "First Approval Received" notification fires (1 approved, 1 pending)
+//	  - Workflow remains PAUSED (quorum not met)
+//
+//	Subtest "rejection triggers rejection notification":
+//	  - One approver rejects
+//	  - Expected: "Request Rejected" notification fires
 //
 // Why This Matters:
-//   Approval workflows often need to notify stakeholders as progress occurs. Using
-//   assignments.by_action["action_key"].approved/rejected/pending in "when" clauses
-//   enables reactive notifications based on approval state transitions.
+//
+//	Approval workflows often need to notify stakeholders as progress occurs. Using
+//	assignments.by_action["action_key"].approved/rejected/pending in "when" clauses
+//	enables reactive notifications based on approval state transitions.
 func (s *WorkflowEngineTestSuite) TestApprovalStatusBasedNotifications() {
-	s.ClearWorkflowDefinitions()
-
 	approver1ID, orgID, userCtx := s.SetupTestUser()
 	approver2ID, approver2Ctx := s.CreateTestUserInOrg(orgID, enums.RoleMember)
 
@@ -643,8 +640,6 @@ func (s *WorkflowEngineTestSuite) TestApprovalStatusBasedNotifications() {
 	s.Require().NoError(err)
 
 	s.Run("first approval triggers partial notification", func() {
-		s.ClearWorkflowDefinitions()
-
 		def, err := s.client.WorkflowDefinition.Create().
 			SetName("Approval Status Notifications " + ulid.Make().String()).
 			SetWorkflowKind(enums.WorkflowKindApproval).
@@ -726,6 +721,8 @@ func (s *WorkflowEngineTestSuite) TestApprovalStatusBasedNotifications() {
 		err = wfEngine.CompleteAssignment(userCtx, assignmentsByUser[approver1ID].ID, enums.WorkflowAssignmentStatusApproved, nil, nil)
 		s.Require().NoError(err)
 
+		s.WaitForEvents()
+
 		// Check the assignment was actually updated
 		updatedAssignment, err := s.client.WorkflowAssignment.Get(userCtx, assignmentsByUser[approver1ID].ID)
 		s.Require().NoError(err)
@@ -763,8 +760,6 @@ func (s *WorkflowEngineTestSuite) TestApprovalStatusBasedNotifications() {
 	})
 
 	s.Run("rejection triggers rejection notification", func() {
-		s.ClearWorkflowDefinitions()
-
 		def, err := s.client.WorkflowDefinition.Create().
 			SetName("Rejection Notifications " + ulid.Make().String()).
 			SetWorkflowKind(enums.WorkflowKindApproval).
@@ -834,6 +829,8 @@ func (s *WorkflowEngineTestSuite) TestApprovalStatusBasedNotifications() {
 		err = wfEngine.CompleteAssignment(approver2Ctx, assignmentsByUser[approver2ID].ID, enums.WorkflowAssignmentStatusRejected, nil, nil)
 		s.Require().NoError(err)
 
+		s.WaitForEvents()
+
 		events, err := s.client.WorkflowEvent.Query().
 			Where(workflowevent.WorkflowInstanceIDEQ(instance.ID)).
 			All(userCtx)
@@ -865,9 +862,10 @@ func (s *WorkflowEngineTestSuite) TestApprovalStatusBasedNotifications() {
 // Based on: evidence-review-workflow.json
 //
 // Workflow Definition (Plain English):
-//   Actions:
-//     1. "Evidence Review" approval (requires 1 approver)
-//     2. Webhook notification (fires after approval completes)
+//
+//	Actions:
+//	  1. "Evidence Review" approval (requires 1 approver)
+//	  2. Webhook notification (fires after approval completes)
 //
 // Test Flow:
 //  1. Creates a workflow with an approval followed by a webhook action
@@ -879,12 +877,11 @@ func (s *WorkflowEngineTestSuite) TestApprovalStatusBasedNotifications() {
 //  7. Confirms the workflow instance completed successfully
 //
 // Why This Matters:
-//   Real-world workflows often need to notify external systems after approval. This test
-//   confirms that actions execute in sequence and that post-approval webhooks receive
-//   appropriate context about the completed workflow.
+//
+//	Real-world workflows often need to notify external systems after approval. This test
+//	confirms that actions execute in sequence and that post-approval webhooks receive
+//	appropriate context about the completed workflow.
 func (s *WorkflowEngineTestSuite) TestApprovalWithWebhook() {
-	s.ClearWorkflowDefinitions()
-
 	userID, orgID, userCtx := s.SetupTestUser()
 
 	wfEngine := s.Engine()
@@ -919,7 +916,6 @@ func (s *WorkflowEngineTestSuite) TestApprovalWithWebhook() {
 	s.Require().NoError(err)
 
 	s.Run("webhook fires after approval completes", func() {
-		s.ClearWorkflowDefinitions()
 
 		def, err := s.client.WorkflowDefinition.Create().
 			SetName("Approval with Webhook " + ulid.Make().String()).
@@ -981,6 +977,8 @@ func (s *WorkflowEngineTestSuite) TestApprovalWithWebhook() {
 		payload := <-webhookCalled
 		s.Equal(instance.ID, payload["instance_id"])
 
+		s.WaitForEvents()
+
 		updatedInstance, err := s.client.WorkflowInstance.Get(userCtx, instance.ID)
 		s.Require().NoError(err)
 		s.Equal(enums.WorkflowInstanceStateCompleted, updatedInstance.State)
@@ -993,32 +991,32 @@ func (s *WorkflowEngineTestSuite) TestApprovalWithWebhook() {
 // Based on: evidence-review-workflow.json
 //
 // Workflow Definition (Plain English):
-//   "Trigger when the 'controls' edge is modified AND at least one control was added"
-//   Trigger: edges = ["controls"]
-//   Condition: 'controls' in changed_edges && size(added_ids['controls']) > 0
+//
+//	"Trigger when the 'controls' edge is modified AND at least one control was added"
+//	Trigger: edges = ["controls"]
+//	Condition: 'controls' in changed_edges && size(added_ids['controls']) > 0
 //
 // Test Scenarios:
-//   1. Changed edges = ["controls"], added_ids = ["control-1", "control-2"]
-//      -> Condition passes (edge changed AND controls were added)
 //
-//   2. Changed edges = ["controls"], added_ids = [] (empty)
-//      -> Condition fails (edge changed but no controls added)
+//  1. Changed edges = ["controls"], added_ids = ["control-1", "control-2"]
+//     -> Condition passes (edge changed AND controls were added)
 //
-//   3. Changed edges = ["other_edge"]
-//      -> Condition fails ('controls' not in changed_edges)
+//  2. Changed edges = ["controls"], added_ids = [] (empty)
+//     -> Condition fails (edge changed but no controls added)
+//
+//  3. Changed edges = ["other_edge"]
+//     -> Condition fails ('controls' not in changed_edges)
 //
 // Why This Matters:
-//   Edge-based workflows enable triggering on relationship changes, not just field changes.
-//   The size() function allows distinguishing between "edge touched" and "items actually added".
+//
+//	Edge-based workflows enable triggering on relationship changes, not just field changes.
+//	The size() function allows distinguishing between "edge touched" and "items actually added".
 func (s *WorkflowEngineTestSuite) TestEdgeTriggerWithCondition() {
-	s.ClearWorkflowDefinitions()
-
 	_, orgID, userCtx := s.SetupTestUser()
 
 	wfEngine := s.Engine()
 
 	s.Run("edge trigger with size condition evaluates correctly", func() {
-		s.ClearWorkflowDefinitions()
 
 		def, err := s.client.WorkflowDefinition.Create().
 			SetName("Edge Trigger Size " + ulid.Make().String()).
@@ -1101,28 +1099,27 @@ func (s *WorkflowEngineTestSuite) TestEdgeTriggerWithCondition() {
 // allows resuming paused workflow instances but rejects already-completed instances.
 //
 // Test Scenarios:
-//   Subtest "resumes paused instance successfully":
-//     1. Triggers an approval workflow (instance pauses waiting for approval)
-//     2. Calls TriggerExistingInstance on the PAUSED instance
-//     3. Expected: No error (resumption allowed)
 //
-//   Subtest "rejects completed instance":
-//     1. Triggers a notification workflow (instance completes immediately)
-//     2. Calls TriggerExistingInstance on the COMPLETED instance
-//     3. Expected: ErrInvalidState error (cannot resume completed work)
+//	Subtest "resumes paused instance successfully":
+//	  1. Triggers an approval workflow (instance pauses waiting for approval)
+//	  2. Calls TriggerExistingInstance on the PAUSED instance
+//	  3. Expected: No error (resumption allowed)
+//
+//	Subtest "rejects completed instance":
+//	  1. Triggers a notification workflow (instance completes immediately)
+//	  2. Calls TriggerExistingInstance on the COMPLETED instance
+//	  3. Expected: ErrInvalidState error (cannot resume completed work)
 //
 // Why This Matters:
-//   Proposal submission uses TriggerExistingInstance to resume paused approval workflows.
-//   This test ensures the API correctly handles valid (PAUSED) and invalid (COMPLETED) states.
+//
+//	Proposal submission uses TriggerExistingInstance to resume paused approval workflows.
+//	This test ensures the API correctly handles valid (PAUSED) and invalid (COMPLETED) states.
 func (s *WorkflowEngineTestSuite) TestTriggerExistingInstanceResumes() {
-	s.ClearWorkflowDefinitions()
-
 	userID, orgID, userCtx := s.SetupTestUser()
 
 	wfEngine := s.Engine()
 
 	s.Run("resumes paused instance successfully", func() {
-		s.ClearWorkflowDefinitions()
 
 		approvalParams := workflows.ApprovalActionParams{
 			TargetedActionParams: workflows.TargetedActionParams{
@@ -1185,7 +1182,6 @@ func (s *WorkflowEngineTestSuite) TestTriggerExistingInstanceResumes() {
 	})
 
 	s.Run("rejects completed instance", func() {
-		s.ClearWorkflowDefinitions()
 
 		def, err := s.client.WorkflowDefinition.Create().
 			SetName("Reject Completed Workflow " + ulid.Make().String()).
@@ -1236,7 +1232,8 @@ func (s *WorkflowEngineTestSuite) TestTriggerExistingInstanceResumes() {
 // approval requests for the same change.
 //
 // Workflow Definition (Plain English):
-//   "Require approval for Control.status changes"
+//
+//	"Require approval for Control.status changes"
 //
 // Test Flow:
 //  1. Triggers an approval workflow for a Control (instance created, proposal pending)
@@ -1244,18 +1241,16 @@ func (s *WorkflowEngineTestSuite) TestTriggerExistingInstanceResumes() {
 //  3. Expected: ErrWorkflowAlreadyActive error (duplicate blocked)
 //
 // Why This Matters:
-//   Without this guard, users could trigger multiple parallel approval workflows for the
-//   same object change, leading to confusion and potential data inconsistencies. The guard
-//   ensures at most one active approval workflow per domain.
+//
+//	Without this guard, users could trigger multiple parallel approval workflows for the
+//	same object change, leading to confusion and potential data inconsistencies. The guard
+//	ensures at most one active approval workflow per domain.
 func (s *WorkflowEngineTestSuite) TestTriggerWorkflowGuardsActiveDomainInstance() {
-	s.ClearWorkflowDefinitions()
-
 	userID, orgID, userCtx := s.SetupTestUser()
 
 	wfEngine := s.Engine()
 
 	s.Run("blocks duplicate approval workflow for same domain", func() {
-		s.ClearWorkflowDefinitions()
 
 		approvalParams := workflows.ApprovalActionParams{
 			TargetedActionParams: workflows.TargetedActionParams{
@@ -1323,8 +1318,9 @@ func (s *WorkflowEngineTestSuite) TestTriggerWorkflowGuardsActiveDomainInstance(
 // preventing rapid re-triggering of the same workflow within a configured time window.
 //
 // Workflow Definition (Plain English):
-//   "Send notification on Control.status change, with 1-hour cooldown"
-//   CooldownSeconds = 3600
+//
+//	"Send notification on Control.status change, with 1-hour cooldown"
+//	CooldownSeconds = 3600
 //
 // Test Flow:
 //  1. Triggers a notification workflow for a Control (completes immediately)
@@ -1332,18 +1328,16 @@ func (s *WorkflowEngineTestSuite) TestTriggerWorkflowGuardsActiveDomainInstance(
 //  3. Expected: ErrWorkflowAlreadyActive error (cooldown not elapsed)
 //
 // Why This Matters:
-//   Cooldowns prevent notification spam when objects are rapidly updated. Without cooldowns,
-//   a burst of updates would generate a burst of notifications. The cooldown ensures
-//   workflows have a "quiet period" after execution.
+//
+//	Cooldowns prevent notification spam when objects are rapidly updated. Without cooldowns,
+//	a burst of updates would generate a burst of notifications. The cooldown ensures
+//	workflows have a "quiet period" after execution.
 func (s *WorkflowEngineTestSuite) TestTriggerWorkflowCooldownGuard() {
-	s.ClearWorkflowDefinitions()
-
 	_, orgID, userCtx := s.SetupTestUser()
 
 	wfEngine := s.Engine()
 
 	s.Run("cooldown blocks workflow trigger after recent completion", func() {
-		s.ClearWorkflowDefinitions()
 
 		def, err := s.client.WorkflowDefinition.Create().
 			SetName("Cooldown Workflow " + ulid.Make().String()).
@@ -1402,19 +1396,17 @@ func (s *WorkflowEngineTestSuite) TestTriggerWorkflowCooldownGuard() {
 //  4. The workflow instance should still be created, but the event wasn't published
 //
 // Why This Matters:
-//   Event emission failures should not crash the workflow system. By recording failures,
-//   a reconciliation process can later retry publishing the events, ensuring eventual
-//   consistency even during infrastructure issues.
+//
+//	Event emission failures should not crash the workflow system. By recording failures,
+//	a reconciliation process can later retry publishing the events, ensuring eventual
+//	consistency even during infrastructure issues.
 func (s *WorkflowEngineTestSuite) TestTriggerWorkflowRecordsEmitFailure() {
-	s.ClearWorkflowDefinitions()
-
 	_, orgID, userCtx := s.SetupTestUser()
 
 	// Create isolated engine without emitter to test failure recording
 	wfEngine := s.NewIsolatedEngine(nil)
 
 	s.Run("records emit failure when emitter is nil", func() {
-		s.ClearWorkflowDefinitions()
 
 		def, err := s.client.WorkflowDefinition.Create().
 			SetName("Emit Failure Workflow " + ulid.Make().String()).
@@ -1465,8 +1457,9 @@ func (s *WorkflowEngineTestSuite) TestTriggerWorkflowRecordsEmitFailure() {
 // that have the required tags. Objects without the tag should not trigger the workflow.
 //
 // Workflow Definition (Plain English):
-//   "Trigger on Control.status change, but ONLY for Controls tagged with 'RequiredTag'"
-//   Trigger selector: { tagIDs: ["tag-123"] }
+//
+//	"Trigger on Control.status change, but ONLY for Controls tagged with 'RequiredTag'"
+//	Trigger selector: { tagIDs: ["tag-123"] }
 //
 // Test Flow:
 //  1. Creates a TagDefinition
@@ -1476,19 +1469,17 @@ func (s *WorkflowEngineTestSuite) TestTriggerWorkflowRecordsEmitFailure() {
 //  5. Expected: Empty result (no matching definitions)
 //
 // Why This Matters:
-//   Tag selectors enable scoping workflows to specific subsets of objects. This is essential
-//   for teams that want different approval workflows for different categories of controls
-//   (e.g., PCI-tagged controls require extra approval).
+//
+//	Tag selectors enable scoping workflows to specific subsets of objects. This is essential
+//	for teams that want different approval workflows for different categories of controls
+//	(e.g., PCI-tagged controls require extra approval).
 func (s *WorkflowEngineTestSuite) TestSelectorWithTagMismatch() {
-	s.ClearWorkflowDefinitions()
-
 	userID, orgID, userCtx := s.SetupTestUser()
 	seedCtx := s.SeedContext(userID, orgID)
 
 	wfEngine := s.Engine()
 
 	s.Run("workflow skipped when object lacks required tag", func() {
-		s.ClearWorkflowDefinitions()
 
 		tag, err := s.client.TagDefinition.Create().
 			SetName("RequiredTag-" + ulid.Make().String()).
@@ -1540,8 +1531,9 @@ func (s *WorkflowEngineTestSuite) TestSelectorWithTagMismatch() {
 // associated with the required group. Objects not in the group should not trigger the workflow.
 //
 // Workflow Definition (Plain English):
-//   "Trigger on Control.status change, but ONLY for Controls in 'RequiredGroup'"
-//   Trigger selector: { groupIDs: ["group-123"] }
+//
+//	"Trigger on Control.status change, but ONLY for Controls in 'RequiredGroup'"
+//	Trigger selector: { groupIDs: ["group-123"] }
 //
 // Test Flow:
 //  1. Creates a Group
@@ -1551,18 +1543,16 @@ func (s *WorkflowEngineTestSuite) TestSelectorWithTagMismatch() {
 //  5. Expected: Empty result (no matching definitions)
 //
 // Why This Matters:
-//   Group selectors enable department-specific workflows. Different teams can have different
-//   approval requirements for controls they own, without affecting other teams' controls.
+//
+//	Group selectors enable department-specific workflows. Different teams can have different
+//	approval requirements for controls they own, without affecting other teams' controls.
 func (s *WorkflowEngineTestSuite) TestSelectorWithGroupMismatch() {
-	s.ClearWorkflowDefinitions()
-
 	userID, orgID, userCtx := s.SetupTestUser()
 	seedCtx := s.SeedContext(userID, orgID)
 
 	wfEngine := s.Engine()
 
 	s.Run("workflow skipped when object lacks required group", func() {
-		s.ClearWorkflowDefinitions()
 
 		group, err := s.client.Group.Create().
 			SetName("RequiredGroup-" + ulid.Make().String()).
@@ -1614,9 +1604,10 @@ func (s *WorkflowEngineTestSuite) TestSelectorWithGroupMismatch() {
 // evaluating to false are completely skipped, allowing the workflow to complete without blocking.
 //
 // Workflow Definition (Plain English):
-//   "Optional approval for Control.status change, but ONLY when condition is true"
-//   When expression: "false" (always skips)
-//   Required: false (optional)
+//
+//	"Optional approval for Control.status change, but ONLY when condition is true"
+//	When expression: "false" (always skips)
+//	Required: false (optional)
 //
 // Test Flow:
 //  1. Creates an optional approval workflow with when="false"
@@ -1625,18 +1616,16 @@ func (s *WorkflowEngineTestSuite) TestSelectorWithGroupMismatch() {
 //  4. Confirms the workflow completed immediately (not blocked)
 //
 // Why This Matters:
-//   Optional approvals with "when" clauses allow for conditional approval gates. When the
-//   condition is false, the approval is not needed and the workflow should proceed without
-//   creating unnecessary assignments.
+//
+//	Optional approvals with "when" clauses allow for conditional approval gates. When the
+//	condition is false, the approval is not needed and the workflow should proceed without
+//	creating unnecessary assignments.
 func (s *WorkflowEngineTestSuite) TestOptionalApprovalSkipped() {
-	s.ClearWorkflowDefinitions()
-
 	userID, orgID, userCtx := s.SetupTestUser()
 
 	wfEngine := s.Engine()
 
 	s.Run("optional approval skipped when when clause is false", func() {
-		s.ClearWorkflowDefinitions()
 
 		approvalParams := workflows.ApprovalActionParams{
 			TargetedActionParams: workflows.TargetedActionParams{
@@ -1689,6 +1678,8 @@ func (s *WorkflowEngineTestSuite) TestOptionalApprovalSkipped() {
 		})
 		s.Require().NoError(err)
 
+		s.WaitForEvents()
+
 		// No assignments should be created since when clause is false
 		assignments, err := s.client.WorkflowAssignment.Query().
 			Where(workflowassignment.WorkflowInstanceIDEQ(instance.ID)).
@@ -1707,9 +1698,10 @@ func (s *WorkflowEngineTestSuite) TestOptionalApprovalSkipped() {
 // in the order they are defined, ensuring predictable action sequencing.
 //
 // Workflow Definition (Plain English):
-//   Actions:
-//     1. Webhook to server1 (key: "webhook1")
-//     2. Webhook to server2 (key: "webhook2")
+//
+//	Actions:
+//	  1. Webhook to server1 (key: "webhook1")
+//	  2. Webhook to server2 (key: "webhook2")
 //
 // Test Flow:
 //  1. Sets up two test HTTP servers that record call order
@@ -1719,18 +1711,16 @@ func (s *WorkflowEngineTestSuite) TestOptionalApprovalSkipped() {
 //  5. Confirms the workflow completed successfully
 //
 // Why This Matters:
-//   Action ordering is often critical for integrations. For example, you might want to
-//   notify an upstream system before notifying downstream consumers. This test ensures
-//   the engine respects the defined action order.
+//
+//	Action ordering is often critical for integrations. For example, you might want to
+//	notify an upstream system before notifying downstream consumers. This test ensures
+//	the engine respects the defined action order.
 func (s *WorkflowEngineTestSuite) TestMultipleWebhooksInSequence() {
-	s.ClearWorkflowDefinitions()
-
 	_, orgID, userCtx := s.SetupTestUser()
 
 	wfEngine := s.Engine()
 
 	s.Run("multiple webhooks execute in sequence", func() {
-		s.ClearWorkflowDefinitions()
 
 		callOrder := make(chan string, 2)
 		server1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1805,6 +1795,8 @@ func (s *WorkflowEngineTestSuite) TestMultipleWebhooksInSequence() {
 		s.Equal("webhook1", first)
 		s.Equal("webhook2", second)
 
+		s.WaitForEvents()
+
 		updatedInstance, err := s.client.WorkflowInstance.Get(userCtx, instance.ID)
 		s.Require().NoError(err)
 		s.Equal(enums.WorkflowInstanceStateCompleted, updatedInstance.State)
@@ -1815,26 +1807,26 @@ func (s *WorkflowEngineTestSuite) TestMultipleWebhooksInSequence() {
 // approval assignment outcomes and their effect on the workflow instance state.
 //
 // Test Scenarios:
-//   Subtest "rejected required approval fails instance":
-//     Workflow: Required approval with 1 approver
-//     1. Triggers workflow, assignment created
-//     2. Rejects the assignment
-//     3. Expected: Instance state = FAILED (required approval was rejected)
 //
-//   Subtest "approved required approval completes instance":
-//     Workflow: Required approval with 1 approver
-//     1. Triggers workflow, assignment created
-//     2. Approves the assignment
-//     3. Expected: Instance state = COMPLETED, proposal applied
-//     4. Verifies the Control.status was updated to the proposed value
+//	Subtest "rejected required approval fails instance":
+//	  Workflow: Required approval with 1 approver
+//	  1. Triggers workflow, assignment created
+//	  2. Rejects the assignment
+//	  3. Expected: Instance state = FAILED (required approval was rejected)
+//
+//	Subtest "approved required approval completes instance":
+//	  Workflow: Required approval with 1 approver
+//	  1. Triggers workflow, assignment created
+//	  2. Approves the assignment
+//	  3. Expected: Instance state = COMPLETED, proposal applied
+//	  4. Verifies the Control.status was updated to the proposed value
 //
 // Why This Matters:
-//   The workflow engine must correctly transition instance state based on approval outcomes.
-//   Rejection of required approvals should fail the workflow, while approval should complete
-//   it and apply the proposed changes.
+//
+//	The workflow engine must correctly transition instance state based on approval outcomes.
+//	Rejection of required approvals should fail the workflow, while approval should complete
+//	it and apply the proposed changes.
 func (s *WorkflowEngineTestSuite) TestResolveAssignmentStateTransitions() {
-	s.ClearWorkflowDefinitions()
-
 	userID, orgID, userCtx := s.SetupTestUser()
 
 	wfEngine := s.Engine()
@@ -1851,32 +1843,30 @@ func (s *WorkflowEngineTestSuite) TestResolveAssignmentStateTransitions() {
 	paramsBytes, err := json.Marshal(approvalParams)
 	s.Require().NoError(err)
 
+	def, err := s.client.WorkflowDefinition.Create().
+		SetName("State Transition Workflow " + ulid.Make().String()).
+		SetWorkflowKind(enums.WorkflowKindApproval).
+		SetSchemaType("Control").
+		SetActive(true).
+		SetOwnerID(orgID).
+		SetTriggerOperations([]string{"UPDATE"}).
+		SetTriggerFields([]string{"status"}).
+		SetDefinitionJSON(models.WorkflowDefinitionDocument{
+			Triggers: []models.WorkflowTrigger{
+				{Operation: "UPDATE", Fields: []string{"status"}},
+			},
+			Actions: []models.WorkflowAction{
+				{
+					Type:   enums.WorkflowActionTypeApproval.String(),
+					Key:    "status_approval",
+					Params: paramsBytes,
+				},
+			},
+		}).
+		Save(userCtx)
+	s.Require().NoError(err)
+
 	s.Run("rejected required approval fails instance", func() {
-		s.ClearWorkflowDefinitions()
-
-		def, err := s.client.WorkflowDefinition.Create().
-			SetName("Rejection Workflow " + ulid.Make().String()).
-			SetWorkflowKind(enums.WorkflowKindApproval).
-			SetSchemaType("Control").
-			SetActive(true).
-			SetOwnerID(orgID).
-			SetTriggerOperations([]string{"UPDATE"}).
-			SetTriggerFields([]string{"status"}).
-			SetDefinitionJSON(models.WorkflowDefinitionDocument{
-				Triggers: []models.WorkflowTrigger{
-					{Operation: "UPDATE", Fields: []string{"status"}},
-				},
-				Actions: []models.WorkflowAction{
-					{
-						Type:   enums.WorkflowActionTypeApproval.String(),
-						Key:    "status_approval",
-						Params: paramsBytes,
-					},
-				},
-			}).
-			Save(userCtx)
-		s.Require().NoError(err)
-
 		control, err := s.client.Control.Create().
 			SetRefCode("CTL-REJECT-" + ulid.Make().String()).
 			SetOwnerID(orgID).
@@ -1903,6 +1893,8 @@ func (s *WorkflowEngineTestSuite) TestResolveAssignmentStateTransitions() {
 		err = wfEngine.CompleteAssignment(userCtx, assignments[0].ID, enums.WorkflowAssignmentStatusRejected, nil, nil)
 		s.Require().NoError(err)
 
+		s.WaitForEvents()
+
 		// Instance should be failed
 		updatedInstance, err := s.client.WorkflowInstance.Get(userCtx, instance.ID)
 		s.Require().NoError(err)
@@ -1910,31 +1902,6 @@ func (s *WorkflowEngineTestSuite) TestResolveAssignmentStateTransitions() {
 	})
 
 	s.Run("approved required approval completes instance", func() {
-		s.ClearWorkflowDefinitions()
-
-		def, err := s.client.WorkflowDefinition.Create().
-			SetName("Approval Workflow " + ulid.Make().String()).
-			SetWorkflowKind(enums.WorkflowKindApproval).
-			SetSchemaType("Control").
-			SetActive(true).
-			SetOwnerID(orgID).
-			SetTriggerOperations([]string{"UPDATE"}).
-			SetTriggerFields([]string{"status"}).
-			SetDefinitionJSON(models.WorkflowDefinitionDocument{
-				Triggers: []models.WorkflowTrigger{
-					{Operation: "UPDATE", Fields: []string{"status"}},
-				},
-				Actions: []models.WorkflowAction{
-					{
-						Type:   enums.WorkflowActionTypeApproval.String(),
-						Key:    "status_approval",
-						Params: paramsBytes,
-					},
-				},
-			}).
-			Save(userCtx)
-		s.Require().NoError(err)
-
 		control, err := s.client.Control.Create().
 			SetRefCode("CTL-APPROVE-" + ulid.Make().String()).
 			SetOwnerID(orgID).
@@ -1960,6 +1927,8 @@ func (s *WorkflowEngineTestSuite) TestResolveAssignmentStateTransitions() {
 		// Approve the assignment
 		err = wfEngine.CompleteAssignment(userCtx, assignments[0].ID, enums.WorkflowAssignmentStatusApproved, nil, nil)
 		s.Require().NoError(err)
+
+		s.WaitForEvents()
 
 		// Instance should be completed
 		updatedInstance, err := s.client.WorkflowInstance.Get(userCtx, instance.ID)

--- a/internal/workflows/engine/executor_test.go
+++ b/internal/workflows/engine/executor_test.go
@@ -26,7 +26,8 @@ import (
 //  2. Verifies the engine is not nil (properly initialized)
 //
 // Why This Matters:
-//   Foundational test ensuring the workflow engine is available for action execution.
+//
+//	Foundational test ensuring the workflow engine is available for action execution.
 func (s *WorkflowEngineTestSuite) TestWorkflowEngineExecute() {
 	wfEngine := s.Engine()
 	s.Require().NotNil(wfEngine)
@@ -36,25 +37,25 @@ func (s *WorkflowEngineTestSuite) TestWorkflowEngineExecute() {
 // and WorkflowAssignmentTarget records when processing an approval action.
 //
 // Test Scenarios:
-//   Subtest "creates approval assignment with user target":
-//     1. Executes an approval action targeting a specific user
-//     2. Verifies a WorkflowAssignment was created with:
-//        - Status = PENDING
-//        - Required = true
-//        - Label = "Test Approval"
-//     3. Verifies a WorkflowAssignmentTarget was created linking to the user
 //
-//   Subtest "creates assignment with no targets warns":
-//     1. Executes an approval action with an empty targets list
-//     2. Expected: ErrApprovalNoTargets error (cannot create assignment without approvers)
+//	Subtest "creates approval assignment with user target":
+//	  1. Executes an approval action targeting a specific user
+//	  2. Verifies a WorkflowAssignment was created with:
+//	     - Status = PENDING
+//	     - Required = true
+//	     - Label = "Test Approval"
+//	  3. Verifies a WorkflowAssignmentTarget was created linking to the user
+//
+//	Subtest "creates assignment with no targets warns":
+//	  1. Executes an approval action with an empty targets list
+//	  2. Expected: ErrApprovalNoTargets error (cannot create assignment without approvers)
 //
 // Why This Matters:
-//   The approval executor is responsible for creating the database records that represent
-//   pending approval work. This test ensures the executor correctly translates action
-//   parameters into database entities.
+//
+//	The approval executor is responsible for creating the database records that represent
+//	pending approval work. This test ensures the executor correctly translates action
+//	parameters into database entities.
 func (s *WorkflowEngineTestSuite) TestExecuteApproval() {
-	s.ClearWorkflowDefinitions()
-
 	userID, orgID, userCtx := s.SetupTestUser()
 
 	wfEngine := s.Engine()
@@ -155,11 +156,10 @@ func (s *WorkflowEngineTestSuite) TestExecuteApproval() {
 //  3. Expected: ErrInvalidActionType error
 //
 // Why This Matters:
-//   The workflow engine must validate action types before execution. Unknown action types
-//   should fail fast with a clear error rather than silently passing or causing cryptic failures.
+//
+//	The workflow engine must validate action types before execution. Unknown action types
+//	should fail fast with a clear error rather than silently passing or causing cryptic failures.
 func (s *WorkflowEngineTestSuite) TestExecuteInvalidActionType() {
-	s.ClearWorkflowDefinitions()
-
 	_, orgID, userCtx := s.SetupTestUser()
 
 	wfEngine := s.Engine()
@@ -200,11 +200,10 @@ func (s *WorkflowEngineTestSuite) TestExecuteInvalidActionType() {
 //  3. Expected: No error (action completes successfully)
 //
 // Why This Matters:
-//   Notification actions should complete without blocking the workflow, even if the
-//   actual notification delivery is async or external.
+//
+//	Notification actions should complete without blocking the workflow, even if the
+//	actual notification delivery is async or external.
 func (s *WorkflowEngineTestSuite) TestExecuteNotification() {
-	s.ClearWorkflowDefinitions()
-
 	_, orgID, userCtx := s.SetupTestUser()
 
 	wfEngine := s.Engine()
@@ -231,28 +230,28 @@ func (s *WorkflowEngineTestSuite) TestExecuteNotification() {
 // and handles various success and failure scenarios.
 //
 // Test Scenarios:
-//   Subtest "executes webhook with valid URL":
-//     1. Sets up a test HTTP server
-//     2. Executes a webhook action with URL pointing to the server
-//     3. Verifies the server received the request
-//     4. Verifies the payload contains the instance ID
-//     5. Verifies the X-Workflow-Signature header is present (when secret configured)
 //
-//   Subtest "fails webhook without URL":
-//     1. Executes a webhook action with no URL configured
-//     2. Expected: ErrWebhookURLRequired error
+//	Subtest "executes webhook with valid URL":
+//	  1. Sets up a test HTTP server
+//	  2. Executes a webhook action with URL pointing to the server
+//	  3. Verifies the server received the request
+//	  4. Verifies the payload contains the instance ID
+//	  5. Verifies the X-Workflow-Signature header is present (when secret configured)
 //
-//   Subtest "fails webhook on non-success status":
-//     1. Sets up a server that returns HTTP 418 (Teapot)
-//     2. Executes a webhook action
-//     3. Expected: Error (non-2xx response codes are failures)
+//	Subtest "fails webhook without URL":
+//	  1. Executes a webhook action with no URL configured
+//	  2. Expected: ErrWebhookURLRequired error
+//
+//	Subtest "fails webhook on non-success status":
+//	  1. Sets up a server that returns HTTP 418 (Teapot)
+//	  2. Executes a webhook action
+//	  3. Expected: Error (non-2xx response codes are failures)
 //
 // Why This Matters:
-//   Webhook actions are the primary integration point for external systems. This test
-//   ensures correct HTTP behavior, error handling, and security features like HMAC signing.
+//
+//	Webhook actions are the primary integration point for external systems. This test
+//	ensures correct HTTP behavior, error handling, and security features like HMAC signing.
 func (s *WorkflowEngineTestSuite) TestExecuteWebhook() {
-	s.ClearWorkflowDefinitions()
-
 	_, orgID, userCtx := s.SetupTestUser()
 
 	wfEngine := s.Engine()
@@ -359,12 +358,11 @@ func (s *WorkflowEngineTestSuite) TestExecuteWebhook() {
 //  3. Verifies the Control.Status is now enums.ControlStatusApproved (typed enum)
 //
 // Why This Matters:
-//   Proposal changes are stored as map[string]any where enum values are serialized as strings.
-//   When applying these changes, the workflow system must coerce strings back to typed enums
-//   to match the entity schema. Without coercion, database updates would fail with type errors.
+//
+//	Proposal changes are stored as map[string]any where enum values are serialized as strings.
+//	When applying these changes, the workflow system must coerce strings back to typed enums
+//	to match the entity schema. Without coercion, database updates would fail with type errors.
 func (s *WorkflowEngineTestSuite) TestApplyObjectFieldUpdates_CoercesEnums() {
-	s.ClearWorkflowDefinitions()
-
 	userID, orgID, userCtx := s.SetupTestUser()
 	seedCtx := s.SeedContext(userID, orgID)
 
@@ -399,22 +397,22 @@ func (s *WorkflowEngineTestSuite) TestApplyObjectFieldUpdates_CoercesEnums() {
 // field changes to the target object.
 //
 // Test Scenarios:
-//   Subtest "executes field update with valid params":
-//     1. Creates a Control with initial status
-//     2. Executes a field_update action with updates = { "status": "APPROVED" }
-//     3. Verifies the Control.status is now APPROVED
 //
-//   Subtest "fails field update without updates":
-//     1. Executes a field_update action with empty updates
-//     2. Expected: ErrMissingRequiredField error
+//	Subtest "executes field update with valid params":
+//	  1. Creates a Control with initial status
+//	  2. Executes a field_update action with updates = { "status": "APPROVED" }
+//	  3. Verifies the Control.status is now APPROVED
+//
+//	Subtest "fails field update without updates":
+//	  1. Executes a field_update action with empty updates
+//	  2. Expected: ErrMissingRequiredField error
 //
 // Why This Matters:
-//   Field update actions enable workflows to programmatically modify object fields as part
-//   of their execution. This is useful for automated status transitions after approval
-//   or other workflow-driven field changes.
+//
+//	Field update actions enable workflows to programmatically modify object fields as part
+//	of their execution. This is useful for automated status transitions after approval
+//	or other workflow-driven field changes.
 func (s *WorkflowEngineTestSuite) TestExecuteFieldUpdate() {
-	s.ClearWorkflowDefinitions()
-
 	_, orgID, userCtx := s.SetupTestUser()
 
 	wfEngine := s.Engine()

--- a/internal/workflows/engine/proposal_manager_test.go
+++ b/internal/workflows/engine/proposal_manager_test.go
@@ -40,7 +40,6 @@ import (
 //   verification should match that scoped set of changes. This prevents cross-contamination
 //   of approval hashes between unrelated workflows.
 func (s *WorkflowEngineTestSuite) TestProposalManagerComputeHashUsesDomainKey() {
-	s.ClearWorkflowDefinitions()
 
 	userID, orgID, _ := s.SetupTestUser()
 	seedCtx := s.SeedContext(userID, orgID)

--- a/internal/workflows/engine/resolver_test.go
+++ b/internal/workflows/engine/resolver_test.go
@@ -20,7 +20,8 @@ import (
 //  2. Verifies the engine is not nil (resolver infrastructure ready)
 //
 // Why This Matters:
-//   Foundational test ensuring the target resolution subsystem is available.
+//
+//	Foundational test ensuring the target resolution subsystem is available.
 func (s *WorkflowEngineTestSuite) TestResolveTargetsRequiresEngine() {
 	wfEngine := s.Engine()
 	s.Require().NotNil(wfEngine)
@@ -30,20 +31,20 @@ func (s *WorkflowEngineTestSuite) TestResolveTargetsRequiresEngine() {
 // User targets are the simplest target type - a direct reference to a specific user.
 //
 // Test Scenarios:
-//   "resolve user with ID":
-//     - Target: { type: USER, id: "user-123" }
-//     - Expected: Returns ["user-123"]
 //
-//   "user target without ID returns error":
-//     - Target: { type: USER, id: "" }
-//     - Expected: ErrMissingRequiredField error
+//	"resolve user with ID":
+//	  - Target: { type: USER, id: "user-123" }
+//	  - Expected: Returns ["user-123"]
+//
+//	"user target without ID returns error":
+//	  - Target: { type: USER, id: "" }
+//	  - Expected: ErrMissingRequiredField error
 //
 // Why This Matters:
-//   User targets enable explicit assignment to specific individuals. The resolver must
-//   validate that the user ID is provided and return it directly.
+//
+//	User targets enable explicit assignment to specific individuals. The resolver must
+//	validate that the user ID is provided and return it directly.
 func (s *WorkflowEngineTestSuite) TestResolveUserTarget() {
-	s.ClearWorkflowDefinitions()
-
 	_, orgID, userCtx := s.SetupTestUser()
 
 	wfEngine := s.Engine()
@@ -93,20 +94,20 @@ func (s *WorkflowEngineTestSuite) TestResolveUserTarget() {
 //  1. Creates a Group with two user members
 //
 // Test Scenarios:
-//   "resolve group members":
-//     - Target: { type: GROUP, id: "group-123" }
-//     - Expected: Returns user IDs of all group members
 //
-//   "group target without ID returns error":
-//     - Target: { type: GROUP, id: "" }
-//     - Expected: ErrMissingRequiredField error
+//	"resolve group members":
+//	  - Target: { type: GROUP, id: "group-123" }
+//	  - Expected: Returns user IDs of all group members
+//
+//	"group target without ID returns error":
+//	  - Target: { type: GROUP, id: "" }
+//	  - Expected: ErrMissingRequiredField error
 //
 // Why This Matters:
-//   Group targets enable dynamic assignment to team members. As group membership changes,
-//   workflow assignments automatically reflect the current membership.
+//
+//	Group targets enable dynamic assignment to team members. As group membership changes,
+//	workflow assignments automatically reflect the current membership.
 func (s *WorkflowEngineTestSuite) TestResolveGroupTarget() {
-	s.ClearWorkflowDefinitions()
-
 	userID, orgID, userCtx := s.SetupTestUser()
 	seedCtx := s.SeedContext(userID, orgID)
 
@@ -168,24 +169,24 @@ func (s *WorkflowEngineTestSuite) TestResolveGroupTarget() {
 // the specified role within the object's owning organization.
 //
 // Test Scenarios:
-//   "role target requires ID":
-//     - Target: { type: ROLE, id: "" }
-//     - Expected: ErrMissingRequiredField error
 //
-//   "role resolution returns org members by role":
-//     - Target: { type: ROLE, id: "OWNER" }
-//     - Expected: Returns user IDs of org members with OWNER role
+//	"role target requires ID":
+//	  - Target: { type: ROLE, id: "" }
+//	  - Expected: ErrMissingRequiredField error
 //
-//   "invalid role returns error":
-//     - Target: { type: ROLE, id: "NOT_A_ROLE" }
-//     - Expected: Error (unrecognized role)
+//	"role resolution returns org members by role":
+//	  - Target: { type: ROLE, id: "OWNER" }
+//	  - Expected: Returns user IDs of org members with OWNER role
+//
+//	"invalid role returns error":
+//	  - Target: { type: ROLE, id: "NOT_A_ROLE" }
+//	  - Expected: Error (unrecognized role)
 //
 // Why This Matters:
-//   Role targets enable automatic assignment to users based on their organizational role.
-//   This is useful for "assign to all org owners" or "assign to all admins" workflows.
+//
+//	Role targets enable automatic assignment to users based on their organizational role.
+//	This is useful for "assign to all org owners" or "assign to all admins" workflows.
 func (s *WorkflowEngineTestSuite) TestResolveRoleTarget() {
-	s.ClearWorkflowDefinitions()
-
 	wfEngine := s.Engine()
 
 	s.Run("role target requires ID", func() {
@@ -260,21 +261,21 @@ func (s *WorkflowEngineTestSuite) TestResolveRoleTarget() {
 // to dynamically determine target users based on object relationships.
 //
 // Test Scenarios:
-//   "resolve CONTROL_OWNER":
-//     - Target: { type: RESOLVER, resolverKey: "CONTROL_OWNER" }
-//     - Expected: Returns user IDs of the Control's owning organization's owners
 //
-//   "resolve OBJECT_CREATOR":
-//     - Target: { type: RESOLVER, resolverKey: "OBJECT_CREATOR" }
-//     - Expected: Returns user ID(s) who created the object (if tracked)
+//	"resolve CONTROL_OWNER":
+//	  - Target: { type: RESOLVER, resolverKey: "CONTROL_OWNER" }
+//	  - Expected: Returns user IDs of the Control's owning organization's owners
+//
+//	"resolve OBJECT_CREATOR":
+//	  - Target: { type: RESOLVER, resolverKey: "OBJECT_CREATOR" }
+//	  - Expected: Returns user ID(s) who created the object (if tracked)
 //
 // Why This Matters:
-//   Resolver targets enable dynamic assignment based on object context. For example,
-//   "CONTROL_OWNER" automatically assigns to whoever owns the control being modified,
-//   without hardcoding specific user IDs in the workflow definition.
+//
+//	Resolver targets enable dynamic assignment based on object context. For example,
+//	"CONTROL_OWNER" automatically assigns to whoever owns the control being modified,
+//	without hardcoding specific user IDs in the workflow definition.
 func (s *WorkflowEngineTestSuite) TestResolveControlTarget() {
-	s.ClearWorkflowDefinitions()
-
 	userID, orgID, userCtx := s.SetupTestUser()
 
 	wfEngine := s.Engine()
@@ -318,20 +319,20 @@ func (s *WorkflowEngineTestSuite) TestResolveControlTarget() {
 // TestResolveInvalidTarget verifies error handling for malformed or invalid target configurations.
 //
 // Test Scenarios:
-//   "invalid target type":
-//     - Target: { type: "INVALID" }
-//     - Expected: ErrInvalidTargetType error
 //
-//   "resolver without resolver key":
-//     - Target: { type: RESOLVER, resolverKey: "" }
-//     - Expected: ErrMissingRequiredField error
+//	"invalid target type":
+//	  - Target: { type: "INVALID" }
+//	  - Expected: ErrInvalidTargetType error
+//
+//	"resolver without resolver key":
+//	  - Target: { type: RESOLVER, resolverKey: "" }
+//	  - Expected: ErrMissingRequiredField error
 //
 // Why This Matters:
-//   The resolver must validate target configurations and fail fast with clear errors
-//   rather than silently returning empty results or causing downstream failures.
+//
+//	The resolver must validate target configurations and fail fast with clear errors
+//	rather than silently returning empty results or causing downstream failures.
 func (s *WorkflowEngineTestSuite) TestResolveInvalidTarget() {
-	s.ClearWorkflowDefinitions()
-
 	wfEngine := s.Engine()
 
 	obj := &workflows.Object{


### PR DESCRIPTION
The workflow engine uses an async event-driven architecture. When you call something like `CompleteAssignment()`, the function returns immediately after emitting an event to the pool. The actual work (state transitions, creating assignments, applying proposals) happens asynchronously in worker goroutines. The flakiness was caused by tests checking state before async event handlers had finished updating it. `WaitForEvents()` calls `WaitForIdle()` on the event pool, which blocks until workers + tasks are completed processing.

Decided to keep the ClearWorkflowDefinitions helper but make it org constrained and it's only called in instances where we re-used the same organization but created multiple definitions that would need to be re-set inbetween sub tests.                                 