### PR TITLE
deps: go 1.25.6

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/theopenlane/core/cli
 
-go 1.25.5
+go 1.25.6
 
 require (
 	github.com/99designs/gqlgen v0.17.86

--- a/common/go.mod
+++ b/common/go.mod
@@ -1,6 +1,6 @@
 module github.com/theopenlane/core/common
 
-go 1.25.5
+go 1.25.6
 
 require (
 	entgo.io/ent v0.14.6-0.20260108211107-2eb36418a02e

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/theopenlane/core
 
-go 1.25.5
+go 1.25.6
 
 tool (
 	github.com/dave/jennifer

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.25.5
+go 1.25.6
 
 use (
 	// core is the main module containing the API and business logic, nothing in pkg or internal should be imported by other modules


### PR DESCRIPTION
addresses High CVE-2025-61726 in go stdlib