### PR TITLE
Simplify GenericMutation Adapter & Call Sites

### DIFF
--- a/internal/ent/hooks/avatar.go
+++ b/internal/ent/hooks/avatar.go
@@ -8,9 +8,9 @@ import (
 
 // AvatarMutation is an interface for setting the local file ID for an avatar
 type AvatarMutation interface {
+	pkgobjects.Mutation
+
 	SetAvatarLocalFileID(s string)
-	ID() (id string, exists bool)
-	Type() string
 }
 
 // checkAvatarFile checks if an avatar file is provided and sets the local file ID
@@ -29,10 +29,5 @@ func checkAvatarFile[T AvatarMutation](ctx context.Context, m T) (context.Contex
 
 	m.SetAvatarLocalFileID(files[0].ID)
 
-	adapter := pkgobjects.NewGenericMutationAdapter(m,
-		func(mut T) (string, bool) { return mut.ID() },
-		func(mut T) string { return mut.Type() },
-	)
-
-	return pkgobjects.ProcessFilesForMutation(ctx, adapter, key)
+	return pkgobjects.ProcessFilesForMutation(ctx, m, key)
 }

--- a/internal/ent/hooks/documentdata.go
+++ b/internal/ent/hooks/documentdata.go
@@ -171,7 +171,7 @@ func HookDocumentDataFile() ent.Hook {
 				return nil, errOnlyOneDocumentData
 			}
 
-			// first checks the authenicated user context,
+			// first checks the authenticated user context,
 			// second checks specifically for the SystemAdminContextKey key in the context
 			if !auth.IsSystemAdminFromContext(ctx) {
 				if user, ok := auth.SystemAdminFromContext(ctx); ok && !user.IsSystemAdmin {
@@ -196,12 +196,7 @@ func HookDocumentDataFile() ent.Hook {
 				return nil, generated.ErrPermissionDenied
 			}
 
-			adapter := objects.NewGenericMutationAdapter(m,
-				func(mut *generated.DocumentDataMutation) (string, bool) { return mut.ID() },
-				func(mut *generated.DocumentDataMutation) string { return mut.Type() },
-			)
-
-			ctx, err = objects.ProcessFilesForMutation(ctx, adapter, "documentDataFile")
+			ctx, err = objects.ProcessFilesForMutation(ctx, m, "documentDataFile")
 			if err != nil {
 				return nil, err
 			}

--- a/internal/ent/hooks/documents.go
+++ b/internal/ent/hooks/documents.go
@@ -99,13 +99,9 @@ func HookImportDocument() ent.Hook {
 			default:
 				// Derive the expected file key for this mutation and attach parent metadata to uploaded files
 				key := mutationToFileKey(mut)
-				adapter := objects.NewGenericMutationAdapter(mut,
-					func(mm importSchemaMutation) (string, bool) { return mm.ID() },
-					func(mm importSchemaMutation) string { return mm.Type() },
-				)
 
 				var err error
-				ctx, err = objects.ProcessFilesForMutation(ctx, adapter, key)
+				ctx, err = objects.ProcessFilesForMutation(ctx, mut, key)
 				if err != nil {
 					return nil, err
 				}

--- a/internal/ent/hooks/evidence.go
+++ b/internal/ent/hooks/evidence.go
@@ -88,14 +88,7 @@ func HookEvidenceFiles() ent.Hook {
 func checkEvidenceFiles[T utils.GenericMutation](ctx context.Context, m T) (context.Context, error) {
 	key := "evidenceFiles"
 
-	// Create adapter for the existing mutation interface
-	adapter := objects.NewGenericMutationAdapter(m,
-		func(mut T) (string, bool) { return mut.ID() },
-		func(mut T) string { return mut.Type() },
-	)
-
-	// Use the generic helper to process files
-	return objects.ProcessFilesForMutation(ctx, adapter, key)
+	return objects.ProcessFilesForMutation(ctx, m, key)
 }
 
 // checkEvidenceHasFiles checks if evidence has any attached files

--- a/internal/ent/hooks/export.go
+++ b/internal/ent/hooks/export.go
@@ -157,10 +157,5 @@ func checkExportFiles(ctx context.Context, m *generated.ExportMutation) (context
 		return ctx, nil
 	}
 
-	adapter := pkgobjects.NewGenericMutationAdapter(m,
-		func(mut *generated.ExportMutation) (string, bool) { return mut.ID() },
-		func(mut *generated.ExportMutation) string { return mut.Type() },
-	)
-
-	return pkgobjects.ProcessFilesForMutation(ctx, adapter, key)
+	return pkgobjects.ProcessFilesForMutation(ctx, m, key)
 }

--- a/internal/ent/hooks/file_helpers.go
+++ b/internal/ent/hooks/file_helpers.go
@@ -8,15 +8,13 @@ import (
 
 // processSingleMutationFile applies a single uploaded file to a mutation and processes it
 // yes the function inputs are ugly but this is to keep it generic
-func processSingleMutationFile[T any](
+func processSingleMutationFile[T objects.Mutation](
 	ctx context.Context,
 	mutation T,
 	key string,
 	parentType string,
 	errTooMany error,
 	setID func(T, string),
-	idFunc func(T) (string, bool),
-	typeFunc func(T) string,
 ) (context.Context, error) {
 	files, _ := objects.FilesFromContextWithKey(ctx, key)
 	if len(files) == 0 {
@@ -29,7 +27,5 @@ func processSingleMutationFile[T any](
 
 	setID(mutation, files[0].ID)
 
-	adapter := objects.NewGenericMutationAdapter(mutation, idFunc, typeFunc)
-
-	return objects.ProcessFilesForMutation(ctx, adapter, key, parentType)
+	return objects.ProcessFilesForMutation(ctx, mutation, key, parentType)
 }

--- a/internal/ent/hooks/jobresult.go
+++ b/internal/ent/hooks/jobresult.go
@@ -45,10 +45,5 @@ func checkJobResultFiles[T utils.GenericMutation](ctx context.Context, m T) (con
 		return ctx, nil
 	}
 
-	adapter := pkgobjects.NewGenericMutationAdapter(m,
-		func(mut T) (string, bool) { return mut.ID() },
-		func(mut T) string { return mut.Type() },
-	)
-
-	return pkgobjects.ProcessFilesForMutation(ctx, adapter, key)
+	return pkgobjects.ProcessFilesForMutation(ctx, m, key)
 }

--- a/internal/ent/hooks/memberhelpers.go
+++ b/internal/ent/hooks/memberhelpers.go
@@ -22,12 +22,10 @@ import (
 
 // MutationMember is an interface that can be implemented by a member mutation to get IDs
 type MutationMember interface {
+	utils.GenericMutation
+
 	UserIDs() []string
 	UserID() (string, bool)
-	ID() (string, bool)
-	IDs(ctx context.Context) ([]string, error)
-	Op() ent.Op
-	Client() *generated.Client
 }
 
 // HookMembershipSelf is a hook that runs on membership mutations
@@ -117,8 +115,7 @@ func createMembershipCheck(m MutationMember, actorID string) error {
 
 // updateMembershipCheck is a helper function to check if a user is trying to update themselves in a membership
 func updateMembershipCheck(ctx context.Context, m MutationMember, table string, actorID string) error {
-	mut := m.(utils.GenericMutation)
-	memberIDs := getMutationIDs(ctx, mut)
+	memberIDs := getMutationIDs(ctx, m)
 	if len(memberIDs) == 0 {
 		return nil
 	}

--- a/internal/ent/hooks/note.go
+++ b/internal/ent/hooks/note.go
@@ -102,10 +102,5 @@ func checkNoteFiles(ctx context.Context, m *generated.NoteMutation) (context.Con
 
 	m.AddFileIDs(fileIDs...)
 
-	adapter := pkgobjects.NewGenericMutationAdapter(m,
-		func(mut *generated.NoteMutation) (string, bool) { return mut.ID() },
-		func(mut *generated.NoteMutation) string { return mut.Type() },
-	)
-
-	return pkgobjects.ProcessFilesForMutation(ctx, adapter, key)
+	return pkgobjects.ProcessFilesForMutation(ctx, m, key)
 }

--- a/internal/ent/hooks/standard.go
+++ b/internal/ent/hooks/standard.go
@@ -414,10 +414,5 @@ func checkStandardLogoFile(ctx context.Context, m *generated.StandardMutation) (
 
 	m.SetLogoFileID(logoFiles[0].ID)
 
-	adapter := pkgobjects.NewGenericMutationAdapter(m,
-		func(mut *generated.StandardMutation) (string, bool) { return mut.ID() },
-		func(mut *generated.StandardMutation) string { return mut.Type() },
-	)
-
-	return pkgobjects.ProcessFilesForMutation(ctx, adapter, logoKey)
+	return pkgobjects.ProcessFilesForMutation(ctx, m, logoKey)
 }

--- a/internal/ent/hooks/subprocessor.go
+++ b/internal/ent/hooks/subprocessor.go
@@ -43,10 +43,5 @@ func checkSubprocessorLogoFile(ctx context.Context, m *generated.SubprocessorMut
 
 	m.SetLogoFileID(logoFiles[0].ID)
 
-	adapter := pkgobjects.NewGenericMutationAdapter(m,
-		func(mut *generated.SubprocessorMutation) (string, bool) { return mut.ID() },
-		func(mut *generated.SubprocessorMutation) string { return mut.Type() },
-	)
-
-	return pkgobjects.ProcessFilesForMutation(ctx, adapter, logoKey)
+	return pkgobjects.ProcessFilesForMutation(ctx, m, logoKey)
 }

--- a/internal/ent/hooks/template.go
+++ b/internal/ent/hooks/template.go
@@ -84,10 +84,5 @@ func checkTemplateFiles(ctx context.Context, m *generated.TemplateMutation) (con
 		return ctx, nil
 	}
 
-	adapter := objects.NewGenericMutationAdapter(m,
-		func(mut *generated.TemplateMutation) (string, bool) { return mut.ID() },
-		func(mut *generated.TemplateMutation) string { return mut.Type() },
-	)
-
-	return objects.ProcessFilesForMutation(ctx, adapter, key)
+	return objects.ProcessFilesForMutation(ctx, m, key)
 }

--- a/internal/ent/hooks/trustcenter_entity.go
+++ b/internal/ent/hooks/trustcenter_entity.go
@@ -89,8 +89,6 @@ func checkTrustCenterEntityFiles(ctx context.Context, m *generated.TrustCenterEn
 	key := "logoFile"
 	ctx, err := processSingleMutationFile(ctx, m, key, "trust_center_entity", ErrTooManyAvatarFiles,
 		func(mut *generated.TrustCenterEntityMutation, id string) { mut.SetLogoFileID(id) },
-		func(mut *generated.TrustCenterEntityMutation) (string, bool) { return mut.ID() },
-		func(mut *generated.TrustCenterEntityMutation) string { return mut.Type() },
 	)
 	if err != nil {
 		return ctx, err

--- a/internal/ent/hooks/trustcenterdoc.go
+++ b/internal/ent/hooks/trustcenterdoc.go
@@ -348,26 +348,12 @@ func updateTrustCenterDocVisibility(ctx context.Context, m *generated.TrustCente
 func checkTrustCenterDocFile(ctx context.Context, m *generated.TrustCenterDocMutation) (context.Context, error) {
 	key := "trustCenterDocFile"
 
-	// Create adapter for the existing mutation interface
-	adapter := objects.NewGenericMutationAdapter(m,
-		func(mut *generated.TrustCenterDocMutation) (string, bool) { return mut.ID() },
-		func(mut *generated.TrustCenterDocMutation) string { return mut.Type() },
-	)
-
-	// Use the generic helper to process files
-	return objects.ProcessFilesForMutation(ctx, adapter, key, "trust_center_doc")
+	return objects.ProcessFilesForMutation(ctx, m, key, "trust_center_doc")
 }
 
 // checkWatermarkedTrustCenterDocFile checks if the watermarked doc file is provided and sets the parent information
 func checkWatermarkedTrustCenterDocFile(ctx context.Context, m *generated.TrustCenterDocMutation) (context.Context, error) {
 	key := "watermarkedTrustCenterDocFile"
 
-	// Create adapter for the existing mutation interface
-	adapter := objects.NewGenericMutationAdapter(m,
-		func(mut *generated.TrustCenterDocMutation) (string, bool) { return mut.ID() },
-		func(mut *generated.TrustCenterDocMutation) string { return mut.Type() },
-	)
-
-	// Use the generic helper to process files
-	return objects.ProcessFilesForMutation(ctx, adapter, key, "trust_center_doc")
+	return objects.ProcessFilesForMutation(ctx, m, key, "trust_center_doc")
 }

--- a/internal/ent/hooks/trustcentersetting.go
+++ b/internal/ent/hooks/trustcentersetting.go
@@ -198,8 +198,6 @@ func checkTrustCenterFiles(ctx context.Context, m *generated.TrustCenterSettingM
 
 	ctx, err = processSingleMutationFile(ctx, m, logoKey, "trust_center_setting", ErrTooManyLogoFiles,
 		func(mut *generated.TrustCenterSettingMutation, id string) { mut.SetLogoLocalFileID(id) },
-		func(mut *generated.TrustCenterSettingMutation) (string, bool) { return mut.ID() },
-		func(mut *generated.TrustCenterSettingMutation) string { return mut.Type() },
 	)
 	if err != nil {
 		return ctx, err
@@ -207,8 +205,6 @@ func checkTrustCenterFiles(ctx context.Context, m *generated.TrustCenterSettingM
 
 	ctx, err = processSingleMutationFile(ctx, m, faviconKey, "trust_center_setting", ErrTooManyFaviconFiles,
 		func(mut *generated.TrustCenterSettingMutation, id string) { mut.SetFaviconLocalFileID(id) },
-		func(mut *generated.TrustCenterSettingMutation) (string, bool) { return mut.ID() },
-		func(mut *generated.TrustCenterSettingMutation) string { return mut.Type() },
 	)
 	if err != nil {
 		return ctx, err

--- a/internal/ent/hooks/trustcenterwatermarkconfig.go
+++ b/internal/ent/hooks/trustcenterwatermarkconfig.go
@@ -69,8 +69,6 @@ func checkTrustCenterWatermarkConfigFiles(ctx context.Context, m *generated.Trus
 			mut.SetFileID(id)
 			mut.ClearText()
 		},
-		func(mut *generated.TrustCenterWatermarkConfigMutation) (string, bool) { return mut.ID() },
-		func(mut *generated.TrustCenterWatermarkConfigMutation) string { return mut.Type() },
 	)
 	if err != nil {
 		return ctx, err

--- a/internal/ent/mixin/systemowned_mixin.go
+++ b/internal/ent/mixin/systemowned_mixin.go
@@ -128,7 +128,6 @@ func (d SystemOwnedMixin) Policy() ent.Policy {
 type SystemOwnedMutation interface {
 	utils.GenericMutation
 
-	Field(name string) (ent.Value, bool)
 	FieldCleared(name string) bool
 	SystemOwned() (bool, bool)
 	SetSystemOwned(bool)

--- a/internal/ent/privacy/rule/modules.go
+++ b/internal/ent/privacy/rule/modules.go
@@ -268,7 +268,7 @@ func ShouldSkipFeatureCheck(ctx context.Context) bool {
 // DenyIfMissingAllModules acts as a prerequisite check - denies if features missing, Allows if present
 func DenyIfMissingAllModules() privacy.MutationRule {
 	return privacy.MutationRuleFunc(func(ctx context.Context, m ent.Mutation) error {
-		if mut, ok := m.(interface{ Client() *generated.Client }); ok {
+		if mut, ok := m.(utils.MutationClient); ok {
 			if !utils.ModulesEnabled(mut.Client()) {
 				return privacy.Skip
 			}

--- a/internal/ent/privacy/rule/organization.go
+++ b/internal/ent/privacy/rule/organization.go
@@ -17,14 +17,9 @@ import (
 	"github.com/theopenlane/core/pkg/permissioncache"
 )
 
-// genericMutation is an interface for getting a mutation ID and type
-type genericMutation interface {
-	ID() (id string, exists bool)
-	IDs(ctx context.Context) ([]string, error)
+// ownerMutation is a minimal mutation contract used to resolve organization ownership.
+type ownerMutation interface {
 	OwnerID() (id string, exists bool)
-	Type() string
-	Op() ent.Op
-	Client() *generated.Client
 }
 
 // CheckCurrentOrgAccess checks if the authenticated user has access to the organization
@@ -49,7 +44,7 @@ func CheckCurrentOrgAccess(ctx context.Context, m ent.Mutation, relation string)
 	}
 
 	// else we need to get the object id from the mutation and get the owner id, this should only happen on deletes when using personal access tokens
-	mut, ok := m.(genericMutation)
+	mut, ok := m.(ownerMutation)
 	if ok {
 		orgID, ok = mut.OwnerID()
 		if ok && orgID != "" {

--- a/pkg/objects/adapter.go
+++ b/pkg/objects/adapter.go
@@ -2,7 +2,7 @@ package objects
 
 // Mutation represents any ent mutation that can provide ID and Type
 type Mutation interface {
-	ID() (string, error)
+	ID() (string, bool)
 	Type() string
 }
 
@@ -23,13 +23,8 @@ func NewGenericMutationAdapter[T any](mutation T, idFunc func(T) (string, bool),
 }
 
 // ID implements the Mutation interface
-func (a *GenericMutationAdapter[T]) ID() (string, error) {
-	id, exists := a.idFunc(a.mutation)
-	if !exists {
-		return "", ErrMutationIDNotFound
-	}
-
-	return id, nil
+func (a *GenericMutationAdapter[T]) ID() (string, bool) {
+	return a.idFunc(a.mutation)
 }
 
 // Type implements the Mutation interface

--- a/pkg/objects/adapter_test.go
+++ b/pkg/objects/adapter_test.go
@@ -38,32 +38,32 @@ func TestNewGenericMutationAdapter(t *testing.T) {
 
 func TestGenericMutationAdapter_ID(t *testing.T) {
 	tests := []struct {
-		name        string
-		id          string
-		idExists    bool
-		expectID    string
-		expectError error
+		name         string
+		id           string
+		idExists     bool
+		expectedID   string
+		expectedBool bool
 	}{
 		{
-			name:        "ID exists",
-			id:          "test-id-123",
-			idExists:    true,
-			expectID:    "test-id-123",
-			expectError: nil,
+			name:         "ID exists",
+			id:           "test-id-123",
+			idExists:     true,
+			expectedID:   "test-id-123",
+			expectedBool: true,
 		},
 		{
-			name:        "ID does not exist",
-			id:          "",
-			idExists:    false,
-			expectID:    "",
-			expectError: ErrMutationIDNotFound,
+			name:         "ID does not exist",
+			id:           "",
+			idExists:     false,
+			expectedID:   "",
+			expectedBool: false,
 		},
 		{
-			name:        "empty ID but exists flag is true",
-			id:          "",
-			idExists:    true,
-			expectID:    "",
-			expectError: nil,
+			name:         "empty ID but exists flag is true",
+			id:           "",
+			idExists:     true,
+			expectedID:   "",
+			expectedBool: true,
 		},
 	}
 
@@ -85,14 +85,9 @@ func TestGenericMutationAdapter_ID(t *testing.T) {
 
 			adapter := NewGenericMutationAdapter(mutation, idFunc, typeFunc)
 
-			id, err := adapter.ID()
-
-			if tt.expectError != nil {
-				assert.ErrorIs(t, err, tt.expectError)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tt.expectID, id)
-			}
+			id, exists := adapter.ID()
+			assert.Equal(t, tt.expectedID, id)
+			assert.Equal(t, tt.expectedBool, exists)
 		})
 	}
 }
@@ -147,12 +142,12 @@ func TestGenericMutationAdapter_Type(t *testing.T) {
 func TestGenericMutationAdapter_WithMock(t *testing.T) {
 	mockMutation := mocks.NewMockMutation(t)
 
-	mockMutation.EXPECT().ID().Return("mock-id", nil)
+	mockMutation.EXPECT().ID().Return("mock-id", true)
 	mockMutation.EXPECT().Type().Return("MockType")
 
-	id, err := mockMutation.ID()
-	require.NoError(t, err)
+	id, exists := mockMutation.ID()
 	assert.Equal(t, "mock-id", id)
+	assert.True(t, exists)
 
 	typeName := mockMutation.Type()
 	assert.Equal(t, "MockType", typeName)
@@ -172,9 +167,9 @@ func TestGenericMutationAdapter_WithDifferentTypes(t *testing.T) {
 
 		adapter := NewGenericMutationAdapter(stringMutation, idFunc, typeFunc)
 
-		id, err := adapter.ID()
-		require.NoError(t, err)
+		id, exists := adapter.ID()
 		assert.Equal(t, "string-id", id)
+		assert.True(t, exists)
 
 		typeName := adapter.Type()
 		assert.Equal(t, "String", typeName)
@@ -193,9 +188,9 @@ func TestGenericMutationAdapter_WithDifferentTypes(t *testing.T) {
 
 		adapter := NewGenericMutationAdapter(intMutation, idFunc, typeFunc)
 
-		id, err := adapter.ID()
-		require.NoError(t, err)
+		id, exists := adapter.ID()
 		assert.Equal(t, "42", id)
+		assert.True(t, exists)
 
 		typeName := adapter.Type()
 		assert.Equal(t, "Integer", typeName)

--- a/pkg/objects/errors.go
+++ b/pkg/objects/errors.go
@@ -9,8 +9,6 @@ var (
 	ErrInsufficientProviderInfo = errors.New("insufficient information to resolve storage client: need integration_id+hush_id or organization_id")
 	// ErrProviderHintsRequired is returned when provider hints are required for file upload
 	ErrProviderHintsRequired = errors.New("provider hints required for file upload")
-	// ErrMutationIDNotFound is returned when mutation ID is not found
-	ErrMutationIDNotFound = errors.New("mutation ID not found")
 	// ErrReaderCannotBeNil is returned when a nil reader is provided to BufferedReader
 	ErrReaderCannotBeNil = errors.New("reader cannot be nil")
 	// ErrFailedToReadData is returned when reading data from a reader fails

--- a/pkg/objects/mocks/mocks.go
+++ b/pkg/objects/mocks/mocks.go
@@ -36,7 +36,7 @@ func (_m *MockMutation) EXPECT() *MockMutation_Expecter {
 }
 
 // ID provides a mock function for the type MockMutation
-func (_mock *MockMutation) ID() (string, error) {
+func (_mock *MockMutation) ID() (string, bool) {
 	ret := _mock.Called()
 
 	if len(ret) == 0 {
@@ -44,8 +44,8 @@ func (_mock *MockMutation) ID() (string, error) {
 	}
 
 	var r0 string
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (string, error)); ok {
+	var r1 bool
+	if returnFunc, ok := ret.Get(0).(func() (string, bool)); ok {
 		return returnFunc()
 	}
 	if returnFunc, ok := ret.Get(0).(func() string); ok {
@@ -53,10 +53,10 @@ func (_mock *MockMutation) ID() (string, error) {
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
+	if returnFunc, ok := ret.Get(1).(func() bool); ok {
 		r1 = returnFunc()
 	} else {
-		r1 = ret.Error(1)
+		r1 = ret.Get(1).(bool)
 	}
 	return r0, r1
 }
@@ -78,12 +78,12 @@ func (_c *MockMutation_ID_Call) Run(run func()) *MockMutation_ID_Call {
 	return _c
 }
 
-func (_c *MockMutation_ID_Call) Return(s string, err error) *MockMutation_ID_Call {
-	_c.Call.Return(s, err)
+func (_c *MockMutation_ID_Call) Return(s string, exists bool) *MockMutation_ID_Call {
+	_c.Call.Return(s, exists)
 	return _c
 }
 
-func (_c *MockMutation_ID_Call) RunAndReturn(run func() (string, error)) *MockMutation_ID_Call {
+func (_c *MockMutation_ID_Call) RunAndReturn(run func() (string, bool)) *MockMutation_ID_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/objects/upload_test.go
+++ b/pkg/objects/upload_test.go
@@ -653,7 +653,7 @@ func TestProcessFilesForMutation(t *testing.T) {
 
 		mockMutation := mocks.NewMockMutation(t)
 		mockMutation.EXPECT().Type().Return("TestType")
-		mockMutation.EXPECT().ID().Return("mutation-id-123", nil)
+		mockMutation.EXPECT().ID().Return("mutation-id-123", true)
 
 		newCtx, err := ProcessFilesForMutation(ctx, mockMutation, "file1")
 		require.NoError(t, err)
@@ -676,7 +676,7 @@ func TestProcessFilesForMutation(t *testing.T) {
 
 		mockMutation := mocks.NewMockMutation(t)
 		mockMutation.EXPECT().Type().Return("TestType")
-		mockMutation.EXPECT().ID().Return("mutation-id-456", nil)
+		mockMutation.EXPECT().ID().Return("mutation-id-456", true)
 
 		newCtx, err := ProcessFilesForMutation(ctx, mockMutation, "file1", "OverrideType")
 		require.NoError(t, err)


### PR DESCRIPTION
Randomly got frustrated at the annoying boilerplate the objects package required as a result of past-Matt being dumb and not properly satisfying the interface contract by doing `ID() (string, bool)` instead of `ID() (string, error)`, so made the updates and then simplified the callers. While I was cleaning this up, also simplified similar interfaces, removed redundant fields, standardized on the existing GenericMutation interface where appropriate.