### PR TITLE
fix: missing fga model definitions, token scopes on cli

### DIFF
--- a/cli/cmd/apitokens/create.go
+++ b/cli/cmd/apitokens/create.go
@@ -28,7 +28,7 @@ func init() {
 	createCmd.Flags().StringP("name", "n", "", "name of the api token token")
 	createCmd.Flags().StringP("description", "d", "", "description of the api token")
 	createCmd.Flags().DurationP("expiration", "e", 0, "duration of the api token to be valid, leave empty to never expire")
-	createCmd.Flags().StringSlice("scopes", []string{"can_view", "can_edit"}, "scopes to associate with the api token"+scopeFlagConfig())
+	createCmd.Flags().StringSlice("scopes", []string{}, "scopes to associate with the api token, use scopes command to see all available scopes")
 }
 
 // createValidation validates the required fields for the command

--- a/cli/cmd/apitokens/scopes.go
+++ b/cli/cmd/apitokens/scopes.go
@@ -5,32 +5,46 @@ package apitokens
 import (
 	"fmt"
 	"sort"
-	"strings"
 
+	"github.com/spf13/cobra"
 	fgamodel "github.com/theopenlane/core/fga/model"
 )
 
-// scopeFlagConfig returns a description suffix listing available scopes.
-func scopeFlagConfig() string {
-	scopes, err := fgamodel.RelationsForService()
+var scopesCmd = &cobra.Command{
+	Use:   "scopes",
+	Short: "list scopes available for an api token",
+	Run: func(cmd *cobra.Command, args []string) {
+		err := allScopes()
+		cobra.CheckErr(err)
+	},
+}
+
+func init() {
+	command.AddCommand(scopesCmd)
+}
+
+// allScopes returns all available scopes
+func allScopes() error {
+	scopes, err := fgamodel.ScopeOptions()
 	if err != nil {
-		panic(fmt.Sprintf("failed to load service scopes: %v", err))
+		return fmt.Errorf("failed to load service scopes: %v", err)
 	}
 
-	desc := fmt.Sprintf(" (available: %s)", strings.Join(scopes, ", "))
+	objects := make([]string, 0, len(scopes))
+	for obj := range scopes {
+		objects = append(objects, obj)
+	}
+	sort.Strings(objects)
 
-	aliases := fgamodel.ScopeAliases()
-	if len(aliases) > 0 {
-		aliasPairs := make([]string, 0, len(aliases))
-
-		for alias, relation := range aliases {
-			aliasPairs = append(aliasPairs, fmt.Sprintf("%s->%s", alias, relation))
+	desc := fmt.Sprintf("available scopes: \n\n")
+	for _, obj := range objects {
+		for _, v := range scopes[obj] {
+			desc += fmt.Sprintf("%s:%s ", obj, v)
 		}
-
-		sort.Strings(aliasPairs)
-
-		desc = fmt.Sprintf("%s; aliases: %s", desc, strings.Join(aliasPairs, ", "))
+		desc += fmt.Sprintf("\n")
 	}
 
-	return desc
+	fmt.Println(desc)
+
+	return nil
 }

--- a/cli/cmd/apitokens/scopes.go
+++ b/cli/cmd/apitokens/scopes.go
@@ -23,6 +23,11 @@ func init() {
 	command.AddCommand(scopesCmd)
 }
 
+const (
+	boldStart = "\033[1m"
+	boldEnd   = "\033[0m"
+)
+
 // allScopes returns all available scopes
 func allScopes() error {
 	scopes, err := fgamodel.ScopeOptions()
@@ -36,10 +41,10 @@ func allScopes() error {
 	}
 	sort.Strings(objects)
 
-	desc := fmt.Sprintf("available scopes: \n\n")
+	desc := fmt.Sprintf(boldStart + "Available Scopes: \n\n" + boldEnd)
 	for _, obj := range objects {
 		for _, v := range scopes[obj] {
-			desc += fmt.Sprintf("%s:%s ", obj, v)
+			desc += fmt.Sprintf(boldStart+"%s"+boldEnd+":%s ", obj, v)
 		}
 		desc += fmt.Sprintf("\n")
 	}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -2,9 +2,6 @@ module github.com/theopenlane/core/cli
 
 go 1.26.3
 
-// temporary replace for core local while fga package does not exist
-replace github.com/theopenlane/core => ../.
-
 require (
 	github.com/99designs/gqlgen v0.17.90
 	github.com/TylerBrock/colorjson v0.0.0-20200706003622-8a50f05110d2
@@ -20,8 +17,8 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/samber/lo v1.53.0
 	github.com/spf13/cobra v1.10.2
-	github.com/theopenlane/core v1.21.22
-	github.com/theopenlane/core/common v1.0.23
+	github.com/theopenlane/core v1.22.0
+	github.com/theopenlane/core/common v1.0.24
 	github.com/theopenlane/go-client v0.11.0
 	github.com/theopenlane/httpsling v0.3.0
 	github.com/theopenlane/iam v0.31.1

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -204,8 +204,9 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/theopenlane/core/common v1.0.23 h1:ZGpFADXgsbBLt0FVYZdJL+FEYJz1NCEnrCfcdRAJ84c=
-github.com/theopenlane/core/common v1.0.23/go.mod h1:de/V2poZlK0gmqUxNjyVHwirz2wcXtCrQHks71H7xrY=
+github.com/theopenlane/core v1.22.0 h1:qK5+Kk/rDcDOXW8YHrs2xT8aw0FiZIMkqyQ8AcBAa5w=
+github.com/theopenlane/core/common v1.0.24 h1:MIRjz6vnOwCHFSbC1oWjsuPCUCr8Xr9Z29+uLkMf694=
+github.com/theopenlane/core/common v1.0.24/go.mod h1:c3Jykrf6ENOf7bR7Wod4GpvCnspv9EAX49dgiWLY7DU=
 github.com/theopenlane/echox v0.3.0 h1:uwOKEw+r1utGQoOR6dZQqAVuY5j8TcasqnTwO5+rMsA=
 github.com/theopenlane/echox v0.3.0/go.mod h1:yTrXnj7s3VNIg0FCvB7Dut2Elr+LqJKU/nruxx1E1cM=
 github.com/theopenlane/go-client v0.11.0 h1:OoSQ+9zM2YZe+z0wSdo96vzWTRpAdpnxdlUirXobzwQ=

--- a/fga/model/automation/assessments.fga
+++ b/fga/model/automation/assessments.fga
@@ -45,7 +45,7 @@ type document_data
 type assessment
   relations
     # base permissions - these should all be derived permissions
-    define can_view: (viewer but not blocked)
+    define can_view: [user:*, service:*] or (viewer but not blocked)
     define can_edit: (editor but not blocked) or can_delete
     define can_delete: (editor but not blocked)
 
@@ -71,11 +71,11 @@ type assessment_response
     # base permissions - these should all be derived permissions
     define can_view: (viewer but not blocked)
     define can_edit: (editor but not blocked) or can_delete
-    define can_delete: (editor but not blocked)
+    define can_delete: parent_editor # response owners cannot delete
 
     # tuple based permissions for edit, view, blocked, and audit log viewing
-    define editor: [user, service, group#member] or parent_editor
-    define viewer: [user, service, group#member] or editor or parent_viewer or response_owner
+    define editor: [user, service, group#member] or parent_editor or response_owner
+    define viewer: [user, service, group#member] or editor or parent_viewer
     define blocked: [user, service, group#member]
     define audit_log_viewer: ([user, service, group#member] or audit_log_viewer from parent) and can_view
 

--- a/fga/model/automation/checkresult.fga
+++ b/fga/model/automation/checkresult.fga
@@ -1,0 +1,19 @@
+module automation
+
+type check_result
+  relations
+    # base permissions - these should all be derived permissions
+    define can_view: (viewer but not blocked)
+    define can_edit: (editor but not blocked) or can_delete
+    define can_delete: (editor but not blocked)
+
+    # tuple based permissions for edit, view, blocked, and audit log viewing
+    define editor: [user, service, group#member] or parent_editor
+    define viewer: [user, service, group#member] or editor or parent_viewer
+    define blocked: [user, service, group#member]
+    define audit_log_viewer: ([user, service, group#member] or audit_log_viewer from parent) and can_view
+
+    # parent permissions derived based on `crud` permissions or parents
+    define parent_editor: can_edit from parent
+    define parent_viewer: can_view from parent
+    define parent: [control]

--- a/fga/model/automation/directory.fga
+++ b/fga/model/automation/directory.fga
@@ -29,13 +29,14 @@ type directory_account
     define can_delete: (editor but not blocked)
 
     # tuple based permissions for edit, view, blocked, and audit log viewing
-    define editor: [service]
+    define editor: [service] or parent_editor
     define viewer: [service] or editor or parent_viewer
     define blocked: [user, service, group#member]
     define audit_log_viewer: (([user, service, group#member] or audit_log_viewer from parent or audit_log_viewer from parent_context) and can_view) or can_view
 
     # parent permissions derived based on `crud` permissions or parents
     define parent_viewer: can_view from parent_context or can_view_directory_account from parent_context or can_view from parent
+    define parent_editor: full_access from parent_context or can_edit from parent
     define parent_context: [organization]
     define parent: [integration, directory_sync_run, identity_holder, platform]
 
@@ -56,7 +57,7 @@ type directory_group
     # parent permissions derived based on `crud` permissions or parents
     define parent_viewer: can_view from parent_context or can_view_directory_account from parent_context or can_view from parent
     define parent_context: [organization]
-    define parent: [integration, directory_sync_run, platform]
+    define parent: [integration, directory_sync_run, platform, identity_holder]
 
 
 # directory memberships are service-managed joins between directory accounts and groups

--- a/fga/model/compliance/exposure.fga
+++ b/fga/model/compliance/exposure.fga
@@ -132,7 +132,6 @@ type vendor_scoring_config
     define can_edit: (editor but not blocked) or can_delete
     define can_delete: (editor but not blocked)
 
-
     # tuple based permissions for edit, view, blocked, and audit log viewing
     define editor: [user, service, group#member] or parent_editor
     define viewer: [user, service, group#member] or editor or parent_viewer
@@ -151,7 +150,6 @@ type vendor_risk_score
     define can_edit: (editor but not blocked) or can_delete
     define can_delete: (editor but not blocked)
 
-
     # tuple based permissions for edit, view, blocked, and audit log viewing
     define editor: [user, service, group#member] or parent_editor
     define viewer: [user, service, group#member] or editor or parent_viewer
@@ -164,14 +162,12 @@ type vendor_risk_score
     define parent_context: [organization]
     define parent: [vendor_scoring_config, entity, assessment_response]
 
-
 type sla_definition
   relations
     # base permissions - these should all be derived permissions
     define can_view: (viewer but not blocked)
     define can_edit: (editor but not blocked) or can_delete
     define can_delete: (editor but not blocked)
-
 
     # tuple based permissions for edit, view, blocked, and audit log viewing
     define editor: [user, service, group#member] or parent_editor

--- a/fga/tests/tests.yaml
+++ b/fga/tests/tests.yaml
@@ -1799,26 +1799,31 @@ tests:
         object: assessment_response:response-1
         assertions:
           can_view: true
+          can_edit: true
           can_delete: false
       - user: user:ulid-of-owner
         object: assessment_response:response-1
         assertions:
           can_view: true
+          can_edit: true
           can_delete: true
       - user: user:ulid-of-admin
         object: assessment_response:response-1
         assertions:
           can_view: true
+          can_edit: true
           can_delete: true
       - user: user:ulid-of-member
         object: assessment_response:response-1
         assertions:
           can_view: true
+          can_edit: false
           can_delete: false
       - user: user:ulid-of-owner-foobar
         object: assessment_response:response-1
         assertions:
           can_view: false
+          can_edit: false
           can_delete: false
     list_objects:
       - user: user:ulid-response-owner


### PR DESCRIPTION
- Adds missing fga tuples from when I started permissions to when I finished
- adds new cli command to list available scopes, removes output from `create` help

New `scopes` command:
```bash
go run -tags cli cli/main.go token scopes
Available Scopes: 

action_plan:delete action_plan:read action_plan:write 
api_token:delete api_token:read api_token:write 
assessment:delete assessment:read assessment:write 
asset:delete asset:read asset:write 
campaign:delete campaign:read campaign:write 
campaign_target:delete campaign_target:read campaign_target:write 
check_result:delete check_result:read check_result:write 
contact:delete contact:read contact:write 
...
````

Help command updated:
```bash
create a new api token

Usage:
  openlane token create [flags]

Flags:
  -d, --description string    description of the api token
  -e, --expiration duration   duration of the api token to be valid, leave empty to never expire
  -h, --help                  help for create
  -n, --name string           name of the api token token
      --scopes strings        scopes to associate with the api token, use scopes command to see all available scopes
```

Tests run locally to confirm nothing broke api changes:

```
✓  internal/httpserve/handlers (3m9.209s)
✓  internal/graphapi (5m19.071s)

=== Skipped
=== SKIP: pkg/summarizer TestLLM_Summarize (0.00s)

DONE 5554 tests, 1 skipped in 334.712s
```