### PR TITLE
fix: nil pointer bug due to non comparable map

### DIFF
--- a/pkg/slateparser/utils.go
+++ b/pkg/slateparser/utils.go
@@ -2,7 +2,7 @@ package slateparser
 
 import (
 	"encoding/json"
-	"maps"
+	"strings"
 )
 
 // ContainsCommentsInTextJSON checks if the provided slate JSON elements contain any comments
@@ -20,8 +20,10 @@ func ContainsCommentsInTextJSON(elements []any) bool {
 	return false
 }
 
+// getChildrenFromSlateTextJSON recursively collects all leaf nodes (nodes with a "text" key)
+// from the slate element tree, handling both JSON string and map[string]any inputs
 func getChildrenFromSlateTextJSON(elements []any) []any {
-	children := make([]any, 0)
+	var leaves []any
 	for _, elem := range elements {
 		var m map[string]any
 		switch v := elem.(type) {
@@ -34,67 +36,97 @@ func getChildrenFromSlateTextJSON(elements []any) []any {
 		default:
 			continue
 		}
+		collectLeafNodes(m, &leaves)
+	}
+	return leaves
+}
 
-		if c, ok := m["children"].([]any); ok {
-			children = append(children, c...)
-		}
+// collectLeafNodes walks a slate node tree and appends leaf nodes (those with a "text" key) to leaves
+func collectLeafNodes(m map[string]any, leaves *[]any) {
+	if _, hasText := m["text"]; hasText {
+		*leaves = append(*leaves, m)
+		return
 	}
 
-	return children
+	if children, ok := m["children"].([]any); ok {
+		for _, child := range children {
+			if childMap, ok := child.(map[string]any); ok {
+				collectLeafNodes(childMap, leaves)
+			}
+		}
+	}
+}
+
+// valEqualBestEffort compares two any values for scalar JSON types without panicking on non-comparable types
+func valEqualBestEffort(a, b any) bool {
+	switch av := a.(type) {
+	case string:
+		bv, ok := b.(string)
+		return ok && av == bv
+	case bool:
+		bv, ok := b.(bool)
+		return ok && av == bv
+	case float64:
+		bv, ok := b.(float64)
+		return ok && av == bv
+	case nil:
+		return b == nil
+	default:
+		// non-comparable type (slice, nested map, etc.) — conservatively treat as not equal
+		return false
+	}
+}
+
+func isCommentKey(key string) bool {
+	return key == "comment" || strings.HasPrefix(key, "comment_")
 }
 
 // OnlyCommentsAdded checks if the only changes between the old and new slate JSON elements are the addition of comments
 func OnlyCommentsAdded(oldText []any, newText []any) bool {
-	// for each I want to see if the only change is the addition of a comment, if so return true, otherwise false
-	oldChildren := getChildrenFromSlateTextJSON(oldText)
-	newChildren := getChildrenFromSlateTextJSON(newText)
+	oldLeaves := getChildrenFromSlateTextJSON(oldText)
+	newLeaves := getChildrenFromSlateTextJSON(newText)
 
-	if len(oldChildren) != len(newChildren) {
+	if len(oldLeaves) != len(newLeaves) || len(newLeaves) == 0 {
 		return false
 	}
 
-	// compare all children, and check the text is the same, comments are OK
-	for i, oldChild := range oldChildren {
-		// get the map
-		oldChildMap, oldOK := oldChild.(map[string]any)
-		newChildMap, newOK := newChildren[i].(map[string]any)
+	for i, oldChild := range oldLeaves {
+		oldLeaf, oldOK := oldChild.(map[string]any)
+		newLeaf, newOK := newLeaves[i].(map[string]any)
 
-		// if its not a map, we can't compare, so we assume it's not just a comment change and return false
-		if !oldOK || !newOK {
+		if !oldOK || !newOK || oldLeaf == nil || newLeaf == nil {
 			return false
 		}
 
-		// if they are equal, continue to the next one
-		if maps.Equal(oldChildMap, newChildMap) {
-			continue
+		// text must be unchanged
+		oldTextStr, _ := oldLeaf["text"].(string)
+		newTextStr, _ := newLeaf["text"].(string)
+		if oldTextStr != newTextStr {
+			return false
 		}
 
-		allowedKeys := map[string]bool{
-			"text":    true,
-			"comment": true,
-		}
+		// new leaf may only add comment-related keys; all other keys must exist in old with equal values
+		for key, newVal := range newLeaf {
+			if isCommentKey(key) {
+				continue
+			}
 
-		// if there are other keys besides text and comment, return false
-		for key := range newChildMap {
-			if !allowedKeys[key] {
+			oldVal, exists := oldLeaf[key]
+			if !exists || !valEqualBestEffort(oldVal, newVal) {
 				return false
 			}
 		}
 
-		// if they are not equal, check the text is the same
-		oldText, oldOK := oldChildMap["text"]
-		newText, newOK := newChildMap["text"]
+		// no non-comment keys should be removed from old
+		for key := range oldLeaf {
+			if isCommentKey(key) {
+				continue
+			}
 
-		if oldOK && newOK {
-			oldTextStr, oldOK := oldText.(string)
-			newTextStr, newOK := newText.(string)
-
-			// if they are strings and they are not equal, then it's not just a comment change, return false
-			if oldOK && newOK && oldTextStr != newTextStr {
+			if _, exists := newLeaf[key]; !exists {
 				return false
 			}
 		}
-
 	}
 
 	return true

--- a/pkg/slateparser/utils_test.go
+++ b/pkg/slateparser/utils_test.go
@@ -203,6 +203,17 @@ func TestOnlyCommentsAdded(t *testing.T) {
 		assert.Check(t, slateparser.OnlyCommentsAdded(oldText, newText))
 	})
 
+	t.Run("child with non-comparable value does not panic", func(t *testing.T) {
+		// []any values can't be safely compared; best-effort returns false rather than panicking
+		makeSlateWith := func(child map[string]any) []any {
+			return []any{map[string]any{"type": "paragraph", "children": []any{child}}}
+		}
+		marks := []any{"bold"}
+		oldText := makeSlateWith(map[string]any{"text": "hello", "marks": marks})
+		newText := makeSlateWith(map[string]any{"text": "hello", "marks": marks})
+		assert.Check(t, !slateparser.OnlyCommentsAdded(oldText, newText))
+	})
+
 	t.Run("multiple children, extra key added", func(t *testing.T) {
 		oldText := makeSlate(
 			map[string]any{"text": "a"},
@@ -213,5 +224,201 @@ func TestOnlyCommentsAdded(t *testing.T) {
 			map[string]any{"text": "b", "comment": "c2"},
 		)
 		assert.Check(t, !slateparser.OnlyCommentsAdded(oldText, newText))
+	})
+
+	// bold/italic/underline are stored as booleans on leaf nodes in Slate
+	t.Run("bold mark unchanged, comment added", func(t *testing.T) {
+		oldText := makeSlate(map[string]any{"text": "hello", "bold": true})
+		newText := makeSlate(map[string]any{"text": "hello", "bold": true, "comment": true})
+		assert.Check(t, slateparser.OnlyCommentsAdded(oldText, newText))
+	})
+
+	t.Run("bold mark changed", func(t *testing.T) {
+		oldText := makeSlate(map[string]any{"text": "hello", "bold": true})
+		newText := makeSlate(map[string]any{"text": "hello", "bold": false})
+		assert.Check(t, !slateparser.OnlyCommentsAdded(oldText, newText))
+	})
+
+	t.Run("bold mark added (formatting change, not comment)", func(t *testing.T) {
+		oldText := makeSlate(map[string]any{"text": "hello"})
+		newText := makeSlate(map[string]any{"text": "hello", "bold": true})
+		assert.Check(t, !slateparser.OnlyCommentsAdded(oldText, newText))
+	})
+
+	t.Run("multiple marks unchanged, comment added", func(t *testing.T) {
+		oldText := makeSlate(map[string]any{"text": "hello", "bold": true, "italic": true, "underline": true})
+		newText := makeSlate(map[string]any{"text": "hello", "bold": true, "italic": true, "underline": true, "comment": true})
+		assert.Check(t, slateparser.OnlyCommentsAdded(oldText, newText))
+	})
+
+	// Slate adds both "comment" and "comment_<id>" keys when creating a comment
+	t.Run("comment and comment_id keys added", func(t *testing.T) {
+		oldText := makeSlate(map[string]any{"text": "hello"})
+		newText := makeSlate(map[string]any{"text": "hello", "comment": true, "comment_MDHGnHfbfTfX": true})
+		assert.Check(t, slateparser.OnlyCommentsAdded(oldText, newText))
+	})
+
+	t.Run("multiple comment_id keys added", func(t *testing.T) {
+		oldText := makeSlate(map[string]any{"text": "hello"})
+		newText := makeSlate(map[string]any{"text": "hello", "comment": true, "comment_abc": true, "comment_xyz": true})
+		assert.Check(t, slateparser.OnlyCommentsAdded(oldText, newText))
+	})
+
+	t.Run("bold with comment_id added", func(t *testing.T) {
+		oldText := makeSlate(map[string]any{"text": "hello", "bold": true})
+		newText := makeSlate(map[string]any{"text": "hello", "bold": true, "comment": true, "comment_abc123": true})
+		assert.Check(t, slateparser.OnlyCommentsAdded(oldText, newText))
+	})
+
+	// Slate table elements have colSizes []float64 on the element node (not on leaf nodes),
+	// and deeply nested children: table → tr → td → p → {text: "..."}
+	t.Run("table with colSizes, no changes", func(t *testing.T) {
+		makeTable := func() []any {
+			return []any{map[string]any{
+				"type":     "table",
+				"id":       "tbl1",
+				"colSizes": []any{0.0, 190.45703125, 296.11328125},
+				"children": []any{
+					map[string]any{
+						"type": "tr", "id": "tr1",
+						"children": []any{
+							map[string]any{
+								"type": "td", "id": "td1",
+								"children": []any{
+									map[string]any{
+										"type": "p", "id": "p1",
+										"children": []any{map[string]any{"text": "Version"}},
+									},
+								},
+							},
+							map[string]any{
+								"type": "td", "id": "td2",
+								"children": []any{
+									map[string]any{
+										"type": "p", "id": "p2",
+										"children": []any{map[string]any{"text": "Date"}},
+									},
+								},
+							},
+						},
+					},
+				},
+			}}
+		}
+		assert.Check(t, slateparser.OnlyCommentsAdded(makeTable(), makeTable()))
+	})
+
+	t.Run("table with colSizes, comment added to leaf", func(t *testing.T) {
+		makeTableLeaf := func(leaf map[string]any) []any {
+			return []any{map[string]any{
+				"type":     "table",
+				"id":       "tbl1",
+				"colSizes": []any{0.0, 190.45703125},
+				"children": []any{
+					map[string]any{
+						"type": "tr", "id": "tr1",
+						"children": []any{
+							map[string]any{
+								"type": "td", "id": "td1",
+								"children": []any{
+									map[string]any{
+										"type": "p", "id": "p1",
+										"children": []any{leaf},
+									},
+								},
+							},
+						},
+					},
+				},
+			}}
+		}
+		oldText := makeTableLeaf(map[string]any{"text": "Version"})
+		newText := makeTableLeaf(map[string]any{"text": "Version", "comment": true, "comment_abc": true})
+		assert.Check(t, slateparser.OnlyCommentsAdded(oldText, newText))
+	})
+
+	t.Run("table with colSizes, text changed in leaf", func(t *testing.T) {
+		makeTableLeaf := func(text string) []any {
+			return []any{map[string]any{
+				"type":     "table",
+				"id":       "tbl1",
+				"colSizes": []any{0.0, 190.45703125},
+				"children": []any{
+					map[string]any{
+						"type": "tr", "id": "tr1",
+						"children": []any{
+							map[string]any{
+								"type": "td", "id": "td1",
+								"children": []any{
+									map[string]any{
+										"type": "p", "id": "p1",
+										"children": []any{map[string]any{"text": text}},
+									},
+								},
+							},
+						},
+					},
+				},
+			}}
+		}
+		assert.Check(t, !slateparser.OnlyCommentsAdded(makeTableLeaf("Version"), makeTableLeaf("Changed")))
+	})
+
+	// td cells in some Slate table plugins carry colSpan/rowSpan as float64
+	t.Run("table cell with colSpan and rowSpan, comment added to leaf", func(t *testing.T) {
+		makeCell := func(leaf map[string]any) []any {
+			return []any{map[string]any{
+				"type": "table", "id": "tbl1",
+				"children": []any{
+					map[string]any{
+						"type": "tr", "id": "tr1",
+						"children": []any{
+							map[string]any{
+								"type": "td", "id": "td1",
+								"colSpan": float64(1), "rowSpan": float64(1),
+								"children": []any{
+									map[string]any{
+										"type": "p", "id": "p1",
+										"children": []any{leaf},
+									},
+								},
+							},
+						},
+					},
+				},
+			}}
+		}
+		oldText := makeCell(map[string]any{"text": "hello"})
+		newText := makeCell(map[string]any{"text": "hello", "comment": true})
+		assert.Check(t, slateparser.OnlyCommentsAdded(oldText, newText))
+	})
+
+	// list items use indent (float64) and listStyleType (string) on the element, not the leaf
+	t.Run("list item with indent, no changes", func(t *testing.T) {
+		makeList := func(leaf map[string]any) []any {
+			return []any{map[string]any{
+				"type":          "p",
+				"indent":        float64(1),
+				"listStyleType": "disc",
+				"children":      []any{leaf},
+			}}
+		}
+		oldText := makeList(map[string]any{"text": "Confidentiality Policy"})
+		newText := makeList(map[string]any{"text": "Confidentiality Policy"})
+		assert.Check(t, slateparser.OnlyCommentsAdded(oldText, newText))
+	})
+
+	t.Run("list item with indent, comment added to leaf", func(t *testing.T) {
+		makeList := func(leaf map[string]any) []any {
+			return []any{map[string]any{
+				"type":          "p",
+				"indent":        float64(1),
+				"listStyleType": "disc",
+				"children":      []any{leaf},
+			}}
+		}
+		oldText := makeList(map[string]any{"text": "Confidentiality Policy"})
+		newText := makeList(map[string]any{"text": "Confidentiality Policy", "comment": true, "comment_xyz": true})
+		assert.Check(t, slateparser.OnlyCommentsAdded(oldText, newText))
 	})
 }


### PR DESCRIPTION
fixes a prod bug updating a policy with tables that results in an internal server error due to uncomparable map; adds tests cases that catches the issue and adds other tests