### PR TITLE
ensure caller is set for gala operations

### DIFF
--- a/internal/integrations/runtime/execution.go
+++ b/internal/integrations/runtime/execution.go
@@ -105,6 +105,8 @@ func (r *Runtime) HandleReconcile(ctx context.Context, envelope operations.Recon
 		return 0, err
 	}
 
+	ctx = ensureCallerOrg(ctx, installation.OwnerID)
+
 	db := r.DB()
 	startedAt := time.Now()
 
@@ -261,6 +263,10 @@ func (r *Runtime) HandleOperation(ctx context.Context, envelope operations.Envel
 		return failRun(bootstrapErr, nil)
 	}
 
+	if integration != nil {
+		ctx = ensureCallerOrg(ctx, integration.OwnerID)
+	}
+
 	if tracked {
 		if err := operations.MarkRunRunning(ctx, db, envelope.RunID); err != nil {
 			return failRun(err, nil)
@@ -413,7 +419,7 @@ func (r *Runtime) SeedReconcileJobs(ctx context.Context) error {
 	logx.FromContext(ctx).Debug().Int("count", len(installations)).Msg("installations found to check for reconciliation")
 
 	for _, inst := range installations {
-		if err := r.seedReconcileJobsForInstallation(systemCtx, inst); err != nil {
+		if err := r.seedReconcileJobsForInstallation(ensureCallerOrg(systemCtx, inst.OwnerID), inst); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -428,7 +434,7 @@ func (r *Runtime) SeedReconcileJobsForInstallation(ctx context.Context, inst *en
 		Capabilities: auth.CapBypassOrgFilter | auth.CapBypassFGA | auth.CapInternalOperation,
 	})
 
-	return r.seedReconcileJobsForInstallation(systemCtx, inst)
+	return r.seedReconcileJobsForInstallation(ensureCallerOrg(systemCtx, inst.OwnerID), inst)
 }
 
 // seedReconcileJobsForInstallation is the shared implementation used by both
@@ -491,6 +497,28 @@ func (r *Runtime) seedReconcileJobsForInstallation(ctx context.Context, inst *en
 	}
 
 	return errors.Join(errs...)
+}
+
+// ensureCallerOrg sets the organization on the existing caller if not already present
+func ensureCallerOrg(ctx context.Context, orgID string) context.Context {
+	if orgID == "" {
+		return ctx
+	}
+
+	caller, ok := auth.CallerFromContext(ctx)
+	if !ok || caller == nil {
+		return ctx
+	}
+
+	if _, hasOrg := caller.ActiveOrg(); hasOrg {
+		return ctx
+	}
+
+	scoped := *caller
+	scoped.OrganizationID = orgID
+	scoped.OrganizationIDs = append([]string{orgID}, caller.OrgIDs()...)
+
+	return auth.WithCaller(ctx, &scoped)
 }
 
 // reconcilableDefinitionIDs returns the IDs of all registered definitions that

--- a/internal/integrations/runtime/execution_test.go
+++ b/internal/integrations/runtime/execution_test.go
@@ -12,6 +12,7 @@ import (
 	ent "github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/integrations/registry"
 	"github.com/theopenlane/core/internal/integrations/types"
+	"github.com/theopenlane/iam/auth"
 )
 
 func TestExecuteOperationNilInstallation(t *testing.T) {
@@ -283,5 +284,94 @@ func TestExecuteOperationPassesRequestFields(t *testing.T) {
 
 	if string(captured.Config) != `{"key":"value"}` {
 		t.Fatalf("expected config to be passed through, got %s", string(captured.Config))
+	}
+}
+
+func TestEnsureCallerOrg(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		ctx     func() context.Context
+		orgID   string
+		wantOrg string
+		wantCap auth.Capability
+	}{
+		{
+			name:  "sets org on caller without one",
+			orgID: "org-123",
+			ctx: func() context.Context {
+				return auth.WithCaller(context.Background(), &auth.Caller{
+					Capabilities: auth.CapBypassOrgFilter | auth.CapInternalOperation,
+				})
+			},
+			wantOrg: "org-123",
+			wantCap: auth.CapBypassOrgFilter | auth.CapInternalOperation,
+		},
+		{
+			name:  "preserves existing org",
+			orgID: "org-override",
+			ctx: func() context.Context {
+				return auth.WithCaller(context.Background(), &auth.Caller{
+					OrganizationID: "org-original",
+					Capabilities:   auth.CapInternalOperation,
+				})
+			},
+			wantOrg: "org-original",
+			wantCap: auth.CapInternalOperation,
+		},
+		{
+			name:  "preserves org from OrganizationIDs",
+			orgID: "org-override",
+			ctx: func() context.Context {
+				return auth.WithCaller(context.Background(), &auth.Caller{
+					OrganizationIDs: []string{"org-from-ids"},
+				})
+			},
+			wantOrg: "org-from-ids",
+		},
+		{
+			name:  "no-op for empty orgID",
+			orgID: "",
+			ctx: func() context.Context {
+				return auth.WithCaller(context.Background(), &auth.Caller{
+					Capabilities: auth.CapInternalOperation,
+				})
+			},
+		},
+		{
+			name:  "no-op when no caller in context",
+			orgID: "org-123",
+			ctx:   context.Background,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := ensureCallerOrg(tc.ctx(), tc.orgID)
+			caller, ok := auth.CallerFromContext(result)
+
+			if tc.wantOrg == "" {
+				if ok && caller != nil {
+					if orgID, has := caller.ActiveOrg(); has && orgID != "" {
+						assert.Assert(t, orgID == "", "expected no org, got %q", orgID)
+					}
+				}
+
+				return
+			}
+
+			assert.Assert(t, ok && caller != nil, "expected caller in context")
+
+			orgID, hasOrg := caller.ActiveOrg()
+			assert.Assert(t, hasOrg, "expected caller to have active org")
+			assert.Equal(t, tc.wantOrg, orgID)
+
+			if tc.wantCap != 0 {
+				assert.Assert(t, caller.Has(tc.wantCap), "expected capabilities to be preserved")
+			}
+		})
 	}
 }


### PR DESCRIPTION
`pkg/gala` already correctly restores the Caller context, we need to be sure its actually set before performing the event submission. This adds a small function that updates the Caller organization ID(s) if they are not already set and inserts them at key junctures.