### PR TITLE
fix: add mw to graph, user query for non-db user, org interceptor, task assigner

### DIFF
--- a/internal/ent/hooks/task.go
+++ b/internal/ent/hooks/task.go
@@ -29,8 +29,10 @@ func HookTaskCreate() ent.Hook {
 	return hook.On(func(next ent.Mutator) ent.Mutator {
 		return hook.TaskFunc(func(ctx context.Context, m *generated.TaskMutation) (generated.Value, error) {
 			if assigner, _ := m.AssignerID(); assigner == "" {
-				// if the assigner is not provided, set it to the current user if not using an API token
-				if !auth.IsAPITokenAuthentication(ctx) {
+				// if the assigner is not provided, set it to the current user if not using an API token or support caller
+				caller, _ := auth.CallerFromContext(ctx)
+
+				if !auth.IsAPITokenAuthentication(ctx) && !caller.Has(auth.CapOrgSupport) {
 					assigner, err := auth.GetSubjectIDFromContext(ctx)
 					if err != nil {
 						return nil, err

--- a/internal/ent/interceptors/organization.go
+++ b/internal/ent/interceptors/organization.go
@@ -43,6 +43,13 @@ func InterceptorOrganization() ent.Interceptor {
 		// query to fga
 		caller, ok := auth.CallerFromContext(ctx)
 		if ok && caller != nil && len(caller.OrgIDs()) > 0 {
+			// // support callers are scoped to one org and have no FGA tuples; bypass FGA and restrict directly
+			if caller.Has(auth.CapOrgSupport) {
+				q.WhereP(organization.IDIn(caller.OrgIDs()...))
+
+				return nil
+			}
+
 			// if the request is not using a JWT, we can restrict to the authorized orgs
 			// from the context
 			if caller.AuthenticationType != auth.JWTAuthentication {

--- a/internal/ent/interceptors/user.go
+++ b/internal/ent/interceptors/user.go
@@ -39,6 +39,11 @@ func TraverseUser() ent.Interceptor {
 			return nil
 		}
 
+		caller, callerOK := auth.CallerFromContext(ctx)
+		if callerOK && caller.Has(auth.CapOrgSupport) {
+			return nil
+		}
+
 		switch userFilterType(ctx) {
 		// if we are looking at a user in the context of an organization or group
 		// filter for just those users
@@ -46,7 +51,7 @@ func TraverseUser() ent.Interceptor {
 			return filterUsingFGA(ctx, q)
 		case "user":
 			// if we are looking at self
-			if caller, ok := auth.CallerFromContext(ctx); ok && caller != nil && caller.SubjectID != "" {
+			if callerOK && caller != nil && caller.SubjectID != "" {
 				q.Where(user.ID(caller.SubjectID))
 
 				return nil

--- a/internal/graphapi/resolver.go
+++ b/internal/graphapi/resolver.go
@@ -157,6 +157,9 @@ func (r *Resolver) Handler() *Handler {
 		common.AddAllExtensions(srv)
 	}
 
+	// prevent synthetic support-user list edges from falling through to QueryXxx()
+	WithSupportUserEdges(srv)
+
 	// Set the error presenter to use the custom error presenter
 	srv.SetErrorPresenter(gqlerrors.ErrorPresenter)
 

--- a/internal/graphapi/supportuserextension.go
+++ b/internal/graphapi/supportuserextension.go
@@ -1,0 +1,82 @@
+package graphapi
+
+import (
+	"context"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/theopenlane/iam/auth"
+
+	"github.com/theopenlane/core/common/enums"
+	"github.com/theopenlane/core/internal/ent/generated"
+)
+
+// supportUserEdgeExtension prevents list-edge model methods on a synthetic support
+type supportUserEdgeExtension struct{}
+
+// ExtensionName satisfies the extension interface
+func (supportUserEdgeExtension) ExtensionName() string { return "SupportUserEdges" }
+
+// Validate satisfies the extension interface
+func (supportUserEdgeExtension) Validate(graphql.ExecutableSchema) error { return nil }
+
+// InterceptField set named edges for the support user when retrieving the user data
+func (supportUserEdgeExtension) InterceptField(ctx context.Context, next graphql.Resolver) (any, error) {
+	fc := graphql.GetFieldContext(ctx)
+	if fc == nil || (fc.Object != "User") {
+		return next(ctx)
+	}
+
+	caller, ok := auth.CallerFromContext(ctx)
+	if !ok || caller == nil || !caller.Has(auth.CapOrgSupport) {
+		return next(ctx)
+	}
+
+	switch fc.Field.Name {
+	case "tfaSettings":
+		return &generated.TFASettingConnection{Edges: []*generated.TFASettingEdge{}}, nil
+	case "organizations":
+		return &generated.OrganizationConnection{Edges: []*generated.OrganizationEdge{}}, nil
+	case "orgMemberships":
+		return &generated.OrgMembershipConnection{Edges: []*generated.OrgMembershipEdge{}}, nil
+	case "groups":
+		return &generated.GroupConnection{Edges: []*generated.GroupEdge{}}, nil
+	case "groupMemberships":
+		return &generated.GroupMembershipConnection{Edges: []*generated.GroupMembershipEdge{}}, nil
+	case "personalAccessTokens":
+		return &generated.PersonalAccessTokenConnection{Edges: []*generated.PersonalAccessTokenEdge{}}, nil
+	}
+
+	return next(ctx)
+}
+
+// WithSupportUserEdges registers the support-user edge extension
+func WithSupportUserEdges(srv *handler.Server) {
+	srv.Use(supportUserEdgeExtension{})
+}
+
+// supportUserFromCaller defines the support user for calls from the UI such as GetUserProfile
+func supportUserFromCaller(caller *auth.Caller) *generated.User {
+	orgID := caller.OrganizationID
+
+	setting := &generated.UserSetting{
+		UserID:         caller.SubjectID,
+		Status:         enums.UserStatusActive,
+		EmailConfirmed: true,
+		Edges: generated.UserSettingEdges{
+			DefaultOrg: &generated.Organization{
+				ID: orgID,
+			},
+		},
+	}
+
+	return &generated.User{
+		ID:          caller.SubjectID,
+		DisplayName: caller.SubjectName,
+		Email:       caller.SubjectEmail,
+		Edges: generated.UserEdges{
+			Setting:    setting,
+			AvatarFile: &generated.File{},
+		},
+	}
+}

--- a/internal/graphapi/user.resolvers.go
+++ b/internal/graphapi/user.resolvers.go
@@ -61,6 +61,12 @@ func (r *mutationResolver) DeleteUser(ctx context.Context, id string) (*model.Us
 
 // User is the resolver for the user field.
 func (r *queryResolver) User(ctx context.Context, id string) (*generated.User, error) {
+	// return support user when looking up user from support context
+	caller, ok := auth.CallerFromContext(ctx)
+	if ok && caller != nil && caller.Has(auth.CapOrgSupport) {
+		return supportUserFromCaller(caller), nil
+	}
+
 	query, err := withTransactionalMutation(ctx).User.Query().Where(user.ID(id)).CollectFields(ctx)
 	if err != nil {
 		return nil, parseRequestError(ctx, err, common.Action{Action: common.ActionGet, Object: "user"})
@@ -80,6 +86,11 @@ func (r *queryResolver) Self(ctx context.Context) (*generated.User, error) {
 	if !ok || caller == nil {
 		return nil, parseRequestError(ctx, auth.ErrNoAuthUser, common.Action{Action: common.ActionGet, Object: "user"})
 	}
+
+	if caller.Has(auth.CapOrgSupport) {
+		return supportUserFromCaller(caller), nil
+	}
+
 	userID := caller.SubjectID
 	if userID == "" {
 		return nil, parseRequestError(ctx, auth.ErrNoAuthUser, common.Action{Action: common.ActionGet, Object: "user"})

--- a/internal/graphapi/user_test.go
+++ b/internal/graphapi/user_test.go
@@ -370,6 +370,44 @@ func TestMutationDeleteUser(t *testing.T) {
 	}
 }
 
+func TestQueryUserSupportContext(t *testing.T) {
+	const (
+		supportSubjectID = "01JSPPRT000000000000000000"
+		supportName      = "Openlane Support"
+		supportEmail     = "support@theopenlane.io"
+	)
+
+	orgID := sharedTestUser1.OrganizationID
+
+	caller := auth.NewOrgSupportCaller(orgID, supportSubjectID, supportName, supportEmail)
+	supportCtx := auth.WithCaller(sharedTestUser1.UserCtx, caller)
+
+	t.Run("Self returns synthetic support user", func(t *testing.T) {
+		resp, err := suite.client.api.GetSelf(supportCtx)
+
+		assert.NilError(t, err)
+		assert.Assert(t, resp != nil)
+
+		assert.Check(t, is.Equal(supportSubjectID, resp.Self.ID))
+		assert.Check(t, is.Equal(supportName, resp.Self.DisplayName))
+		assert.Check(t, is.Equal(supportEmail, resp.Self.Email))
+		assert.Check(t, resp.Self.Setting.EmailConfirmed)
+		assert.Check(t, resp.Self.Setting.DefaultOrg != nil)
+		assert.Check(t, is.Equal(orgID, resp.Self.Setting.DefaultOrg.ID))
+	})
+
+	t.Run("User returns synthetic support user", func(t *testing.T) {
+		resp, err := suite.client.api.GetUserByID(supportCtx, supportSubjectID)
+
+		assert.NilError(t, err)
+		assert.Assert(t, resp != nil)
+
+		assert.Check(t, is.Equal(supportSubjectID, resp.User.ID))
+		assert.Check(t, is.Equal(supportName, resp.User.DisplayName))
+		assert.Check(t, is.Equal(supportEmail, resp.User.Email))
+	})
+}
+
 func TestMutationDeleteUser_OrgOwnerCannotBeDeleted(t *testing.T) {
 	t.Parallel()
 	localTestOrg := suite.seedFreshOrgUsers(t)

--- a/internal/httpserve/handlers/impersonation.go
+++ b/internal/httpserve/handlers/impersonation.go
@@ -12,6 +12,7 @@ import (
 	"github.com/theopenlane/core/common/enums"
 	models "github.com/theopenlane/core/common/openapi"
 	"github.com/theopenlane/core/internal/ent/generated"
+	"github.com/theopenlane/core/internal/ent/generated/privacy"
 	"github.com/theopenlane/core/pkg/logx"
 	"github.com/theopenlane/utils/rout"
 )
@@ -115,7 +116,7 @@ func (h *Handler) StartImpersonation(ctx echo.Context, openapi *OpenAPIContext) 
 		ImpersonatorEmail: caller.SubjectEmail,
 		TargetUserID:      req.TargetUserID,
 		TargetUserEmail:   targetUser.Email,
-		Action:            "start",
+		Action:            enums.ImpersonationActionStart.String(),
 		Reason:            req.Reason,
 		Timestamp:         time.Now(),
 		IPAddress:         ctx.RealIP(),
@@ -171,7 +172,7 @@ func (h *Handler) EndImpersonation(ctx echo.Context, openapi *OpenAPIContext) er
 		ImpersonatorEmail: caller.Impersonation.ImpersonatorEmail,
 		TargetUserID:      caller.Impersonation.TargetUserID,
 		TargetUserEmail:   caller.Impersonation.TargetUserEmail,
-		Action:            "end",
+		Action:            enums.ImpersonationActionStop.String(),
 		Reason:            req.Reason,
 		Timestamp:         time.Now(),
 		IPAddress:         ctx.RealIP(),
@@ -246,6 +247,7 @@ func (h *Handler) getTargetUser(ctx context.Context, userID string, orgID string
 func (h *Handler) logImpersonationEvent(ctx context.Context, action string, auditLog *auth.ImpersonationAuditLog) error {
 	logx.FromContext(ctx).Info().Str("action", action).Str("target_user_id", auditLog.TargetUserID).Msg("impersonation event")
 
+	allowCtx := privacy.DecisionContext(ctx, privacy.Allow)
 	_, err := h.DBClient.ImpersonationEvent.Create().
 		SetAction(*enums.ToImpersonationAction(action)).
 		SetImpersonationType(*enums.ToImpersonationType(string(auditLog.Type))).
@@ -257,7 +259,7 @@ func (h *Handler) logImpersonationEvent(ctx context.Context, action string, audi
 		SetOrganizationID(auditLog.OrganizationID).
 		SetCreatedBy(auditLog.ImpersonatorID).
 		SetCreatedAt(time.Now()).
-		Save(ctx)
+		Save(allowCtx)
 	return err
 }
 

--- a/internal/httpserve/handlers/support.go
+++ b/internal/httpserve/handlers/support.go
@@ -15,6 +15,7 @@ import (
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 	"golang.org/x/oauth2"
 
+	"github.com/theopenlane/core/common/enums"
 	apimodels "github.com/theopenlane/core/common/openapi"
 	ent "github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
@@ -197,7 +198,7 @@ func (h *Handler) SupportCallbackHandler(ctx echo.Context, openapi *OpenAPIConte
 		ImpersonatorEmail: individualEmail,
 		TargetUserID:      cfg.SubjectID,
 		TargetUserEmail:   cfg.Email,
-		Action:            "start",
+		Action:            enums.ImpersonationActionStart.String(),
 		Reason:            reason,
 		Timestamp:         time.Now(),
 		IPAddress:         ctx.RealIP(),

--- a/internal/httpserve/handlers/support_test.go
+++ b/internal/httpserve/handlers/support_test.go
@@ -20,6 +20,7 @@ import (
 	ent "github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/organizationsetting"
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
+	"github.com/theopenlane/core/internal/graphapi/testclient"
 	"github.com/theopenlane/core/internal/httpserve/handlers"
 	"github.com/theopenlane/core/pkg/middleware/impersonation"
 	"github.com/theopenlane/utils/ulids"
@@ -387,18 +388,33 @@ func (suite *HandlerTestSuite) TestSupportAccessCanUpdateOrgData() {
 
 	supportCtx := suite.supportCallerContext(token)
 
-	const updatedContact = "support-updated-contact"
+	// ensure org interceptor works for support
+	orgMembers, err := suite.api.GetOrgMembersByOrgID(supportCtx, &testclient.OrgMembershipWhereInput{OrganizationID: &org.ID})
+	require.NoError(t, err)
+	assert.NotEmpty(t, orgMembers.OrgMemberships.Edges)
 
-	setting, err := suite.db.OrganizationSetting.Query().
-		Where(organizationsetting.OrganizationID(org.ID)).
-		Only(supportCtx)
+	resp, err := suite.api.GetOrganizationSettings(supportCtx, testclient.OrganizationSettingWhereInput{})
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.OrganizationSettings.Edges)
+	assert.Len(t, resp.OrganizationSettings.Edges, 1)
+
+	// set for other tests
+	setting := resp.OrganizationSettings.Edges[0].Node
+
+	var updatedContact = "support-updated-contact"
+
+	_, err = suite.api.UpdateOrganizationSetting(supportCtx, setting.ID, testclient.UpdateOrganizationSettingInput{
+		BillingContact: &updatedContact,
+	})
 	require.NoError(t, err)
 
-	_, err = suite.db.OrganizationSetting.UpdateOneID(setting.ID).
-		SetBillingContact(updatedContact).
-		Save(supportCtx)
+	got, err := suite.db.OrganizationSetting.Get(supportCtx, setting.ID)
 	require.NoError(t, err)
-
-	got := suite.db.OrganizationSetting.GetX(supportCtx, setting.ID)
 	assert.Equal(t, updatedContact, got.BillingContact, "support update should persist to the org setting")
+
+	// create task to ensure assigner doesn't error on constraint
+	_, err = suite.api.CreateTask(supportCtx, testclient.CreateTaskInput{
+		Title: "new task from support user",
+	})
+	require.NoError(t, err)
 }

--- a/internal/httpserve/serveropts/option.go
+++ b/internal/httpserve/serveropts/option.go
@@ -198,7 +198,8 @@ func WithAuth() ServerOption {
 
 		s.Config.Handler.WebAuthn = webauthn.NewWithConfig(s.Config.Settings.Auth.Providers.Webauthn)
 
-		s.Config.GraphMiddleware = append(s.Config.GraphMiddleware, authmw.Authenticate(&conf), impersonation.SystemAdminUserContextMiddleware(), authmw.BlockNonTrustCenterAnonymous())
+		impersonationMW := impersonation.New(s.Config.Handler.TokenManager, s.Config.Handler.SupportAccessConfig.SubjectID, s.Config.Handler.SupportAccessConfig.DisplayName)
+		s.Config.GraphMiddleware = append(s.Config.GraphMiddleware, impersonationMW.Process, authmw.Authenticate(&conf), impersonation.SystemAdminUserContextMiddleware(), authmw.BlockNonTrustCenterAnonymous())
 		s.Config.Handler.AuthMiddleware = append(s.Config.Handler.AuthMiddleware, authmw.Authenticate(&conf))
 	})
 }

--- a/internal/testutils/client.go
+++ b/internal/testutils/client.go
@@ -242,6 +242,9 @@ func testGraphServer(c *ent.Client, u *objects.Service) *handler.Server {
 
 	common.WithResultLimit(srv, &MaxResultLimit)
 
+	// prevent synthetic support-user list edges from falling through to QueryXxx()
+	graphapi.WithSupportUserEdges(srv)
+
 	// Set the error presenter to use the custom error presenter
 	srv.SetErrorPresenter(gqlerrors.ErrorPresenter)
 

--- a/pkg/middleware/impersonation/impersonation.go
+++ b/pkg/middleware/impersonation/impersonation.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"slices"
 
+	"github.com/rs/zerolog"
 	"github.com/theopenlane/core/pkg/logx"
 	echo "github.com/theopenlane/echox"
 	"github.com/theopenlane/iam/auth"
@@ -77,6 +78,12 @@ func (m *Middleware) Process(next echo.HandlerFunc) echo.HandlerFunc {
 		// Set the impersonated caller in the context.
 		ctx = auth.WithCaller(ctx, impersonatedCaller)
 		c.SetRequest(c.Request().WithContext(ctx))
+
+		// add the user and org ID to the logger context
+		logx.FromContext(ctx).UpdateContext(func(c zerolog.Context) zerolog.Context {
+			return c.Str("support_user_id", impersonatedCaller.SubjectID).
+				Strs("org_id", impersonatedCaller.OrganizationIDs)
+		})
 
 		// Log the impersonation action
 		m.logImpersonationAccess(claims, c)


### PR DESCRIPTION
- Adds skip for support user when creating tasks so it doesn't attempt to set `Assigner` as a non-valid user
- Adds skip for interceptor to not filter orgs with FGA and use the orgs in the claims
- Adds skip for user for support
- Updates the user resolvers to return the support user when doing a GetUser/GetSelf query
- Adds more tests/uses api instead of db to ensure same paths are checked for the found bugs
- Adds impersonation middleware to graph route before authMW to fix queries
- Adds user id and org id to logger context to match the auth mw logger