### PR TITLE
fix: cleanup go binary size

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -12,7 +12,6 @@ env:
   GRAPHQL_HISTORY_SCHEMA_LOCATION: "internal/graphapi/historyschema/schema.graphql"
   GRAPHQL_SCHEMA_NAME: "Openlane-0dedz@current"
   GRAPHQL_HISTORY_SCHEMA_NAME: "Openlane-History@current"
-  GOFLAGS: -buildvcs=false
   GOCACHE: $HOME/.cache/go-build
   GOMODCACHE: $HOME/.cache/go/pkg/mod
   GOLANGCI_LINT_CACHE: $HOME/.cache/golangci-lint
@@ -573,9 +572,7 @@ steps:
                 - $GOMODCACHE:$GOMODCACHE
                 - $GOLANGCI_LINT_CACHE:$GOLANGCI_LINT_CACHE
               environment:
-                - CGO_ENABLED=0
                 - GOOS=linux
-                - GOFLAGS="-buildvcs=false -gcflags=all=-l"
               command: ["task", "go:build:ci"]
       - label: ":terminal: build cli"
         key: "gobuild-cli"
@@ -599,10 +596,8 @@ steps:
                 - $GOMODCACHE:$GOMODCACHE
                 - $GOLANGCI_LINT_CACHE:$GOLANGCI_LINT_CACHE
               environment:
-                - CGO_ENABLED=0
                 - GOOS=darwin
                 - GOARCH=arm64
-                - GOFLAGS="-buildvcs=false -gcflags=all=-l"
               command: ["task", "go:build-cli:ci"]
       - label: ":golang: build release"
         key: "gobuild-server-release"
@@ -622,9 +617,8 @@ steps:
                 - $GOMODCACHE:$GOMODCACHE
                 - $GOLANGCI_LINT_CACHE:$GOLANGCI_LINT_CACHE
               environment:
-                - CGO_ENABLED=0
                 - GOOS=linux
-              command: ["task", "go:build:ci"]
+              command: ["task", "go:build:ci:release"]
       - label: ":terminal: build cli release"
         if: build.tag != null && build.tag =~ /cli\//
         key: "gobuild-cli-release"
@@ -643,7 +637,6 @@ steps:
                 - $GOMODCACHE:$GOMODCACHE
                 - $GOLANGCI_LINT_CACHE:$GOLANGCI_LINT_CACHE
               environment:
-                - CGO_ENABLED=0
                 - GOOS=darwin
                 - GOARCH=arm64
               command: ["task", "go:build-cli:ci"]

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -448,9 +448,19 @@ tasks:
       - "CGO_ENABLED=0 {{ .GOOS }} {{ .GOARCH }} go build -o core"
 
   go:build:ci:
-    desc: Runs go build for the core server
+    desc: Runs go build for the core server for PR/branch CI, favors build speed over binary size
     cmds:
-      - CGO_ENABLED=0 go build -mod=readonly -o bin/core
+      # -gcflags=all=-l disables inlining, which is faster to compile and gives more
+      # accurate stack traces, at the cost of a larger, unstripped binary
+      # these binaries are not published so the larger size is ok here
+      - CGO_ENABLED=0 go build -mod=readonly -gcflags=all=-l -o bin/core
+
+  go:build:ci:release:
+    desc: Runs go build for the core server for tagged releases, favors binary size over build speed
+    cmds:
+      # -s -w strip the symbol table and DWARF debug info (biggest size win)
+      # -trimpath removes local build paths from the binary
+      - CGO_ENABLED=0 go build -mod=readonly -trimpath -ldflags="-s -w" -o bin/core
 
   go:build-cli:
     aliases: [buildcli]


### PR DESCRIPTION
The CI build for the core server binary (`go:build:ci`) was missing `-ldflags="-s -w"` and `-trimpath`, and was also picking up `-gcflags=all=-l`(disables inlining) inherited from pipeline.yaml's container env — none of which should be used for the final production binary. This produced an unstripped ~750MB+ binary, bloating the final image to over 1GB.

- Added -trimpath `-ldflags="-s -w"` to new `go:build:ci:release` in Taskfile.yaml to strip debug symbols and build paths. Non-prod builds will use `go:build:ci` which favors speed over binary size. 
- Removed the stray `GOFLAGS`/`CGO_ENABLED=0` overrides from pipeline.yaml's build steps which were duplicated and confusing compared to the taskfile

Before:
```
 752M Jul  6 13:36 core
```
After: 
```
  557M Jul  6 13:30 core
```

Running test build: https://buildkite.com/theopenlane/core/builds/11441