### PR TITLE
fix: policy revision always bumping minor

### DIFF
--- a/internal/ent/hooks/revision.go
+++ b/internal/ent/hooks/revision.go
@@ -64,16 +64,16 @@ func HookRevisionUpdate() ent.Hook {
 // If the revision is not set, it retrieves the current revision from the database and bumps the version based on the revision bump
 // If there is no revision bump set, it bumps the patch version
 func SetNewRevision(ctx context.Context, mut MutationWithRevision) error {
-	// if the revision is set, continue
 	revision, ok := mut.Revision()
-	if ok && revision != "" {
-		// revision is already set, do nothing
-		return nil
-	}
 
 	currentRevision, err := mut.OldRevision(ctx)
 	if err != nil {
 		return err
+	}
+
+	// if the revision is set and the old and new don't match, return - user manually set
+	if ok && revision != currentRevision {
+		return nil
 	}
 
 	revisionBump, ok := models.VersionBumpFromRequestContext(ctx)
@@ -135,7 +135,7 @@ func detailsUpdated(ctx context.Context, m MutationWithRevision) bool {
 		oldDetailsTyped, _ := oldDetailsJSON.([]any)
 		newDetailsTyped, _ := newDetailsJSON.([]any)
 
-		return !slateparser.OnlyCommentsAdded(oldDetailsTyped, newDetailsTyped)
+		return !slateparser.NoDetailsChanged(oldDetailsTyped, newDetailsTyped)
 	}
 
 	// if details json is not set, fallback to check details

--- a/internal/ent/hooks/revision_test.go
+++ b/internal/ent/hooks/revision_test.go
@@ -47,10 +47,15 @@ func (suite *HookTestSuite) TestSetNewRevision() {
 		{
 			name: "mutation with revision set",
 			mutation: func() *generated.StandardMutation {
-				m := generated.StandardMutation{}
-				m.SetOp(ent.OpUpdateOne)
-				m.SetRevision("v0.4.3")
-				return &m
+				std, err := suite.client.Standard.Create().SetName(gofakeit.Name()).Save(ctx)
+				require.NoError(t, err)
+
+				update := suite.client.Standard.UpdateOne(std).SetRevision("v0.4.3")
+
+				err = update.Exec(ctx)
+				require.NoError(t, err)
+
+				return update.Mutation()
 			}(),
 			ctx:              context.Background(),
 			expectedRevision: "v0.4.3",

--- a/internal/ent/privacy/rule/allow_comments.go
+++ b/internal/ent/privacy/rule/allow_comments.go
@@ -53,7 +53,7 @@ func CheckIfCommentOnly() privacy.MutationRuleFunc {
 			oldDetailsTyped, _ := oldDetailsJSON.([]any)
 			newDetailsTyped, _ := newDetailsJSON.([]any)
 
-			if slateparser.OnlyCommentsAdded(oldDetailsTyped, newDetailsTyped) {
+			if slateparser.NoDetailsChanged(oldDetailsTyped, newDetailsTyped) {
 				return privacy.Allowf("mutation has only comments added to details_json, allowing")
 			}
 		}

--- a/pkg/slateparser/utils.go
+++ b/pkg/slateparser/utils.go
@@ -2,6 +2,7 @@ package slateparser
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 )
 
@@ -72,8 +73,7 @@ func valEqualBestEffort(a, b any) bool {
 	case nil:
 		return b == nil
 	default:
-		// non-comparable type (slice, nested map, etc.) — conservatively treat as not equal
-		return false
+		return reflect.DeepEqual(a, b)
 	}
 }
 
@@ -81,8 +81,8 @@ func isCommentKey(key string) bool {
 	return key == "comment" || strings.HasPrefix(key, "comment_")
 }
 
-// OnlyCommentsAdded checks if the only changes between the old and new slate JSON elements are the addition of comments
-func OnlyCommentsAdded(oldText []any, newText []any) bool {
+// NoDetailsChanged checks if the only changes between the old and new slate JSON elements are the addition of comments (or no changes at all)
+func NoDetailsChanged(oldText []any, newText []any) bool {
 	oldLeaves := getChildrenFromSlateTextJSON(oldText)
 	newLeaves := getChildrenFromSlateTextJSON(newText)
 
@@ -105,7 +105,7 @@ func OnlyCommentsAdded(oldText []any, newText []any) bool {
 			return false
 		}
 
-		// new leaf may only add comment-related keys; all other keys must exist in old with equal values
+		// new leaf may only add/modify comment-related keys; all other keys must exist in old with equal values
 		for key, newVal := range newLeaf {
 			if isCommentKey(key) {
 				continue

--- a/pkg/slateparser/utils_test.go
+++ b/pkg/slateparser/utils_test.go
@@ -114,7 +114,7 @@ func TestContainsCommentsInTextJSON(t *testing.T) {
 	}
 }
 
-func TestOnlyCommentsAdded(t *testing.T) {
+func TestNoDetailsChanged(t *testing.T) {
 	// Helper to wrap children in Slate element
 	makeSlate := func(children ...any) []any {
 		return []any{
@@ -128,31 +128,31 @@ func TestOnlyCommentsAdded(t *testing.T) {
 	t.Run("no changes", func(t *testing.T) {
 		oldText := makeSlate(map[string]any{"text": "hello"})
 		newText := makeSlate(map[string]any{"text": "hello"})
-		assert.Check(t, slateparser.OnlyCommentsAdded(oldText, newText))
+		assert.Check(t, slateparser.NoDetailsChanged(oldText, newText))
 	})
 
 	t.Run("comment added", func(t *testing.T) {
 		oldText := makeSlate(map[string]any{"text": "hello"})
 		newText := makeSlate(map[string]any{"text": "hello", "comment": "my comment"})
-		assert.Check(t, slateparser.OnlyCommentsAdded(oldText, newText))
+		assert.Check(t, slateparser.NoDetailsChanged(oldText, newText))
 	})
 
 	t.Run("comment changed", func(t *testing.T) {
 		oldText := makeSlate(map[string]any{"text": "hello", "comment": "old"})
 		newText := makeSlate(map[string]any{"text": "hello", "comment": "new"})
-		assert.Check(t, slateparser.OnlyCommentsAdded(oldText, newText))
+		assert.Check(t, slateparser.NoDetailsChanged(oldText, newText))
 	})
 
 	t.Run("text changed", func(t *testing.T) {
 		oldText := makeSlate(map[string]any{"text": "hello"})
 		newText := makeSlate(map[string]any{"text": "world"})
-		assert.Check(t, !slateparser.OnlyCommentsAdded(oldText, newText))
+		assert.Check(t, !slateparser.NoDetailsChanged(oldText, newText))
 	})
 
 	t.Run("comment removed", func(t *testing.T) {
 		oldText := makeSlate(map[string]any{"text": "hello", "comment": "gone"})
 		newText := makeSlate(map[string]any{"text": "hello"})
-		assert.Check(t, slateparser.OnlyCommentsAdded(oldText, newText))
+		assert.Check(t, slateparser.NoDetailsChanged(oldText, newText))
 	})
 
 	t.Run("multiple children, only comments added", func(t *testing.T) {
@@ -164,7 +164,7 @@ func TestOnlyCommentsAdded(t *testing.T) {
 			map[string]any{"text": "a", "comment": "c1"},
 			map[string]any{"text": "b", "comment": "c2"},
 		)
-		assert.Check(t, slateparser.OnlyCommentsAdded(oldText, newText))
+		assert.Check(t, slateparser.NoDetailsChanged(oldText, newText))
 	})
 
 	t.Run("multiple children, text changed in one", func(t *testing.T) {
@@ -176,19 +176,19 @@ func TestOnlyCommentsAdded(t *testing.T) {
 			map[string]any{"text": "a"},
 			map[string]any{"text": "B"},
 		)
-		assert.Check(t, !slateparser.OnlyCommentsAdded(oldText, newText))
+		assert.Check(t, !slateparser.NoDetailsChanged(oldText, newText))
 	})
 
 	t.Run("different number of children", func(t *testing.T) {
 		oldText := makeSlate(map[string]any{"text": "a"})
 		newText := makeSlate(map[string]any{"text": "a"}, map[string]any{"text": "b"})
-		assert.Check(t, !slateparser.OnlyCommentsAdded(oldText, newText))
+		assert.Check(t, !slateparser.NoDetailsChanged(oldText, newText))
 	})
 
 	t.Run("non-map children", func(t *testing.T) {
 		oldText := makeSlate("not a map")
 		newText := makeSlate("not a map")
-		assert.Check(t, !slateparser.OnlyCommentsAdded(oldText, newText))
+		assert.Check(t, !slateparser.NoDetailsChanged(oldText, newText))
 	})
 
 	t.Run("comment added to one of multiple children", func(t *testing.T) {
@@ -200,18 +200,17 @@ func TestOnlyCommentsAdded(t *testing.T) {
 			map[string]any{"text": "a", "comment": "c"},
 			map[string]any{"text": "b"},
 		)
-		assert.Check(t, slateparser.OnlyCommentsAdded(oldText, newText))
+		assert.Check(t, slateparser.NoDetailsChanged(oldText, newText))
 	})
 
-	t.Run("child with non-comparable value does not panic", func(t *testing.T) {
-		// []any values can't be safely compared; best-effort returns false rather than panicking
+	t.Run("leaf with non-scalar attribute, no changes", func(t *testing.T) {
 		makeSlateWith := func(child map[string]any) []any {
 			return []any{map[string]any{"type": "paragraph", "children": []any{child}}}
 		}
 		marks := []any{"bold"}
 		oldText := makeSlateWith(map[string]any{"text": "hello", "marks": marks})
 		newText := makeSlateWith(map[string]any{"text": "hello", "marks": marks})
-		assert.Check(t, !slateparser.OnlyCommentsAdded(oldText, newText))
+		assert.Check(t, slateparser.NoDetailsChanged(oldText, newText))
 	})
 
 	t.Run("multiple children, extra key added", func(t *testing.T) {
@@ -223,51 +222,57 @@ func TestOnlyCommentsAdded(t *testing.T) {
 			map[string]any{"text": "a", "comment": "c1", "extra": "not allowed"},
 			map[string]any{"text": "b", "comment": "c2"},
 		)
-		assert.Check(t, !slateparser.OnlyCommentsAdded(oldText, newText))
+		assert.Check(t, !slateparser.NoDetailsChanged(oldText, newText))
 	})
 
 	// bold/italic/underline are stored as booleans on leaf nodes in Slate
 	t.Run("bold mark unchanged, comment added", func(t *testing.T) {
 		oldText := makeSlate(map[string]any{"text": "hello", "bold": true})
 		newText := makeSlate(map[string]any{"text": "hello", "bold": true, "comment": true})
-		assert.Check(t, slateparser.OnlyCommentsAdded(oldText, newText))
+		assert.Check(t, slateparser.NoDetailsChanged(oldText, newText))
 	})
 
 	t.Run("bold mark changed", func(t *testing.T) {
 		oldText := makeSlate(map[string]any{"text": "hello", "bold": true})
 		newText := makeSlate(map[string]any{"text": "hello", "bold": false})
-		assert.Check(t, !slateparser.OnlyCommentsAdded(oldText, newText))
+		assert.Check(t, !slateparser.NoDetailsChanged(oldText, newText))
 	})
 
 	t.Run("bold mark added (formatting change, not comment)", func(t *testing.T) {
 		oldText := makeSlate(map[string]any{"text": "hello"})
 		newText := makeSlate(map[string]any{"text": "hello", "bold": true})
-		assert.Check(t, !slateparser.OnlyCommentsAdded(oldText, newText))
+		assert.Check(t, !slateparser.NoDetailsChanged(oldText, newText))
 	})
 
 	t.Run("multiple marks unchanged, comment added", func(t *testing.T) {
 		oldText := makeSlate(map[string]any{"text": "hello", "bold": true, "italic": true, "underline": true})
 		newText := makeSlate(map[string]any{"text": "hello", "bold": true, "italic": true, "underline": true, "comment": true})
-		assert.Check(t, slateparser.OnlyCommentsAdded(oldText, newText))
+		assert.Check(t, slateparser.NoDetailsChanged(oldText, newText))
+	})
+
+	t.Run("multiple marks unchanged, no comment changes", func(t *testing.T) {
+		oldText := makeSlate(map[string]any{"text": "hello", "bold": true, "italic": true, "underline": true})
+		newText := makeSlate(map[string]any{"text": "hello", "bold": true, "italic": true, "underline": true})
+		assert.Check(t, slateparser.NoDetailsChanged(oldText, newText))
 	})
 
 	// Slate adds both "comment" and "comment_<id>" keys when creating a comment
 	t.Run("comment and comment_id keys added", func(t *testing.T) {
 		oldText := makeSlate(map[string]any{"text": "hello"})
 		newText := makeSlate(map[string]any{"text": "hello", "comment": true, "comment_MDHGnHfbfTfX": true})
-		assert.Check(t, slateparser.OnlyCommentsAdded(oldText, newText))
+		assert.Check(t, slateparser.NoDetailsChanged(oldText, newText))
 	})
 
 	t.Run("multiple comment_id keys added", func(t *testing.T) {
 		oldText := makeSlate(map[string]any{"text": "hello"})
 		newText := makeSlate(map[string]any{"text": "hello", "comment": true, "comment_abc": true, "comment_xyz": true})
-		assert.Check(t, slateparser.OnlyCommentsAdded(oldText, newText))
+		assert.Check(t, slateparser.NoDetailsChanged(oldText, newText))
 	})
 
 	t.Run("bold with comment_id added", func(t *testing.T) {
 		oldText := makeSlate(map[string]any{"text": "hello", "bold": true})
 		newText := makeSlate(map[string]any{"text": "hello", "bold": true, "comment": true, "comment_abc123": true})
-		assert.Check(t, slateparser.OnlyCommentsAdded(oldText, newText))
+		assert.Check(t, slateparser.NoDetailsChanged(oldText, newText))
 	})
 
 	// Slate table elements have colSizes []float64 on the element node (not on leaf nodes),
@@ -305,7 +310,7 @@ func TestOnlyCommentsAdded(t *testing.T) {
 				},
 			}}
 		}
-		assert.Check(t, slateparser.OnlyCommentsAdded(makeTable(), makeTable()))
+		assert.Check(t, slateparser.NoDetailsChanged(makeTable(), makeTable()))
 	})
 
 	t.Run("table with colSizes, comment added to leaf", func(t *testing.T) {
@@ -334,7 +339,7 @@ func TestOnlyCommentsAdded(t *testing.T) {
 		}
 		oldText := makeTableLeaf(map[string]any{"text": "Version"})
 		newText := makeTableLeaf(map[string]any{"text": "Version", "comment": true, "comment_abc": true})
-		assert.Check(t, slateparser.OnlyCommentsAdded(oldText, newText))
+		assert.Check(t, slateparser.NoDetailsChanged(oldText, newText))
 	})
 
 	t.Run("table with colSizes, text changed in leaf", func(t *testing.T) {
@@ -361,7 +366,7 @@ func TestOnlyCommentsAdded(t *testing.T) {
 				},
 			}}
 		}
-		assert.Check(t, !slateparser.OnlyCommentsAdded(makeTableLeaf("Version"), makeTableLeaf("Changed")))
+		assert.Check(t, !slateparser.NoDetailsChanged(makeTableLeaf("Version"), makeTableLeaf("Changed")))
 	})
 
 	// td cells in some Slate table plugins carry colSpan/rowSpan as float64
@@ -390,7 +395,7 @@ func TestOnlyCommentsAdded(t *testing.T) {
 		}
 		oldText := makeCell(map[string]any{"text": "hello"})
 		newText := makeCell(map[string]any{"text": "hello", "comment": true})
-		assert.Check(t, slateparser.OnlyCommentsAdded(oldText, newText))
+		assert.Check(t, slateparser.NoDetailsChanged(oldText, newText))
 	})
 
 	// list items use indent (float64) and listStyleType (string) on the element, not the leaf
@@ -405,7 +410,7 @@ func TestOnlyCommentsAdded(t *testing.T) {
 		}
 		oldText := makeList(map[string]any{"text": "Confidentiality Policy"})
 		newText := makeList(map[string]any{"text": "Confidentiality Policy"})
-		assert.Check(t, slateparser.OnlyCommentsAdded(oldText, newText))
+		assert.Check(t, slateparser.NoDetailsChanged(oldText, newText))
 	})
 
 	t.Run("list item with indent, comment added to leaf", func(t *testing.T) {
@@ -419,6 +424,6 @@ func TestOnlyCommentsAdded(t *testing.T) {
 		}
 		oldText := makeList(map[string]any{"text": "Confidentiality Policy"})
 		newText := makeList(map[string]any{"text": "Confidentiality Policy", "comment": true, "comment_xyz": true})
-		assert.Check(t, slateparser.OnlyCommentsAdded(oldText, newText))
+		assert.Check(t, slateparser.NoDetailsChanged(oldText, newText))
 	})
 }


### PR DESCRIPTION
Fixes issue with the best-effort that still didnt work well on complex data. This will end up being a fallback; making a frontend update to send the `RevisionBump` minor as well as this will be a much more efficient method. 