### PR TITLE
feat: reconcile integration jobs

### DIFF
--- a/common/go.mod
+++ b/common/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/agnivade/levenshtein v1.2.1 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/bmatcuk/doublestar v1.3.4 // indirect
+	github.com/brianvoe/gofakeit/v7 v7.15.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fxamacker/cbor/v2 v2.9.2 // indirect

--- a/common/go.sum
+++ b/common/go.sum
@@ -22,8 +22,8 @@ github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
 github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
-github.com/brianvoe/gofakeit/v7 v7.14.1 h1:a7fe3fonbj0cW3wgl5VwIKfZtiH9C3cLnwcIXWT7sow=
-github.com/brianvoe/gofakeit/v7 v7.14.1/go.mod h1:QXuPeBw164PJCzCUZVmgpgHJ3Llj49jSLVkKPMtxtxA=
+github.com/brianvoe/gofakeit/v7 v7.15.0 h1:kGLYAWN8tnmxq2PelKVK6zwpM7kMxdz9SGPH31mFkNs=
+github.com/brianvoe/gofakeit/v7 v7.15.0/go.mod h1:QXuPeBw164PJCzCUZVmgpgHJ3Llj49jSLVkKPMtxtxA=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/httpserve/handlers/integration_config.go
+++ b/internal/httpserve/handlers/integration_config.go
@@ -106,6 +106,15 @@ func (h *Handler) ConfigureIntegrationProvider(ctx echo.Context, openapiCtx *Ope
 		resp.WebhookSecret = primaryWebhookSecret
 	}
 
+	// ensure all reconcile jobs exist after any config update; a previously-disabled
+	// operation that was just re-enabled needs a new job seeded - this is a no-op
+	// when all jobs are already active
+	if installationRec.Status == enums.IntegrationStatusConnected {
+		if err := h.IntegrationsRuntime.SeedReconcileJobsForInstallation(requestCtx, installationRec); err != nil {
+			logx.FromContext(requestCtx).Warn().Err(err).Str("installation_id", installationRec.ID).Msg("failed to seed missing reconcile jobs after config update")
+		}
+	}
+
 	return h.Success(ctx, resp)
 }
 

--- a/internal/httpserve/handlers/integration_operations.go
+++ b/internal/httpserve/handlers/integration_operations.go
@@ -116,6 +116,10 @@ func (h *Handler) RunIntegrationOperation(ctx echo.Context, openapiCtx *OpenAPIC
 			// not failing the request at this point since the operation itself succeeded and this is just a best-effort update to the integration record
 		}
 
+		if err := h.IntegrationsRuntime.SeedReconcileJobsForInstallation(queueCtx, integrationRef); err != nil {
+			logx.FromContext(requestCtx).Warn().Err(err).Str("integrationID", integrationRef.ID).Msg("failed to seed missing reconcile jobs during health check")
+		}
+
 		return h.Success(ctx, RunIntegrationOperationResponse{
 			Reply:     rout.Reply{Success: true},
 			Provider:  def.ID,

--- a/internal/httpserve/serveropts/integration_base.go
+++ b/internal/httpserve/serveropts/integration_base.go
@@ -1,6 +1,8 @@
 package serveropts
 
 import (
+	"context"
+
 	"github.com/rs/zerolog/log"
 
 	ent "github.com/theopenlane/core/internal/ent/generated"
@@ -49,6 +51,13 @@ func WithIntegrationsRuntime(dbClient *ent.Client) ServerOption {
 
 		// set the runtime on the ent client so hooks/mutations can access it
 		dbClient.IntegrationsRuntime = rt
+
+		// ensure all connected integrations have a corresponding job
+		go func() {
+			if err := rt.SeedReconcileJobs(context.Background()); err != nil {
+				log.Warn().Err(err).Msg("failed to seed one or more missing reconcile jobs at startup")
+			}
+		}()
 
 		if wf == nil {
 			return

--- a/internal/integrations/runtime/execution.go
+++ b/internal/integrations/runtime/execution.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/theopenlane/core/common/enums"
 	ent "github.com/theopenlane/core/internal/ent/generated"
+	"github.com/theopenlane/core/internal/ent/generated/integration"
+	"github.com/theopenlane/core/internal/ent/generated/privacy"
 	"github.com/theopenlane/core/internal/ent/integrationgenerated"
 	intobvs "github.com/theopenlane/core/internal/integrations/observability"
 	"github.com/theopenlane/core/internal/integrations/operations"
@@ -17,6 +19,7 @@ import (
 	"github.com/theopenlane/core/pkg/gala"
 	"github.com/theopenlane/core/pkg/jsonx"
 	"github.com/theopenlane/core/pkg/logx"
+	"github.com/theopenlane/iam/auth"
 )
 
 // reconcileOperations emits one reconciliation envelope per reconcilable operation,
@@ -380,6 +383,161 @@ func (r *Runtime) executeResolvedOperation(ctx context.Context, integration *ent
 	}
 
 	return response, 0, nil
+}
+
+// SeedReconcileJobs ensures every connected integration with reconcilable operations
+// has an active River job. It is intended to be called once at startup to recover
+// reconcile cycles that were lost due to job deletion or a queue flush
+func (r *Runtime) SeedReconcileJobs(ctx context.Context) error {
+	definitionIDs := r.reconcilableDefinitionIDs()
+	if len(definitionIDs) == 0 {
+		return nil
+	}
+
+	systemCtx := auth.WithCaller(privacy.DecisionContext(ctx, privacy.Allow), &auth.Caller{
+		Capabilities: auth.CapBypassOrgFilter | auth.CapBypassFGA | auth.CapInternalOperation,
+	})
+
+	installations, err := r.DB().Integration.Query().
+		Where(
+			integration.StatusEQ(enums.IntegrationStatusConnected),
+			integration.DefinitionIDIn(definitionIDs...),
+		).
+		All(systemCtx)
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+
+	logx.FromContext(ctx).Debug().Int("count", len(installations)).Msg("installations found to check for reconciliation")
+
+	for _, inst := range installations {
+		if err := r.seedReconcileJobsForInstallation(systemCtx, inst); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// SeedReconcileJobsForInstallation checks every reconcilable operation on the given
+// installation and emits a ReconcileEnvelope for any that do not have an active River job
+func (r *Runtime) SeedReconcileJobsForInstallation(ctx context.Context, inst *ent.Integration) error {
+	systemCtx := auth.WithCaller(privacy.DecisionContext(ctx, privacy.Allow), &auth.Caller{
+		Capabilities: auth.CapBypassOrgFilter | auth.CapBypassFGA | auth.CapInternalOperation,
+	})
+
+	return r.seedReconcileJobsForInstallation(systemCtx, inst)
+}
+
+// seedReconcileJobsForInstallation is the shared implementation used by both
+// SeedReconcileJobs and SeedReconcileJobsForInstallation
+func (r *Runtime) seedReconcileJobsForInstallation(ctx context.Context, inst *ent.Integration) error {
+	def, ok := r.Registry().Definition(inst.DefinitionID)
+	if !ok {
+		return nil
+	}
+
+	var errs []error
+
+	for _, op := range def.Operations {
+		if !op.Policy.Reconcile {
+			continue
+		}
+
+		if op.Disabled != nil && op.Disabled(inst.Config.ClientConfig) {
+			continue
+		}
+
+		fragment, err := reconcileMetadataFragment(inst.ID, op.Name)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		active, err := r.Gala().HasActiveJobWithMetadata(ctx, fragment)
+		if err != nil {
+			logx.FromContext(ctx).Error().Err(err).Str("integration_id", inst.ID).Str("operation", op.Name).Msg("failed to check for active reconcile job")
+			errs = append(errs, err)
+			continue
+		}
+
+		if active {
+			logx.FromContext(ctx).Debug().Str("integration_id", inst.ID).Str("operation", op.Name).Msg("reconcile job already active, skipping seed")
+			continue
+		}
+
+		logx.FromContext(ctx).Info().Str("integration_id", inst.ID).Str("operation", op.Name).Msg("seeding missing reconcile job")
+
+		metadata := types.ExecutionMetadata{
+			OwnerID:       inst.OwnerID,
+			IntegrationID: inst.ID,
+			DefinitionID:  inst.DefinitionID,
+			Operation:     op.Name,
+			RunType:       enums.IntegrationRunTypeReconcile,
+		}
+
+		receipt := r.Gala().EmitWithHeaders(
+			types.WithExecutionMetadata(ctx, metadata),
+			operations.ReconcileTopic,
+			operations.ReconcileEnvelope{ExecutionMetadata: metadata},
+			gala.Headers{Properties: metadata.Properties()},
+		)
+		if receipt.Err != nil {
+			logx.FromContext(ctx).Error().Err(receipt.Err).Str("integration_id", inst.ID).Str("operation", op.Name).Msg("failed to seed reconcile job")
+			errs = append(errs, receipt.Err)
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// reconcilableDefinitionIDs returns the IDs of all registered definitions that
+// have at least one operation with Policy.Reconcile set
+func (r *Runtime) reconcilableDefinitionIDs() []string {
+	var ids []string
+
+	for _, spec := range r.Registry().Catalog() {
+		def, ok := r.Registry().Definition(spec.ID)
+		if !ok {
+			continue
+		}
+
+		if !def.Active {
+			continue
+		}
+
+		for _, op := range def.Operations {
+			if op.Policy.Reconcile {
+				ids = append(ids, spec.ID)
+				break
+			}
+		}
+	}
+
+	return ids
+}
+
+// reconcileMetadataFragment builds the JSONB containment fragment used to query
+// River for an active reconcile job for the given integration and operation
+func reconcileMetadataFragment(integrationID, operationName string) (string, error) {
+	fragment := struct {
+		Properties struct {
+			InstallationID string `json:"installationId"`
+			Operation      string `json:"operation"`
+		} `json:"properties"`
+	}{}
+
+	fragment.Properties.InstallationID = integrationID
+	fragment.Properties.Operation = operationName
+
+	b, err := json.Marshal(fragment)
+	if err != nil {
+		return "", err
+	}
+
+	return string(b), nil
 }
 
 // resolveOperationClient resolves the client for an operation. When integration

--- a/internal/integrations/runtime/payment_reminder.go
+++ b/internal/integrations/runtime/payment_reminder.go
@@ -23,10 +23,21 @@ import (
 )
 
 // SeedPaymentReminders starts the durable payment reminder polling loop
-// after runtime listeners have been registered
+// after runtime listeners have been registered. It is a no-op when an active job
+// already exists, preventing duplicate loops from accumulating across restarts
 func (r *Runtime) SeedPaymentReminders(ctx context.Context) error {
 	if !r.paymentReminderConfig.Enabled {
 		logx.FromContext(ctx).Info().Msg("payment reminder listener disabled, skipping seed")
+		return nil
+	}
+
+	active, err := r.Gala().HasActiveJobForTopic(ctx, operations.PaymentReminderTopic)
+	if err != nil {
+		return err
+	}
+
+	if active {
+		logx.FromContext(ctx).Debug().Msg("payment reminder poller already active, skipping seed")
 		return nil
 	}
 

--- a/internal/integrations/runtime/recurring_campaign.go
+++ b/internal/integrations/runtime/recurring_campaign.go
@@ -20,8 +20,19 @@ import (
 )
 
 // SeedRecurringCampaigns starts the durable recurring campaign polling loop
-// after runtime listeners have been registered.
+// after runtime listeners have been registered. It is a no-op when an active job
+// already exists, preventing duplicate loops from accumulating across restarts
 func (r *Runtime) SeedRecurringCampaigns(ctx context.Context) error {
+	active, err := r.Gala().HasActiveJobForTopic(ctx, operations.RecurringCampaignTopic)
+	if err != nil {
+		return err
+	}
+
+	if active {
+		logx.FromContext(ctx).Debug().Msg("recurring campaign poller already active, skipping seed")
+		return nil
+	}
+
 	receipt := r.Gala().EmitWithHeaders(ctx, operations.RecurringCampaignTopic, operations.RecurringCampaignEnvelope{}, gala.Headers{
 		Tags: []string{"campaigns"},
 	})

--- a/pkg/gala/gala.go
+++ b/pkg/gala/gala.go
@@ -2,6 +2,7 @@ package gala
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -506,6 +507,44 @@ const (
 	durableWaitPollInterval = 50 * time.Millisecond
 	durableIdleThreshold    = 3
 )
+
+// HasActiveJobForTopic reports whether at least one River job for the given topic
+// exists in an active state (available, scheduled, running, or retryable).
+// Returns false without error when Gala is not in durable mode
+func (g *Gala) HasActiveJobForTopic(ctx context.Context, topic TopicName) (bool, error) {
+	fragment, err := json.Marshal(map[string]string{"topic": string(topic)})
+	if err != nil {
+		return false, err
+	}
+
+	return g.HasActiveJobWithMetadata(ctx, string(fragment))
+}
+
+// HasActiveJobWithMetadata reports whether at least one River job whose metadata
+// JSONB contains the given fragment exists in an active state (available, scheduled,
+// running, or retryable). Returns false without error when Gala is not in durable mode
+func (g *Gala) HasActiveJobWithMetadata(ctx context.Context, metadataFragment string) (bool, error) {
+	if g.jobClient == nil {
+		return false, nil
+	}
+
+	params := river.NewJobListParams().
+		Metadata(metadataFragment).
+		States(
+			rivertype.JobStateAvailable,
+			rivertype.JobStateRunning,
+			rivertype.JobStateScheduled,
+			rivertype.JobStateRetryable,
+		).
+		First(1)
+
+	result, err := g.jobClient.GetRiverClient().JobList(ctx, params)
+	if err != nil {
+		return false, err
+	}
+
+	return len(result.Jobs) > 0, nil
+}
 
 // Close closes the dedicated Gala queue client
 func (g *Gala) Close() error {

--- a/pkg/objects/storage/utils_test.go
+++ b/pkg/objects/storage/utils_test.go
@@ -476,4 +476,3 @@ func TestParseDocument_EmptyContent(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
- esnures integation jobs exists on startup, run in a go routine to prevent delay of startup
- ensures only one pending deletion and recurring campaign job is added, currently 1 per pod is created on every startup
- ensures integration job exists during health check (best effort, logs warnings)
- ensures integration job exists when config is updated 

Tested locally, if all jobs are there:

```
4:21M DBG internal/integrations/runtime/execution.go:413 | installations found to check for reconciliation count=1 severity=DEBUG
4:21PM DBG internal/integrations/runtime/execution.go:467 | reconcile job already active, skipping seed integration_id=01KS3N4QWRW096C7MEHBE98HKJ operation=RepositorySync severity=DEBUG
4:21PM DBG internal/integrations/runtime/execution.go:467 | reconcile job already active, skipping seed integration_id=01KS3N4QWRW096C7MEHBE98HKJ operation=VulnerabilitySync severity=DEBUG
```

If they get deleted:
```
4:22PM DBG internal/integrations/runtime/execution.go:413 | installations found to check for reconciliation count=1 severity=DEBUG
4:22PM INF internal/integrations/runtime/execution.go:471 | seeding missing reconcile job integration_id=01KS3N4QWRW096C7MEHBE98HKJ operation=RepositorySync severity=INFO
4:22PM DBG pkg/gala/gala.go:293 | gala event emitted event_id=01KS3QQJSM1JVHP76BS932J1NT severity=DEBUG topic=integration.ReconcileEnvelope
4:22PM INF internal/integrations/runtime/execution.go:471 | seeding missing reconcile job integration_id=01KS3N4QWRW096C7MEHBE98HKJ operation=VulnerabilitySync severity=INFO
```