### PR TITLE
feat: tailscale int to sync users and assets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -160,6 +160,8 @@ require (
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	github.com/std-uritemplate/std-uritemplate/go/v2 v2.0.8 // indirect
+	github.com/tailscale/hujson v0.0.0-20220506213045-af5ed07155e5 // indirect
+	github.com/tailscale/tailscale-client-go/v2 v2.0.0-20250129222324-74c8fc3cb4d7 // indirect
 	github.com/tinylib/msgp v1.6.4 // indirect
 	github.com/valyala/fastjson v1.6.10 // indirect
 	github.com/vanng822/css v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -722,6 +722,10 @@ github.com/stripe/stripe-go/v84 v84.4.1 h1:ixq1fG3y0k4OORVaN+LFAMBFaWiMrvKIcR9dS
 github.com/stripe/stripe-go/v84 v84.4.1/go.mod h1:Z4gcKw1zl4geDG2+cjpSaJES9jaohGX6n7FP8/kHIqw=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+github.com/tailscale/hujson v0.0.0-20220506213045-af5ed07155e5 h1:erxeiTyq+nw4Cz5+hLDkOwNF5/9IQWCQPv0gpb3+QHU=
+github.com/tailscale/hujson v0.0.0-20220506213045-af5ed07155e5/go.mod h1:DFSS3NAGHthKo1gTlmEcSBiZrRJXi28rLNd/1udP1c8=
+github.com/tailscale/tailscale-client-go/v2 v2.0.0-20250129222324-74c8fc3cb4d7 h1:mNv0N8L5geeR9d4FKecN1WoebLmWx52i30GRh4qKabQ=
+github.com/tailscale/tailscale-client-go/v2 v2.0.0-20250129222324-74c8fc3cb4d7/go.mod h1:i/MSgQ71kdyh1Wdp50XxrIgtsyO4uZ2SZSPd83lGKHM=
 github.com/testcontainers/testcontainers-go v0.42.0 h1:He3IhTzTZOygSXLJPMX7n44XtK+qhjat1nI9cneBbUY=
 github.com/testcontainers/testcontainers-go v0.42.0/go.mod h1:vZjdY1YmUA1qEForxOIOazfsrdyORJAbhi0bp8plN30=
 github.com/testcontainers/testcontainers-go/modules/openfga v0.42.0 h1:o539g4y8NzQWNy3tHcq4Bjv0VodzkNQgwhGVARf2oMo=

--- a/internal/integrations/definitions/catalog/catalog.go
+++ b/internal/integrations/definitions/catalog/catalog.go
@@ -16,6 +16,7 @@ import (
 	"github.com/theopenlane/core/internal/integrations/definitions/okta"
 	"github.com/theopenlane/core/internal/integrations/definitions/scim"
 	"github.com/theopenlane/core/internal/integrations/definitions/slack"
+	"github.com/theopenlane/core/internal/integrations/definitions/tailscale"
 	"github.com/theopenlane/core/internal/integrations/registry"
 )
 
@@ -39,5 +40,6 @@ func Builders(cfg Config, devMode bool) []registry.Builder {
 		okta.Builder(),
 		scim.Builder(),
 		slack.Builder(cfg.Slack, &cfg.SlackRuntime, devMode),
+		tailscale.Builder(),
 	}
 }

--- a/internal/integrations/definitions/tailscale/builder.go
+++ b/internal/integrations/definitions/tailscale/builder.go
@@ -91,7 +91,7 @@ func Builder() registry.Builder {
 					},
 					IngestHandle:        DirectorySync{}.IngestHandle(),
 					SkipDefaultLookback: true,
-					RequiredPermissions: []string{"users:read"},
+					RequiredPermissions: []string{"users:read", "policy_file:read"},
 					ReconcileSchedule:   gala.NewFullFetchSchedule(),
 				},
 				{

--- a/internal/integrations/definitions/tailscale/builder.go
+++ b/internal/integrations/definitions/tailscale/builder.go
@@ -1,0 +1,120 @@
+package tailscale
+
+import (
+	"github.com/theopenlane/core/internal/ent/integrationgenerated"
+	"github.com/theopenlane/core/internal/integrations/providerkit"
+	"github.com/theopenlane/core/internal/integrations/registry"
+	"github.com/theopenlane/core/internal/integrations/types"
+	"github.com/theopenlane/core/pkg/gala"
+	"github.com/theopenlane/core/pkg/jsonx"
+)
+
+// Builder returns the Tailscale definition builder
+func Builder() registry.Builder {
+	return registry.Builder(func() (types.Definition, error) {
+		return types.Definition{
+			DefinitionSpec: types.DefinitionSpec{
+				ID:          definitionID.ID(),
+				Family:      "Tailscale",
+				DisplayName: "Tailscale",
+				Description: "Sync Tailscale users and role groups as directory accounts, and Tailscale devices as assets.",
+				Category:    "identity",
+				DocsURL:     "https://docs.theopenlane.io/docs/platform/integrations/tailscale/overview",
+				Tags:        []string{"directory", "assets"},
+				Active:      true,
+				Visible:     true,
+			},
+			UserInput: &types.UserInputRegistration{
+				Schema: jsonx.SchemaFrom[UserInput](),
+			},
+			CredentialRegistrations: []types.CredentialRegistration{
+				{
+					Ref:         tailscaleCredential.ID(),
+					Name:        "Tailscale OAuth Client",
+					Description: "OAuth client credentials used to read users and devices from your tailnet.",
+					Schema:      tailscaleSchema,
+				},
+			},
+			Connections: []types.ConnectionRegistration{
+				{
+					CredentialRef:       tailscaleCredential.ID(),
+					Name:                "Tailscale OAuth",
+					Description:         "Configure Tailscale access using an OAuth client scoped to your tailnet.",
+					CredentialRefs:      []types.CredentialSlotID{tailscaleCredential.ID()},
+					ClientRefs:          []types.ClientID{tailscaleClient.ID()},
+					ValidationOperation: healthCheckOperation.Name(),
+					Integration:         installation.Registration(),
+					Disconnect: &types.DisconnectRegistration{
+						CredentialRef: tailscaleCredential.ID(),
+						Description:   "Removes the stored OAuth credentials from Openlane. If the client is no longer needed, revoke it in the Tailscale admin console.",
+					},
+				},
+			},
+			Clients: []types.ClientRegistration{
+				{
+					Ref:            tailscaleClient.ID(),
+					CredentialRefs: []types.CredentialSlotID{tailscaleCredential.ID()},
+					Description:    "Tailscale HTTP API client",
+					Build:          Client{}.Build,
+				},
+			},
+			Operations: []types.OperationRegistration{
+				{
+					Name:                healthCheckOperation.Name(),
+					Description:         "Verify Tailscale OAuth credentials by listing tailnet users",
+					Topic:               definitionID.OperationTopic(healthCheckOperation.Name()),
+					ClientRef:           tailscaleClient.ID(),
+					Policy:              types.ExecutionPolicy{Inline: true},
+					Handle:              HealthCheck{}.Handle(),
+					ConfigSchema:        healthCheckSchema,
+					RequiredPermissions: []string{"users:read"},
+				},
+				{
+					Name:           directorySyncOperation.Name(),
+					Description:    "Sync Tailscale users and role-based groups as directory accounts",
+					Topic:          definitionID.OperationTopic(directorySyncOperation.Name()),
+					ClientRef:      tailscaleClient.ID(),
+					ConfigSchema:   directorySyncSchema,
+					Policy:         types.ExecutionPolicy{Reconcile: true},
+					Disabled:       providerkit.DisabledWhen(func(u UserInput) bool { return u.DirectorySync.Disable }),
+					ConfigResolver: providerkit.ConfigFrom(func(u UserInput) DirectorySync { return u.DirectorySync }),
+					Ingest: []types.IngestContract{
+						{
+							Schema: integrationgenerated.IntegrationMappingSchemaDirectoryAccount,
+						},
+						{
+							Schema: integrationgenerated.IntegrationMappingSchemaDirectoryGroup,
+						},
+						{
+							Schema: integrationgenerated.IntegrationMappingSchemaDirectoryMembership,
+						},
+					},
+					IngestHandle:        DirectorySync{}.IngestHandle(),
+					SkipDefaultLookback: true,
+					RequiredPermissions: []string{"users:read"},
+					ReconcileSchedule:   gala.NewFullFetchSchedule(),
+				},
+				{
+					Name:           assetSyncOperation.Name(),
+					Description:    "Sync Tailscale devices as assets",
+					Topic:          definitionID.OperationTopic(assetSyncOperation.Name()),
+					ClientRef:      tailscaleClient.ID(),
+					ConfigSchema:   assetSyncSchema,
+					Policy:         types.ExecutionPolicy{Reconcile: true},
+					Disabled:       providerkit.DisabledWhen(func(u UserInput) bool { return u.AssetSync.Disable }),
+					ConfigResolver: providerkit.ConfigFrom(func(u UserInput) AssetSync { return u.AssetSync }),
+					Ingest: []types.IngestContract{
+						{
+							Schema: integrationgenerated.IntegrationMappingSchemaAsset,
+						},
+					},
+					IngestHandle:        AssetSync{}.IngestHandle(),
+					SkipDefaultLookback: true,
+					RequiredPermissions: []string{"devices:core:read", "devices:posture_attributes:read", "devices:routes:read"},
+					ReconcileSchedule:   gala.NewFullFetchSchedule(),
+				},
+			},
+			Mappings: tailscaleMappings(),
+		}, nil
+	})
+}

--- a/internal/integrations/definitions/tailscale/client.go
+++ b/internal/integrations/definitions/tailscale/client.go
@@ -1,0 +1,52 @@
+package tailscale
+
+import (
+	"context"
+
+	tsclient "github.com/tailscale/tailscale-client-go/v2"
+
+	"github.com/theopenlane/core/internal/integrations/types"
+)
+
+// Client builds Tailscale API clients for one installation
+type Client struct{}
+
+// Build constructs the Tailscale API client for one installation
+func (Client) Build(_ context.Context, req types.ClientBuildRequest) (any, error) {
+	cred, err := resolveCredential(req.Credentials)
+	if err != nil {
+		return nil, err
+	}
+
+	if cred.ClientID == "" {
+		return nil, ErrClientIDMissing
+	}
+
+	if cred.ClientSecret == "" {
+		return nil, ErrClientSecretMissing
+	}
+
+	httpClient := tsclient.OAuthConfig{
+		ClientID:     cred.ClientID,
+		ClientSecret: cred.ClientSecret,
+	}.HTTPClient()
+
+	return &tsclient.Client{
+		Tailnet: "-",
+		HTTP:    httpClient,
+	}, nil
+}
+
+// resolveCredential extracts the Tailscale credential from the binding set
+func resolveCredential(bindings types.CredentialBindings) (CredentialSchema, error) {
+	cred, ok, err := tailscaleCredential.Resolve(bindings)
+	if err != nil {
+		return CredentialSchema{}, ErrCredentialInvalid
+	}
+
+	if !ok {
+		return CredentialSchema{}, ErrCredentialMetadataRequired
+	}
+
+	return cred, nil
+}

--- a/internal/integrations/definitions/tailscale/doc.go
+++ b/internal/integrations/definitions/tailscale/doc.go
@@ -1,0 +1,2 @@
+// Package tailscale provides the Tailscale integration definition for integrations
+package tailscale

--- a/internal/integrations/definitions/tailscale/errors.go
+++ b/internal/integrations/definitions/tailscale/errors.go
@@ -1,0 +1,26 @@
+package tailscale
+
+import "errors"
+
+var (
+	// ErrClientIDMissing indicates the OAuth client ID is missing from the credential
+	ErrClientIDMissing = errors.New("tailscale: oauth client id missing")
+	// ErrClientSecretMissing indicates the OAuth client secret is missing from the credential
+	ErrClientSecretMissing = errors.New("tailscale: oauth client secret missing")
+	// ErrCredentialInvalid indicates credential metadata could not be decoded
+	ErrCredentialInvalid = errors.New("tailscale: credential invalid")
+	// ErrCredentialMetadataRequired indicates no credential metadata was provided
+	ErrCredentialMetadataRequired = errors.New("tailscale: credential metadata required")
+	// ErrHealthCheckFailed indicates the Tailscale API health check failed
+	ErrHealthCheckFailed = errors.New("tailscale: health check failed")
+	// ErrResultEncode indicates an operation result could not be serialized
+	ErrResultEncode = errors.New("tailscale: result encode failed")
+	// ErrUsersFetchFailed indicates the Tailscale users list request failed
+	ErrUsersFetchFailed = errors.New("tailscale: users fetch failed")
+	// ErrDevicesFetchFailed indicates the Tailscale devices list request failed
+	ErrDevicesFetchFailed = errors.New("tailscale: devices fetch failed")
+	// ErrPayloadEncode indicates a collected Tailscale payload could not be serialized for ingest
+	ErrPayloadEncode = errors.New("tailscale: ingest payload encode failed")
+	// ErrOperationConfigInvalid indicates operation config could not be decoded
+	ErrOperationConfigInvalid = errors.New("tailscale: operation config invalid")
+)

--- a/internal/integrations/definitions/tailscale/installation.go
+++ b/internal/integrations/definitions/tailscale/installation.go
@@ -1,0 +1,23 @@
+package tailscale
+
+import (
+	"context"
+
+	"github.com/theopenlane/core/internal/integrations/types"
+)
+
+// resolveInstallationMetadata derives Tailscale tailnet metadata from the installation credential
+func resolveInstallationMetadata(_ context.Context, req types.InstallationRequest) (InstallationMetadata, bool, error) {
+	cred, err := resolveCredential(req.Credentials)
+	if err != nil {
+		return InstallationMetadata{}, false, err
+	}
+
+	if cred.ClientID == "" {
+		return InstallationMetadata{}, false, nil
+	}
+
+	return InstallationMetadata{
+		ClientID: cred.ClientID,
+	}, true, nil
+}

--- a/internal/integrations/definitions/tailscale/mappings.go
+++ b/internal/integrations/definitions/tailscale/mappings.go
@@ -1,0 +1,79 @@
+package tailscale
+
+import (
+	"github.com/theopenlane/core/internal/ent/integrationgenerated"
+	"github.com/theopenlane/core/internal/integrations/providerkit"
+	"github.com/theopenlane/core/internal/integrations/types"
+)
+
+// mapExprDirectoryAccount is the CEL mapping expression for Tailscale user payloads mapped to DirectoryAccount
+var mapExprDirectoryAccount = providerkit.CelMapExpr([]providerkit.CelMapEntry{
+	{Key: integrationgenerated.IntegrationMappingDirectoryAccountExternalID, Expr: `'id' in payload ? payload.id : ""`},
+	{Key: integrationgenerated.IntegrationMappingDirectoryAccountCanonicalEmail, Expr: `'loginName' in payload ? payload.loginName : ""`},
+	{Key: integrationgenerated.IntegrationMappingDirectoryAccountDisplayName, Expr: `'displayName' in payload && payload.displayName != "" ? payload.displayName : ('loginName' in payload ? payload.loginName : "")`},
+	{Key: integrationgenerated.IntegrationMappingDirectoryAccountStatus, Expr: `dyn('status' in payload ? (payload.status == "active" ? "ACTIVE" : (payload.status == "suspended" ? "INACTIVE" : "INACTIVE")) : "INACTIVE")`},
+	{Key: integrationgenerated.IntegrationMappingDirectoryAccountProfile, Expr: "payload"},
+})
+
+// mapExprDirectoryGroup is the CEL mapping expression for Tailscale role group payloads mapped to DirectoryGroup
+// Payload is tailscaleGroupPayload — a known struct, so direct field access is safe without 'key' in payload guards
+var mapExprDirectoryGroup = providerkit.CelMapExpr([]providerkit.CelMapEntry{
+	{Key: integrationgenerated.IntegrationMappingDirectoryGroupExternalID, Expr: `payload.id`},
+	{Key: integrationgenerated.IntegrationMappingDirectoryGroupDisplayName, Expr: `payload.name != "" ? payload.name : payload.id`},
+	{Key: integrationgenerated.IntegrationMappingDirectoryGroupStatus, Expr: `dyn("ACTIVE")`},
+	{Key: integrationgenerated.IntegrationMappingDirectoryGroupProfile, Expr: "payload"},
+})
+
+// mapExprDirectoryMembership is the CEL mapping expression for Tailscale membership payloads mapped to DirectoryMembership
+var mapExprDirectoryMembership = providerkit.CelMapExpr([]providerkit.CelMapEntry{
+	{Key: integrationgenerated.IntegrationMappingDirectoryMembershipDirectoryAccountID, Expr: `'user_id' in payload ? payload.user_id : ""`},
+	{Key: integrationgenerated.IntegrationMappingDirectoryMembershipDirectoryGroupID, Expr: `'group_id' in payload ? payload.group_id : ""`},
+	{Key: integrationgenerated.IntegrationMappingDirectoryMembershipRole, Expr: `dyn("MEMBER")`},
+	{Key: integrationgenerated.IntegrationMappingDirectoryMembershipMetadata, Expr: "payload"},
+})
+
+// mapExprAsset is the CEL mapping expression for Tailscale device payloads mapped to Asset
+var mapExprAsset = providerkit.CelMapExpr([]providerkit.CelMapEntry{
+	{Key: integrationgenerated.IntegrationMappingAssetSourceIdentifier, Expr: `'id' in payload ? payload.id : ""`},
+	{Key: integrationgenerated.IntegrationMappingAssetName, Expr: `'name' in payload && payload.name != "" ? payload.name : ('hostname' in payload ? payload.hostname : "")`},
+	{Key: integrationgenerated.IntegrationMappingAssetDisplayName, Expr: `'hostname' in payload && payload.hostname != "" ? payload.hostname : ('name' in payload ? payload.name : "")`},
+	{Key: integrationgenerated.IntegrationMappingAssetDescription, Expr: `'os' in payload && payload.os != "" ? "OS: " + payload.os : ""`},
+	{Key: integrationgenerated.IntegrationMappingAssetTags, Expr: `'tags' in payload && payload.tags != null ? payload.tags : []`},
+	{Key: integrationgenerated.IntegrationMappingAssetAssetType, Expr: `"DEVICE"`},
+	{Key: integrationgenerated.IntegrationMappingAssetInternalOwner, Expr: `'user' in payload && payload.user != "" ? payload.user : 'creator' in payload && payload.creator != "" ? payload.creator : null`},
+})
+
+// tailscaleMappings returns the built-in Tailscale ingest mappings
+func tailscaleMappings() []types.MappingRegistration {
+	return []types.MappingRegistration{
+		{
+			Schema: integrationgenerated.IntegrationMappingSchemaDirectoryAccount,
+			Spec: types.MappingOverride{
+				FilterExpr: "true",
+				MapExpr:    mapExprDirectoryAccount,
+			},
+		},
+		{
+			Schema: integrationgenerated.IntegrationMappingSchemaDirectoryGroup,
+			Spec: types.MappingOverride{
+				FilterExpr: "true",
+				MapExpr:    mapExprDirectoryGroup,
+			},
+		},
+		{
+			Schema: integrationgenerated.IntegrationMappingSchemaDirectoryMembership,
+			Spec: types.MappingOverride{
+				FilterExpr: "true",
+				MapExpr:    mapExprDirectoryMembership,
+			},
+		},
+		{
+			Schema:  integrationgenerated.IntegrationMappingSchemaAsset,
+			Variant: deviceAssetVariant,
+			Spec: types.MappingOverride{
+				FilterExpr: "true",
+				MapExpr:    mapExprAsset,
+			},
+		},
+	}
+}

--- a/internal/integrations/definitions/tailscale/mappings_test.go
+++ b/internal/integrations/definitions/tailscale/mappings_test.go
@@ -1,0 +1,26 @@
+package tailscale
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/theopenlane/core/internal/integrations/providerkit"
+)
+
+func TestMappingExpressionsValid(t *testing.T) {
+	for _, m := range tailscaleMappings() {
+		name := m.Schema
+		if m.Variant != "" {
+			name += "/" + m.Variant
+		}
+
+		t.Run(name+"/filter", func(t *testing.T) {
+			assert.NilError(t, providerkit.ValidateExpr(m.Spec.FilterExpr))
+		})
+
+		t.Run(name+"/map", func(t *testing.T) {
+			assert.NilError(t, providerkit.ValidateExpr(m.Spec.MapExpr))
+		})
+	}
+}

--- a/internal/integrations/definitions/tailscale/operation_asset_sync.go
+++ b/internal/integrations/definitions/tailscale/operation_asset_sync.go
@@ -1,0 +1,62 @@
+package tailscale
+
+import (
+	"context"
+	"fmt"
+
+	tsclient "github.com/tailscale/tailscale-client-go/v2"
+
+	"github.com/theopenlane/core/internal/ent/integrationgenerated"
+	"github.com/theopenlane/core/internal/integrations/providerkit"
+	"github.com/theopenlane/core/internal/integrations/types"
+	"github.com/theopenlane/core/pkg/logx"
+)
+
+// repositoryAssetVariant is the mapping variant for device asset payloads
+const deviceAssetVariant = "DEVICE"
+
+// IngestHandle adapts Tailscale asset sync to the ingest operation registration boundary
+func (a AssetSync) IngestHandle() types.IngestHandler {
+	return providerkit.WithClientRequest(tailscaleClient, func(ctx context.Context, request types.OperationRequest, client *tsclient.Client) ([]types.IngestPayloadSet, error) {
+		return a.Run(ctx, client)
+	})
+}
+
+// Run collects Tailscale devices and emits asset ingest payloads
+func (AssetSync) Run(ctx context.Context, client *tsclient.Client) ([]types.IngestPayloadSet, error) {
+	devices, err := listTailscaleDevices(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+
+	envelopes := make([]types.MappingEnvelope, 0, len(devices))
+
+	for _, device := range devices {
+		envelope, err := providerkit.MarshalEnvelopeVariant(deviceAssetVariant, device.ID, device, ErrPayloadEncode)
+		if err != nil {
+			logx.FromContext(ctx).Error().Err(err).Str("device", device.Name).Msg("tailscale: failed to marshal device")
+			return nil, err
+		}
+
+		envelopes = append(envelopes, envelope)
+	}
+
+	logx.FromContext(ctx).Debug().Int("device_count", len(envelopes)).Msg("tailscale: collected devices")
+
+	return []types.IngestPayloadSet{
+		{
+			Schema:    integrationgenerated.IntegrationMappingSchemaAsset,
+			Envelopes: envelopes,
+		},
+	}, nil
+}
+
+// listTailscaleDevices fetches all devices from the Tailscale API and maps them to payloads
+func listTailscaleDevices(ctx context.Context, client *tsclient.Client) ([]tsclient.Device, error) {
+	devices, err := client.Devices().List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrDevicesFetchFailed, err)
+	}
+
+	return devices, nil
+}

--- a/internal/integrations/definitions/tailscale/operation_asset_sync.go
+++ b/internal/integrations/definitions/tailscale/operation_asset_sync.go
@@ -17,7 +17,7 @@ const deviceAssetVariant = "DEVICE"
 
 // IngestHandle adapts Tailscale asset sync to the ingest operation registration boundary
 func (a AssetSync) IngestHandle() types.IngestHandler {
-	return providerkit.WithClientRequest(tailscaleClient, func(ctx context.Context, request types.OperationRequest, client *tsclient.Client) ([]types.IngestPayloadSet, error) {
+	return providerkit.WithClientRequest(tailscaleClient, func(ctx context.Context, _ types.OperationRequest, client *tsclient.Client) ([]types.IngestPayloadSet, error) {
 		return a.Run(ctx, client)
 	})
 }

--- a/internal/integrations/definitions/tailscale/operation_directory_sync.go
+++ b/internal/integrations/definitions/tailscale/operation_directory_sync.go
@@ -1,0 +1,195 @@
+package tailscale
+
+import (
+	"context"
+	"fmt"
+
+	tsclient "github.com/tailscale/tailscale-client-go/v2"
+
+	"github.com/theopenlane/core/internal/ent/integrationgenerated"
+	"github.com/theopenlane/core/internal/integrations/providerkit"
+	"github.com/theopenlane/core/internal/integrations/types"
+	"github.com/theopenlane/core/pkg/logx"
+)
+
+// tailscaleGroupPayload is the envelope payload for one Tailscale role group record
+type tailscaleGroupPayload struct {
+	// ID is the role identifier (e.g. "admin", "member")
+	ID string `json:"id"`
+	// Name is the human-readable role label
+	Name string `json:"name"`
+}
+
+// tailscaleMembershipPayload is the envelope payload for one Tailscale role membership record
+type tailscaleMembershipPayload struct {
+	// GroupID is the role identifier the user belongs to
+	GroupID string `json:"group_id"`
+	// UserID is the Tailscale user identifier
+	UserID string `json:"user_id"`
+}
+
+// IngestHandle adapts Tailscale directory sync to the ingest operation registration boundary
+func (d DirectorySync) IngestHandle() types.IngestHandler {
+	return providerkit.WithClientRequestConfig(tailscaleClient, directorySyncOperation, ErrOperationConfigInvalid, func(ctx context.Context, _ types.OperationRequest, client *tsclient.Client, cfg DirectorySync) ([]types.IngestPayloadSet, error) {
+		if cfg.Disable {
+			logx.FromContext(ctx).Debug().Msg("tailscale: directory sync is disabled")
+			return nil, nil
+		}
+
+		return d.Run(ctx, client, cfg)
+	})
+}
+
+// Run collects Tailscale users and optionally role-based groups and memberships
+func (DirectorySync) Run(ctx context.Context, client *tsclient.Client, cfg DirectorySync) ([]types.IngestPayloadSet, error) {
+	users, err := listTailscaleUsers(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+
+	accountEnvelopes := make([]types.MappingEnvelope, 0, len(users))
+
+	for _, user := range users {
+		envelope, err := providerkit.MarshalEnvelope(user.ID, user, ErrPayloadEncode)
+		if err != nil {
+			logx.FromContext(ctx).Error().Err(err).Str("user", user.LoginName).Msg("tailscale: failed to marshal user")
+			return nil, err
+		}
+
+		accountEnvelopes = append(accountEnvelopes, envelope)
+	}
+
+	payloadSets := []types.IngestPayloadSet{
+		{
+			Schema:    integrationgenerated.IntegrationMappingSchemaDirectoryAccount,
+			Envelopes: accountEnvelopes,
+		},
+	}
+
+	if cfg.DisableGroupSync {
+		logx.FromContext(ctx).Debug().Int("user_count", len(accountEnvelopes)).Msg("tailscale: collected users; group sync disabled")
+		return payloadSets, nil
+	}
+
+	// Build role-based groups from the unique set of roles across all users
+	rolesSeen := make(map[tsclient.UserRole]struct{})
+	groupEnvelopes := make([]types.MappingEnvelope, 0)
+	membershipEnvelopes := make([]types.MappingEnvelope, 0)
+
+	for _, user := range users {
+		role := user.Role
+		if role == "" {
+			continue
+		}
+
+		if _, seen := rolesSeen[role]; !seen {
+			rolesSeen[role] = struct{}{}
+
+			group := tailscaleGroupPayload{
+				ID:   string(role),
+				Name: string(role),
+			}
+
+			envelope, err := providerkit.MarshalEnvelope(string(role), group, ErrPayloadEncode)
+			if err != nil {
+				logx.FromContext(ctx).Error().Err(err).Str("role", string(role)).Msg("tailscale: failed to marshal role group")
+				return nil, err
+			}
+
+			groupEnvelopes = append(groupEnvelopes, envelope)
+		}
+
+		membership := tailscaleMembershipPayload{
+			GroupID: string(role),
+			UserID:  user.ID,
+		}
+
+		membershipKey := fmt.Sprintf("%s:%s", role, user.ID)
+
+		envelope, err := providerkit.MarshalEnvelope(membershipKey, membership, ErrPayloadEncode)
+		if err != nil {
+			logx.FromContext(ctx).Error().Err(err).Str("user", user.LoginName).Str("role", string(role)).Msg("tailscale: failed to marshal membership")
+			return nil, err
+		}
+
+		membershipEnvelopes = append(membershipEnvelopes, envelope)
+	}
+
+	// Also sync user-defined ACL groups from the policy file
+	userByEmail := make(map[string]string, len(users))
+	for _, u := range users {
+		userByEmail[u.LoginName] = u.ID
+	}
+
+	acl, err := client.PolicyFile().Get(ctx)
+	if err != nil {
+		logx.FromContext(ctx).Warn().Err(err).Msg("tailscale: failed to fetch policy file; skipping user-defined groups")
+	} else {
+		for groupName, members := range acl.Groups {
+			group := tailscaleGroupPayload{
+				ID:   groupName,
+				Name: groupName,
+			}
+
+			groupEnvelope, err := providerkit.MarshalEnvelope(groupName, group, ErrPayloadEncode)
+			if err != nil {
+				logx.FromContext(ctx).Error().Err(err).Str("group", groupName).Msg("tailscale: failed to marshal ACL group")
+				return nil, err
+			}
+
+			groupEnvelopes = append(groupEnvelopes, groupEnvelope)
+
+			for _, member := range members {
+				userID, ok := userByEmail[member]
+				if !ok {
+					// skip group references, tags, autogroups, wildcards
+					continue
+				}
+
+				membership := tailscaleMembershipPayload{
+					GroupID: groupName,
+					UserID:  userID,
+				}
+
+				membershipKey := fmt.Sprintf("%s:%s", groupName, userID)
+
+				membershipEnvelope, err := providerkit.MarshalEnvelope(membershipKey, membership, ErrPayloadEncode)
+				if err != nil {
+					logx.FromContext(ctx).Error().Err(err).Str("group", groupName).Str("user", member).Msg("tailscale: failed to marshal ACL group membership")
+					return nil, err
+				}
+
+				membershipEnvelopes = append(membershipEnvelopes, membershipEnvelope)
+			}
+		}
+	}
+
+	logx.FromContext(ctx).Debug().
+		Int("user_count", len(accountEnvelopes)).
+		Int("group_count", len(groupEnvelopes)).
+		Int("membership_count", len(membershipEnvelopes)).
+		Msg("tailscale: collected users, role groups, and memberships")
+
+	payloadSets = append(payloadSets,
+		types.IngestPayloadSet{
+			Schema:    integrationgenerated.IntegrationMappingSchemaDirectoryGroup,
+			Envelopes: groupEnvelopes,
+		},
+		types.IngestPayloadSet{
+			Schema:    integrationgenerated.IntegrationMappingSchemaDirectoryMembership,
+			Envelopes: membershipEnvelopes,
+		},
+	)
+
+	return payloadSets, nil
+}
+
+// listTailscaleUsers fetches all users from the Tailscale API and maps them to payloads
+func listTailscaleUsers(ctx context.Context, client *tsclient.Client) ([]tsclient.User, error) {
+	users, err := client.Users().List(ctx, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrUsersFetchFailed, err)
+	}
+
+	return users, nil
+}

--- a/internal/integrations/definitions/tailscale/operation_health.go
+++ b/internal/integrations/definitions/tailscale/operation_health.go
@@ -1,0 +1,40 @@
+package tailscale
+
+import (
+	"context"
+	"encoding/json"
+
+	tsclient "github.com/tailscale/tailscale-client-go/v2"
+
+	"github.com/theopenlane/core/internal/integrations/providerkit"
+	"github.com/theopenlane/core/internal/integrations/types"
+	"github.com/theopenlane/core/pkg/logx"
+)
+
+// HealthCheck holds the result of a Tailscale API health check
+type HealthCheck struct {
+	// UserCount is the number of users visible to the credential
+	UserCount int `json:"userCount,omitempty"`
+}
+
+// Handle adapts the health check to the generic operation registration boundary
+func (h HealthCheck) Handle() types.OperationHandler {
+	return providerkit.WithClientRequest(tailscaleClient, func(ctx context.Context, _ types.OperationRequest, client *tsclient.Client) (json.RawMessage, error) {
+		return h.Run(ctx, client)
+	})
+}
+
+// Run validates Tailscale API access by listing users
+func (HealthCheck) Run(ctx context.Context, client *tsclient.Client) (json.RawMessage, error) {
+	users, err := client.Users().List(ctx, nil, nil)
+	if err != nil {
+		logx.FromContext(ctx).Error().Err(err).Msg("tailscale: health check failed listing users")
+		return nil, ErrHealthCheckFailed
+	}
+
+	details := HealthCheck{
+		UserCount: len(users),
+	}
+
+	return providerkit.EncodeResult(details, ErrResultEncode)
+}

--- a/internal/integrations/definitions/tailscale/types.go
+++ b/internal/integrations/definitions/tailscale/types.go
@@ -1,0 +1,72 @@
+package tailscale
+
+import (
+	tsclient "github.com/tailscale/tailscale-client-go/v2"
+
+	"github.com/theopenlane/core/internal/integrations/providerkit"
+	"github.com/theopenlane/core/internal/integrations/types"
+)
+
+var (
+	// definitionID is the stable identifier for the Tailscale integration definition
+	definitionID = types.NewDefinitionRef("def_01K0TAILSCALE0000000000001")
+	// installation is the typed installation metadata handle for the Tailscale definition
+	installation = types.NewInstallationRef(resolveInstallationMetadata)
+	// tailscaleSchema is the credential schema for the Tailscale integration definition
+	tailscaleSchema, tailscaleCredential = providerkit.CredentialSchema[CredentialSchema]()
+	// tailscaleClient is the client ref for the Tailscale API client used by this definition
+	tailscaleClient = types.NewClientRef[*tsclient.Client]()
+	// healthCheckSchema is the operation schema for the health check
+	healthCheckSchema, healthCheckOperation = providerkit.OperationSchema[HealthCheck]()
+	// directorySyncSchema is the operation schema for the directory sync operation
+	directorySyncSchema, directorySyncOperation = providerkit.OperationSchema[DirectorySync]()
+	// assetSyncSchema is the operation schema for the asset sync operation
+	assetSyncSchema, assetSyncOperation = providerkit.OperationSchema[AssetSync]()
+)
+
+// UserInput holds installation-specific configuration collected from the user
+type UserInput struct {
+	// DirectorySync includes the configuration for syncing users, groups, and memberships from Tailscale
+	DirectorySync DirectorySync `json:"directorySync,omitempty" jsonschema:"title=Directory Sync"`
+	// AssetSync includes the configuration for syncing Tailscale devices as assets
+	AssetSync AssetSync `json:"assetSync,omitempty" jsonschema:"title=Asset Sync"`
+}
+
+// DirectorySync holds configuration for the Tailscale directory sync operation
+type DirectorySync struct {
+	// Disable stops the directory sync operation from running
+	Disable bool `json:"disable,omitempty" jsonschema:"title=Disable,description=Disable the syncing of users and groups from Tailscale"`
+	// DisableGroupSync skips group and membership sync, importing only users
+	DisableGroupSync bool `json:"disableGroupSync,omitempty" jsonschema:"title=Disable Group Sync,description=Only sync users from Tailscale; disable role-based group sync"`
+	// FilterExpr limits imported records to envelopes matching the CEL expression
+	FilterExpr string `json:"filterExpr,omitempty" jsonschema:"title=Filter Expression,description=Optional CEL expression to apply to records before ingesting,example=Example: payload.status == 'active'"`
+}
+
+// AssetSync holds configuration for the Tailscale asset sync operation
+type AssetSync struct {
+	// Disable stops the asset sync operation from running
+	Disable bool `json:"disable,omitempty" jsonschema:"title=Disable,description=Disable the syncing of Tailscale devices as assets"`
+	// FilterExpr limits imported records to envelopes matching the CEL expression
+	FilterExpr string `json:"filterExpr,omitempty" jsonschema:"title=Filter Expression,description=Optional CEL expression to apply to records before ingesting"`
+}
+
+// CredentialSchema holds the Tailscale OAuth credentials for one installation
+type CredentialSchema struct {
+	// ClientID is the OAuth client ID generated in the Tailscale admin console
+	ClientID string `json:"clientId" jsonschema:"required,title=Client ID,description=OAuth client ID from the Tailscale admin console."`
+	// ClientSecret is the OAuth client secret paired with ClientID
+	ClientSecret string `json:"clientSecret" jsonschema:"required,title=Client Secret,description=OAuth client secret from the Tailscale admin console.,secret=true"`
+}
+
+// InstallationMetadata holds the stable Tailscale identity for one installation
+type InstallationMetadata struct {
+	// ClientID is the OAuth client ID used to connect this installation
+	ClientID string `json:"clientId,omitempty" jsonschema:"title=Client ID"`
+}
+
+// InstallationIdentity implements types.InstallationIdentifiable
+func (m InstallationMetadata) InstallationIdentity() types.IntegrationInstallationIdentity {
+	return types.IntegrationInstallationIdentity{
+		ExternalID: m.ClientID,
+	}
+}

--- a/internal/integrations/operations/ingest_asset_persist.go
+++ b/internal/integrations/operations/ingest_asset_persist.go
@@ -3,10 +3,13 @@ package operations
 
 import (
 	"context"
+	"net/mail"
 
 	"github.com/theopenlane/core/common/enums"
 	ent "github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/asset"
+	"github.com/theopenlane/core/internal/ent/generated/user"
+	"github.com/theopenlane/core/pkg/logx"
 )
 
 // persistAssetInput upserts one Asset record using the ingest lookup key fields
@@ -21,6 +24,20 @@ func persistAssetInput(ctx context.Context, db *ent.Client, integration *ent.Int
 
 	if createInput.IntegrationID == nil {
 		createInput.IntegrationID = &integration.ID
+	}
+
+	// if user is in system, replace internal owner with
+	// internal owner user id
+	if createInput.InternalOwner != nil {
+		userID, err := resolveInternalOwner(ctx, db, *createInput.InternalOwner)
+		if err == nil && userID != nil {
+			createInput.InternalOwnerUserID = userID
+			createInput.InternalOwner = nil
+		}
+
+		if err != nil {
+			logx.FromContext(ctx).Error().Err(err).Msg("error converting internal owner to user, keeping original internal owner")
+		}
 	}
 
 	return persistRoundTripUpsert(
@@ -39,4 +56,24 @@ func persistAssetInput(ctx context.Context, db *ent.Client, integration *ent.Int
 			return db.Asset.UpdateOneID(existing.ID).SetInput(input).Exec(ctx)
 		},
 	)
+}
+
+// resolveInternalOwner resolves internal owner
+func resolveInternalOwner(ctx context.Context, client *ent.Client, rawValue string) (*string, error) {
+	if _, err := mail.ParseAddress(rawValue); err == nil {
+		userID, err := client.User.Query().
+			Where(
+				user.EmailEqualFold(rawValue),
+			).
+			OnlyID(ctx)
+		if err != nil && !ent.IsNotFound(err) {
+			return nil, err
+		}
+
+		if userID != "" {
+			return &userID, nil
+		}
+	}
+
+	return nil, nil
 }


### PR DESCRIPTION
 - creates vendor record
 - links to integration
 - adds users, groups, asssets
 - resolvers internal owner for assets based on email, falls back to string 
 - uses scope oauth client credentials to authentication

<img width="716" height="436" alt="image" src="https://github.com/user-attachments/assets/5d8ce3cd-f3a7-406f-aca6-24f55f4c1b66" />
<img width="606" height="707" alt="image" src="https://github.com/user-attachments/assets/9e42dde5-71f2-4032-9935-5fd3eba21ea1" />
