### PR TITLE
Organization deletion fails on custom domains

### DIFF
--- a/internal/ent/hooks/custom_domain.go
+++ b/internal/ent/hooks/custom_domain.go
@@ -50,7 +50,7 @@ func HookCreateCustomDomain() ent.Hook {
 	)
 }
 
-// HookCustomDomain runs on create mutations
+// HookDeleteCustomDomain runs on single and bulk deletions.
 func HookDeleteCustomDomain() ent.Hook {
 	return hook.If(
 		func(next ent.Mutator) ent.Mutator {
@@ -68,70 +68,31 @@ func HookDeleteCustomDomain() ent.Hook {
 					return next.Mutate(ctx, m)
 				}
 
-				id, ok := m.ID()
-				if !ok {
-					return nil, fmt.Errorf("%w: %s", ErrInvalidInput, "id is required")
-				}
+				var ids []string
 
-				cd, err := m.Client().CustomDomain.Query().Where(customdomain.ID(id)).
-					Select(customdomain.FieldDNSVerificationID, customdomain.FieldMappableDomainID, customdomain.FieldDNSVerificationID).
-					Only(ctx)
-				if err != nil {
-					return nil, err
-				}
+				switch m.Op() {
 
-				trustCenters, err := m.Client().TrustCenter.Query().
-					Where(trustcenter.Or(
-						trustcenter.HasCustomDomainWith(customdomain.ID(id)),
-						trustcenter.HasPreviewDomainWith(customdomain.ID(id)),
-					)).
-					All(ctx)
-				if err != nil {
-					return nil, err
-				}
-
-				for _, tc := range trustCenters {
-					update := m.Client().TrustCenter.UpdateOneID(tc.ID)
-					if tc.CustomDomainID != nil && *tc.CustomDomainID == id {
-						update.ClearCustomDomain()
-					}
-					if tc.PreviewDomainID == id {
-						update.ClearPreviewDomain()
-					}
-
-					if err = update.Exec(ctx); err != nil {
+				case ent.OpDelete, ent.OpUpdate:
+					var err error
+					ids, err = m.IDs(ctx)
+					if err != nil {
 						return nil, err
 					}
+
+				case ent.OpDeleteOne, ent.OpUpdateOne:
+
+					id, ok := m.ID()
+					if !ok {
+						return nil, fmt.Errorf("%w: %s", ErrInvalidInput, "id is required")
+					}
+
+					ids = []string{id}
 				}
 
-				if cd.DNSVerificationID == "" {
-					return next.Mutate(ctx, m)
-				}
-
-				mappableDomain, err := m.Client().MappableDomain.Query().
-					Where(mappabledomain.ID(cd.MappableDomainID)).
-					Select(mappabledomain.FieldZoneID).
-					Only(ctx)
-				if err != nil {
-					return nil, err
-				}
-
-				dnsVerification, err := m.Client().DNSVerification.Query().
-					Where(dnsverification.ID(cd.DNSVerificationID)).
-					Select(dnsverification.FieldCloudflareHostnameID).
-					Only(ctx)
-				if err != nil {
-					return nil, err
-				}
-
-				err = enqueueJob(ctx, m.Job, jobspec.DeleteCustomDomainArgs{
-					CustomDomainID:             id,
-					DNSVerificationID:          cd.DNSVerificationID,
-					CloudflareCustomHostnameID: dnsVerification.CloudflareHostnameID,
-					CloudflareZoneID:           mappableDomain.ZoneID,
-				}, nil)
-				if err != nil {
-					return nil, err
+				for _, id := range ids {
+					if err := deleteCustomDomain(ctx, m, id); err != nil {
+						return nil, err
+					}
 				}
 
 				return next.Mutate(ctx, m)
@@ -139,4 +100,64 @@ func HookDeleteCustomDomain() ent.Hook {
 		},
 		hook.HasOp(ent.OpDeleteOne|ent.OpDelete|ent.OpUpdate|ent.OpUpdateOne),
 	)
+}
+
+func deleteCustomDomain(ctx context.Context, m *generated.CustomDomainMutation, id string) error {
+	cd, err := m.Client().CustomDomain.Query().Where(customdomain.ID(id)).
+		Select(customdomain.FieldDNSVerificationID, customdomain.FieldMappableDomainID).
+		Only(ctx)
+	if err != nil {
+		return err
+	}
+
+	trustCenters, err := m.Client().TrustCenter.Query().
+		Where(trustcenter.Or(
+			trustcenter.HasCustomDomainWith(customdomain.ID(id)),
+			trustcenter.HasPreviewDomainWith(customdomain.ID(id)),
+		)).
+		All(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, tc := range trustCenters {
+		update := m.Client().TrustCenter.UpdateOneID(tc.ID)
+		if tc.CustomDomainID != nil && *tc.CustomDomainID == id {
+			update.ClearCustomDomain()
+		}
+		if tc.PreviewDomainID == id {
+			update.ClearPreviewDomain()
+		}
+
+		if err = update.Exec(ctx); err != nil {
+			return err
+		}
+	}
+
+	if cd.DNSVerificationID == "" {
+		return nil
+	}
+
+	mappableDomain, err := m.Client().MappableDomain.Query().
+		Where(mappabledomain.ID(cd.MappableDomainID)).
+		Select(mappabledomain.FieldZoneID).
+		Only(ctx)
+	if err != nil {
+		return err
+	}
+
+	dnsVerification, err := m.Client().DNSVerification.Query().
+		Where(dnsverification.ID(cd.DNSVerificationID)).
+		Select(dnsverification.FieldCloudflareHostnameID).
+		Only(ctx)
+	if err != nil {
+		return err
+	}
+
+	return enqueueJob(ctx, m.Job, jobspec.DeleteCustomDomainArgs{
+		CustomDomainID:             id,
+		DNSVerificationID:          cd.DNSVerificationID,
+		CloudflareCustomHostnameID: dnsVerification.CloudflareHostnameID,
+		CloudflareZoneID:           mappableDomain.ZoneID,
+	}, nil)
 }

--- a/internal/ent/hooks/trustcenterndarequest.go
+++ b/internal/ent/hooks/trustcenterndarequest.go
@@ -265,40 +265,51 @@ func HookTrustCenterNDARequestUpdate() ent.Hook {
 
 			return v, nil
 		})
-	}, ent.OpUpdateOne|ent.OpUpdate|ent.OpDeleteOne)
+	}, ent.OpUpdateOne|ent.OpUpdate|ent.OpDeleteOne|ent.OpDelete)
 }
 
 func handleNDARequestDelete(ctx context.Context, m *generated.TrustCenterNDARequestMutation) error {
-	id, ok := m.ID()
-	if !ok {
-		logx.FromContext(ctx).Error().Msg("missing ID for deleted NDA request, unable to cleanup tuples")
+	var ids []string
 
+	switch m.Op() {
+	case ent.OpDelete, ent.OpUpdate:
+		var err error
+		ids, err = m.IDs(ctx)
+		if err != nil {
+			return err
+		}
+	case ent.OpDeleteOne, ent.OpUpdateOne:
+		id, ok := m.ID()
+		if !ok {
+			return fmt.Errorf("%w: %s", ErrInvalidInput, "id is required")
+		}
+
+		ids = []string{id}
+	}
+
+	requests, err := m.Client().TrustCenterNDARequest.Query().
+		Where(trustcenterndarequest.IDIn(ids...)).
+		Select(trustcenterndarequest.FieldID, trustcenterndarequest.FieldTrustCenterID).
+		All(ctx)
+	if err != nil {
+		return err
+	}
+	if len(requests) == 0 {
 		return nil
 	}
 
-	tcID, ok := m.TrustCenterID()
-	if !ok && m.Op().Is(ent.OpUpdateOne) {
-
-		oldTrustcenterID, err := m.OldTrustCenterID(ctx)
-		if err != nil {
-			logx.FromContext(ctx).Error().Err(err).Msg("missing trust center ID for deleted NDA request, unable to cleanup tuples")
-
-			return err
-		}
-
-		tcID = oldTrustcenterID
+	deleteTuples := make([]fgax.TupleKey, 0, len(requests))
+	for _, request := range requests {
+		deleteTuples = append(deleteTuples, fgax.GetTupleKey(fgax.TupleRequest{
+			SubjectID:   fmt.Sprintf("%s%s", authmanager.AnonTrustCenterJWTPrefix, request.ID),
+			SubjectType: "user",
+			ObjectID:    request.TrustCenterID,
+			ObjectType:  "trust_center",
+			Relation:    "nda_signed",
+		}))
 	}
 
-	// delete any tuples associated with the nda request
-	deleteTuple := fgax.GetTupleKey(fgax.TupleRequest{
-		SubjectID:   fmt.Sprintf("%s%s", authmanager.AnonTrustCenterJWTPrefix, id),
-		SubjectType: "user",
-		ObjectID:    tcID,
-		ObjectType:  "trust_center",
-		Relation:    "nda_signed",
-	})
-
-	if _, err := m.Authz.WriteTupleKeys(ctx, nil, []fgax.TupleKey{deleteTuple}); err != nil {
+	if _, err := m.Authz.WriteTupleKeys(ctx, nil, deleteTuples); err != nil {
 		logx.FromContext(ctx).Error().Err(err).Msg("failed to delete relationship tuple for deleted NDA request")
 
 		return ErrInternalServerError

--- a/internal/graphapi/organization_test.go
+++ b/internal/graphapi/organization_test.go
@@ -997,6 +997,7 @@ func TestMutationOrganizationCascadeDelete(t *testing.T) {
 
 	reqCtx := auth.NewTestContextWithOrgID(orgUser.ID, org.ID)
 	group1 := (&GroupBuilder{client: suite.client}).MustNew(reqCtx, t)
+	customDomain := (&CustomDomainBuilder{client: suite.client}).MustNew(reqCtx, t)
 
 	// add child org
 	childOrg := (&OrganizationBuilder{client: suite.client, ParentOrgID: org.ID}).MustNew(reqCtx, t)
@@ -1024,6 +1025,13 @@ func TestMutationOrganizationCascadeDelete(t *testing.T) {
 		_, err := suite.client.api.GetGroupByID(reqCtx, group1.ID)
 		return err != nil && strings.Contains(err.Error(), notFoundErrorMsg)
 	}, "group should be deleted by async edge cleanup")
+
+	waitForCondition(t, func() bool {
+		// make sure the custom domain(s) no longer exists
+		ctx := privacy.DecisionContext(reqCtx, privacy.Allow)
+		_, err := suite.client.db.CustomDomain.Get(ctx, customDomain.ID)
+		return generated.IsNotFound(err)
+	}, "custom domain should be deleted by async edge cleanup")
 
 	// verify the parent org is soft-deleted (not hard-deleted) by querying the db directly
 	ctx := privacy.DecisionContext(reqCtx, privacy.Allow)


### PR DESCRIPTION
the bug was actually from custom domain deletions.

found the same error on the nda requests deletion path too `missing ID for deleted NDA request, unable to cleanup tuples`