### PR TITLE
drop trivy ignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,6 +1,0 @@
-## https://github.com/testcontainers/testcontainers-go/issues/3614
-## requires a lot of changes since docker/docker updated import paths to
-## moby/moby, so waiting until this is fixed.
-##
-## this is also a transient dependency for us
-CVE-2026-34040


### PR DESCRIPTION
https://github.com/testcontainers/testcontainers-go/issues/3614#issuecomment-4265746350 fixed in 0.42 which we already use 