### PR TITLE
fix: graph rate limit missing dry-run config flag

### DIFF
--- a/internal/httpserve/serveropts/graph_ratelimit_test.go
+++ b/internal/httpserve/serveropts/graph_ratelimit_test.go
@@ -10,12 +10,19 @@ import (
 
 	coreconfig "github.com/theopenlane/core/config"
 	serverconfig "github.com/theopenlane/core/internal/httpserve/config"
+	"github.com/theopenlane/core/pkg/middleware/ratelimit"
 )
 
 func TestGraphRateLimitConfig(t *testing.T) {
 	t.Parallel()
 
-	cfg := graphRateLimitConfig()
+	in := ratelimit.Config{
+		Enabled:              true,
+		SendRetryAfterHeader: true,
+		DryRun:               true,
+	}
+
+	cfg := graphRateLimitConfig(in)
 
 	if !cfg.Enabled {
 		t.Fatalf("expected graph rate limit config to be enabled")
@@ -23,6 +30,10 @@ func TestGraphRateLimitConfig(t *testing.T) {
 
 	if !cfg.SendRetryAfterHeader {
 		t.Fatalf("expected graph rate limit config to send Retry-After")
+	}
+
+	if !cfg.DryRun {
+		t.Fatalf("expected graph rate limit config to inherit DryRun from the base config")
 	}
 
 	if len(cfg.Options) != 1 || cfg.Options[0].Requests != graphRateLimitRequests || cfg.Options[0].Window != graphRateLimitWindow {
@@ -48,7 +59,12 @@ func TestWithGraphRateLimiterEnforcesAheadOfGraphMiddleware(t *testing.T) {
 		}
 	}
 
-	so := &ServerOptions{Config: serverconfig.Config{Settings: coreconfig.Config{}}}
+	so := &ServerOptions{Config: serverconfig.Config{Settings: coreconfig.Config{
+		Ratelimit: ratelimit.Config{
+			Enabled:              true,
+			SendRetryAfterHeader: true,
+		},
+	}}}
 	so.Config.GraphMiddleware = append(so.Config.GraphMiddleware, marker)
 
 	WithGraphRateLimiter().apply(so)

--- a/internal/httpserve/serveropts/option.go
+++ b/internal/httpserve/serveropts/option.go
@@ -471,12 +471,13 @@ const (
 
 // graphRateLimitConfig builds the dedicated limiter applied to the GraphQL endpoints, keyed on the real client IP
 // (Cloudflare's CF-Connecting-IP, falling back to the socket peer) to match the other per-route limiters
-func graphRateLimitConfig() *ratelimit.Config {
+func graphRateLimitConfig(cfg ratelimit.Config) *ratelimit.Config {
 	return &ratelimit.Config{
-		Enabled:              true,
+		Enabled:              cfg.Enabled,
 		Headers:              ratelimit.DefaultClientIPHeaders,
 		Options:              []ratelimit.RateOption{{Requests: graphRateLimitRequests, Window: graphRateLimitWindow}},
-		SendRetryAfterHeader: true,
+		SendRetryAfterHeader: cfg.SendRetryAfterHeader,
+		DryRun:               cfg.DryRun,
 	}
 }
 
@@ -484,8 +485,10 @@ func graphRateLimitConfig() *ratelimit.Config {
 // throttled ahead of authentication and resolver work
 func WithGraphRateLimiter() ServerOption {
 	return newApplyFunc(func(s *ServerOptions) {
-		limiter := ratelimit.RateLimiterWithConfig(graphRateLimitConfig())
-		s.Config.GraphMiddleware = append([]echo.MiddlewareFunc{limiter}, s.Config.GraphMiddleware...)
+		if s.Config.Settings.Ratelimit.Enabled || s.Config.Settings.Ratelimit.DryRun {
+			limiter := ratelimit.RateLimiterWithConfig(graphRateLimitConfig(s.Config.Settings.Ratelimit))
+			s.Config.GraphMiddleware = append([]echo.MiddlewareFunc{limiter}, s.Config.GraphMiddleware...)
+		}
 	})
 }
 


### PR DESCRIPTION
This was being set to always enforced, breaking local dev. It should use the same enabled + dry run flags as the regular rate limit config 