### PR TITLE
fix: fix trust center nda attestation email send, add to tests

### DIFF
--- a/internal/ent/hooks/listeners_nda_attestation.go
+++ b/internal/ent/hooks/listeners_nda_attestation.go
@@ -32,21 +32,25 @@ func RegisterGalaNDAAttestationListeners(registry *gala.Registry) ([]gala.Listen
 func handleNDAAttestationCreated(ctx gala.HandlerContext, payload eventqueue.MutationGalaPayload) error {
 	ctx, client, ok := eventqueue.ClientFromHandler(ctx)
 	if !ok {
+		logx.FromContext(ctx.Context).Error().Msg("nda attestation listener: no client in context")
 		return nil
 	}
 
 	docDataID, ok := eventqueue.MutationEntityID(payload, ctx.Envelope.Headers.Properties)
 	if !ok || docDataID == "" {
+		logx.FromContext(ctx.Context).Error().Msg("nda attestation listener: no document data id")
 		return nil
 	}
 
 	templateID, _ := eventqueue.MutationStringValue(payload, "template_id")
 	if templateID == "" {
+		logx.FromContext(ctx.Context).Error().Msg("nda attestation listener: no template")
 		return nil
 	}
 
 	docTemplate, err := client.Template.Query().Where(template.ID(templateID)).Only(ctx.Context)
 	if err != nil {
+		logx.FromContext(ctx.Context).Error().Err(err).Msg("nda attestation listener: cannot get template")
 		return nil
 	}
 
@@ -61,40 +65,43 @@ func handleNDAAttestationCreated(ctx gala.HandlerContext, payload eventqueue.Mut
 		return nil
 	}
 
-	docData, err := client.DocumentData.Get(ctx.Context, docDataID)
+	// bypass the org context filter when calling from inside the listener
+	allowCtx := auth.WithCaller(ctx.Context, caller.WithCapabilities(auth.CapBypassOrgFilter))
+
+	docData, err := client.DocumentData.Get(allowCtx, docDataID)
 	if err != nil {
-		logx.FromContext(ctx.Context).Error().Err(err).Str("document_data_id", docDataID).Msg("failed to get document data for nda attestation")
+		logx.FromContext(ctx.Context).Error().Err(err).Str("document_data_id", docDataID).Msg("nda attestation listener: failed to get document data for nda attestation")
 
 		return nil
 	}
 
 	var ndaMetadata signedNDADocumentData
 	if err := jsonx.RoundTrip(docData.Data, &ndaMetadata); err != nil {
-		logx.FromContext(ctx.Context).Error().Err(err).Msg("failed to unmarshal nda metadata from document data")
+		logx.FromContext(ctx.Context).Error().Err(err).Msg("nda attestation listener: failed to unmarshal nda metadata from document data")
 
 		return nil
 	}
 
 	tcID := ndaMetadata.TrustCenterID
 	if tcID == "" {
-		logx.FromContext(ctx.Context).Error().Msg("nda attestation listener: trust center id not found in document data")
+		logx.FromContext(ctx.Context).Error().Msg("nda attestation listener: nda attestation listener: trust center id not found in document data")
 
 		return nil
 	}
 
-	result, err := attestNDADocument(ctx.Context, client, docData, templateID, tcID)
+	result, err := attestNDADocument(allowCtx, client, docData, templateID, tcID)
 	if err != nil {
-		logx.FromContext(ctx.Context).Error().Err(err).Msg("failed to attest NDA document")
+		logx.FromContext(ctx.Context).Error().Err(err).Msg("nda attestation listener: failed to attest NDA document")
 
 		return err
 	}
 
-	allowctx := privacy.DecisionContext(ctx.Context, privacy.Allow)
+	allowCtx = privacy.DecisionContext(allowCtx, privacy.Allow)
 	if err := client.TrustCenterNDARequest.Update().Where(
 		trustcenterndarequest.EmailEqualFold(caller.SubjectEmail),
 		trustcenterndarequest.TrustCenterID(tcID),
-	).SetFileID(result.TemplateFileID).Exec(allowctx); err != nil {
-		logx.FromContext(ctx.Context).Error().Err(err).Str("email", caller.SubjectEmail).Str("trust_center_id", tcID).Msg("failed to set file ID on nda request")
+	).SetFileID(result.TemplateFileID).Exec(allowCtx); err != nil {
+		logx.FromContext(ctx.Context).Error().Err(err).Str("email", caller.SubjectEmail).Str("trust_center_id", tcID).Msg("nda attestation listener: failed to set file ID on nda request")
 
 		return err
 	}
@@ -103,9 +110,9 @@ func handleNDAAttestationCreated(ctx gala.HandlerContext, payload eventqueue.Mut
 		trustcenterndarequest.EmailEqualFold(caller.SubjectEmail),
 		trustcenterndarequest.TrustCenterID(tcID),
 		trustcenterndarequest.StatusEQ(enums.TrustCenterNDARequestStatusSigned),
-	).FirstID(ctx.Context)
+	).FirstID(allowCtx)
 	if err != nil {
-		logx.FromContext(ctx.Context).Error().Err(err).Str("email", caller.SubjectEmail).Str("trust_center_id", tcID).Msg("failed to resolve nda request id for email")
+		logx.FromContext(ctx.Context).Error().Err(err).Str("email", caller.SubjectEmail).Str("trust_center_id", tcID).Msg("nda attestation listener: failed to resolve nda request id for email")
 
 		return err
 	}
@@ -118,7 +125,7 @@ func handleNDAAttestationCreated(ctx gala.HandlerContext, payload eventqueue.Mut
 		AttachmentFilename: "signed_nda_file.pdf",
 		AttachmentData:     result.AttestedPDF,
 	}); err != nil {
-		logx.FromContext(ctx.Context).Error().Err(err).Msg("failed to send NDA signed email")
+		logx.FromContext(ctx.Context).Error().Err(err).Msg("nda attestation listener: failed to send NDA signed email")
 
 		return err
 	}

--- a/internal/ent/interceptors/trustcenter.go
+++ b/internal/ent/interceptors/trustcenter.go
@@ -121,8 +121,9 @@ func applyTrustCenterChildFilters(ctx context.Context, q intercept.Query, applyT
 	// get the trust center key from the context
 	tcID, ok := auth.ActiveTrustCenterIDKey.Get(ctx)
 	if ok && tcID != "" {
-		if !allowAnonAccess {
-			return privacy.Denyf("anonymous trust center access not allowed for this resource")
+		_, allowRequest := privacy.DecisionFromContext(ctx)
+		if !allowAnonAccess && !allowRequest {
+			return privacy.Denyf("anonymous trust center access not allowed for this resource: %s", q.Type())
 		}
 
 		// filter the request by trust center

--- a/internal/graphapi/tools_test.go
+++ b/internal/graphapi/tools_test.go
@@ -304,6 +304,9 @@ func (suite *GraphTestSuite) SetupSuite(t *testing.T) {
 	_, err = hooks.RegisterGalaEntitlementListeners(galaInstance.Registry())
 	requireNoError(t, err)
 
+	_, err = hooks.RegisterGalaNDAAttestationListeners(galaInstance.Registry())
+	requireNoError(t, err)
+
 	requireNoError(t, galaInstance.StartWorkers(ctx))
 
 	suite.galaRuntime = galaInstance

--- a/internal/graphapi/trustcenternda_test.go
+++ b/internal/graphapi/trustcenternda_test.go
@@ -80,9 +80,12 @@ func TestMutationSubmitTrustCenterNDADocAccess(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, getTrustCenterDocResp.TrustCenterDoc.OriginalFile == nil)
 
-	// Clear any existing jobs
+	// Clear any existing jobs and emails before submitting
 	err = suite.client.db.Job.TruncateRiverTables(tcOrg.owner.UserCtx)
 	assert.NilError(t, err)
+
+	suite.mockEmailSender().Reset()
+	expectAttestedUpload(t, suite.client.mockProvider)
 
 	resp, err := suite.client.api.SubmitTrustCenterNDAResponse(anonCtx, input)
 
@@ -97,6 +100,16 @@ func TestMutationSubmitTrustCenterNDADocAccess(t *testing.T) {
 	assert.Assert(t, len(ndaRequest.TrustCenterNdaRequests.Edges) == 1)
 	assert.Equal(t, ndaRequest.TrustCenterNdaRequests.Edges[0].Node.Status.String(), enums.TrustCenterNDARequestStatusSigned.String())
 	assert.Check(t, ndaRequest.TrustCenterNdaRequests.Edges[0].Node.SignedAt != nil)
+
+	// wait for the NDA attestation listener to process the document data creation
+	suite.WaitForEvents()
+
+	// verify the signed NDA email was sent with the attested PDF attached
+	msgs := suite.mockEmailSender().Messages()
+	assert.Assert(t, len(msgs) == 1, "expected 1 email after NDA signing, got %d", len(msgs))
+	assert.Assert(t, len(msgs[0].Attachments) == 1, "expected signed PDF attachment")
+	assert.Equal(t, "signed_nda_file.pdf", msgs[0].Attachments[0].Filename)
+	assert.Assert(t, len(msgs[0].Attachments[0].Content) > 0, "expected non-empty PDF content in attachment")
 
 	// now, check that the anonymous user can query the protected doc's files
 	getTrustCenterDocResp, err = suite.client.api.GetTrustCenterDocByID(anonCtx, trustCenterDocProtected.ID)


### PR DESCRIPTION
fixes a bug in the latest release that prevented the attested email from being sent because it couldn't query document data; added to test suite to catch issues in the future; added more verbose logging to pinpoint issues quickly