### PR TITLE
remove go mod download from install

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -587,7 +587,6 @@ tasks:
       - command -v gcloud &> /dev/null || curl https://sdk.cloud.google.com | bash
       - sudo npm install jsonschema2mk --global
       - sudo npm install format-graphql
-      - go mod download
       - pre-commit install && pre-commit install-hooks
       - pre-commit autoupdate
       - go mod tidy && go get -u ./... &> /dev/null


### PR DESCRIPTION
`go mod download`  attempts to pull ever dep, including ones that aren't reference in the go mod file, because riverboat has an indirect dependency on corejobs, `go mod download` thinks it might need it so it pulls it. This however, is not actually a requirement for this repo. Additionally, theres not really a need to do `go mod download` because the go build process will already pull these deps so removing this to avoid confusion

should resolve https://github.com/theopenlane/core/issues/2032