### PR TITLE
fix: do not overwrite approved for use bool, also set on active

### DIFF
--- a/internal/ent/hooks/entity.go
+++ b/internal/ent/hooks/entity.go
@@ -3,6 +3,7 @@ package hooks
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"entgo.io/ent"
@@ -36,13 +37,22 @@ func HookEntityFiles() ent.Hook {
 	}, ent.OpCreate|ent.OpUpdateOne|ent.OpUpdate)
 }
 
+var (
+	approvedStatus = []enums.EntityStatus{enums.EntityStatusApproved, enums.EntityStatusActive}
+)
+
 // HookEntityApprovedForUse sets approved_for_use based on the entity status.
 func HookEntityApprovedForUse() ent.Hook {
 	return hook.If(func(next ent.Mutator) ent.Mutator {
 		return hook.EntityFunc(func(ctx context.Context, m *generated.EntityMutation) (generated.Value, error) {
+			_, ok := m.ApprovedForUse()
+			if ok {
+				return next.Mutate(ctx, m)
+			}
+
 			status, _ := m.Status()
 
-			m.SetApprovedForUse(status == enums.EntityStatusApproved)
+			m.SetApprovedForUse(slices.Contains(approvedStatus, status))
 
 			return next.Mutate(ctx, m)
 		})

--- a/internal/graphapi/entity_test.go
+++ b/internal/graphapi/entity_test.go
@@ -371,6 +371,15 @@ func TestMutationUpdateEntity(t *testing.T) {
 			ctx:    testUser1.UserCtx,
 		},
 		{
+			name: "conflicting status and approved for use, approved should take precedence",
+			request: testclient.UpdateEntityInput{
+				Status:         &enums.EntityStatusActive,
+				ApprovedForUse: lo.ToPtr(false),
+			},
+			client: suite.client.api,
+			ctx:    testUser1.UserCtx,
+		},
+		{
 			name: "not allowed to update",
 			request: testclient.UpdateEntityInput{
 				Description: lo.ToPtr("pine trees of the west"),
@@ -436,11 +445,11 @@ func TestMutationUpdateEntity(t *testing.T) {
 				assert.Check(t, is.Equal(tc.request.Note.Text, resp.UpdateEntity.Entity.Notes.Edges[0].Node.Text))
 			}
 
+			// if approed for use is set, it should always respect that over status
 			if tc.request.ApprovedForUse != nil {
 				assert.Check(t, is.Equal(*tc.request.ApprovedForUse, *resp.UpdateEntity.Entity.ApprovedForUse))
-			}
-
-			if tc.request.Status != nil {
+			} else if tc.request.Status != nil {
+				// else its done based on status, where active and approved are approved
 				status := *tc.request.Status
 				if slices.Contains([]enums.EntityStatus{enums.EntityStatusApproved, enums.EntityStatusActive}, status) {
 					assert.Check(t, *resp.UpdateEntity.Entity.ApprovedForUse)

--- a/internal/graphapi/entity_test.go
+++ b/internal/graphapi/entity_test.go
@@ -2,6 +2,7 @@ package graphapi_test
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/samber/lo"
@@ -329,7 +330,8 @@ func TestMutationUpdateEntity(t *testing.T) {
 		{
 			name: "happy path, update display name",
 			request: testclient.UpdateEntityInput{
-				DisplayName: lo.ToPtr("blue spruce"),
+				DisplayName:    lo.ToPtr("blue spruce"),
+				ApprovedForUse: lo.ToPtr(true),
 				Note: &testclient.CreateNoteInput{
 					Text: "the pine tree with blue-green colored needles",
 				},
@@ -341,6 +343,7 @@ func TestMutationUpdateEntity(t *testing.T) {
 			name: "update description using api token",
 			request: testclient.UpdateEntityInput{
 				Description: lo.ToPtr("the pine tree with blue-green colored needles"),
+				Status:      &enums.EntityStatusDraft,
 			},
 			client: suite.client.apiWithToken,
 			ctx:    context.Background(),
@@ -352,6 +355,7 @@ func TestMutationUpdateEntity(t *testing.T) {
 					Text: "the pine tree with blue-green colored needles",
 				},
 				Domains: []string{"https://appalachiatrees.com"},
+				Status:  &enums.EntityStatusActive,
 			},
 			client: suite.client.apiWithPAT,
 			ctx:    context.Background(),
@@ -359,8 +363,9 @@ func TestMutationUpdateEntity(t *testing.T) {
 		{
 			name: "update status and domain",
 			request: testclient.UpdateEntityInput{
-				Status:        &enums.EntityStatusSuspended,
-				AppendDomains: []string{"example.com"},
+				Status:         &enums.EntityStatusSuspended,
+				AppendDomains:  []string{"example.com"},
+				ApprovedForUse: lo.ToPtr(false),
 			},
 			client: suite.client.api,
 			ctx:    testUser1.UserCtx,
@@ -429,6 +434,19 @@ func TestMutationUpdateEntity(t *testing.T) {
 
 				assert.Check(t, is.Len(resp.UpdateEntity.Entity.Notes.Edges, numNotes))
 				assert.Check(t, is.Equal(tc.request.Note.Text, resp.UpdateEntity.Entity.Notes.Edges[0].Node.Text))
+			}
+
+			if tc.request.ApprovedForUse != nil {
+				assert.Check(t, is.Equal(*tc.request.ApprovedForUse, *resp.UpdateEntity.Entity.ApprovedForUse))
+			}
+
+			if tc.request.Status != nil {
+				status := *tc.request.Status
+				if slices.Contains([]enums.EntityStatus{enums.EntityStatusApproved, enums.EntityStatusActive}, status) {
+					assert.Check(t, *resp.UpdateEntity.Entity.ApprovedForUse)
+				} else {
+					assert.Check(t, !*resp.UpdateEntity.Entity.ApprovedForUse)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
the status was overwriting user-set approved for use values; this should take precedence. Also active should also default to approved.