### PR TITLE
Move watermarking enqueing from hook to gala listener

### DIFF
--- a/internal/ent/hooks/listeners_gala_registration_test.go
+++ b/internal/ent/hooks/listeners_gala_registration_test.go
@@ -43,6 +43,21 @@ func TestRegisterGalaTrustCenterCacheListeners(t *testing.T) {
 	require.True(t, registry.InterestedIn(gala.TopicName(entgen.TypeTrustCenter), eventqueue.SoftDeleteOne))
 }
 
+func TestRegisterGalaTrustCenterWatermarkListeners(t *testing.T) {
+	t.Parallel()
+
+	registry := gala.NewRegistry()
+
+	ids, err := RegisterGalaTrustCenterWatermarkListeners(registry)
+	require.NoError(t, err)
+	require.Len(t, ids, 1)
+
+	topic := eventqueue.MutationTopicName(eventqueue.MutationConcernDirect, entgen.TypeTrustCenterDoc)
+	require.True(t, registry.InterestedIn(topic, ent.OpCreate.String()))
+	require.True(t, registry.InterestedIn(topic, ent.OpUpdateOne.String()))
+	require.False(t, registry.InterestedIn(topic, ent.OpDelete.String()))
+}
+
 func TestRegisterGalaWorkflowMutationListeners(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ent/hooks/listeners_trustcenter_watermark.go
+++ b/internal/ent/hooks/listeners_trustcenter_watermark.go
@@ -1,0 +1,65 @@
+package hooks
+
+import (
+	"entgo.io/ent"
+
+	"github.com/theopenlane/core/common/jobspec"
+	"github.com/theopenlane/core/internal/ent/eventqueue"
+	"github.com/theopenlane/core/internal/ent/generated"
+	"github.com/theopenlane/core/internal/ent/generated/trustcenterdoc"
+	"github.com/theopenlane/core/pkg/gala"
+	"github.com/theopenlane/core/pkg/logx"
+)
+
+// RegisterGalaTrustCenterWatermarkListeners registers listeners that enqueue
+// watermarking jobs after trust center document db transactions have been committed.
+func RegisterGalaTrustCenterWatermarkListeners(registry *gala.Registry) ([]gala.ListenerID, error) {
+	return gala.RegisterListeners(registry,
+		gala.Definition[eventqueue.MutationGalaPayload]{
+			Topic:      eventqueue.MutationTopic(eventqueue.MutationConcernDirect, generated.TypeTrustCenterDoc),
+			Name:       "trustcenter.watermark.doc",
+			Operations: []string{ent.OpCreate.String(), ent.OpUpdateOne.String()},
+			Handle:     handleTrustCenterDocWatermarkGala,
+		},
+	)
+}
+
+func handleTrustCenterDocWatermarkGala(ctx gala.HandlerContext, payload eventqueue.MutationGalaPayload) error {
+	ctx, client, ok := eventqueue.ClientFromHandler(ctx)
+	if !ok {
+		return nil
+	}
+
+	if payload.Operation == ent.OpUpdateOne.String() && !eventqueue.MutationFieldChanged(payload, trustcenterdoc.FieldOriginalFileID) {
+		return nil
+	}
+
+	documentID, ok := eventqueue.MutationEntityID(payload, ctx.Envelope.Headers.Properties)
+	if !ok || documentID == "" {
+		return nil
+	}
+
+	document, err := client.TrustCenterDoc.Query().
+		Where(trustcenterdoc.ID(documentID)).
+		Select(trustcenterdoc.FieldID, trustcenterdoc.FieldWatermarkingEnabled).
+		Only(ctx.Context)
+	if err != nil {
+		if generated.IsNotFound(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	if !document.WatermarkingEnabled {
+		return nil
+	}
+
+	logx.FromContext(ctx.Context).Debug().
+		Str("trust_center_doc_id", document.ID).
+		Msg("watermarking enabled, queuing job")
+
+	return enqueueJob(ctx.Context, client.Job, jobspec.WatermarkDocArgs{
+		TrustCenterDocumentID: document.ID,
+	}, nil)
+}

--- a/internal/ent/hooks/listeners_trustcenter_watermark.go
+++ b/internal/ent/hooks/listeners_trustcenter_watermark.go
@@ -27,39 +27,56 @@ func RegisterGalaTrustCenterWatermarkListeners(registry *gala.Registry) ([]gala.
 func handleTrustCenterDocWatermarkGala(ctx gala.HandlerContext, payload eventqueue.MutationGalaPayload) error {
 	ctx, client, ok := eventqueue.ClientFromHandler(ctx)
 	if !ok {
+		logx.FromContext(ctx.Context).Info().Msg("no ent client found in gala handler context, skipping trust center doc watermark job")
 		return nil
 	}
 
 	if payload.Operation == ent.OpUpdateOne.String() && !eventqueue.MutationFieldChanged(payload, trustcenterdoc.FieldOriginalFileID) {
+		logx.FromContext(ctx.Context).Info().Msg("no original file change detected in mutation, skipping trust center doc watermark job")
 		return nil
 	}
 
 	documentID, ok := eventqueue.MutationEntityID(payload, ctx.Envelope.Headers.Properties)
 	if !ok || documentID == "" {
+		logx.FromContext(ctx.Context).Info().Msg("no trust center document ID found in mutation, skipping watermark job")
 		return nil
 	}
 
 	document, err := client.TrustCenterDoc.Query().
 		Where(trustcenterdoc.ID(documentID)).
-		Select(trustcenterdoc.FieldID, trustcenterdoc.FieldWatermarkingEnabled).
+		Where(trustcenterdoc.WatermarkingEnabled(true)).
+		Select(trustcenterdoc.FieldID).
 		Only(ctx.Context)
 	if err != nil {
 		if generated.IsNotFound(err) {
+			logx.FromContext(ctx.Context).Info().
+				Str("trust_center_doc_id", documentID).
+				Msg("trust center document not found or watermarking disabled, skipping watermark job")
 			return nil
 		}
 
-		return err
-	}
+		logx.FromContext(ctx.Context).Error().
+			Err(err).
+			Str("trust_center_doc_id", documentID).
+			Msg("failed to query trust center document for watermark job")
 
-	if !document.WatermarkingEnabled {
-		return nil
+		return err
 	}
 
 	logx.FromContext(ctx.Context).Debug().
 		Str("trust_center_doc_id", document.ID).
 		Msg("watermarking enabled, queuing job")
 
-	return enqueueJob(ctx.Context, client.Job, jobspec.WatermarkDocArgs{
+	if err := enqueueJob(ctx.Context, client.Job, jobspec.WatermarkDocArgs{
 		TrustCenterDocumentID: document.ID,
-	}, nil)
+	}, nil); err != nil {
+		logx.FromContext(ctx.Context).Error().
+			Err(err).
+			Str("trust_center_doc_id", document.ID).
+			Msg("failed to enqueue trust center doc watermark job")
+
+		return err
+	}
+
+	return nil
 }

--- a/internal/ent/hooks/trustcenterdoc.go
+++ b/internal/ent/hooks/trustcenterdoc.go
@@ -9,7 +9,6 @@ import (
 	"github.com/theopenlane/utils/contextx"
 
 	"github.com/theopenlane/core/common/enums"
-	"github.com/theopenlane/core/common/jobspec"
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/hook"
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
@@ -122,15 +121,6 @@ func HookCreateTrustCenterDoc() ent.Hook {
 					logx.FromContext(ctx).Error().Err(err).Msg("failed to create relationship tuple for trust center doc visibility")
 
 					return nil, ErrInternalServerError
-				}
-			}
-
-			if trustCenterDoc.WatermarkingEnabled {
-				logx.FromContext(ctx).Debug().Msg("watermarking enabled, queuing job")
-				if err := enqueueJob(ctx, m.Job, jobspec.WatermarkDocArgs{
-					TrustCenterDocumentID: trustCenterDoc.ID,
-				}, nil); err != nil {
-					return nil, err
 				}
 			}
 
@@ -265,22 +255,14 @@ func HookUpdateTrustCenterDoc() ent.Hook {
 				}
 			}
 
-			if mutationSetsOriginalFileID || len(docFiles) > 0 {
-				if trustCenterDoc.WatermarkingEnabled {
-					if err := enqueueJob(ctx, m.Job, jobspec.WatermarkDocArgs{
-						TrustCenterDocumentID: trustCenterDoc.ID,
-					}, nil); err != nil {
-						return nil, err
-					}
-				} else {
-					// Use privacy allow context for internal update operation to bypass authorization checks
-					// and mark as internal operation to avoid triggering the update hook logic
-					allowCtx := privacy.DecisionContext(ctx, privacy.Allow)
-					internalCtx := internalTrustCenterDocUpdateContextKey.Set(allowCtx, struct{}{})
-					trustCenterDoc, err = m.Client().TrustCenterDoc.UpdateOne(trustCenterDoc).SetFileID(*trustCenterDoc.OriginalFileID).Save(internalCtx)
-					if err != nil {
-						return nil, err
-					}
+			if (mutationSetsOriginalFileID || len(docFiles) > 0) && !trustCenterDoc.WatermarkingEnabled {
+				// Use privacy allow context for internal update operation to bypass authorization checks
+				// and mark as internal operation to avoid triggering the update hook logic
+				allowCtx := privacy.DecisionContext(ctx, privacy.Allow)
+				internalCtx := internalTrustCenterDocUpdateContextKey.Set(allowCtx, struct{}{})
+				trustCenterDoc, err = m.Client().TrustCenterDoc.UpdateOne(trustCenterDoc).SetFileID(*trustCenterDoc.OriginalFileID).Save(internalCtx)
+				if err != nil {
+					return nil, err
 				}
 			}
 

--- a/internal/httpserve/serveropts/gala.go
+++ b/internal/httpserve/serveropts/gala.go
@@ -87,6 +87,7 @@ func ConfigureGala(ctx context.Context, galaApp, notificationGala *gala.Gala, db
 	}{
 		{galaApp, hooks.RegisterGalaEntitlementListeners},
 		{galaApp, hooks.RegisterGalaTrustCenterCacheListeners},
+		{galaApp, hooks.RegisterGalaTrustCenterWatermarkListeners},
 		{galaApp, hooks.RegisterGalaWorkflowListeners},
 		{galaApp, hooks.RegisterGalaVendorScoringListeners},
 		{galaApp, hooks.RegisterGalaIdentityResolutionListeners},


### PR DESCRIPTION
this prevents random race conditions where the jobs tries to fetch the document and it is not existent. only for the job to succeeed on 2nd run