### PR TITLE
set entity type for vendor intake

### DIFF
--- a/fga/model/automation/assessments.fga
+++ b/fga/model/automation/assessments.fga
@@ -85,7 +85,7 @@ type assessment_response
     # parent permissions derived based on `crud` permissions or parents
     define parent_editor: can_edit from parent
     define parent_viewer: can_view from parent
-    define parent: [assessment, campaign]
+    define parent: [assessment, campaign, entity]
 
 # campaign, similar to assessments, are viewable by organization admin+, by can_edit_campaign or inherited from the parent objects such as campaigns. They are not viewable by org members (view only) access by default
 type campaign

--- a/fga/tests/tests.yaml
+++ b/fga/tests/tests.yaml
@@ -1825,17 +1825,27 @@ tests:
           can_view: false
           can_edit: false
           can_delete: false
+      - user: user:ulid-of-owner
+        object: assessment_response:response-entity
+        assertions:
+          can_view: true
+          can_edit: true
+          can_delete: true
     list_objects:
       - user: user:ulid-response-owner
         type: assessment_response
+        context:
+          email_domain: "example.com"
         assertions:
           can_view:
             - assessment_response:response-1
+            - assessment_response:response-entity
       - user: user:ulid-of-owner
         type: assessment_response
         assertions:
           can_delete:
             - assessment_response:response-1
+            - assessment_response:response-entity
   - name: campaigns
     description: test campaign and campaign_target relationships with various parent types
     tuple_file: tuples/campaigns.yaml

--- a/fga/tests/tuples/assessment_responses.yaml
+++ b/fga/tests/tuples/assessment_responses.yaml
@@ -18,6 +18,13 @@
   relation: parent
   object: assessment_response:response-1
 
+- user: organization:openlane
+  relation: parent_context
+  object: entity:entity-1
+- user: entity:entity-1
+  relation: parent
+  object: assessment_response:response-entity
+
 # response owner
 - user: user:ulid-response-owner
   relation: response_owner

--- a/internal/ent/hooks/listeners_questionnaire_transform.go
+++ b/internal/ent/hooks/listeners_questionnaire_transform.go
@@ -21,6 +21,7 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated/assessmentresponse"
 	"github.com/theopenlane/core/internal/ent/generated/customtypeenum"
 	"github.com/theopenlane/core/internal/ent/generated/entity"
+	"github.com/theopenlane/core/internal/ent/generated/entitytype"
 	"github.com/theopenlane/core/internal/ent/generated/group"
 	"github.com/theopenlane/core/internal/ent/generated/note"
 	"github.com/theopenlane/core/internal/ent/generated/orgmembership"
@@ -107,6 +108,7 @@ func handleAssessmentResponse(ctx gala.HandlerContext, payload eventqueue.Mutati
 	err = transformQuestionnaire(allowCtx, client, questionnaireTransformRequest{
 		OrganizationID:       organizationID,
 		TemplateID:           assessment.TemplateID,
+		TemplateKind:         assessment.Edges.Template.Kind,
 		AssessmentID:         assessment.ID,
 		AssessmentResponseID: response.ID,
 		DocumentDataID:       response.DocumentDataID,
@@ -172,6 +174,7 @@ func questionnaireTransformFieldChanged(payload eventqueue.MutationGalaPayload) 
 
 const transformMetadataKey = "questionnaire_transform"
 const entityTransformFieldNotes = "notes"
+const entityTransformFieldEntityTypeID = "entityTypeID"
 const questionnaireTransformDefinitionID = "questionnaire_transform"
 
 type questionnaireValidationError struct {
@@ -188,6 +191,7 @@ func isQuestionnaireValidationError(err error) bool {
 type questionnaireTransformRequest struct {
 	OrganizationID       string
 	TemplateID           string
+	TemplateKind         enums.TemplateKind
 	AssessmentID         string
 	AssessmentResponseID string
 	DocumentDataID       string
@@ -232,6 +236,10 @@ func handleEntityTransform(ctx context.Context, client *entgen.Client, req quest
 
 	mapped, err := buildMappedTransformPayload(integrationgenerated.IntegrationMappingSchemaEntity, values, req)
 	if err != nil {
+		return err
+	}
+
+	if err := setVendorEntityType(ctx, client, req, mapped.Payload); err != nil {
 		return err
 	}
 
@@ -405,6 +413,30 @@ func resolveEnvironment(ctx context.Context, client *entgen.Client, organization
 	values[entity.FieldEnvironmentID] = enum.ID
 	values[entity.FieldEnvironmentName] = enum.Name
 
+	return nil
+}
+
+func setVendorEntityType(ctx context.Context, client *entgen.Client, req questionnaireTransformRequest, payload map[string]any) error {
+	if req.TemplateKind != enums.TemplateKindExternalIntake || payload[entityTransformFieldEntityTypeID] != nil {
+		return nil
+	}
+
+	id, err := client.EntityType.Query().
+		Where(
+			entitytype.OwnerIDEQ(req.OrganizationID),
+			entitytype.NameEqualFold("vendor"),
+		).
+		FirstID(ctx)
+
+	if entgen.IsNotFound(err) {
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("resolve external intake entity type: %w", err)
+	}
+
+	payload[entityTransformFieldEntityTypeID] = id
 	return nil
 }
 


### PR DESCRIPTION

- set the `vendor` entity type id ( of vendor ).
- this also fixes a fga issue on creation of an assessment response

```
5:33PM DBG Users/lanreadelowo/go/pkg/mod/github.com/theopenlane/iam@v0.32.0/fgax/tuples.go:320 | error in relationship tuples operation error=POST validation error for Write POST with body {"code":"validation_error","message":"Invalid tuple 'assessment_response:01KT206E38KVKEPHXWBTEZDM88#parent@entity:01KT206F6AZ64CB3913XPKXJ17'. Reason: type 'entity' is not an allowed type restriction for 'assessment_response#parent'"}
 with error code validation_error error message: Invalid tuple 'assessment_response:01KT206E38KVKEPHXWBTEZDM88#parent@entity:01KT206F6AZ64CB3913XPKXJ17'. Reason: type 'entity' is not an allowed type restriction for 'assessment_response#parent' deletes=[] severity=DEBUG writes=[map[error:map[] status:CLIENT_WRITE_STATUS_FAILURE tuple_key:map[object:assessment_response:01KT206E38KVKEPHXWBTEZDM88 relation:parent user:entity:01KT206F6AZ64CB3913XPKXJ17]]]
5:33PM ERR internal/ent/hooks/objectownedtuples.go:76 | failed to create relationship tuple error=POST validation error for Write POST with body {"code":"validation_error","message":"Invalid tuple 'assessment_response:01KT206E38KVKEPHXWBTEZDM88#parent@entity:01KT206F6AZ64CB3913XPKXJ17'. Reason: type 'entity' is not an allowed type restriction for 'assessment_response#parent'"}
 with error code validation_error error message: Invalid tuple 'assessment_response:01KT206E38KVKEPHXWBTEZDM88#parent@entity:01KT206F6AZ64CB3913XPKXJ17'. Reason: type 'entity' is not an allowed type restriction for 'assessment_response#parent' remote_ip=::1 request_id=KeZxxzCRLsZKlXNIQEsbWodjaEVnDRBC request_protocol=HTTP/1.1 severity=ERROR user_agent=node
5:33PM ERR internal/ent/hooks/listeners_questionnaire_transform.go:136 | questionnaire transform failed error=link transformed entity to assessment response: internal server error assessment_id=01KSR9XCJNTE3ZDX4K8J860MYS assessment_response_id=01KT206E38KVKEPHXWBTEZDM88 document_data_id=01KT206CES0DZDT3NW64XCVHN2 remote_ip=::1 request_id=KeZxxzCRLsZKlXNIQEsbWodjaEVnDRBC request_protocol=HTTP/1.1 severity=ERROR template_id=01KSR9XCJ6A7YV6HRA0X0AHS5D user_agent=node
5:33PM WRN pkg/gala/gala.go:359 | gala listener failed error=gala: listener "questionnaire.transform.assessment" execution failed: link transformed entity to assessment response: internal server error event_id=01KT206E38KVKEPHXWBTEZDM88 listener=questionnaire.transform.assessment operation=OpCreate remote_ip=::1 request_id=KeZxxzCRLsZKlXNIQEsbWodjaEVnDRBC request_protocol=HTTP/1.1 severity=WARNING topic=AssessmentResponse user_agent=node
```

