### PR TITLE
feat: add redis to share notifications across processes

### DIFF
--- a/docker/configs/riverboat/.config.dev.yaml
+++ b/docker/configs/riverboat/.config.dev.yaml
@@ -35,6 +35,16 @@ river:
     openlaneconfig:
       openlaneapihost: "http://host.docker.internal:17608"
       openlaneapitoken: "tolp_REDACTED"
+    createdomainscanworker:
+      config:
+        cloudflareaccountid: ""
+        cloudflareapikey: ""
+        enabled: false
+    retrievedomainscanworker:
+      config:
+        cloudflareaccountid: ""
+        cloudflareapikey: ""
+        enabled: false
     cleartrustcentercacheworker:
       config:
         enabled: false

--- a/internal/graphapi/resolver.go
+++ b/internal/graphapi/resolver.go
@@ -8,6 +8,7 @@ import (
 	"github.com/99designs/gqlgen/graphql/handler/extension"
 	"github.com/99designs/gqlgen/graphql/handler/lru"
 	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/redis/go-redis/v9"
 	echo "github.com/theopenlane/echox"
 	"github.com/vektah/gqlparser/v2/ast"
 
@@ -94,11 +95,16 @@ func NewResolver(db *ent.Client, u *objects.Service) *Resolver {
 	}
 }
 
-// WithSubscriptions enables graphql subscriptions to the server using websockets or sse
-func (r Resolver) WithSubscriptions(enabled bool) *Resolver {
+// WithSubscriptions enables graphql subscriptions to the server using websockets or sse. When
+// redisClient is non-nil, notifications are also distributed across processes via redis pub/sub
+func (r Resolver) WithSubscriptions(enabled bool, redisClient *redis.Client) *Resolver {
 	if enabled {
 		r.subscriptionManager = graphsubscriptions.NewManager()
 		r.subscriptionsEnabled = true
+
+		if redisClient != nil {
+			r.subscriptionManager.WithRedis(redisClient)
+		}
 	}
 
 	return &r

--- a/internal/graphapi/subscription_helpers.go
+++ b/internal/graphapi/subscription_helpers.go
@@ -2,6 +2,7 @@ package graphapi
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -31,6 +32,8 @@ func (r *subscriptionResolver) handleNotificationSubscription(ctx context.Contex
 	if userID == "" {
 		return nil, fmt.Errorf("failed to get user ID from context: %w", auth.ErrNoAuthUser)
 	}
+
+	logx.FromContext(ctx).Debug().Str("user_id", userID).Bool("redis_enabled", r.subscriptionManager.HasRedis()).Msg("notification subscription: subscribing")
 
 	// Create a channel with the interface type for the subscription manager
 	internalChan := make(chan graphsubscriptions.Notification, graphsubscriptions.NotificationChannelBufferSize)
@@ -97,14 +100,31 @@ func (r *subscriptionResolver) handleNotificationSubscription(ctx context.Contex
 				if !ok {
 					return
 				}
-				// Cast back to concrete type
-				if concreteNotif, ok := notif.(*generated.Notification); ok {
-					select {
-					case notifChan <- concreteNotif:
-					case <-ctx.Done():
-						r.subscriptionManager.Unsubscribe(userID, internalChan)
-						return
+
+				var concreteNotif *generated.Notification
+
+				switch v := notif.(type) {
+				case *generated.Notification:
+					// delivered directly by a local Publish() call
+					concreteNotif = v
+				case graphsubscriptions.RawNotification:
+					// delivered via redis from another process, still needs unmarshaling
+					var n generated.Notification
+					if err := json.Unmarshal(v.Payload, &n); err != nil {
+						logx.FromContext(ctx).Error().Err(err).Msg("failed to unmarshal redis-delivered notification")
+						continue
 					}
+					concreteNotif = &n
+				default:
+					logx.FromContext(ctx).Warn().Msg("received notification of unexpected type, skipping")
+					continue
+				}
+
+				select {
+				case notifChan <- concreteNotif:
+				case <-ctx.Done():
+					r.subscriptionManager.Unsubscribe(userID, internalChan)
+					return
 				}
 			}
 		}

--- a/internal/graphapi/tools_test.go
+++ b/internal/graphapi/tools_test.go
@@ -839,7 +839,7 @@ func newTestGraphServer(t *testing.T) http.Handler {
 	r := graphapi.NewResolver(suite.client.db, nil).
 		WithExtensions(true).
 		WithDevelopment(true).
-		WithSubscriptions(true).
+		WithSubscriptions(true, nil).
 		WithAuthOptions(
 			authmw.WithSkipperFunc(
 				func(c echo.Context) bool {

--- a/internal/graphsubscriptions/manager.go
+++ b/internal/graphsubscriptions/manager.go
@@ -1,14 +1,21 @@
 package graphsubscriptions
 
 import (
+	"context"
+	"encoding/json"
 	"slices"
 	"sync"
 
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
 	"github.com/rs/zerolog/log"
 )
 
 // NotificationChannelBufferSize is the buffer size for task subscription channels
 const NotificationChannelBufferSize = 10
+
+// redisChannelName is the pub/sub channel used to distribute notifications across processes
+const redisChannelName = "graphsubscriptions:notifications"
 
 var (
 	// globalManager is the singleton subscription manager instance
@@ -20,12 +27,26 @@ var (
 type Manager struct {
 	mu          sync.RWMutex
 	subscribers map[string][]chan Notification // map of userID to list of notification channels
+
+	// redisClient, when set via WithRedis, distributes published notifications to other processes over Redis
+	redisClient *redis.Client
+	// instanceID identifies this process's Manager so it can ignore its own messages when they're echoed back by Redis
+	// since Publish already delivers to local subscribers directly
+	instanceID string
+}
+
+// redisEnvelope is the payload published to the Redis notification channel
+type redisEnvelope struct {
+	OriginID string          `json:"origin_id"`
+	UserID   string          `json:"user_id"`
+	Payload  json.RawMessage `json:"payload"`
 }
 
 // NewManager creates a new subscription manager
 func NewManager() *Manager {
 	m := &Manager{
 		subscribers: make(map[string][]chan Notification),
+		instanceID:  uuid.NewString(),
 	}
 
 	// Set as global manager
@@ -34,6 +55,58 @@ func NewManager() *Manager {
 	globalMu.Unlock()
 
 	return m
+}
+
+// WithRedis enables cross-process notification delivery
+func (sm *Manager) WithRedis(client *redis.Client) *Manager {
+	sm.redisClient = client
+
+	go sm.subscribeRedis(context.Background())
+
+	return sm
+}
+
+// subscribeRedis listens for notifications published by other processes and forwards them to local subscribers
+func (sm *Manager) subscribeRedis(ctx context.Context) {
+	pubsub := sm.redisClient.Subscribe(ctx, redisChannelName)
+	defer pubsub.Close()
+
+	if _, err := pubsub.Receive(ctx); err != nil {
+		log.Error().Err(err).Str("instance_id", sm.instanceID).Msg("graphsubscriptions: failed to subscribe to redis channel")
+		return
+	}
+
+	ch := pubsub.Channel()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg, ok := <-ch:
+			if !ok {
+				log.Warn().Str("instance_id", sm.instanceID).Msg("graphsubscriptions: redis subscription channel closed")
+				return
+			}
+
+			var env redisEnvelope
+			if err := json.Unmarshal([]byte(msg.Payload), &env); err != nil {
+				log.Error().Err(err).Msg("graphsubscriptions: failed to unmarshal redis notification envelope")
+				continue
+			}
+
+			if env.OriginID == sm.instanceID {
+				log.Debug().Str("user_id", env.UserID).Msg("graphsubscriptions: skipping self-originated redis message, already delivered locally")
+				continue
+			}
+
+			sm.dispatchLocal(env.UserID, RawNotification{Payload: env.Payload})
+		}
+	}
+}
+
+// HasRedis reports whether this manager is configured to distribute notifications across processes via redis
+func (sm *Manager) HasRedis() bool {
+	return sm.redisClient != nil
 }
 
 // GetGlobalManager returns the global subscription manager instance
@@ -49,7 +122,7 @@ func (sm *Manager) Subscribe(userID string, ch chan Notification) {
 	defer sm.mu.Unlock()
 
 	sm.subscribers[userID] = append(sm.subscribers[userID], ch)
-	log.Debug().Str("user_id", userID).Int("subscriber_count", len(sm.subscribers[userID])).Msg("user subscribed to notifications")
+	log.Debug().Str("instance_id", sm.instanceID).Str("user_id", userID).Int("subscriber_count", len(sm.subscribers[userID])).Msg("graphsubscriptions: user subscribed to notifications")
 }
 
 // Unsubscribe removes a subscriber
@@ -80,21 +153,56 @@ func (sm *Manager) Unsubscribe(userID string, ch chan Notification) {
 	}
 }
 
-// Publish sends a notification to all subscribers for that user
+// Publish sends a notification to all subscribers for that user in this process, and, when
+// Redis is configured, to subscribers of other processes as well
 func (sm *Manager) Publish(userID string, notification Notification) error {
-	sm.mu.RLock()
-	defer sm.mu.RUnlock()
+	sm.dispatchLocal(userID, notification)
 
-	log.Debug().Str("user_id", userID).Int("total_subscribers", len(sm.subscribers)).Msg("Publish called")
-
-	channels, ok := sm.subscribers[userID]
-	if !ok {
-		// No subscribers for this user, which is fine
-		log.Debug().Str("user_id", userID).Msg("no subscribers found for user")
+	if sm.redisClient == nil {
+		log.Debug().Str("user_id", userID).Msg("graphsubscriptions: redis not configured on this manager, notification only delivered to subscribers in this process")
 		return nil
 	}
 
-	log.Debug().Str("user_id", userID).Int("subscriber_count", len(channels)).Msg("found subscribers for user, sending notification")
+	payload, err := json.Marshal(notification)
+	if err != nil {
+		log.Error().Err(err).Str("user_id", userID).Msg("graphsubscriptions: failed to marshal notification for redis publish")
+		return nil
+	}
+
+	envelope, err := json.Marshal(redisEnvelope{
+		OriginID: sm.instanceID,
+		UserID:   userID,
+		Payload:  payload,
+	})
+	if err != nil {
+		log.Error().Err(err).Str("user_id", userID).Msg("graphsubscriptions: failed to marshal redis notification envelope")
+		return nil
+	}
+
+	_, err = sm.redisClient.Publish(context.Background(), redisChannelName, envelope).Result()
+	if err != nil {
+		log.Error().Err(err).Str("user_id", userID).Msg("graphsubscriptions: failed to publish notification to redis")
+		return nil
+	}
+
+	return nil
+}
+
+// dispatchLocal sends a notification to all subscribers for that user within this process
+func (sm *Manager) dispatchLocal(userID string, notification Notification) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	log.Debug().Str("instance_id", sm.instanceID).Str("user_id", userID).Int("total_subscribed_users", len(sm.subscribers)).Msg("graphsubscriptions: dispatchLocal called")
+
+	channels, ok := sm.subscribers[userID]
+	if !ok {
+		// No subscribers for this user in this process, which is fine
+		log.Debug().Str("instance_id", sm.instanceID).Str("user_id", userID).Msg("graphsubscriptions: no local subscribers found for user")
+		return
+	}
+
+	log.Debug().Str("instance_id", sm.instanceID).Str("user_id", userID).Int("subscriber_count", len(channels)).Msg("graphsubscriptions: found local subscribers for user, sending notification")
 
 	// Send to all subscribers
 	for i, ch := range channels {
@@ -107,6 +215,4 @@ func (sm *Manager) Publish(userID string, notification Notification) error {
 			log.Info().Str("user_id", userID).Int("subscriber_index", i).Msg("channel closed or full, unable to send notification to subscriber for user")
 		}
 	}
-
-	return nil
 }

--- a/internal/graphsubscriptions/notification.go
+++ b/internal/graphsubscriptions/notification.go
@@ -4,3 +4,8 @@ package graphsubscriptions
 // This avoids import cycles with ent/generated
 // The ent/generated.Notification type has ID and UserID fields that satisfy this interface
 type Notification interface{}
+
+// RawNotification wraps a notification received over Redis that hasn't been unmarshaled into its concrete type yet
+type RawNotification struct {
+	Payload []byte
+}

--- a/internal/httpserve/serveropts/option.go
+++ b/internal/httpserve/serveropts/option.go
@@ -274,6 +274,18 @@ func WithReadyChecks(c *entx.EntClientConfig, f *fgax.Client, r *redis.Client, j
 // WithGraphRoute adds the graph handler to the server
 func WithGraphRoute(srv *server.Server, c *ent.Client) ServerOption {
 	return newApplyFunc(func(s *ServerOptions) {
+		// only pass the redis client through to subscriptions when redis itself is enabled
+		var subscriptionRedisClient *redis.Client
+		if s.Config.Settings.Redis.Enabled {
+			subscriptionRedisClient = s.Config.Handler.RedisClient
+		}
+
+		log.Debug().
+			Bool("subscriptions_enabled", s.Config.Settings.Server.EnableGraphSubscriptions).
+			Bool("redis_enabled", s.Config.Settings.Redis.Enabled).
+			Bool("redis_client_set", subscriptionRedisClient != nil).
+			Msg("graphsubscriptions: server bootstrap config")
+
 		// Setup Graph API Handlers
 		r := graphapi.NewResolver(c, s.Config.StorageService).
 			WithExtensions(s.Config.Settings.Server.EnableGraphExtensions).
@@ -283,7 +295,7 @@ func WithGraphRoute(srv *server.Server, c *ent.Client) ServerOption {
 			WithWorkflowsConfig(s.Config.Settings.Workflows).
 			WithTrustCenterCnameTarget(s.Config.Settings.Server.TrustCenterCnameTarget).
 			WithTrustCenterDefaultDomain(s.Config.Settings.Server.DefaultTrustCenterDomain).
-			WithSubscriptions(s.Config.Settings.Server.EnableGraphSubscriptions).
+			WithSubscriptions(s.Config.Settings.Server.EnableGraphSubscriptions, subscriptionRedisClient).
 			WithAllowedOrigins(s.Config.Settings.Server.CORS.AllowOrigins).
 			WithAuthOptions(getAuthOptions(s)...).
 			WithNotificationLookbackDays(s.Config.Settings.Server.NotificationLookbackDays)

--- a/internal/testutils/client.go
+++ b/internal/testutils/client.go
@@ -197,7 +197,7 @@ func testGraphServer(c *ent.Client, u *objects.Service) *handler.Server {
 		WithMaxResultLimit(MaxResultLimit).
 		WithTrustCenterCnameTarget(TrustCenterCnameTarget).
 		WithTrustCenterDefaultDomain(TrustCenterDefaultDomain).
-		WithSubscriptions(true)
+		WithSubscriptions(true, nil)
 
 	// add the pool to the resolver
 	r.WithPool(100) //nolint:mnd

--- a/pkg/logx/consolelog/consolelog.go
+++ b/pkg/logx/consolelog/consolelog.go
@@ -253,7 +253,7 @@ func (w *ConsoleWriter) setDefaultFormatters() {
 	// field value
 	w.SetFormatter(
 		"field_value", func(i any) string {
-			return fmt.Sprintf("%s", i)
+			return fmt.Sprintf("%v", i)
 		})
 	// errors
 	w.SetFormatter(


### PR DESCRIPTION
- Adds redis backed subscriptions to ensure delivery across multiple processes; notifications now show up immediately in the UI 
- Example: 
```
127.0.0.1:6379> SUBSCRIBE  "graphsubscriptions:notifications"
1) "subscribe"
2) "graphsubscriptions:notifications"
3) (integer) 1
1) "message"
2) "graphsubscriptions:notifications"
3) "{\"origin_id\":\"77d70cfe-e860-427b-95eb-df44581a0dde\",\"user_id\":\"01KWZ7KXQRMP4SAA3C70G498NV\",\"payload\":{\"id\":\"01KX2PV10RG8G430FKBPHB1SXN\",\"created_at\":\"2026-07-08T23:50:32.984035-06:00\",\"updated_at\":\"2026-07-08T23:50:32.984018-06:00\",\"created_by\":\"01KWZ7KXQRMP4SAA3C70G498NV\",\"updated_by\":\"01KWZ7KXQRMP4SAA3C70G498NV\",\"owner_id\":\"01KX2P6KAEYXN18BJ4Z08GCMSS\",\"user_id\":\"01KWZ7KXQRMP4SAA3C70G498NV\",\"notification_type\":\"USER\",\"object_type\":\"TASK\",\"title\":\"Export Complete\",\"body\":\"Export of task is ready for download\",\"data\":{\"export_id\":\"01KX2PV0RAM1HZWX24E57AEWN9\",\"export_type\":\"TASK\"},\"topic\":\"EXPORT\",\"edges\":{}}}"
1) "message"
2) "graphsubscriptions:notifications"
3) "{\"origin_id\":\"77d70cfe-e860-427b-95eb-df44581a0dde\",\"user_id\":\"01KWZ7KXQRMP4SAA3C70G498NV\",\"payload\":{\"id\":\"01KX2PV81BBY1VXCR802FHFQ1P\",\"created_at\":\"2026-07-08T23:50:40.171381-06:00\",\"updated_at\":\"2026-07-08T23:50:40.171367-06:00\",\"created_by\":\"01KWZ7KXQRMP4SAA3C70G498NV\",\"updated_by\":\"01KWZ7KXQRMP4SAA3C70G498NV\",\"owner_id\":\"01KX2P6KAEYXN18BJ4Z08GCMSS\",\"user_id\":\"01KWZ7KXQRMP4SAA3C70G498NV\",\"notification_type\":\"USER\",\"object_type\":\"TASK\",\"title\":\"Export Complete\",\"body\":\"Export of task is ready for download\",\"data\":{\"export_id\":\"01KX2PV7P4E3PYTPYT1928WNGY\",\"export_type\":\"TASK\"},\"topic\":\"EXPORT\",\"edges\":{}}}"
```
- Adds dev config for create/retrieve domain scan in river