### PR TITLE
bug: typo should be internal_policy not policy

### DIFF
--- a/fga/model/generated/crud.fga
+++ b/fga/model/generated/crud.fga
@@ -171,7 +171,7 @@ extend type organization
     define identity_holder_creator: [group#member]
     define can_create_identity_holder: can_edit or can_edit_identity_holder or identity_holder_creator or can_manage_registry or can_manage_compliance
 
-    define can_view_internal_policy: [service, user, group#member] or can_edit_internal_policy or can_manage_compliance or can_manage_policies or full_access
+    define can_view_internal_policy: [service, user, group#member] or auditor or can_edit_internal_policy or can_manage_compliance or can_manage_policies or full_access
     define can_edit_internal_policy: [service, user, group#member] or can_delete_internal_policy or can_manage_compliance or can_manage_policies or full_access
     define can_delete_internal_policy: [service, user, group#member] or can_manage_compliance or can_manage_policies or full_access
     define internal_policy_creator: [group#member]

--- a/fga/model/roles/roles.fga
+++ b/fga/model/roles/roles.fga
@@ -14,7 +14,7 @@ extend type organization
     define owner: [user] or owner from parent
 
     # @create: comment, discussion, task
-    # @view: control, subcontrol, program, evidence, policy, procedure, review, platform
+    # @view: control, subcontrol, program, evidence, internal_policy, procedure, review, platform
     # @crud: evidence, review
     define auditor: [user] or auditor from parent
 


### PR DESCRIPTION
Auditors could view the able, but when viewing a specific policy it would get not found because the auditor role wasn't actually granted view of policies. 