### PR TITLE
fix: return early for nil creds schema

### DIFF
--- a/internal/graphapi/integrationextended.resolvers.go
+++ b/internal/graphapi/integrationextended.resolvers.go
@@ -67,15 +67,25 @@ func (r *integrationResolver) Credentials(ctx context.Context, obj *generated.In
 		}
 	}
 
+	// not all schemas have a credential schema, those with oauth like Google Workspace, will
+	// have an empty schema
+	if credentialType.Schema == nil {
+		return nil, nil
+	}
+
 	currentCreds, err := jsonx.ToMap(obj.InstallationMetadata.Attributes)
 	if err != nil {
-		logx.FromContext(ctx).Error().Err(err).Msg("error getting current credentials, returning full schema")
+		logx.FromContext(ctx).Error().Err(err).Str("integration", obj.Family).Msg("error getting current credentials, returning full schema")
 		return credentialType.Schema, nil
+	}
+
+	if currentCreds == nil {
+		return nil, nil
 	}
 
 	out, err := providerkit.InjectDefaults(credentialType.Schema, currentCreds)
 	if err != nil {
-		logx.FromContext(ctx).Error().Err(err).Msg("error getting current credentials, returning full schema")
+		logx.FromContext(ctx).Error().Err(err).Str("integration", obj.Family).Msg("error getting current credentials, returning full schema")
 		return credentialType.Schema, nil
 	}
 

--- a/internal/integrations/definitions/cloudflare/operation_health.go
+++ b/internal/integrations/definitions/cloudflare/operation_health.go
@@ -32,7 +32,7 @@ func (h HealthCheck) Handle() types.OperationHandler {
 func (HealthCheck) Run(ctx context.Context, credentials types.CredentialBindings, c *cf.Client) (json.RawMessage, error) {
 	meta, err := resolveCredential(credentials)
 	if err != nil {
-		logx.FromContext(ctx).Error().Err(err).Msg("gcpscc: error attempting to resolve credentials")
+		logx.FromContext(ctx).Error().Err(err).Msg("cloudflare: error attempting to resolve credentials")
 		return nil, err
 	}
 
@@ -40,7 +40,7 @@ func (HealthCheck) Run(ctx context.Context, credentials types.CredentialBindings
 		AccountID: cf.F(meta.AccountID),
 	})
 	if err != nil {
-		logx.FromContext(ctx).Error().Err(err).Msg("githubapp: healthcheck failed on token verification")
+		logx.FromContext(ctx).Error().Err(err).Msg("cloudflare: healthcheck failed on token verification")
 		return nil, ErrTokenVerificationFailed
 	}
 

--- a/internal/integrations/providerkit/schema.go
+++ b/internal/integrations/providerkit/schema.go
@@ -108,14 +108,18 @@ func SchemaID(schema json.RawMessage) string {
 // as "default" at every level of nesting, following $ref pointers into $defs recursively.
 // Using jsonschema.Schema preserves the original property ordering on serialization
 func InjectDefaults(schema json.RawMessage, defaults map[string]any) (json.RawMessage, error) {
-	var doc jsonschema.Schema
-	if err := json.Unmarshal(schema, &doc); err != nil {
-		return schema, err
+	if schema == nil {
+		return nil, nil
 	}
 
 	typeName := SchemaID(schema)
 	if typeName == "" {
 		return schema, nil
+	}
+
+	var doc jsonschema.Schema
+	if err := json.Unmarshal(schema, &doc); err != nil {
+		return schema, err
 	}
 
 	typeDef, ok := doc.Definitions[typeName]

--- a/internal/integrations/runtime/recurring_campaign.go
+++ b/internal/integrations/runtime/recurring_campaign.go
@@ -22,7 +22,9 @@ import (
 // SeedRecurringCampaigns starts the durable recurring campaign polling loop
 // after runtime listeners have been registered.
 func (r *Runtime) SeedRecurringCampaigns(ctx context.Context) error {
-	receipt := r.Gala().EmitWithHeaders(ctx, operations.RecurringCampaignTopic, operations.RecurringCampaignEnvelope{}, gala.Headers{})
+	receipt := r.Gala().EmitWithHeaders(ctx, operations.RecurringCampaignTopic, operations.RecurringCampaignEnvelope{}, gala.Headers{
+		Tags: []string{"campaigns"},
+	})
 
 	return receipt.Err
 }


### PR DESCRIPTION
- returns early for nil creds schema (e.g. Google Workspace because it is done via oauth)
- Fixes log lines for CF
- adds integration family name to logs to help diagnose issues in the future
- adds tag for Campaign events to help with UI filtering later