### PR TITLE
fix: allow system admin to bypass interceptors for docs + watermarks

### DIFF
--- a/common/go.mod
+++ b/common/go.mod
@@ -29,7 +29,6 @@ require (
 	github.com/agnivade/levenshtein v1.2.1 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/bmatcuk/doublestar v1.3.4 // indirect
-	github.com/brianvoe/gofakeit/v7 v7.15.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fxamacker/cbor/v2 v2.9.2 // indirect

--- a/internal/ent/schema/file.go
+++ b/internal/ent/schema/file.go
@@ -163,6 +163,7 @@ func (f File) Mixin() []ent.Mixin {
 					TrustCenterDoc{}, Standard{}, TrustCenterEntity{}, TrustCenterSubprocessor{}, Entity{}, IdentityHolder{}, Contact{}, Review{}),
 				withHookFuncs(), // use an empty hook, file processing is handled in middleware
 				withAllowAnonymousTrustCenterAccess(true),
+				withSkipperFunc(skipInterceptorForSystemAdmins),
 			),
 			mixin.NewSystemOwnedMixin(mixin.SkipTupleCreation()),
 			newCustomEnumMixin(f, withEnumFieldName("environment"), withGlobalEnum()),

--- a/internal/ent/schema/mixin_objectowned.go
+++ b/internal/ent/schema/mixin_objectowned.go
@@ -476,16 +476,7 @@ func skipInterceptorForOrgMembers(ctx context.Context) bool {
 
 // skipInterceptorForSystemAdmins skips the filter interceptor for system admins
 func skipInterceptorForSystemAdmins(ctx context.Context) bool {
-	caller, ok := auth.CallerFromContext(ctx)
-	if !ok || caller == nil {
-		return false
-	}
-
-	if caller.Has(auth.CapSystemAdmin) {
-		return true
-	}
-
-	return false
+	return auth.IsSystemAdminFromContext(ctx)
 }
 
 // getObjectInterceptor adds the interceptor for the object owned mixin

--- a/internal/ent/schema/mixin_objectowned.go
+++ b/internal/ent/schema/mixin_objectowned.go
@@ -474,6 +474,20 @@ func skipInterceptorForOrgMembers(ctx context.Context) bool {
 	return false
 }
 
+// skipInterceptorForSystemAdmins skips the filter interceptor for system admins
+func skipInterceptorForSystemAdmins(ctx context.Context) bool {
+	caller, ok := auth.CallerFromContext(ctx)
+	if !ok || caller == nil {
+		return false
+	}
+
+	if caller.Has(auth.CapSystemAdmin) {
+		return true
+	}
+
+	return false
+}
+
 // getObjectInterceptor adds the interceptor for the object owned mixin
 // based on the settings configured in the mixin
 func getObjectInterceptor[V any](o *ObjectOwnedMixin) {

--- a/internal/ent/schema/trustcenterdocument.go
+++ b/internal/ent/schema/trustcenterdocument.go
@@ -96,6 +96,7 @@ func (t TrustCenterDoc) Mixin() []ent.Mixin {
 		additionalMixins: []ent.Mixin{
 			newObjectOwnedMixin[generated.TrustCenterDoc](t,
 				withParents(TrustCenter{}),
+				withSkipperFunc(skipInterceptorForSystemAdmins),
 			),
 			newCustomEnumMixin(t),
 			newGroupPermissionsMixin(withSkipViewPermissions()),

--- a/internal/ent/schema/trustcenterwatermarkconfig.go
+++ b/internal/ent/schema/trustcenterwatermarkconfig.go
@@ -117,6 +117,7 @@ func (t TrustCenterWatermarkConfig) Mixin() []ent.Mixin {
 			newObjectOwnedMixin[generated.TrustCenterWatermarkConfig](t,
 				withParents(TrustCenter{}),
 				withOrganizationOwner(true),
+				withSkipperFunc(skipInterceptorForSystemAdmins),
 			),
 			newGroupPermissionsMixin(withSkipViewPermissions()),
 		},

--- a/internal/graphapi/models_test.go
+++ b/internal/graphapi/models_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/theopenlane/iam/auth"
-	"github.com/theopenlane/iam/fgax"
 	"github.com/theopenlane/utils/ulids"
 
 	"github.com/theopenlane/core/common/enums"
@@ -2022,27 +2021,6 @@ func (tc *TrustCenterBuilder) MustNew(ctx context.Context, t *testing.T) *ent.Tr
 
 	trustCenter, err := mutation.Save(ctx)
 	requireNoError(t, err)
-
-	// Create the organization parent tuple for the trust center
-	// This is normally done by the orgOwnedMixin, but since we're bypassing hooks, we need to do it manually
-	orgCaller, orgCallerOk := auth.CallerFromContext(ctx)
-	if !orgCallerOk || orgCaller == nil {
-		requireNoError(t, auth.ErrNoAuthUser)
-	}
-	orgID := orgCaller.OrganizationID
-
-	parentReq := fgax.TupleRequest{
-		SubjectID:   orgID,
-		SubjectType: "organization",
-		ObjectID:    trustCenter.ID,
-		ObjectType:  "trust_center",
-		Relation:    "parent",
-	}
-
-	tuple := fgax.GetTupleKey(parentReq)
-	if _, err := tc.client.db.Authz.WriteTupleKeys(ctx, []fgax.TupleKey{tuple}, nil); err != nil {
-		requireNoError(t, err)
-	}
 
 	return trustCenter
 }

--- a/internal/graphapi/notification_test.go
+++ b/internal/graphapi/notification_test.go
@@ -76,7 +76,7 @@ func TestMutationCreateNotification(t *testing.T) {
 			assert.Check(t, is.Equal(tc.request.Body, resp.CreateNotification.Notification.Body))
 			assert.Check(t, is.Equal(tc.request.ObjectType, resp.CreateNotification.Notification.ObjectType))
 
-			(&Cleanup[*generated.NotificationDeleteOne]{client: suite.client.db.Notification, ID: resp.CreateNotification.Notification.ID}).MustDelete(adminUser.UserCtx, t)
+			(&Cleanup[*generated.NotificationDeleteOne]{client: suite.client.db.Notification, ID: resp.CreateNotification.Notification.ID}).MustDelete(systemAdminUser.UserCtx, t)
 		})
 	}
 }

--- a/internal/graphapi/trustcenterdoc_test.go
+++ b/internal/graphapi/trustcenterdoc_test.go
@@ -56,6 +56,13 @@ func TestQueryTrustCenterDocByID(t *testing.T) {
 			shouldShowFileDetails: true,
 		},
 		{
+			name:                  "happy path, by system admin can see not visible docs",
+			queryID:               trustCenterDocNotVisible.ID,
+			client:                suite.client.api,
+			ctx:                   systemAdminUser.UserCtx,
+			shouldShowFileDetails: true,
+		},
+		{
 			name:                  "happy path, view only user",
 			queryID:               trustCenterDocProtected.ID,
 			client:                suite.client.api,
@@ -153,6 +160,7 @@ func TestQueryTrustCenterDocByID(t *testing.T) {
 			assert.Check(t, resp.TrustCenterDoc.OriginalFileID != nil)
 			if tc.shouldShowFileDetails {
 				assert.Check(t, resp.TrustCenterDoc.OriginalFile != nil)
+				assert.Check(t, *resp.TrustCenterDoc.OriginalFile.PresignedURL != "")
 			} else {
 				assert.Check(t, resp.TrustCenterDoc.OriginalFile == nil)
 			}
@@ -700,9 +708,10 @@ func TestQueryTrustCenterDocs(t *testing.T) {
 }
 
 func TestMutationUpdateTrustCenterDoc(t *testing.T) {
-
 	trustCenter := (&TrustCenterBuilder{client: suite.client}).MustNew(testUser1.UserCtx, t)
 	trustCenterDoc := (&TrustCenterDocBuilder{client: suite.client, TrustCenterID: trustCenter.ID}).MustNew(testUser1.UserCtx, t)
+
+	systemAdminPatClient := suite.setupPatClient(systemAdminUser, t)
 
 	(&CustomTypeEnumBuilder{
 		client:     suite.client,
@@ -733,6 +742,16 @@ func TestMutationUpdateTrustCenterDoc(t *testing.T) {
 			client: suite.client.api,
 			ctx:    testUser1.UserCtx,
 		},
+		{
+			name:             "happy path, update watermark status by system admin pat",
+			trustCenterDocID: trustCenterDoc.ID,
+			request: testclient.UpdateTrustCenterDocInput{
+				WatermarkStatus: &enums.WatermarkStatusInProgress,
+			},
+			client: systemAdminPatClient,
+			ctx:    context.Background(),
+		},
+
 		{
 			name:             "happy path, update category",
 			trustCenterDocID: trustCenterDoc.ID,

--- a/internal/graphapi/trustcenterwatermarkconfig_test.go
+++ b/internal/graphapi/trustcenterwatermarkconfig_test.go
@@ -176,11 +176,16 @@ func TestQueryTrustCenterWatermarkConfig(t *testing.T) {
 		expectedErr string
 	}{
 		{
-			name:        "happy path",
-			queryID:     watermarkConfig.ID,
-			client:      suite.client.api,
-			ctx:         testUser1.UserCtx,
-			expectedErr: "",
+			name:    "happy path",
+			queryID: watermarkConfig.ID,
+			client:  suite.client.api,
+			ctx:     testUser1.UserCtx,
+		},
+		{
+			name:    "happy path by system admin",
+			queryID: watermarkConfig.ID,
+			client:  suite.client.api,
+			ctx:     systemAdminUser.UserCtx,
 		},
 		{
 			name:        "not found",
@@ -218,6 +223,22 @@ func TestQueryTrustCenterWatermarkConfig(t *testing.T) {
 			assert.NilError(t, err)
 			assert.Assert(t, resp != nil)
 			assert.Check(t, is.Equal(tc.queryID, resp.TrustCenterWatermarkConfig.ID))
+
+			// check the list as well
+			resp2, err := tc.client.GetTrustCenterWatermarkConfigs(tc.ctx, nil, nil, &testclient.TrustCenterWatermarkConfigWhereInput{
+				TrustCenterID: &trustCenter.ID,
+			})
+			assert.NilError(t, err)
+			assert.Assert(t, resp != nil)
+
+			if tc.expectedErr != "" {
+				assert.Check(t, is.Len(resp2.TrustCenterWatermarkConfigs.Edges, 0))
+
+				return
+			}
+
+			assert.Check(t, is.Len(resp2.TrustCenterWatermarkConfigs.Edges, 1))
+			assert.Check(t, is.Equal(tc.queryID, resp2.TrustCenterWatermarkConfigs.Edges[0].Node.ID))
 		})
 	}
 	(&Cleanup[*generated.TrustCenterWatermarkConfigDeleteOne]{client: suite.client.db.TrustCenterWatermarkConfig, ID: watermarkConfig.ID}).MustDelete(testUser1.UserCtx, t)


### PR DESCRIPTION
- added skippers for the `filter` interceptor for system admins
- added tests to confirm behavior; all of these except one of the docs one was passing without any changes - confirmed this was due to caps added in the test system admin setup that are not in prod: https://github.com/theopenlane/iam/pull/513 - with the iam change and the fixes in this PR those tests do fail as expected. 
- removed unnecessary tuple creation from trust center test (all tests still pass without)