### PR TITLE
fix: github disconnect, slack omitempty, integrationid links

### DIFF
--- a/internal/httpserve/handlers/integration_github_webhook.go
+++ b/internal/httpserve/handlers/integration_github_webhook.go
@@ -9,6 +9,7 @@ import (
 	"entgo.io/ent/dialect/sql/sqljson"
 	echo "github.com/theopenlane/echox"
 	"github.com/theopenlane/iam/auth"
+	"github.com/theopenlane/utils/rout"
 
 	ent "github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/integration"
@@ -56,6 +57,11 @@ func (h *Handler) GitHubAppWebhookHandler(ctx echo.Context, openapiCtx *OpenAPIC
 
 	installation, err := h.resolveGitHubAppWebhookInstallation(webhookCtx, payload)
 	if err != nil {
+		if ent.IsNotFound(err) {
+			// installation already cleaned up — return 200 so GitHub does not retry
+			return h.Success(ctx, rout.Reply{Success: true}, openapiCtx)
+		}
+
 		logx.FromContext(webhookCtx).Error().Err(err).Interface("payload", string(payload)).Msg("failed to resolve github app webhook installation")
 
 		return h.BadRequest(ctx, err, openapiCtx)

--- a/internal/integrations/definitions/githubapp/auth.go
+++ b/internal/integrations/definitions/githubapp/auth.go
@@ -84,7 +84,6 @@ func completeAppInstall(ctx context.Context, cfg Config, state json.RawMessage, 
 		return types.AuthCompleteResult{}, ErrAuthStateMismatch
 	}
 
-	logx.FromContext(ctx).Debug().Interface("query", input.Query).Interface("input", input).Msg("MEOWWW")
 	raw := input.First("installation_id")
 	if raw == "" {
 		return types.AuthCompleteResult{}, ErrInstallationIDMissing
@@ -127,7 +126,6 @@ func disconnectInstallationID(ctx context.Context, req types.DisconnectRequest) 
 	}
 
 	if ok && cred.InstallationID != 0 {
-		logx.FromContext(ctx).Info().Interface("creds", cred).Msg("HERE")
 		return cred.InstallationID, cred.OrganizationName, nil
 	}
 

--- a/internal/integrations/definitions/githubapp/auth.go
+++ b/internal/integrations/definitions/githubapp/auth.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/theopenlane/core/internal/integrations/types"
 	"github.com/theopenlane/core/pkg/jsonx"
+	"github.com/theopenlane/core/pkg/logx"
 )
 
 const (
@@ -37,6 +38,8 @@ const (
 type disconnectDetails struct {
 	// InstallationID is the GitHub App installation ID being disconnected
 	InstallationID string `json:"installationId,omitempty"`
+	// OrganizationName is the organization the Github App was installed into
+	OrganizationName string `json:"organizationName,omitempty"`
 }
 
 // statePayload is the opaque state token round-tripped through the auth flow
@@ -81,6 +84,7 @@ func completeAppInstall(ctx context.Context, cfg Config, state json.RawMessage, 
 		return types.AuthCompleteResult{}, ErrAuthStateMismatch
 	}
 
+	logx.FromContext(ctx).Debug().Interface("query", input.Query).Interface("input", input).Msg("MEOWWW")
 	raw := input.First("installation_id")
 	if raw == "" {
 		return types.AuthCompleteResult{}, ErrInstallationIDMissing
@@ -91,13 +95,19 @@ func completeAppInstall(ctx context.Context, cfg Config, state json.RawMessage, 
 		return types.AuthCompleteResult{}, ErrInstallationIDMissing
 	}
 
-	cred, err := mintCredential(ctx, cfg, integrationID)
+	orgName, err := fetchInstallationAccount(ctx, cfg, integrationID)
+	if err != nil {
+		return types.AuthCompleteResult{}, err
+	}
+
+	cred, err := mintCredential(ctx, cfg, integrationID, orgName)
 	if err != nil {
 		return types.AuthCompleteResult{}, err
 	}
 
 	installInput, err := jsonx.ToRawMessage(InstallationMetadata{
-		InstallationID: strconv.FormatInt(integrationID, 10),
+		InstallationID:   strconv.FormatInt(integrationID, 10),
+		OrganizationName: orgName,
 	})
 	if err != nil {
 		return types.AuthCompleteResult{}, ErrInstallationMetadataEncode
@@ -110,35 +120,60 @@ func completeAppInstall(ctx context.Context, cfg Config, state json.RawMessage, 
 }
 
 // disconnectInstallationID extracts the installation ID from the credential or installation metadata
-func disconnectInstallationID(req types.DisconnectRequest) (int64, error) {
+func disconnectInstallationID(ctx context.Context, req types.DisconnectRequest) (int64, string, error) {
 	cred, ok, err := gitHubAppCredential.Resolve(req.Credentials)
 	if err != nil {
-		return 0, ErrCredentialDecode
+		return 0, "", ErrCredentialDecode
 	}
 
 	if ok && cred.InstallationID != 0 {
-		return cred.InstallationID, nil
+		logx.FromContext(ctx).Info().Interface("creds", cred).Msg("HERE")
+		return cred.InstallationID, cred.OrganizationName, nil
 	}
 
 	var metadata InstallationMetadata
 	if err := jsonx.UnmarshalIfPresent(req.Integration.InstallationMetadata.Attributes, &metadata); err != nil {
-		return 0, ErrInstallationMetadataDecode
+		return 0, "", ErrInstallationMetadataDecode
 	}
 
 	if metadata.InstallationID == "" {
-		return 0, ErrInstallationIDMissing
+		return 0, "", ErrInstallationIDMissing
 	}
 
 	integrationID, err := strconv.ParseInt(metadata.InstallationID, 10, 64)
 	if err != nil || integrationID == 0 {
-		return 0, ErrInstallationIDMissing
+		if err != nil {
+			logx.FromContext(ctx).Error().Err(err).Msg("githubapp: error getting installation id")
+		}
+		return 0, "", ErrInstallationIDMissing
 	}
 
-	return integrationID, nil
+	return integrationID, metadata.OrganizationName, nil
+}
+
+// fetchInstallationAccount fetches the organization name for the given installation ID
+// returns empty string for personal (User-type) account installations
+func fetchInstallationAccount(ctx context.Context, cfg Config, integrationID int64) (string, error) {
+	jwtToken, err := appJWT(cfg)
+	if err != nil {
+		return "", err
+	}
+
+	client := installationTokenClient(ctx, cfg, jwtToken)
+	install, _, err := client.Apps.GetInstallation(ctx, integrationID)
+	if err != nil {
+		return "", ErrInstallationTokenRequestFailed
+	}
+
+	if install.GetAccount().GetType() == "Organization" {
+		return install.GetAccount().GetLogin(), nil
+	}
+
+	return "", nil
 }
 
 // mintCredential mints an installation token and marshals it into a CredentialSet
-func mintCredential(ctx context.Context, cfg Config, integrationID int64) (types.CredentialSet, error) {
+func mintCredential(ctx context.Context, cfg Config, integrationID int64, orgName string) (types.CredentialSet, error) {
 	if cfg.AppID == "" {
 		return types.CredentialSet{}, ErrAppIDMissing
 	}
@@ -159,9 +194,10 @@ func mintCredential(ctx context.Context, cfg Config, integrationID int64) (types
 	}
 
 	cred := githubAppCredential{
-		AppID:          appIDInt,
-		InstallationID: integrationID,
-		AccessToken:    token.AccessToken,
+		AppID:            appIDInt,
+		InstallationID:   integrationID,
+		AccessToken:      token.AccessToken,
+		OrganizationName: orgName,
 	}
 
 	if !token.Expiry.IsZero() {

--- a/internal/integrations/definitions/githubapp/builder.go
+++ b/internal/integrations/definitions/githubapp/builder.go
@@ -64,24 +64,29 @@ func Builder(cfg Config) registry.Builder {
 					Disconnect: &types.DisconnectRegistration{
 						CredentialRef: gitHubAppCredential.ID(),
 						Description:   "Uninstall the Openlane GitHub App from your GitHub organization settings. Openlane will complete the removal after GitHub confirms the uninstall.",
-						Disconnect: func(_ context.Context, req types.DisconnectRequest) (types.DisconnectResult, error) {
-							integrationID, err := disconnectInstallationID(req)
+						Disconnect: func(ctx context.Context, req types.DisconnectRequest) (types.DisconnectResult, error) {
+							integrationID, name, err := disconnectInstallationID(ctx, req)
 							if err != nil {
 								return types.DisconnectResult{}, err
 							}
 
 							details, err := jsonx.ToRawMessage(disconnectDetails{
-								InstallationID: strconv.FormatInt(integrationID, 10),
+								InstallationID:   strconv.FormatInt(integrationID, 10),
+								OrganizationName: name,
 							})
 							if err != nil {
 								return types.DisconnectResult{}, ErrInstallationMetadataEncode
 							}
 
+							url := fmt.Sprintf("https://github.com/settings/installations/%d", integrationID)
+							if name != "" {
+								url = fmt.Sprintf("https://github.com/organizations/%s/settings/installations/%d", name, integrationID)
+							}
+
 							return types.DisconnectResult{
-								RedirectURL:      fmt.Sprintf("https://github.com/settings/installations/%d", integrationID),
-								Message:          "Uninstall the Openlane GitHub App in GitHub to finish disconnecting this integration.",
-								Details:          details,
-								SkipLocalCleanup: true,
+								RedirectURL: url,
+								Message:     "Uninstall the Openlane GitHub App in GitHub to finish disconnecting this integration.",
+								Details:     details,
 							}, nil
 						},
 					},

--- a/internal/integrations/definitions/githubapp/types.go
+++ b/internal/integrations/definitions/githubapp/types.go
@@ -61,6 +61,8 @@ type githubAppCredential struct {
 	AccessToken string `json:"accessToken"`
 	// Expiry is the token expiry timestamp when available
 	Expiry *time.Time `json:"expiry,omitempty"`
+	// OrganizationName is the organization this was installed in, needed for disconnect when installed in an organization
+	OrganizationName string `json:"organizationName,omitempty"`
 }
 
 // UserInput holds installation-specific configuration collected from the user
@@ -100,11 +102,14 @@ type RepositorySync struct {
 type InstallationMetadata struct {
 	// InstallationID is the GitHub App installation identifier
 	InstallationID string `json:"installationId,omitempty" jsonschema:"title=installation ID"`
+	// OrganizationName is the Organization the Github App was installed into, if empty it is installed in a personal org
+	OrganizationName string `json:"organizationName,omitempty"  jsonschema:"title=organization"`
 }
 
 // InstallationIdentity implements types.InstallationIdentifiable
 func (m InstallationMetadata) InstallationIdentity() types.IntegrationInstallationIdentity {
 	return types.IntegrationInstallationIdentity{
-		ExternalID: m.InstallationID,
+		ExternalID:   m.InstallationID,
+		ExternalName: m.OrganizationName,
 	}
 }

--- a/internal/integrations/definitions/slack/mappings.go
+++ b/internal/integrations/definitions/slack/mappings.go
@@ -8,7 +8,7 @@ import (
 
 // mapExprDirectoryAccount is the CEL mapping expression for Slack workspace user payloads mapped to DirectoryAccount
 var mapExprDirectoryAccount = providerkit.CelMapExpr([]providerkit.CelMapEntry{
-	{Key: integrationgenerated.IntegrationMappingDirectoryAccountExternalID, Expr: `payload.id : ""`},
+	{Key: integrationgenerated.IntegrationMappingDirectoryAccountExternalID, Expr: `payload.id`},
 	{Key: integrationgenerated.IntegrationMappingDirectoryAccountCanonicalEmail, Expr: `'email' in payload ? payload.email : ""`},
 	{Key: integrationgenerated.IntegrationMappingDirectoryAccountDisplayName, Expr: `'display_name' in payload && payload.display_name != "" ? payload.display_name : ('real_name' in payload && payload.real_name != "" ? payload.real_name : ('name' in payload ? payload.name : ""))`},
 	{Key: integrationgenerated.IntegrationMappingDirectoryAccountGivenName, Expr: `'first_name' in payload ? payload.first_name : ""`},
@@ -17,7 +17,7 @@ var mapExprDirectoryAccount = providerkit.CelMapExpr([]providerkit.CelMapEntry{
 	{Key: integrationgenerated.IntegrationMappingDirectoryAccountAvatarRemoteURL, Expr: `'avatar_url' in payload ? payload.avatar_url : ""`},
 	{Key: integrationgenerated.IntegrationMappingDirectoryAccountMfaState, Expr: `dyn(payload.has_2fa ? "ENABLED" : "DISABLED")`},
 	{Key: integrationgenerated.IntegrationMappingDirectoryAccountStatus, Expr: `dyn(payload.deleted ? "INACTIVE" : "ACTIVE")`},
-	{Key: integrationgenerated.IntegrationMappingDirectoryAccountDirectoryInstanceID, Expr: `payload.team_id : ""`},
+	{Key: integrationgenerated.IntegrationMappingDirectoryAccountDirectoryInstanceID, Expr: `payload.team_id`},
 	{Key: integrationgenerated.IntegrationMappingDirectoryAccountProfile, Expr: "payload"},
 	{Key: integrationgenerated.IntegrationMappingDirectoryAccountAccountType, Expr: `payload.is_bot ? "SERVICE" : payload.is_external ? "GUEST" : "USER"`},
 })

--- a/internal/integrations/definitions/slack/mappings.go
+++ b/internal/integrations/definitions/slack/mappings.go
@@ -8,18 +8,18 @@ import (
 
 // mapExprDirectoryAccount is the CEL mapping expression for Slack workspace user payloads mapped to DirectoryAccount
 var mapExprDirectoryAccount = providerkit.CelMapExpr([]providerkit.CelMapEntry{
-	{Key: integrationgenerated.IntegrationMappingDirectoryAccountExternalID, Expr: `'id' in payload ? payload.id : ""`},
+	{Key: integrationgenerated.IntegrationMappingDirectoryAccountExternalID, Expr: `payload.id : ""`},
 	{Key: integrationgenerated.IntegrationMappingDirectoryAccountCanonicalEmail, Expr: `'email' in payload ? payload.email : ""`},
 	{Key: integrationgenerated.IntegrationMappingDirectoryAccountDisplayName, Expr: `'display_name' in payload && payload.display_name != "" ? payload.display_name : ('real_name' in payload && payload.real_name != "" ? payload.real_name : ('name' in payload ? payload.name : ""))`},
 	{Key: integrationgenerated.IntegrationMappingDirectoryAccountGivenName, Expr: `'first_name' in payload ? payload.first_name : ""`},
 	{Key: integrationgenerated.IntegrationMappingDirectoryAccountFamilyName, Expr: `'last_name' in payload ? payload.last_name : ""`},
 	{Key: integrationgenerated.IntegrationMappingDirectoryAccountJobTitle, Expr: `'title' in payload ? payload.title : ""`},
 	{Key: integrationgenerated.IntegrationMappingDirectoryAccountAvatarRemoteURL, Expr: `'avatar_url' in payload ? payload.avatar_url : ""`},
-	{Key: integrationgenerated.IntegrationMappingDirectoryAccountMfaState, Expr: `dyn('has_2fa' in payload && payload.has_2fa ? "ENABLED" : "DISABLED")`},
-	{Key: integrationgenerated.IntegrationMappingDirectoryAccountStatus, Expr: `dyn('deleted' in payload && payload.deleted ? "INACTIVE" : "ACTIVE")`},
-	{Key: integrationgenerated.IntegrationMappingDirectoryAccountDirectoryInstanceID, Expr: `'team_id' in payload ? payload.team_id : ""`},
+	{Key: integrationgenerated.IntegrationMappingDirectoryAccountMfaState, Expr: `dyn(payload.has_2fa ? "ENABLED" : "DISABLED")`},
+	{Key: integrationgenerated.IntegrationMappingDirectoryAccountStatus, Expr: `dyn(payload.deleted ? "INACTIVE" : "ACTIVE")`},
+	{Key: integrationgenerated.IntegrationMappingDirectoryAccountDirectoryInstanceID, Expr: `payload.team_id : ""`},
 	{Key: integrationgenerated.IntegrationMappingDirectoryAccountProfile, Expr: "payload"},
-	{Key: integrationgenerated.IntegrationMappingDirectoryAccountAccountType, Expr: `'is_bot' in payload && payload.is_bot ? "SERVICE" : 'is_external' in payload && payload.is_external ? "GUEST" : "USER"`},
+	{Key: integrationgenerated.IntegrationMappingDirectoryAccountAccountType, Expr: `payload.is_bot ? "SERVICE" : payload.is_external ? "GUEST" : "USER"`},
 })
 
 // slackMappings returns the built-in Slack ingest mappings

--- a/internal/integrations/definitions/slack/operation_directory_sync.go
+++ b/internal/integrations/definitions/slack/operation_directory_sync.go
@@ -14,9 +14,9 @@ import (
 // slackUserPayload is the normalized payload for a Slack workspace user
 type slackUserPayload struct {
 	// ID is the Slack user identifier
-	ID string `json:"id,omitempty"`
+	ID string `json:"id"`
 	// TeamID is the Slack team/workspace identifier
-	TeamID string `json:"team_id,omitempty"`
+	TeamID string `json:"team_id"`
 	// Name is the Slack username (handle)
 	Name string `json:"name,omitempty"`
 	// RealName is the user's full display name
@@ -34,21 +34,21 @@ type slackUserPayload struct {
 	// AvatarURL is the user's avatar image URL
 	AvatarURL string `json:"avatar_url,omitempty"`
 	// Deleted reports whether the user account has been deactivated
-	Deleted bool `json:"deleted,omitempty"`
+	Deleted bool `json:"deleted"`
 	// IsBot reports whether this user is a bot account
-	IsBot bool `json:"is_bot,omitempty"`
+	IsBot bool `json:"is_bot"`
 	// IsAdmin reports whether the user is a workspace admin
-	IsAdmin bool `json:"is_admin,omitempty"`
+	IsAdmin bool `json:"is_admin"`
 	// Has2FA reports whether 2FA is enabled for the user
-	Has2FA bool `json:"has_2fa,omitempty"`
+	Has2FA bool `json:"has_2fa"`
 	// IsRestricted reports whether this user is a restricted user (e.g. multi channel guest)
-	IsRestricted bool `json:"is_restricted,omitempty"`
+	IsRestricted bool `json:"is_restricted"`
 	// IsUltraRestricted reports whether this user is a restricted user (e.g. single channel guest)
-	IsUltraRestricted bool `json:"is_ultra_restricted,omitempty"`
+	IsUltraRestricted bool `json:"is_ultra_restricted"`
 	// IsStranger reports whether this user is a external user (e.g. slack-connect)
-	IsStranger bool `json:"is_stranger,omitempty"`
+	IsStranger bool `json:"is_stranger"`
 	// IsExternal reports whether this user is a external user (e.g. slack-connect)
-	IsExternal bool `json:"is_external,omitempty"`
+	IsExternal bool `json:"is_external"`
 }
 
 // IngestHandle adapts directory sync to the ingest operation registration boundary

--- a/internal/integrations/operations/ingest.go
+++ b/internal/integrations/operations/ingest.go
@@ -141,7 +141,7 @@ func applyPayloadSets(ctx context.Context, ic IngestContext, operationName strin
 		for _, envelope := range payloadSet.Envelopes {
 			record, include, err := mapIngestRecord(ctx, definition, payloadSet.Schema, envelope, installationFilterExpr)
 			if err != nil {
-				logx.FromContext(ctx).Error().Err(err).Str("schema", payloadSet.Schema).Msg("integration: error mapping ingest record")
+				logx.FromContext(ctx).Error().Err(err).Str("integration", definition.Family).Str("integration_id", definition.ID).Str("schema", payloadSet.Schema).Msg("integration: error mapping ingest record")
 				return err
 			}
 

--- a/internal/integrations/operations/ingest_asset_persist.go
+++ b/internal/integrations/operations/ingest_asset_persist.go
@@ -19,6 +19,10 @@ func persistAssetInput(ctx context.Context, db *ent.Client, integration *ent.Int
 		createInput.SourceType = &enums.SourceTypeImported
 	}
 
+	if createInput.IntegrationID == nil {
+		createInput.IntegrationID = &integration.ID
+	}
+
 	return persistRoundTripUpsert(
 		ctx,
 		createInput,

--- a/internal/integrations/operations/ingest_checkresult_persist.go
+++ b/internal/integrations/operations/ingest_checkresult_persist.go
@@ -19,6 +19,10 @@ func persistCheckResultInput(ctx context.Context, db *ent.Client, integration *e
 		createInput.Source = integration.Name
 	}
 
+	if createInput.IntegrationID == nil {
+		createInput.IntegrationID = &integration.ID
+	}
+
 	where := []predicate.CheckResult{
 		checkresult.ParentExternalID(*createInput.ParentExternalID),
 		checkresult.IntegrationID(*createInput.IntegrationID),

--- a/internal/integrations/operations/ingest_contact_persist.go
+++ b/internal/integrations/operations/ingest_contact_persist.go
@@ -20,6 +20,10 @@ func persistContactInput(ctx context.Context, db *ent.Client, integration *ent.I
 		return ErrIngestUpsertKeyMissing
 	}
 
+	if createInput.IntegrationID == nil {
+		createInput.IntegrationID = &integration.ID
+	}
+
 	q := db.Contact.Query().Where(contact.OwnerID(integration.OwnerID))
 
 	switch {

--- a/internal/integrations/operations/ingest_entity_persist.go
+++ b/internal/integrations/operations/ingest_entity_persist.go
@@ -3,6 +3,7 @@ package operations
 
 import (
 	"context"
+	"slices"
 
 	ent "github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/entity"
@@ -16,6 +17,10 @@ func persistEntityInput(ctx context.Context, db *ent.Client, integration *ent.In
 
 	if createInput.EntitySourceTypeName == nil && integration.Name != "" {
 		createInput.EntitySourceTypeName = &integration.Name
+	}
+
+	if !slices.Contains(createInput.IntegrationIDs, integration.ID) {
+		createInput.IntegrationIDs = append(createInput.IntegrationIDs, integration.ID)
 	}
 
 	return persistRoundTripUpsert(

--- a/internal/integrations/operations/ingest_finding_persist.go
+++ b/internal/integrations/operations/ingest_finding_persist.go
@@ -3,6 +3,7 @@ package operations
 
 import (
 	"context"
+	"slices"
 
 	ent "github.com/theopenlane/core/internal/ent/generated"
 	finding "github.com/theopenlane/core/internal/ent/generated/finding"
@@ -22,6 +23,10 @@ func persistFindingInput(ctx context.Context, db *ent.Client, integration *ent.I
 	if createInput.Description != nil && *createInput.Description != "" {
 		normalized := normalizeDescription(*createInput.Description)
 		createInput.Description = &normalized
+	}
+
+	if !slices.Contains(createInput.IntegrationIDs, integration.ID) {
+		createInput.IntegrationIDs = append(createInput.IntegrationIDs, integration.ID)
 	}
 
 	return persistRoundTripUpsert(

--- a/internal/integrations/operations/ingest_risk_persist.go
+++ b/internal/integrations/operations/ingest_risk_persist.go
@@ -14,6 +14,10 @@ func persistRiskInput(ctx context.Context, db *ent.Client, integration *ent.Inte
 		return ErrIngestUpsertKeyMissing
 	}
 
+	if createInput.IntegrationID == nil {
+		createInput.IntegrationID = &integration.ID
+	}
+
 	return persistRoundTripUpsert(
 		ctx,
 		createInput,

--- a/internal/integrations/operations/ingest_test.go
+++ b/internal/integrations/operations/ingest_test.go
@@ -890,8 +890,8 @@ func TestProcessPayloadSets_NestedFilterDoesNotLeakAcrossOperations(t *testing.T
 		FilterExpr string `json:"filterExpr,omitempty"`
 	}
 	type userInput struct {
-		FindingSync findingSyncCfg `json:"findingSync,omitempty"`
-		DirectorySync assetSyncCfg `json:"directorySync,omitempty"`
+		FindingSync   findingSyncCfg `json:"findingSync,omitempty"`
+		DirectorySync assetSyncCfg   `json:"directorySync,omitempty"`
 	}
 
 	def := types.Definition{

--- a/internal/integrations/operations/ingest_vulnerability_persist.go
+++ b/internal/integrations/operations/ingest_vulnerability_persist.go
@@ -3,6 +3,7 @@ package operations
 
 import (
 	"context"
+	"slices"
 
 	ent "github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/vulnerability"
@@ -21,6 +22,10 @@ func persistVulnerabilityInput(ctx context.Context, db *ent.Client, integration 
 	if createInput.Description != nil && *createInput.Description != "" {
 		normalized := normalizeDescription(*createInput.Description)
 		createInput.Description = &normalized
+	}
+
+	if !slices.Contains(createInput.IntegrationIDs, integration.ID) {
+		createInput.IntegrationIDs = append(createInput.IntegrationIDs, integration.ID)
 	}
 
 	return persistRoundTripUpsert(

--- a/internal/integrations/runtime/integration.go
+++ b/internal/integrations/runtime/integration.go
@@ -92,7 +92,7 @@ func (r *Runtime) createVendor(ctx context.Context, ownerID string, def types.De
 		entity.OwnerID(ownerID),
 	).IDs(ctx)
 	if err != nil {
-		logx.FromContext(ctx).Info().Err(err).Msg("error looking for existing vendor, skipping creation")
+		logx.FromContext(ctx).Info().Err(err).Str("vendor", def.Family).Str("org_id", ownerID).Msg("error looking for existing vendor, skipping creation")
 		return
 	}
 
@@ -101,8 +101,12 @@ func (r *Runtime) createVendor(ctx context.Context, ownerID string, def types.De
 		ctxAllow := privacy.DecisionContext(ctx, privacy.Allow)
 		if err := r.DB().Entity.Update().Where(entity.IDIn(vendorIDs...)).AddIntegrationIDs(
 			integrationID).Exec(ctxAllow); err != nil {
-			logx.FromContext(ctx).Info().Err(err).Msg("error update vendor edges to integration")
+			logx.FromContext(ctx).Info().Err(err).Str("vendor", def.Family).Str("org_id", ownerID).Msg("error update vendor edges to integration")
 		}
+
+		logx.FromContext(ctx).Debug().Str("vendor", def.Family).Str("org_id", ownerID).Msg("successfully updated vendor from integration setup")
+
+		return
 	}
 
 	vendorInput := ent.CreateEntityInput{
@@ -126,7 +130,7 @@ func (r *Runtime) createVendor(ctx context.Context, ownerID string, def types.De
 		).
 		Only(ctx)
 	if err != nil {
-		logx.FromContext(ctx).Info().Err(err).Msg("error looking up vendor entity type, skipping creation")
+		logx.FromContext(ctx).Info().Err(err).Str("vendor", def.Family).Str("org_id", ownerID).Msg("error looking up vendor entity type, skipping creation")
 		return
 	}
 
@@ -135,5 +139,5 @@ func (r *Runtime) createVendor(ctx context.Context, ownerID string, def types.De
 		return
 	}
 
-	logx.FromContext(ctx).Debug().Str("vendor", def.Family).Msg("successfully created vendor from integration setup")
+	logx.FromContext(ctx).Debug().Str("vendor", def.Family).Str("org_id", ownerID).Msg("successfully created vendor from integration setup")
 }

--- a/internal/integrations/types/ref.go
+++ b/internal/integrations/types/ref.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/rs/zerolog/log"
 	"github.com/theopenlane/core/pkg/gala"
 	"github.com/theopenlane/core/pkg/jsonx"
 )
@@ -142,6 +143,8 @@ func (r CredentialRef[T]) Resolve(bindings CredentialBindings) (T, bool, error) 
 	if err := json.Unmarshal(cred.Data, &out); err != nil {
 		return out, true, err
 	}
+
+	log.Debug().Interface("bindings", bindings).Interface("out", out).Msg("HERE NOW")
 
 	return out, true, nil
 }

--- a/internal/integrations/types/ref.go
+++ b/internal/integrations/types/ref.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/rs/zerolog/log"
 	"github.com/theopenlane/core/pkg/gala"
 	"github.com/theopenlane/core/pkg/jsonx"
 )
@@ -143,8 +142,6 @@ func (r CredentialRef[T]) Resolve(bindings CredentialBindings) (T, bool, error) 
 	if err := json.Unmarshal(cred.Data, &out); err != nil {
 		return out, true, err
 	}
-
-	log.Debug().Interface("bindings", bindings).Interface("out", out).Msg("HERE NOW")
 
 	return out, true, nil
 }


### PR DESCRIPTION
- Fixes issue with github disconnect that would use the personal org url instead of org url when installed in an organization
- Fixes issue where the github integration wasn't actually deleted from our system on disconnect
- Updates slack fields to not `omitempty` on booleans, allowing for easier CEL since `false` would be considered empty
- Sets integration edge on persist options where it was missing from
- Fixes missing return on vendor update so that we dont try to insert a duplicate record