### PR TITLE
Workflow Context

### DIFF
--- a/internal/workflows/context.go
+++ b/internal/workflows/context.go
@@ -137,6 +137,13 @@ func allowContextWithOrg(ctx context.Context, bypass bool) (context.Context, str
 	}
 
 	orgID, err := auth.GetOrganizationIDFromContext(ctx)
+	if err != nil {
+		// PAT-authenticated requests can legitimately carry only OrganizationIDs (no selected OrganizationID)
+		// until an org context header is provided. For single-org tokens, default to that sole org.
+		if orgIDs, orgIDsErr := auth.GetOrganizationIDsFromContext(ctx); orgIDsErr == nil && len(orgIDs) == 1 && orgIDs[0] != "" {
+			return allowCtx, orgIDs[0], nil
+		}
+	}
 
 	return allowCtx, orgID, err
 }


### PR DESCRIPTION
- `AllowContextWithOrg` now falls back to OrganizationIDs when `GetOrganizationIDFromContext` returns an err
- Added tests to verify workflow matching behavior for JWT, PAT, API token, missing auth user, and selected-vs-unselected org permutations