### PR TITLE
 prevent draft PR cleanup hangs

### DIFF
--- a/.buildkite/cleanup-draft-prs.sh
+++ b/.buildkite/cleanup-draft-prs.sh
@@ -69,7 +69,7 @@ while IFS=':' read -r pr_number branch_name title; do
 
     closing_comment=$(generate_closure_comment "$core_pr_number" "closed")
     if close_pr "$pr_number" "$repo" "$closing_comment"; then
-      safe_delete_branch "$branch_name"
+      safe_delete_branch "$branch_name" "$repo"
     fi
     continue
   fi
@@ -97,7 +97,7 @@ while IFS=':' read -r pr_number branch_name title; do
   fi
 
   if close_pr "$pr_number" "$repo" "$closing_comment"; then
-    safe_delete_branch "$branch_name"
+    safe_delete_branch "$branch_name" "$repo"
   fi
 
 done <<< "$draft_prs"

--- a/.buildkite/post-merge-pr-automation.sh
+++ b/.buildkite/post-merge-pr-automation.sh
@@ -58,7 +58,7 @@ while IFS=':' read -r pr_number branch_name title; do
     echo "⚠️  Core PR #$core_pr_number not found, closing draft PR #$pr_number"
     closing_comment=$(generate_closure_comment "$core_pr_number" "closed")
     if close_pr "$pr_number" "$repo" "$closing_comment"; then
-      safe_delete_branch "$branch_name"
+      safe_delete_branch "$branch_name" "$repo"
     fi
     continue
   fi
@@ -80,7 +80,7 @@ while IFS=':' read -r pr_number branch_name title; do
   fi
 
   if close_pr "$pr_number" "$repo" "$closing_comment"; then
-    safe_delete_branch "$branch_name"
+    safe_delete_branch "$branch_name" "$repo"
   fi
 done <<< "$draft_prs"
 

--- a/.buildkite/tests/cleanup-draft-prs.bats
+++ b/.buildkite/tests/cleanup-draft-prs.bats
@@ -24,7 +24,7 @@ find_draft_prs() { echo "1:test-branch:\ud83d\udea7 DRAFT: Config changes from c
 check_core_pr_status() { echo '{"state":"MERGED","title":"Test","updatedAt":"2025-07-15T00:00:00Z"}'; }
 is_recent_pr_activity() { return 0; }
 close_pr() { echo "close_pr $1" >> "$TEST_TEMP_DIR/log"; }
-safe_delete_branch() { echo "delete_branch $1" >> "$TEST_TEMP_DIR/log"; }
+safe_delete_branch() { echo "delete_branch $1 $2" >> "$TEST_TEMP_DIR/log"; }
 extract_core_pr_number() { echo 10; }
 generate_closure_comment() { echo "comment"; }
 STUB
@@ -35,7 +35,7 @@ STUB
     CLEANUP_PR_STUB="$TEST_TEMP_DIR/stubs.sh" run bash .buildkite/cleanup-draft-prs.sh
     [ "$status" -eq 0 ]
     grep -q "close_pr 1" "$TEST_TEMP_DIR/log"
-    grep -q "delete_branch test-branch" "$TEST_TEMP_DIR/log"
+    grep -q "delete_branch test-branch theopenlane/openlane-infra" "$TEST_TEMP_DIR/log"
 }
 
 @test "draft PR kept when core PR open" {
@@ -45,7 +45,7 @@ validate_build_context() { return 0; }
 find_draft_prs() { echo "2:test-branch:\ud83d\udea7 DRAFT: Config changes from core PR #20"; }
 check_core_pr_status() { echo '{"state":"OPEN","title":"Test","updatedAt":"2025-07-15T00:00:00Z"}'; }
 close_pr() { echo "close_pr $1" >> "$TEST_TEMP_DIR/log"; }
-safe_delete_branch() { echo "delete_branch $1" >> "$TEST_TEMP_DIR/log"; }
+safe_delete_branch() { echo "delete_branch $1 $2" >> "$TEST_TEMP_DIR/log"; }
 extract_core_pr_number() { echo 20; }
 STUB
     source "$TEST_TEMP_DIR/stubs.sh"
@@ -64,7 +64,7 @@ validate_build_context() { return 0; }
 find_draft_prs() { echo "3:test-branch:\ud83d\udea7 DRAFT: Config changes from core PR #30"; }
 check_core_pr_status() { echo ""; }
 close_pr() { echo "close_pr $1" >> "$TEST_TEMP_DIR/log"; }
-safe_delete_branch() { echo "delete_branch $1" >> "$TEST_TEMP_DIR/log"; }
+safe_delete_branch() { echo "delete_branch $1 $2" >> "$TEST_TEMP_DIR/log"; }
 extract_core_pr_number() { echo 30; }
 generate_closure_comment() { echo "comment"; }
 STUB

--- a/.buildkite/tests/post-merge-pr-automation.bats
+++ b/.buildkite/tests/post-merge-pr-automation.bats
@@ -18,13 +18,13 @@ find_draft_prs() { echo "5:draft-core-pr-42:🚧 DRAFT: Config changes from core
 check_core_pr_status() { echo '{"state":"MERGED","updatedAt":"2026-01-01T00:00:00Z"}'; }
 generate_closure_comment() { echo "comment"; }
 close_pr() { echo "close_pr $1" >> "$TEST_TEMP_DIR/log"; return 0; }
-safe_delete_branch() { echo "delete_branch $1" >> "$TEST_TEMP_DIR/log"; return 0; }
+safe_delete_branch() { echo "delete_branch $1 $2" >> "$TEST_TEMP_DIR/log"; return 0; }
 STUB
 
     POST_MERGE_PR_STUB="$TEST_TEMP_DIR/stubs.sh" run bash .buildkite/post-merge-pr-automation.sh
     [ "$status" -eq 0 ]
     grep -q "close_pr 5" "$TEST_TEMP_DIR/log"
-    grep -q "delete_branch draft-core-pr-42" "$TEST_TEMP_DIR/log"
+    grep -q "delete_branch draft-core-pr-42 theopenlane/openlane-infra" "$TEST_TEMP_DIR/log"
 }
 
 @test "keeps draft PR open when core PR is still open" {
@@ -35,7 +35,7 @@ find_draft_prs() { echo "6:draft-core-pr-43:🚧 DRAFT: Config changes from core
 check_core_pr_status() { echo '{"state":"OPEN","updatedAt":"2026-01-01T00:00:00Z"}'; }
 generate_closure_comment() { echo "comment"; }
 close_pr() { echo "close_pr $1" >> "$TEST_TEMP_DIR/log"; return 0; }
-safe_delete_branch() { echo "delete_branch $1" >> "$TEST_TEMP_DIR/log"; return 0; }
+safe_delete_branch() { echo "delete_branch $1 $2" >> "$TEST_TEMP_DIR/log"; return 0; }
 STUB
 
     POST_MERGE_PR_STUB="$TEST_TEMP_DIR/stubs.sh" run bash .buildkite/post-merge-pr-automation.sh


### PR DESCRIPTION
Switched draft-branch cleanup from git push origin --delete to gh api repo-specific deletion (with repo normalization), made deletion non-fatal/non-interactive, updated both cleanup scripts to pass repo explicitly