### PR TITLE
Fix: trust center email template seed, key collisions, CORS issues

### DIFF
--- a/internal/ent/hooks/trustcenter.go
+++ b/internal/ent/hooks/trustcenter.go
@@ -17,7 +17,6 @@ import (
 	"github.com/theopenlane/core/internal/controls"
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/control"
-	"github.com/theopenlane/core/internal/ent/generated/emailtemplate"
 	"github.com/theopenlane/core/internal/ent/generated/hook"
 	"github.com/theopenlane/core/internal/ent/generated/organization"
 	emaildef "github.com/theopenlane/core/internal/integrations/definitions/email"
@@ -179,10 +178,10 @@ func HookTrustCenter() ent.Hook {
 				return nil, ErrInternalServerError
 			}
 
-			// seed the customizable message-updates email template so every trust center presents a
-			// base template editors can customize; subscriber and subprocessor messages remain fixed
-			// system sends and are not seeded here
-			if err := seedTrustCenterUpdateTemplate(ctx, m.Client(), orgID, id); err != nil {
+			// seed the customizable update email template so every trust center presents a
+			// base template editors can customize before the first send; subscriber and
+			// subprocessor messages remain fixed system sends and are not seeded here
+			if _, err := emaildef.EnsureTrustCenterUpdateTemplate(privacy.DecisionContext(ctx, privacy.Allow), m.Client(), orgID, id); err != nil {
 				logx.FromContext(ctx).Error().Err(err).Msg("failed seeding trust center update email template")
 
 				return nil, err
@@ -246,39 +245,6 @@ This is the default overview for your Trust Center. You can customize this by ed
 var (
 	defaultWatermarkText = "Controlled Copy — Watermark Required"
 )
-
-// trustCenterUpdateTemplateName is the display name of the seeded customizable message-updates template
-const trustCenterUpdateTemplateName = "Trust Center Update"
-
-// seedTrustCenterUpdateTemplate creates the customizable branded message-updates template for a new
-// trust center if one does not already exist, so editors can customize it before the first send. The
-// template is keyed by the branded message catalog operation and reused by automated update campaigns
-func seedTrustCenterUpdateTemplate(ctx context.Context, client *generated.Client, ownerID, trustCenterID string) error {
-	allowCtx := privacy.DecisionContext(ctx, privacy.Allow)
-
-	exists, err := client.EmailTemplate.Query().
-		Where(
-			emailtemplate.OwnerID(ownerID),
-			emailtemplate.TrustCenterID(trustCenterID),
-			emailtemplate.Key(emaildef.BrandedMessageOp.Name()),
-		).
-		Exist(allowCtx)
-	if err != nil {
-		return err
-	}
-
-	if exists {
-		return nil
-	}
-
-	return client.EmailTemplate.Create().
-		SetOwnerID(ownerID).
-		SetTrustCenterID(trustCenterID).
-		SetName(trustCenterUpdateTemplateName).
-		SetKey(emaildef.BrandedMessageOp.Name()).
-		SetTemplateContext(enums.TemplateContextCampaignRecipient).
-		Exec(allowCtx)
-}
 
 // HookTrustCenterDelete runs on trust center delete mutations
 func HookTrustCenterDelete() ent.Hook {

--- a/internal/ent/hooks/trustcentersetting.go
+++ b/internal/ent/hooks/trustcentersetting.go
@@ -2,6 +2,7 @@ package hooks
 
 import (
 	"context"
+	"time"
 
 	"entgo.io/ent"
 
@@ -62,9 +63,35 @@ func HookTrustCenterSetting() ent.Hook {
 				return nil, err
 			}
 
+			initializeSubprocessorWatermark(ctx, m)
+
 			return next.Mutate(ctx, m)
 		})
 	}, ent.OpCreate|ent.OpUpdateOne)
+}
+
+// initializeSubprocessorWatermark stamps the subprocessor notification watermark when the
+// notify-on-subprocessor-change flag turns on, so subscribers are only notified about changes made
+// after opting in rather than the trust center's entire subprocessor history. A watermark set
+// explicitly on the same mutation wins
+func initializeSubprocessorWatermark(ctx context.Context, m *generated.TrustCenterSettingMutation) {
+	enabled, ok := m.NotifySubscribersOnSubprocessorChange()
+	if !ok || !enabled {
+		return
+	}
+
+	if _, ok := m.SubprocessorsNotifiedAt(); ok {
+		return
+	}
+
+	if m.Op().Is(ent.OpUpdateOne) {
+		wasEnabled, err := m.OldNotifySubscribersOnSubprocessorChange(ctx)
+		if err == nil && wasEnabled {
+			return
+		}
+	}
+
+	m.SetSubprocessorsNotifiedAt(time.Now())
 }
 
 // setDefaultCompanyName will add the company name either from the org display name or if provided in the mutation

--- a/internal/graphapi/emailtemplate_test.go
+++ b/internal/graphapi/emailtemplate_test.go
@@ -145,17 +145,17 @@ func TestPreviewEmailTemplateGate(t *testing.T) {
 	tcOrg := createFreshOrgWithTrustCenter(t)
 
 	// the seeded trust center update template is previewable so editors can see their customizations
-	resp, err := suite.client.api.PreviewEmailTemplate(tcOrg.owner.UserCtx, emaildef.TrustCenterUpdateTemplate, nil)
+	resp, err := suite.client.api.PreviewEmailTemplate(tcOrg.owner.UserCtx, emaildef.TrustCenterUpdateTemplate, map[string]any{})
 	assert.NilError(t, err)
 	assert.Check(t, resp.PreviewEmailTemplate != "")
 
 	// customer-selectable catalog entries remain previewable
-	resp, err = suite.client.api.PreviewEmailTemplate(tcOrg.owner.UserCtx, emaildef.BrandedMessageOp.Name(), nil)
+	resp, err = suite.client.api.PreviewEmailTemplate(tcOrg.owner.UserCtx, emaildef.BrandedMessageOp.Name(), map[string]any{})
 	assert.NilError(t, err)
 	assert.Check(t, resp.PreviewEmailTemplate != "")
 
 	// internal system emails are not previewable
-	_, err = suite.client.api.PreviewEmailTemplate(tcOrg.owner.UserCtx, emaildef.SubprocessorNotificationOp.Name(), nil)
+	_, err = suite.client.api.PreviewEmailTemplate(tcOrg.owner.UserCtx, emaildef.SubprocessorNotificationOp.Name(), map[string]any{})
 	assert.ErrorContains(t, err, "not a customer-selectable")
 }
 

--- a/internal/graphapi/emailtemplate_test.go
+++ b/internal/graphapi/emailtemplate_test.go
@@ -9,6 +9,8 @@ import (
 	is "gotest.tools/v3/assert/cmp"
 
 	"github.com/samber/lo"
+	"github.com/theopenlane/iam/auth"
+
 	"github.com/theopenlane/core/common/enums"
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/emailtemplate"
@@ -29,7 +31,7 @@ func TestSeededTrustCenterUpdateTemplate(t *testing.T) {
 	seeded, err := suite.client.db.EmailTemplate.Query().
 		Where(
 			emailtemplate.TrustCenterID(tcOrg.trustCenter.ID),
-			emailtemplate.Key(emaildef.BrandedMessageOp.Name()),
+			emailtemplate.Key(emaildef.TrustCenterUpdateTemplate),
 		).
 		Only(dbCtx)
 	assert.NilError(t, err)
@@ -52,6 +54,109 @@ func TestSeededTrustCenterUpdateTemplate(t *testing.T) {
 	updated, err := suite.client.db.EmailTemplate.Get(dbCtx, seeded.ID)
 	assert.NilError(t, err)
 	assert.Check(t, is.Len(updated.Defaults, 3))
+}
+
+// TestEnsureTrustCenterUpdateTemplate verifies the shared ensure helper resolves the seeded template
+// without creating a duplicate and recreates it with the dedicated key when it is missing
+func TestEnsureTrustCenterUpdateTemplate(t *testing.T) {
+	tcOrg := createFreshOrgWithTrustCenter(t)
+
+	dbCtx := privacy.DecisionContext(setContext(tcOrg.owner.UserCtx, suite.client.db), privacy.Allow)
+
+	seeded, err := suite.client.db.EmailTemplate.Query().
+		Where(
+			emailtemplate.TrustCenterID(tcOrg.trustCenter.ID),
+			emailtemplate.Key(emaildef.TrustCenterUpdateTemplate),
+		).
+		Only(dbCtx)
+	assert.NilError(t, err)
+
+	// idempotent: resolves the seeded template rather than creating another
+	id, err := emaildef.EnsureTrustCenterUpdateTemplate(dbCtx, suite.client.db, tcOrg.organizationID, tcOrg.trustCenter.ID)
+	assert.NilError(t, err)
+	assert.Equal(t, seeded.ID, id)
+
+	count, err := suite.client.db.EmailTemplate.Query().
+		Where(
+			emailtemplate.TrustCenterID(tcOrg.trustCenter.ID),
+			emailtemplate.Key(emaildef.TrustCenterUpdateTemplate),
+		).
+		Count(dbCtx)
+	assert.NilError(t, err)
+	assert.Equal(t, 1, count)
+
+	// recreates the template with the dedicated key, name, and context when it is missing
+	assert.NilError(t, suite.client.db.EmailTemplate.DeleteOneID(seeded.ID).Exec(dbCtx))
+
+	recreatedID, err := emaildef.EnsureTrustCenterUpdateTemplate(dbCtx, suite.client.db, tcOrg.organizationID, tcOrg.trustCenter.ID)
+	assert.NilError(t, err)
+	assert.Check(t, recreatedID != seeded.ID)
+
+	recreated, err := suite.client.db.EmailTemplate.Get(dbCtx, recreatedID)
+	assert.NilError(t, err)
+	assert.Equal(t, emaildef.TrustCenterUpdateTemplate, recreated.Key)
+	assert.Equal(t, emaildef.TrustCenterUpdateTemplate, recreated.Name)
+	assert.Equal(t, enums.TemplateContextCampaignRecipient, recreated.TemplateContext)
+}
+
+// TestEnsureAllTrustCenterUpdateTemplates verifies the startup backfill body creates the update
+// template for trust centers missing one and leaves already-seeded trust centers with exactly one
+func TestEnsureAllTrustCenterUpdateTemplates(t *testing.T) {
+	tcOrg1 := createFreshOrgWithTrustCenter(t)
+	tcOrg2 := createFreshOrgWithTrustCenter(t)
+
+	dbCtx1 := privacy.DecisionContext(setContext(tcOrg1.owner.UserCtx, suite.client.db), privacy.Allow)
+
+	// remove one seeded template to simulate a trust center that pre-dates seeding
+	seeded, err := suite.client.db.EmailTemplate.Query().
+		Where(
+			emailtemplate.TrustCenterID(tcOrg1.trustCenter.ID),
+			emailtemplate.Key(emaildef.TrustCenterUpdateTemplate),
+		).
+		Only(dbCtx1)
+	assert.NilError(t, err)
+	assert.NilError(t, suite.client.db.EmailTemplate.DeleteOneID(seeded.ID).Exec(dbCtx1))
+
+	// mirror the backfill's cross-org system caller
+	systemCtx := auth.WithCaller(privacy.DecisionContext(context.Background(), privacy.Allow), &auth.Caller{
+		Capabilities: auth.CapBypassOrgFilter | auth.CapBypassFGA | auth.CapInternalOperation,
+	})
+
+	ensured, err := emaildef.EnsureAllTrustCenterUpdateTemplates(systemCtx, suite.client.db)
+	assert.NilError(t, err)
+	assert.Check(t, ensured >= 2)
+
+	// the deleted template is recreated and the untouched trust center is not duplicated
+	for _, tcOrg := range []*trustCenterOrg{tcOrg1, tcOrg2} {
+		count, err := suite.client.db.EmailTemplate.Query().
+			Where(
+				emailtemplate.TrustCenterID(tcOrg.trustCenter.ID),
+				emailtemplate.Key(emaildef.TrustCenterUpdateTemplate),
+			).
+			Count(systemCtx)
+		assert.NilError(t, err)
+		assert.Equal(t, 1, count)
+	}
+}
+
+// TestPreviewEmailTemplateGate verifies the preview resolver admits customer-selectable catalog
+// entries and the seeded trust center update template while rejecting internal system emails
+func TestPreviewEmailTemplateGate(t *testing.T) {
+	tcOrg := createFreshOrgWithTrustCenter(t)
+
+	// the seeded trust center update template is previewable so editors can see their customizations
+	resp, err := suite.client.api.PreviewEmailTemplate(tcOrg.owner.UserCtx, emaildef.TrustCenterUpdateTemplate, nil)
+	assert.NilError(t, err)
+	assert.Check(t, resp.PreviewEmailTemplate != "")
+
+	// customer-selectable catalog entries remain previewable
+	resp, err = suite.client.api.PreviewEmailTemplate(tcOrg.owner.UserCtx, emaildef.BrandedMessageOp.Name(), nil)
+	assert.NilError(t, err)
+	assert.Check(t, resp.PreviewEmailTemplate != "")
+
+	// internal system emails are not previewable
+	_, err = suite.client.api.PreviewEmailTemplate(tcOrg.owner.UserCtx, emaildef.SubprocessorNotificationOp.Name(), nil)
+	assert.ErrorContains(t, err, "not a customer-selectable")
 }
 
 func validEmailTemplateDefaults() map[string]any {

--- a/internal/graphapi/emailtemplatecatalog.go
+++ b/internal/graphapi/emailtemplatecatalog.go
@@ -1,12 +1,21 @@
 package graphapi
 
 import (
+	"context"
+
 	"github.com/theopenlane/core/internal/integrations/definitions/email"
+	integrationsruntime "github.com/theopenlane/core/internal/integrations/runtime"
 )
 
-// emailRuntimeClient resolves the runtime email client from the integrations runtime
-func (r *queryResolver) emailRuntimeClient() (*email.Client, error) {
-	client, ok := r.integrationsRuntime.Registry().RuntimeClient(email.DefinitionID.ID())
+// emailRuntimeClient resolves the runtime email client from the integrations runtime attached to
+// the transactional or resolver db client, matching how campaign dispatch resolves the runtime
+func (r *queryResolver) emailRuntimeClient(ctx context.Context) (*email.Client, error) {
+	rt := integrationsruntime.FromClient(ctx, r.db)
+	if rt == nil {
+		return nil, ErrEmailClientNotAvailable
+	}
+
+	client, ok := rt.Registry().RuntimeClient(email.DefinitionID.ID())
 	if !ok {
 		return nil, ErrEmailClientNotAvailable
 	}

--- a/internal/graphapi/emailtemplateextended.resolvers.go
+++ b/internal/graphapi/emailtemplateextended.resolvers.go
@@ -84,8 +84,10 @@ func (r *queryResolver) PreviewEmailTemplate(ctx context.Context, key string, de
 		return "", err
 	}
 
+	// customer-selectable catalog entries and the seeded trust center update template are
+	// previewable; internal system emails are not
 	d, ok := email.DispatcherByKey(key)
-	if !ok || !lo.FromPtr(d.Registration().CustomerSelectable) {
+	if !ok || (!lo.FromPtr(d.Registration().CustomerSelectable) && key != email.TrustCenterUpdateTemplate) {
 		return "", ErrEmailTemplateNotInCatalog
 	}
 

--- a/internal/graphapi/emailtemplateextended.resolvers.go
+++ b/internal/graphapi/emailtemplateextended.resolvers.go
@@ -18,7 +18,7 @@ import (
 
 // EmailTemplateCatalog is the resolver for the emailTemplateCatalog field.
 func (r *queryResolver) EmailTemplateCatalog(ctx context.Context) (*model.EmailTemplateCatalog, error) {
-	emailClient, err := r.emailRuntimeClient()
+	emailClient, err := r.emailRuntimeClient(ctx)
 	if err != nil {
 		logx.FromContext(ctx).Error().Err(err).Msg("failed resolving email runtime client for template catalog")
 
@@ -77,7 +77,7 @@ func (r *queryResolver) EmailTemplateCatalog(ctx context.Context) (*model.EmailT
 
 // PreviewEmailTemplate is the resolver for the previewEmailTemplate field.
 func (r *queryResolver) PreviewEmailTemplate(ctx context.Context, key string, defaults map[string]any) (string, error) {
-	emailClient, err := r.emailRuntimeClient()
+	emailClient, err := r.emailRuntimeClient(ctx)
 	if err != nil {
 		logx.FromContext(ctx).Error().Err(err).Str("key", key).Msg("failed resolving email runtime client for template preview")
 

--- a/internal/graphapi/trustcenter_subscriber_integration_test.go
+++ b/internal/graphapi/trustcenter_subscriber_integration_test.go
@@ -171,7 +171,7 @@ func TestTrustCenterCampaignDispatchBranding(t *testing.T) {
 
 	emailTemplate, err := suite.client.db.EmailTemplate.Create().
 		SetName("Trust Center Update Template").
-		SetKey(email.BrandedMessageOp.Name()).
+		SetKey(email.TrustCenterUpdateTemplate).
 		SetTemplateContext(enums.TemplateContextCampaignRecipient).
 		SetTrustCenterID(tc.trustCenter.ID).
 		SetDefaults(map[string]any{
@@ -354,9 +354,11 @@ func TestTrustCenterSubprocessorNotificationEmail(t *testing.T) {
 	setting := tcLoaded.Edges.Setting
 	assert.Assert(t, setting != nil)
 
-	// opt the trust center into subprocessor notifications and brand it
+	// opt the trust center into subprocessor notifications and brand it; the watermark is backdated
+	// past the change created below, since enabling the flag stamps it to now otherwise
 	assert.NilError(t, suite.client.db.TrustCenterSetting.UpdateOneID(setting.ID).
 		SetNotifySubscribersOnSubprocessorChange(true).
+		SetSubprocessorsNotifiedAt(time.Now().Add(-3*time.Hour)).
 		SetCompanyName("SecureCorp").
 		SetLogoRemoteURL("https://securecorp.example.com/logo.png").
 		Exec(dbCtx))

--- a/internal/graphapi/trustcentersetting_test.go
+++ b/internal/graphapi/trustcentersetting_test.go
@@ -3,6 +3,7 @@ package graphapi_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivertest"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/theopenlane/core/common/enums"
 	"github.com/theopenlane/core/common/jobspec"
+	"github.com/theopenlane/core/internal/ent/generated/privacy"
 	"github.com/theopenlane/core/internal/graphapi/testclient"
 )
 
@@ -318,6 +320,62 @@ func TestUpdateTrustCenterSetting(t *testing.T) {
 	// Clean up
 	cleanupOrganizationDataWithContext(tcOrg.owner.UserCtx, t)
 	cleanupOrganizationDataWithContext(tcOrg2.owner.UserCtx, t)
+}
+
+// TestSubprocessorNotifyWatermarkInitialized verifies enabling notify-on-subprocessor-change stamps
+// the notification watermark so subscribers are only notified about changes made after opting in,
+// not the trust center's pre-existing subprocessor list
+func TestSubprocessorNotifyWatermarkInitialized(t *testing.T) {
+	tcOrg := createFreshOrgWithTrustCenter(t)
+	settingID := tcOrg.trustCenter.Edges.Setting.ID
+
+	dbCtx := privacy.DecisionContext(setContext(tcOrg.owner.UserCtx, suite.client.db), privacy.Allow)
+
+	setting, err := suite.client.db.TrustCenterSetting.Get(dbCtx, settingID)
+	assert.NilError(t, err)
+	assert.Check(t, setting.SubprocessorsNotifiedAt == nil)
+
+	// enabling the flag stamps the watermark
+	_, err = suite.client.api.UpdateTrustCenterSetting(tcOrg.owner.UserCtx, settingID, testclient.UpdateTrustCenterSettingInput{
+		NotifySubscribersOnSubprocessorChange: lo.ToPtr(true),
+	}, nil, nil, nil, nil, nil, nil)
+	assert.NilError(t, err)
+
+	enabled, err := suite.client.db.TrustCenterSetting.Get(dbCtx, settingID)
+	assert.NilError(t, err)
+	assert.Assert(t, enabled.SubprocessorsNotifiedAt != nil)
+
+	stamped := *enabled.SubprocessorsNotifiedAt
+
+	// updating the setting with the flag already on leaves the watermark alone
+	_, err = suite.client.api.UpdateTrustCenterSetting(tcOrg.owner.UserCtx, settingID, testclient.UpdateTrustCenterSettingInput{
+		Title:                                 lo.ToPtr("Updated Title"),
+		NotifySubscribersOnSubprocessorChange: lo.ToPtr(true),
+	}, nil, nil, nil, nil, nil, nil)
+	assert.NilError(t, err)
+
+	unchanged, err := suite.client.db.TrustCenterSetting.Get(dbCtx, settingID)
+	assert.NilError(t, err)
+	assert.Assert(t, unchanged.SubprocessorsNotifiedAt != nil)
+	assert.Check(t, stamped.Equal(*unchanged.SubprocessorsNotifiedAt))
+
+	// a watermark set explicitly alongside the flag wins over the hook's stamp
+	explicit := time.Now().Add(-3 * time.Hour).Truncate(time.Second)
+	assert.NilError(t, suite.client.db.TrustCenterSetting.UpdateOneID(settingID).
+		SetNotifySubscribersOnSubprocessorChange(false).
+		Exec(dbCtx))
+	assert.NilError(t, suite.client.db.TrustCenterSetting.UpdateOneID(settingID).
+		SetNotifySubscribersOnSubprocessorChange(true).
+		SetSubprocessorsNotifiedAt(explicit).
+		Exec(dbCtx))
+
+	overridden, err := suite.client.db.TrustCenterSetting.Get(dbCtx, settingID)
+	assert.NilError(t, err)
+	assert.Assert(t, overridden.SubprocessorsNotifiedAt != nil)
+	assert.Check(t, explicit.Equal(*overridden.SubprocessorsNotifiedAt))
+
+	// Clean up
+	cleanupOrganizationDataWithContext(tcOrg.owner.UserCtx, t)
 }
 
 // TestDeleteTrustCenterSetting tests the deleteTrustCenterSetting mutation

--- a/internal/httpserve/route/router.go
+++ b/internal/httpserve/route/router.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/theopenlane/core/internal/httpserve/common"
 	"github.com/theopenlane/core/internal/httpserve/handlers"
+	"github.com/theopenlane/core/pkg/middleware/cors"
 	"github.com/theopenlane/core/pkg/middleware/impersonation"
 	"github.com/theopenlane/core/pkg/middleware/mime"
 	"github.com/theopenlane/core/pkg/middleware/ratelimit"
@@ -335,6 +336,10 @@ type Config struct {
 	SimpleHandler func(echo.Context) error // For handlers that don't need OpenAPI context
 	// ExcludeFromOAS skips publishing this route in the OpenAPI specification.
 	ExcludeFromOAS bool
+	// PublicCORS serves the route with a wildcard, credential-less CORS policy, for fully public
+	// token-authorized endpoints called cross-origin from arbitrary domains (e.g. trust centers);
+	// only supported for static paths (no path parameters)
+	PublicCORS bool
 }
 
 // registrationContext is a special echo.Context implementation used during OpenAPI registration
@@ -455,6 +460,10 @@ func (r *Router) AddV1HandlerRoute(config Config) error {
 		return err
 	}
 
+	if config.PublicCORS {
+		cors.RegisterPublicPath("/v1" + config.Path)
+	}
+
 	if !config.ExcludeFromOAS {
 		// Add operation to OpenAPI schema (convert Echo path syntax to OpenAPI syntax)
 		openAPIPath := convertEchoPathToOpenAPI("/v1" + config.Path)
@@ -530,6 +539,10 @@ func (r *Router) AddUnversionedHandlerRoute(config Config) error {
 	_, err := grp.AddRoute(route)
 	if err != nil {
 		return err
+	}
+
+	if config.PublicCORS {
+		cors.RegisterPublicPath(config.Path)
 	}
 
 	// Add operation to OpenAPI schema (convert Echo path syntax to OpenAPI syntax)

--- a/internal/httpserve/route/subscribe.go
+++ b/internal/httpserve/route/subscribe.go
@@ -19,6 +19,7 @@ func registerVerifySubscribeHandler(router *Router) error {
 		Middlewares: *unauthenticatedEndpoint,
 		RateLimit:   authFlowRateLimit,
 		Handler:     router.Handler.VerifySubscriptionHandler,
+		PublicCORS:  true,
 	}
 
 	return router.AddV1HandlerRoute(config)
@@ -37,6 +38,7 @@ func registerUnsubscribeHandler(router *Router) error {
 		Middlewares: *unauthenticatedEndpoint,
 		RateLimit:   authFlowRateLimit,
 		Handler:     router.Handler.UnsubscribeHandler,
+		PublicCORS:  true,
 	}
 
 	return router.AddV1HandlerRoute(config)

--- a/internal/httpserve/serveropts/backfill.go
+++ b/internal/httpserve/serveropts/backfill.go
@@ -16,6 +16,7 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated/orgmembership"
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
 	"github.com/theopenlane/core/internal/ent/interceptors"
+	emaildef "github.com/theopenlane/core/internal/integrations/definitions/email"
 	"github.com/theopenlane/core/internal/objects/upload"
 	"github.com/theopenlane/core/pkg/objects/storage"
 )
@@ -24,9 +25,10 @@ import (
 // skipping the org-filter, FGA, and managed-group guards the membership hooks would otherwise apply
 const backfillBypassCaps = auth.CapBypassOrgFilter | auth.CapBypassFGA | auth.CapInternalOperation | auth.CapBypassManagedGroup
 
-// WithBackfill runs one-time, idempotent startup backfills for fields introduced by recent migrations:
-// organization slug names and the SSO exemption on existing organization owners. It is gated by the
-// Backfill.Enabled config flag and runs in the background so it never blocks server startup
+// WithBackfill runs one-time, idempotent startup backfills for data introduced by recent migrations:
+// organization slug names, owner SSO exemptions, trust center update templates, and file md5 hashes.
+// It is gated by the Backfill.Enabled config flag and runs in the background so it never blocks
+// server startup
 func WithBackfill(ctx context.Context, dbClient *ent.Client) ServerOption {
 	return newApplyFunc(func(s *ServerOptions) {
 		if dbClient == nil || !s.Config.Settings.Backfill.Enabled {
@@ -39,6 +41,7 @@ func WithBackfill(ctx context.Context, dbClient *ent.Client) ServerOption {
 
 			backfillOrganizationSlugs(backfillCtx, dbClient)
 			backfillOwnerSSOExemptions(backfillCtx, dbClient)
+			backfillTrustCenterUpdateTemplates(backfillCtx, dbClient)
 			backfillFileMD5Hashes(backfillCtx, dbClient)
 		}()
 	})
@@ -86,6 +89,18 @@ func backfillOwnerSSOExemptions(ctx context.Context, dbClient *ent.Client) {
 	}
 
 	log.Info().Int("updated", updated).Msg("backfill: owner SSO exemptions populated")
+}
+
+// backfillTrustCenterUpdateTemplates creates the trust center update template for any trust center
+// that does not have one so campaigns never create templates at dispatch time
+func backfillTrustCenterUpdateTemplates(ctx context.Context, dbClient *ent.Client) {
+	ensured, err := emaildef.EnsureAllTrustCenterUpdateTemplates(ctx, dbClient)
+	if err != nil {
+		log.Error().Err(err).Msg("backfill: failed to ensure trust center update templates")
+		return
+	}
+
+	log.Info().Int("ensured", ensured).Msg("backfill: trust center update templates populated")
 }
 
 func backfillFileMD5Hashes(ctx context.Context, dbClient *ent.Client) {

--- a/internal/integrations/definitions/email/op_branded_message.go
+++ b/internal/integrations/definitions/email/op_branded_message.go
@@ -7,6 +7,7 @@ import (
 	"github.com/theopenlane/newman/render"
 
 	"github.com/theopenlane/core/internal/integrations/providerkit"
+	"github.com/theopenlane/core/internal/integrations/types"
 )
 
 // BrandedMessageRequest is a customer-selectable catalog entry providing a flexible,
@@ -123,7 +124,7 @@ var brandedMessageUISchema = json.RawMessage(`{
   "outros": {"items": {"ui:widget": "textarea"}}
 }`)
 
-var _ = RegisterEmailOperation(Operation[BrandedMessageRequest]{
+var brandedMessageOperation = RegisterEmailOperation(Operation[BrandedMessageRequest]{
 	Op:                 BrandedMessageOp,
 	Schema:             brandedMessageSchema,
 	Theme:              baseTheme,
@@ -206,4 +207,23 @@ var _ = RegisterEmailOperation(Operation[BrandedMessageRequest]{
 
 		return cfg
 	},
+})
+
+// TrustCenterUpdateTemplate is the durable identifier for the per-trust-center subscriber update
+// email template, used as the template key and name and the dispatcher registration key
+const TrustCenterUpdateTemplate = "tmpl_trustcenter_update"
+
+// the trust center update entry reuses the branded message renderer under its own key so
+// per-trust-center update templates dispatch through a dedicated, unique template key instead
+// of sharing the customer-selectable branded message key
+var _ = RegisterEmailOperation(Operation[BrandedMessageRequest]{
+	Op:          types.NewOperationRef[BrandedMessageRequest](TrustCenterUpdateTemplate),
+	Schema:      brandedMessageSchema,
+	Theme:       baseTheme,
+	Description: "Trust center subscriber update rendered with the branded message layout",
+	Example:     brandedMessageExample,
+	UISchema:    brandedMessageUISchema,
+	Subject:     brandedMessageOperation.Subject,
+	Build:       brandedMessageOperation.Build,
+	Config:      brandedMessageOperation.Config,
 })

--- a/internal/integrations/definitions/email/op_trustcenter_update_test.go
+++ b/internal/integrations/definitions/email/op_trustcenter_update_test.go
@@ -1,0 +1,65 @@
+package email
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestTrustCenterUpdateRegistered verifies the trust center update entry registers under its own
+// unique identifier, distinct from the customer-selectable branded message key, so templates keyed
+// by it resolve a dispatcher
+func TestTrustCenterUpdateRegistered(t *testing.T) {
+	assert.NotEqual(t, BrandedMessageOp.Name(), TrustCenterUpdateTemplate)
+
+	_, ok := DispatcherByKey(TrustCenterUpdateTemplate)
+	assert.True(t, ok)
+}
+
+// TestTrustCenterUpdateNotCustomerSelectable verifies the entry is excluded from the customer-facing
+// catalog: the per-trust-center template is seeded and customized, never authored from the picker
+func TestTrustCenterUpdateNotCustomerSelectable(t *testing.T) {
+	d, ok := DispatcherByKey(TrustCenterUpdateTemplate)
+	assert.True(t, ok)
+
+	cs := d.Registration().CustomerSelectable
+	assert.NotNil(t, cs)
+	assert.False(t, *cs)
+
+	for _, sel := range CustomerSelectableDispatchers() {
+		assert.NotEqual(t, TrustCenterUpdateTemplate, sel.Name())
+	}
+}
+
+// TestTrustCenterUpdateRendersAsBrandedMessage verifies the entry shares the branded message
+// renderer: the same payload produces identical output through either dispatcher
+func TestTrustCenterUpdateRendersAsBrandedMessage(t *testing.T) {
+	branded, ok := DispatcherByKey(brandedMessageKey)
+	assert.True(t, ok)
+
+	update, ok := DispatcherByKey(TrustCenterUpdateTemplate)
+	assert.True(t, ok)
+
+	client := &Client{Config: *MockRuntimeConfig()}
+
+	payload, err := json.Marshal(BrandedMessageRequest{
+		RecipientInfo: TestRecipient("dolores@example.com"),
+		Subject:       "SecureCorp update",
+		Title:         "An update from SecureCorp",
+		Intros:        []string{"We have news to share."},
+		ButtonText:    "View trust center",
+		ButtonLink:    "https://securecorp.example.com/trust",
+	})
+	assert.NoError(t, err)
+
+	fromBranded, err := branded.RenderMessage(context.Background(), client, payload)
+	assert.NoError(t, err)
+
+	fromUpdate, err := update.RenderMessage(context.Background(), client, payload)
+	assert.NoError(t, err)
+
+	assert.NotEmpty(t, fromUpdate.GetHTML())
+	assert.Equal(t, fromBranded.GetHTML(), fromUpdate.GetHTML())
+}

--- a/internal/integrations/definitions/email/testing.go
+++ b/internal/integrations/definitions/email/testing.go
@@ -74,7 +74,7 @@ func TrustCenterSettingFixture() *generated.TrustCenterSetting {
 // update, with branded message content and a tokenized unsubscribe link
 func TrustCenterUpdateTemplateFixture() *generated.EmailTemplate {
 	return &generated.EmailTemplate{
-		Key: "BrandedMessageRequest",
+		Key: TrustCenterUpdateTemplate,
 		Defaults: map[string]any{
 			"subject":        "{{ .companyName }} trust center update",
 			"title":          "Hi {{ .firstName }}, an update from {{ .companyName }}",

--- a/internal/integrations/definitions/email/trustcenter_campaign.go
+++ b/internal/integrations/definitions/email/trustcenter_campaign.go
@@ -10,11 +10,76 @@ import (
 	"github.com/theopenlane/core/common/enums"
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/campaigntarget"
+	"github.com/theopenlane/core/internal/ent/generated/emailtemplate"
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
 	"github.com/theopenlane/core/internal/ent/generated/subscriber"
 	"github.com/theopenlane/core/internal/integrations/templatekit"
 	"github.com/theopenlane/core/pkg/logx"
 )
+
+// EnsureTrustCenterUpdateTemplate returns the id of the trust center's customizable update template,
+// identified by TrustCenterUpdateTemplate, creating it when the trust center does not have one yet.
+// Trust center creation and the startup backfill seed the template ahead of time; campaign creation
+// calls this as the final guarantee since a campaign cannot send without its template
+func EnsureTrustCenterUpdateTemplate(ctx context.Context, db *generated.Client, ownerID, trustCenterID string) (string, error) {
+	existingID, err := db.EmailTemplate.Query().
+		Where(
+			emailtemplate.OwnerID(ownerID),
+			emailtemplate.TrustCenterID(trustCenterID),
+			emailtemplate.KeyEQ(TrustCenterUpdateTemplate),
+		).
+		FirstID(ctx)
+	if err == nil {
+		return existingID, nil
+	}
+
+	if !generated.IsNotFound(err) {
+		logx.FromContext(ctx).Error().Err(err).Str("owner_id", ownerID).Str("trust_center_id", trustCenterID).Msg("failed querying for trust center update template")
+
+		return "", err
+	}
+
+	created, err := db.EmailTemplate.Create().
+		SetOwnerID(ownerID).
+		SetTrustCenterID(trustCenterID).
+		SetName(TrustCenterUpdateTemplate).
+		SetKey(TrustCenterUpdateTemplate).
+		SetTemplateContext(enums.TemplateContextCampaignRecipient).
+		Save(ctx)
+	if err != nil {
+		logx.FromContext(ctx).Error().Err(err).Str("owner_id", ownerID).Str("trust_center_id", trustCenterID).Msg("failed creating trust center update template")
+
+		return "", err
+	}
+
+	return created.ID, nil
+}
+
+// EnsureAllTrustCenterUpdateTemplates ensures every trust center has its update template, continuing
+// past per-trust-center failures, and returns the number successfully ensured. Used by the startup
+// backfill so organizations that pre-date template seeding get one ahead of any campaign send
+func EnsureAllTrustCenterUpdateTemplates(ctx context.Context, db *generated.Client) (int, error) {
+	trustCenters, err := db.TrustCenter.Query().All(ctx)
+	if err != nil {
+		logx.FromContext(ctx).Error().Err(err).Msg("failed querying trust centers for update templates")
+
+		return 0, err
+	}
+
+	ensured := 0
+
+	// per-trust-center failures are logged inside the ensure and skipped so one broken trust
+	// center does not block the rest of the backfill
+	for _, tc := range trustCenters {
+		if _, err := EnsureTrustCenterUpdateTemplate(ctx, db, tc.OwnerID, tc.ID); err != nil {
+			continue
+		}
+
+		ensured++
+	}
+
+	return ensured, nil
+}
 
 // snapshotTrustCenterSubscribers materializes campaign targets from the trust center's active,
 // verified, subscribed subscribers. It is idempotent: subscribers already represented by a target on

--- a/internal/integrations/definitions/email/trustcenter_campaign_test.go
+++ b/internal/integrations/definitions/email/trustcenter_campaign_test.go
@@ -12,13 +12,14 @@ import (
 // TestRenderTrustCenterCampaignMessages verifies a trust center update renders with branding pulled
 // from the trust center setting, per-recipient content interpolation, and a tokenized unsubscribe link
 func TestRenderTrustCenterCampaignMessages(t *testing.T) {
-	dispatcher, ok := DispatcherByKey(brandedMessageKey)
-	assert.True(t, ok)
-
 	client := &Client{Config: *MockRuntimeConfig()}
 
 	setting := TrustCenterSettingFixture()
 	template := TrustCenterUpdateTemplateFixture()
+
+	// resolve the dispatcher from the template key, mirroring the campaign dispatch path
+	dispatcher, ok := DispatcherByKey(template.Key)
+	assert.True(t, ok)
 
 	targets := []*generated.CampaignTarget{
 		{

--- a/internal/integrations/runtime/trustcenter_notification.go
+++ b/internal/integrations/runtime/trustcenter_notification.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/theopenlane/core/common/enums"
 	ent "github.com/theopenlane/core/internal/ent/generated"
-	"github.com/theopenlane/core/internal/ent/generated/emailtemplate"
 	"github.com/theopenlane/core/internal/ent/generated/note"
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
 	"github.com/theopenlane/core/internal/ent/generated/subscriber"
@@ -31,9 +30,6 @@ const (
 	// trustCenterNotificationGrace is the debounce window a post or subprocessor change must be stable
 	// for before subscribers are notified, giving authors time to make further edits
 	trustCenterNotificationGrace = time.Hour
-	// trustCenterUpdateTemplateName is the display name of the reusable per-trust-center branded
-	// template used to render automated subscriber notifications
-	trustCenterUpdateTemplateName = "Trust Center Update"
 	// subprocessorNotificationSubject and the related copy back the subprocessor change system email
 	subprocessorNotificationSubject    = "Subprocessor update"
 	subprocessorNotificationPreheader  = "Review the latest changes to our subprocessor list"
@@ -89,7 +85,7 @@ func (r *Runtime) dispatchDuePosts(ctx context.Context, cutoff, now time.Time) i
 		Where(
 			note.NotifySubscribers(true),
 			note.NotifiedAtIsNil(),
-			note.TrustCenterIDNEQ(""),
+			note.TrustCenterIDNotNil(),
 			note.UpdatedAtLTE(cutoff),
 		).
 		All(ctx)
@@ -139,7 +135,7 @@ func (r *Runtime) dispatchDueSubprocessorChanges(ctx context.Context, cutoff tim
 	settings, err := r.DB().TrustCenterSetting.Query().
 		Where(
 			trustcentersetting.NotifySubscribersOnSubprocessorChange(true),
-			trustcentersetting.TrustCenterIDNEQ(""),
+			trustcentersetting.TrustCenterIDNotNil(),
 			trustcentersetting.EnvironmentEQ(enums.TrustCenterEnvironmentLive),
 		).
 		All(ctx)
@@ -286,9 +282,12 @@ func trustCenterNotificationContent(subject, title string, intros []string, cust
 // createAndDispatchTrustCenterCampaign creates a trust center update campaign carrying the supplied
 // content and dispatches it through the campaign send, which materializes subscriber targets
 func (r *Runtime) createAndDispatchTrustCenterCampaign(ctx context.Context, ownerID, trustCenterID, name string, content map[string]any) error {
-	templateID, err := r.ensureTrustCenterUpdateTemplate(ctx, ownerID, trustCenterID)
+	// the template is seeded at trust center creation and backfilled for existing organizations;
+	// this resolves it by its dedicated key and only recreates it if it went missing, since the
+	// campaign cannot send without its template
+	templateID, err := emaildef.EnsureTrustCenterUpdateTemplate(ctx, r.DB(), ownerID, trustCenterID)
 	if err != nil {
-		logx.FromContext(ctx).Error().Err(err).Str("owner_id", ownerID).Str("trust_center_id", trustCenterID).Msg("failed ensuring trust center update template")
+		logx.FromContext(ctx).Error().Err(err).Str("owner_id", ownerID).Str("trust_center_id", trustCenterID).Msg("failed resolving trust center update template")
 
 		return err
 	}
@@ -336,43 +335,6 @@ func (r *Runtime) createAndDispatchTrustCenterCampaign(ctx context.Context, owne
 	})
 
 	return err
-}
-
-// ensureTrustCenterUpdateTemplate returns the id of the trust center's reusable branded update
-// template (the customizable message-updates template), creating it on first use. Per-send content is
-// supplied via campaign metadata
-func (r *Runtime) ensureTrustCenterUpdateTemplate(ctx context.Context, ownerID, trustCenterID string) (string, error) {
-	existing, err := r.DB().EmailTemplate.Query().
-		Where(
-			emailtemplate.OwnerID(ownerID),
-			emailtemplate.TrustCenterID(trustCenterID),
-			emailtemplate.Key(emaildef.BrandedMessageOp.Name()),
-		).
-		First(ctx)
-	if err == nil {
-		return existing.ID, nil
-	}
-
-	if !ent.IsNotFound(err) {
-		logx.FromContext(ctx).Error().Err(err).Str("owner_id", ownerID).Str("trust_center_id", trustCenterID).Msg("failed querying for existing trust center update template")
-
-		return "", err
-	}
-
-	created, err := r.DB().EmailTemplate.Create().
-		SetOwnerID(ownerID).
-		SetTrustCenterID(trustCenterID).
-		SetName(trustCenterUpdateTemplateName).
-		SetKey(emaildef.BrandedMessageOp.Name()).
-		SetTemplateContext(enums.TemplateContextCampaignRecipient).
-		Save(ctx)
-	if err != nil {
-		logx.FromContext(ctx).Error().Err(err).Str("owner_id", ownerID).Str("trust_center_id", trustCenterID).Msg("failed creating trust center update template")
-
-		return "", err
-	}
-
-	return created.ID, nil
 }
 
 // subprocessorEntries maps the changed trust center subprocessor join rows into the structured change

--- a/pkg/middleware/cors/cors.go
+++ b/pkg/middleware/cors/cors.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/samber/lo"
 	echo "github.com/theopenlane/echox"
 	"github.com/theopenlane/echox/middleware"
 )
@@ -28,6 +29,16 @@ var DefaultConfig = Config{
 	Prefixes: nil,
 }
 
+// publicPaths holds exact request paths served with a wildcard, credential-less CORS policy;
+// populated via RegisterPublicPath during route registration, before the server accepts traffic
+var publicPaths = map[string]struct{}{}
+
+// RegisterPublicPath marks an exact request path as fully public for CORS: any origin is allowed
+// and credentials are disabled. It must be called during route registration, before serving traffic
+func RegisterPublicPath(path string) {
+	publicPaths[path] = struct{}{}
+}
+
 // MustNew creates a new middleware function with the default config or panics if it fails
 func MustNew(allowedOrigins []string) echo.MiddlewareFunc {
 	DefaultConfig.Prefixes = map[string][]string{
@@ -40,6 +51,19 @@ func MustNew(allowedOrigins []string) echo.MiddlewareFunc {
 	}
 
 	return mw
+}
+
+// corsConfig builds the echox CORS configuration for a set of allowed origins; credentials are
+// enabled except with wildcard origins, where the combination is invalid
+func corsConfig(origins []string) middleware.CORSConfig {
+	return middleware.CORSConfig{
+		AllowOrigins:     origins,
+		AllowMethods:     []string{"GET", "HEAD", "PUT", "POST", "DELETE", "PATCH", "OPTIONS"},
+		AllowHeaders:     []string{"Origin", "Content-Length", "Content-Type", "Authorization", "X-CSRF-Token", "X-User-ID", "X-Organization-ID", "Accept", "Cache-Control"},
+		ExposeHeaders:    []string{"Content-Length", "Cache-Control"},
+		AllowCredentials: !lo.Contains(origins, "*"),      // credentials are required for CSRF to work
+		MaxAge:           int((24 * time.Hour).Seconds()), //nolint:mnd
+	}
 }
 
 // NewWithConfig creates a new middleware function with the provided config
@@ -55,17 +79,10 @@ func NewWithConfig(config Config) (echo.MiddlewareFunc, error) {
 			return nil, fmt.Errorf("CORS config for prefix %s is invalid: %w", prefix, err)
 		}
 
-		conf := middleware.CORSConfig{
-			AllowOrigins:     origins,
-			AllowMethods:     []string{"GET", "HEAD", "PUT", "POST", "DELETE", "PATCH", "OPTIONS"},
-			AllowHeaders:     []string{"Origin", "Content-Length", "Content-Type", "Authorization", "X-CSRF-Token", "X-User-ID", "X-Organization-ID", "Accept", "Cache-Control"},
-			ExposeHeaders:    []string{"Content-Length", "Cache-Control"},
-			AllowCredentials: true,                            // Allow credentials to be sent with requests - this is important for CSRF to work
-			MaxAge:           int((24 * time.Hour).Seconds()), //nolint:mnd
-		}
-
-		prefixes[prefix] = middleware.CORSWithConfig(conf)
+		prefixes[prefix] = middleware.CORSWithConfig(corsConfig(origins))
 	}
+
+	publicMiddleware := middleware.CORSWithConfig(corsConfig([]string{"*"}))
 
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
@@ -74,6 +91,11 @@ func NewWithConfig(config Config) (echo.MiddlewareFunc, error) {
 			}
 
 			path := c.Request().URL.Path
+
+			if _, ok := publicPaths[path]; ok {
+				handler := publicMiddleware(next)
+				return handler(c)
+			}
 
 			var (
 				middlewareFunc echo.MiddlewareFunc

--- a/pkg/middleware/cors/cors_test.go
+++ b/pkg/middleware/cors/cors_test.go
@@ -1,0 +1,117 @@
+package cors_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	echo "github.com/theopenlane/echox"
+
+	"github.com/theopenlane/core/pkg/middleware/cors"
+)
+
+const (
+	allowOriginHeader      = "Access-Control-Allow-Origin"
+	allowCredentialsHeader = "Access-Control-Allow-Credentials"
+	allowMethodsHeader     = "Access-Control-Allow-Methods"
+)
+
+// serveCORS runs a request through the CORS middleware built from config, returning the recorder
+// and the handler chain error so rejection behavior can be asserted
+func serveCORS(t *testing.T, config cors.Config, method, path, origin string) (*httptest.ResponseRecorder, error) {
+	t.Helper()
+
+	mw, err := cors.NewWithConfig(config)
+	require.NoError(t, err)
+
+	e := echo.New()
+	req := httptest.NewRequest(method, path, nil)
+	req.Header.Set("Origin", origin)
+
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	handler := func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	}
+
+	return rec, mw(handler)(c)
+}
+
+func prefixConfig(origins ...string) cors.Config {
+	return cors.Config{
+		Prefixes: map[string][]string{"/v1": origins},
+	}
+}
+
+// TestPublicPathAllowsAnyOriginWithoutCredentials verifies a registered public path answers any
+// origin with a wildcard and never allows credentials, regardless of the configured prefix origins
+func TestPublicPathAllowsAnyOriginWithoutCredentials(t *testing.T) {
+	cors.RegisterPublicPath("/v1/subscribe/verify")
+
+	rec, err := serveCORS(t, prefixConfig("https://console.example.com"), http.MethodGet, "/v1/subscribe/verify", "https://random-customer-domain.example.org")
+	require.NoError(t, err)
+
+	assert.Equal(t, "*", rec.Header().Get(allowOriginHeader))
+	assert.Empty(t, rec.Header().Get(allowCredentialsHeader))
+}
+
+// TestPublicPathPreflight verifies a preflight request to a public path advertises the wildcard
+// origin and the allowed methods so browsers permit the cross-origin call
+func TestPublicPathPreflight(t *testing.T) {
+	cors.RegisterPublicPath("/v1/unsubscribe")
+
+	mw, err := cors.NewWithConfig(prefixConfig("https://console.example.com"))
+	require.NoError(t, err)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodOptions, "/v1/unsubscribe", nil)
+	req.Header.Set("Origin", "https://random-customer-domain.example.org")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, mw(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})(c))
+
+	assert.Equal(t, "*", rec.Header().Get(allowOriginHeader))
+	assert.Contains(t, rec.Header().Get(allowMethodsHeader), http.MethodPost)
+	assert.Empty(t, rec.Header().Get(allowCredentialsHeader))
+}
+
+// TestPrefixPathEchoesAllowedOriginWithCredentials verifies non-public paths keep the existing
+// behavior: a configured origin is echoed back and credentials remain allowed
+func TestPrefixPathEchoesAllowedOriginWithCredentials(t *testing.T) {
+	rec, err := serveCORS(t, prefixConfig("https://console.example.com"), http.MethodGet, "/v1/other", "https://console.example.com")
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://console.example.com", rec.Header().Get(allowOriginHeader))
+	assert.Equal(t, "true", rec.Header().Get(allowCredentialsHeader))
+}
+
+// TestPrefixPathRejectsUnknownOrigin verifies non-public paths reject an unconfigured origin with
+// 401 (echox returns Unauthorized for disallowed non-preflight origins) and grant it nothing
+func TestPrefixPathRejectsUnknownOrigin(t *testing.T) {
+	rec, err := serveCORS(t, prefixConfig("https://console.example.com"), http.MethodGet, "/v1/other", "https://random-customer-domain.example.org")
+
+	require.Error(t, err)
+
+	var httpErr *echo.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusUnauthorized, httpErr.Code)
+
+	assert.Empty(t, rec.Header().Get(allowOriginHeader))
+}
+
+// TestUnmatchedPathSkipsCORS verifies a path outside every configured prefix and the public set
+// passes through without CORS headers
+func TestUnmatchedPathSkipsCORS(t *testing.T) {
+	rec, err := serveCORS(t, prefixConfig("https://console.example.com"), http.MethodGet, "/metrics", "https://console.example.com")
+	require.NoError(t, err)
+
+	assert.Empty(t, rec.Header().Get(allowOriginHeader))
+}


### PR DESCRIPTION
- Trust center update emails now dispatch through a dedicated unique template key instead stupid past-matt idea of using shared branded message key
- Consolidate into single helper to replace the duplicated seed/upsert logic across the hook, backfill, and notification runtime
- Every trust center gets its update template ahead of any send; seeded at creation, backfilled at startup for existing orgs, with the campaign path as a final check-first guarantee
- Fixes subprocessor-change notifications so that they now stamp the notification watermark so subscribers only hear about changes made after opting in rather than the full historical list
- Fixed so Trust center editors can preview their seeded update template
- For probably my own sanity, updated notification poller queries to use explicit not-nil predicates for trust center scoping
- Public trust center endpoints (subscribe verify, unsubscribe) serve wildcard credential-less CORS so they work cross-origin from any domain
