### PR TITLE
feat: try github hosted runner again

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 jobs:
   ldflags_args:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     outputs:
       commit-date: ${{ steps.ldflags.outputs.commit-date }}
       commit: ${{ steps.ldflags.outputs.commit }}
@@ -35,7 +35,7 @@ jobs:
     permissions:
       contents: write # To add assets to a release.
       id-token: write # To do keyless signing with cosign
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
we had moved this to self hosted a long time about before splitting up the ci into its own module, hoping it using a lot less resources and we can flip this back 