### PR TITLE
update default revision bump when document details are updated

### DIFF
--- a/internal/ent/hooks/revision.go
+++ b/internal/ent/hooks/revision.go
@@ -135,7 +135,7 @@ func detailsUpdated(ctx context.Context, m MutationWithRevision) bool {
 		oldDetailsTyped, _ := oldDetailsJSON.([]any)
 		newDetailsTyped, _ := newDetailsJSON.([]any)
 
-		return slateparser.OnlyCommentsAdded(oldDetailsTyped, newDetailsTyped)
+		return !slateparser.OnlyCommentsAdded(oldDetailsTyped, newDetailsTyped)
 	}
 
 	// if details json is not set, fallback to check details

--- a/internal/ent/hooks/revision.go
+++ b/internal/ent/hooks/revision.go
@@ -78,15 +78,12 @@ func SetNewRevision(ctx context.Context, mut MutationWithRevision) error {
 
 	revisionBump, ok := models.VersionBumpFromRequestContext(ctx)
 	if !ok {
-		logx.FromContext(ctx).Error().Msg("HERE")
 		// derive based on if there were meaningful updates to the details of the document
 		revisionBump = &models.Patch
 		if detailsUpdated(ctx, mut) {
 			revisionBump = &models.Minor
 		}
 	}
-
-	logx.FromContext(ctx).Error().Str("bump", revisionBump.String()).Msg("HERE 2")
 
 	var newVersion string
 

--- a/internal/ent/hooks/revision.go
+++ b/internal/ent/hooks/revision.go
@@ -135,11 +135,7 @@ func detailsUpdated(ctx context.Context, m MutationWithRevision) bool {
 		oldDetailsTyped, _ := oldDetailsJSON.([]any)
 		newDetailsTyped, _ := newDetailsJSON.([]any)
 
-		if slateparser.OnlyCommentsAdded(oldDetailsTyped, newDetailsTyped) {
-			return false
-		}
-
-		return true
+		return slateparser.OnlyCommentsAdded(oldDetailsTyped, newDetailsTyped)
 	}
 
 	// if details json is not set, fallback to check details

--- a/internal/ent/hooks/revision.go
+++ b/internal/ent/hooks/revision.go
@@ -5,10 +5,12 @@ import (
 
 	"entgo.io/ent"
 
+	"github.com/samber/lo"
 	"github.com/theopenlane/core/common/models"
 	"github.com/theopenlane/core/internal/ent/generated/hook"
 	"github.com/theopenlane/core/internal/ent/privacy/utils"
 	"github.com/theopenlane/core/pkg/logx"
+	"github.com/theopenlane/core/pkg/slateparser"
 )
 
 // MutationWithRevision is an interface that defines the methods
@@ -19,6 +21,7 @@ type MutationWithRevision interface {
 	RevisionCleared() bool
 	OldRevision(ctx context.Context) (string, error)
 	SetRevision(s string)
+	OldField(ctx context.Context, name string) (ent.Value, error)
 
 	utils.GenericMutation
 }
@@ -26,11 +29,15 @@ type MutationWithRevision interface {
 // HookRevisionUpdate is a hook that runs on update mutations
 // to handle the revision of an object
 // It checks if the revision is set, and if not, it retrieves the current revision from the database
-// and bumps the patch version
+// and bumps the patch version if just metadata was updated, bumps minor for details or details_json updates
 // If the revision is cleared, it sets the revision to the default value
 func HookRevisionUpdate() ent.Hook {
 	return hook.If(func(next ent.Mutator) ent.Mutator {
 		return ent.MutateFunc(func(ctx context.Context, m ent.Mutation) (ent.Value, error) {
+			if isDeleteOp(ctx, m) {
+				return next.Mutate(ctx, m)
+			}
+
 			mut := m.(MutationWithRevision)
 
 			if mut.RevisionCleared() {
@@ -71,8 +78,15 @@ func SetNewRevision(ctx context.Context, mut MutationWithRevision) error {
 
 	revisionBump, ok := models.VersionBumpFromRequestContext(ctx)
 	if !ok {
+		logx.FromContext(ctx).Error().Msg("HERE")
+		// derive based on if there were meaningful updates to the details of the document
 		revisionBump = &models.Patch
+		if detailsUpdated(ctx, mut) {
+			revisionBump = &models.Minor
+		}
 	}
+
+	logx.FromContext(ctx).Error().Str("bump", revisionBump.String()).Msg("HERE 2")
 
 	var newVersion string
 
@@ -99,4 +113,71 @@ func SetNewRevision(ctx context.Context, mut MutationWithRevision) error {
 	mut.SetRevision(newVersion)
 
 	return nil
+}
+
+const (
+	detailsJSONFieldName = "details_json"
+	detailsFieldName     = "details"
+)
+
+// detailsUpdated checks if the details were updated on a mutation, if so
+// this will return true, otherwise returns false.
+// this is always an updateOne mutation that we are concerned about, so we can simplify
+// any logic related to create/delete/update many
+func detailsUpdated(ctx context.Context, m MutationWithRevision) bool {
+	fields := m.Fields()
+
+	// check of the changed fields contains details json
+	// if so, if only comments were added do not bump minor
+	// if more than comments were added, bump minor
+	if lo.Contains(fields, detailsJSONFieldName) {
+		// get the old details json value from the mutation
+		oldDetailsJSON, _ := m.OldField(ctx, detailsJSONFieldName)
+		newDetailsJSON, _ := m.Field(detailsJSONFieldName)
+
+		oldDetailsTyped, _ := oldDetailsJSON.([]any)
+		newDetailsTyped, _ := newDetailsJSON.([]any)
+
+		if slateparser.OnlyCommentsAdded(oldDetailsTyped, newDetailsTyped) {
+			return false
+		}
+
+		return true
+	}
+
+	// if details json is not set, fallback to check details
+	// this will not need to check comments as this would be be an API update
+	// UI will always set details_json.
+	if lo.Contains(fields, detailsFieldName) {
+		// get the old details json value from the mutation
+		oldDetails, oldErr := m.OldField(ctx, detailsFieldName)
+		newDetails, newOk := m.Field(detailsFieldName)
+		if !newOk || (oldErr != nil && !newOk) {
+			return false
+		}
+
+		if oldErr != nil && newOk {
+			return true
+		}
+
+		oldDetailsString, oldOk := oldDetails.(string)
+		newDetailsString, newOk := newDetails.(string)
+		if !newOk || (!oldOk && !newOk) {
+			return false
+		}
+
+		// if the old is not ok,  but new is, that indicates the new value is set and old value is not
+		// so this is an update
+		if !oldOk && newOk {
+			return true
+		}
+
+		if oldDetailsString == newDetailsString {
+			return false
+		}
+
+		return true
+	}
+
+	return false
 }

--- a/internal/graphapi/internalpolicy_test.go
+++ b/internal/graphapi/internalpolicy_test.go
@@ -511,12 +511,13 @@ func TestMutationUpdateInternalPolicy(t *testing.T) {
 	task := (&TaskBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 
 	testCases := []struct {
-		name        string
-		policyID    string
-		request     testclient.UpdateInternalPolicyInput
-		client      *testclient.TestClient
-		ctx         context.Context
-		expectedErr string
+		name             string
+		policyID         string
+		request          testclient.UpdateInternalPolicyInput
+		client           *testclient.TestClient
+		ctx              context.Context
+		expectedErr      string
+		expectedRevision string
 	}{
 		{
 			name:     "happy path, update details field",
@@ -524,8 +525,9 @@ func TestMutationUpdateInternalPolicy(t *testing.T) {
 			request: testclient.UpdateInternalPolicyInput{
 				Details: lo.ToPtr(gofakeit.Sentence()),
 			},
-			client: suite.client.api,
-			ctx:    testUser1.UserCtx,
+			client:           suite.client.api,
+			ctx:              testUser1.UserCtx,
+			expectedRevision: "v0.1.0", // details updated, should be a minor update
 		},
 		{
 			name:     "happy path, update details field on policy created by another user",
@@ -533,8 +535,9 @@ func TestMutationUpdateInternalPolicy(t *testing.T) {
 			request: testclient.UpdateInternalPolicyInput{
 				Details: lo.ToPtr(gofakeit.Sentence()),
 			},
-			client: suite.client.api,
-			ctx:    testUser1.UserCtx, // org owner should always be able to update the policy
+			client:           suite.client.api,
+			ctx:              testUser1.UserCtx, // org owner should always be able to update the policy
+			expectedRevision: "v0.1.0",          // details updated, should be a minor update (different policy than test 1)
 		},
 		{
 			name:     "happy path, update name field",
@@ -543,8 +546,9 @@ func TestMutationUpdateInternalPolicy(t *testing.T) {
 				Name:         lo.ToPtr("Updated InternalPolicy Name"),
 				AddEditorIDs: []string{testUser1.GroupID}, // add the group to the editor groups for subsequent tests
 			},
-			client: suite.client.api,
-			ctx:    testUser1.UserCtx,
+			client:           suite.client.api,
+			ctx:              testUser1.UserCtx,
+			expectedRevision: "v0.1.1", // no details updated, should be a patch update
 		},
 		{
 			name:     "happy path, update multiple fields",
@@ -557,8 +561,9 @@ func TestMutationUpdateInternalPolicy(t *testing.T) {
 				AddSubcontrolIDs: []string{subcontrol.ID},
 				AddTaskIDs:       []string{task.ID},
 			},
-			client: suite.client.apiWithPAT,
-			ctx:    context.Background(),
+			client:           suite.client.apiWithPAT,
+			ctx:              context.Background(),
+			expectedRevision: "v1.0.0", // details updated, but revision bump set to major
 		},
 		{
 			name:     "member allowed to add comment",
@@ -568,8 +573,9 @@ func TestMutationUpdateInternalPolicy(t *testing.T) {
 					Text: "This is a comment from a member user",
 				},
 			},
-			client: suite.client.api,
-			ctx:    viewOnlyUser.UserCtx,
+			client:           suite.client.api,
+			ctx:              viewOnlyUser.UserCtx,
+			expectedRevision: "v1.0.1", // only comment added, should be a patch update
 		},
 		{
 			name:     "member not allowed to update details",
@@ -600,8 +606,9 @@ func TestMutationUpdateInternalPolicy(t *testing.T) {
 			request: testclient.UpdateInternalPolicyInput{
 				Name: lo.ToPtr("Updated Procedure Name Again"),
 			},
-			client: suite.client.api,
-			ctx:    adminUser.UserCtx,
+			client:           suite.client.api,
+			ctx:              adminUser.UserCtx,
+			expectedRevision: "v1.0.2", // no details updated, should be a patch update
 		},
 		{
 			name:     "member update allowed, user in editor group",
@@ -609,8 +616,9 @@ func TestMutationUpdateInternalPolicy(t *testing.T) {
 			request: testclient.UpdateInternalPolicyInput{
 				Name: lo.ToPtr("Updated Procedure Name Again"),
 			},
-			client: suite.client.api,
-			ctx:    anotherViewerUser.UserCtx, // user assigned to the group which has editor permissions
+			client:           suite.client.api,
+			ctx:              anotherViewerUser.UserCtx, // user assigned to the group which has editor permissions
+			expectedRevision: "v1.0.3",                  // no details updated, should be a patch update
 		},
 		{
 			name:     "member update allowed, user in editor group as admin",
@@ -618,8 +626,9 @@ func TestMutationUpdateInternalPolicy(t *testing.T) {
 			request: testclient.UpdateInternalPolicyInput{
 				Name: lo.ToPtr("Updated Procedure Name Again by Group Admin"),
 			},
-			client: suite.client.api,
-			ctx:    anotherViewerGroupAdminUser.UserCtx, // user assigned to the group which has editor permissions as admin
+			client:           suite.client.api,
+			ctx:              anotherViewerGroupAdminUser.UserCtx, // user assigned to the group which has editor permissions as admin
+			expectedRevision: "v1.0.4",                            // no details updated, should be a patch update
 		},
 		{
 			name:     "happy path, block the group from editing",
@@ -627,8 +636,9 @@ func TestMutationUpdateInternalPolicy(t *testing.T) {
 			request: testclient.UpdateInternalPolicyInput{
 				AddBlockedGroupIDs: []string{blockGroup.ID}, // block the group
 			},
-			client: suite.client.api,
-			ctx:    testUser1.UserCtx,
+			client:           suite.client.api,
+			ctx:              testUser1.UserCtx,
+			expectedRevision: "v1.0.5", // no details updated, should be a patch update
 		},
 		{
 			name:     "member update no longer allowed, user in blocked group",
@@ -646,8 +656,9 @@ func TestMutationUpdateInternalPolicy(t *testing.T) {
 			request: testclient.UpdateInternalPolicyInput{
 				RemoveEditorIDs: []string{testUser1.GroupID}, // remove the group from the editor groups
 			},
-			client: suite.client.api,
-			ctx:    testUser1.UserCtx,
+			client:           suite.client.api,
+			ctx:              testUser1.UserCtx,
+			expectedRevision: "v1.0.6", // no details updated, should be a patch update
 		},
 		{
 			name:     "update not allowed, editor group was removed",
@@ -696,9 +707,7 @@ func TestMutationUpdateInternalPolicy(t *testing.T) {
 				assert.Check(t, is.Equal(*tc.request.Status, *resp.UpdateInternalPolicy.InternalPolicy.Status))
 			}
 
-			if tc.request.Revision != nil {
-				assert.Check(t, is.Equal(*tc.request.Revision, *resp.UpdateInternalPolicy.InternalPolicy.Revision))
-			}
+			assert.Check(t, is.Equal(*&tc.expectedRevision, *resp.UpdateInternalPolicy.InternalPolicy.Revision))
 
 			if tc.request.RevisionBump == &models.Major {
 				assert.Check(t, is.Equal("v1.0.0", *resp.UpdateInternalPolicy.InternalPolicy.Revision))

--- a/pkg/slateparser/utils.go
+++ b/pkg/slateparser/utils.go
@@ -2,7 +2,6 @@ package slateparser
 
 import (
 	"encoding/json"
-	"fmt"
 	"maps"
 )
 
@@ -51,7 +50,6 @@ func OnlyCommentsAdded(oldText []any, newText []any) bool {
 	newChildren := getChildrenFromSlateTextJSON(newText)
 
 	if len(oldChildren) != len(newChildren) {
-		fmt.Printf("old and new children have different lengths, old: %d, new: %d\n", len(oldChildren), len(newChildren))
 		return false
 	}
 


### PR DESCRIPTION
In order to better support a history of policies in the UI, this update will now update the `minor` version by default when `details` or `details_json` are changed, keeping the default patch behavior when any metadata fields are changed. 