### PR TITLE
add metrics for integration install vs. disconnect

### DIFF
--- a/internal/integrations/runtime/credentials.go
+++ b/internal/integrations/runtime/credentials.go
@@ -17,6 +17,7 @@ import (
 	"github.com/theopenlane/core/pkg/jsonx"
 	"github.com/theopenlane/core/pkg/logx"
 	"github.com/theopenlane/core/pkg/mapx"
+	"github.com/theopenlane/core/pkg/metrics"
 )
 
 // BeginAuth starts one definition auth flow through the runtime-managed keymaker service
@@ -91,6 +92,8 @@ func (r *Runtime) Disconnect(ctx context.Context, installation *ent.Integration)
 	if err := r.cleanupInstallation(ctx, installation.ID); err != nil {
 		return types.DisconnectResult{}, err
 	}
+
+	metrics.RecordIntegrationDisconnected(installation.DefinitionID)
 
 	return result, nil
 }

--- a/internal/integrations/runtime/integration.go
+++ b/internal/integrations/runtime/integration.go
@@ -13,6 +13,7 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated/subprocessor"
 	"github.com/theopenlane/core/internal/integrations/types"
 	"github.com/theopenlane/core/pkg/logx"
+	"github.com/theopenlane/core/pkg/metrics"
 )
 
 // IntegrationLookup holds the query constraints for resolving an integration
@@ -73,6 +74,9 @@ func (r *Runtime) EnsureInstallation(ctx context.Context, ownerID, integrationID
 	if err != nil {
 		return nil, false, err
 	}
+
+	// record new installed integration
+	metrics.RecordIntegrationInstalled(def.ID)
 
 	// attempt to create vendor record
 	r.createVendor(ctx, ownerID, def, record.ID)

--- a/pkg/metrics/helpers.go
+++ b/pkg/metrics/helpers.go
@@ -289,3 +289,13 @@ func RecordWorkflowOperation(operation, origin, trigger string, duration time.Du
 func RecordWorkflowEmitError(topic, origin string) {
 	WorkflowEmitErrorsTotal.WithLabelValues(topic, origin).Inc()
 }
+
+// RecordIntegrationInstalled records an installation operation for an integration provider
+func RecordIntegrationInstalled(definitionID string) {
+	IntegrationProviderInstalls.WithLabelValues(definitionID).Inc()
+}
+
+// RecordIntegrationDisconnected records a disconnect operation for an integration provider
+func RecordIntegrationDisconnected(definitionID string) {
+	IntegrationProviderDisconnects.WithLabelValues(definitionID).Inc()
+}

--- a/pkg/metrics/vars.go
+++ b/pkg/metrics/vars.go
@@ -217,16 +217,30 @@ var (
 		Help: "The total number of workflow operations by origin, trigger, and success",
 	}, []string{"operation", "origin", "trigger", "success"})
 
+	// WorkflowOperationDuration tracks how long a workflow took in seconds
 	WorkflowOperationDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "openlane_workflow_operation_duration_seconds",
 		Help:    "The duration of workflow operations in seconds",
 		Buckets: prometheus.DefBuckets,
 	}, []string{"operation", "origin", "trigger"})
 
+	// WorkflowEmitErrorsTotal tracks the errors by topic for a workflow
 	WorkflowEmitErrorsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "openlane_workflow_emit_errors_total",
 		Help: "The total number of workflow emit errors by topic and origin",
 	}, []string{"topic", "origin"})
+
+	// IntegrationProviderInstalls tracks the number of install operations per integration provider
+	IntegrationProviderInstalls = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "openlane_integration_provider_installs_total",
+		Help: "Total number of installs per integration provider",
+	}, []string{"provider"})
+
+	// IntegrationProviderDisconnects tracks the number of disconnect operations per integration provider
+	IntegrationProviderDisconnects = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "openlane_integration_provider_disconnect_total",
+		Help: "Total number of disconnect per integration provider",
+	}, []string{"provider"})
 
 	APIMetrics = []prometheus.Collector{
 		WorkerExecutions,
@@ -257,6 +271,8 @@ var (
 		WorkflowOperationsTotal,
 		WorkflowOperationDuration,
 		WorkflowEmitErrorsTotal,
+		IntegrationProviderInstalls,
+		IntegrationProviderDisconnects,
 	}
 
 	// SubscriptionMetrics is the list of all metrics specific to graph subscriptions and websocket connections


### PR DESCRIPTION
```
# HELP openlane_integration_provider_disconnect_total Total number of disconnect per integration provider
# TYPE openlane_integration_provider_disconnect_total counter
openlane_integration_provider_disconnect_total{provider="def_01K0GWKSP000000000000000001"} 1
# HELP openlane_integration_provider_installs_total Total number of installs per integration provider
# TYPE openlane_integration_provider_installs_total counter
openlane_integration_provider_installs_total{provider="def_01K0GWKSP000000000000000001"} 1
```