### PR TITLE
bug: sla definition should not be able to be looked up when creating  risk with api token

### DIFF
--- a/internal/ent/hooks/risks.go
+++ b/internal/ent/hooks/risks.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"entgo.io/ent"
+	"github.com/theopenlane/iam/auth"
+
 	"github.com/theopenlane/core/common/enums"
 	"github.com/theopenlane/core/common/models"
 	"github.com/theopenlane/core/internal/ent/generated"
@@ -16,6 +18,8 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated/remediation"
 	"github.com/theopenlane/core/internal/ent/generated/review"
 	"github.com/theopenlane/core/internal/ent/generated/risk"
+	"github.com/theopenlane/core/internal/ent/generated/sladefinition"
+	"github.com/theopenlane/core/internal/ent/privacy/rule"
 	"github.com/theopenlane/core/pkg/logx"
 )
 
@@ -229,7 +233,16 @@ func setStatusBasedOnRemediation(ctx context.Context, m *generated.RiskMutation)
 
 // setDueDateBasedOnSLAConfig sets the next review due date based on the SLA config for the risk, if the due date is not already set or being updated
 func setDueDateBasedOnSLAConfig(ctx context.Context, m *generated.RiskMutation) error {
-	slaConfig, err := m.Client().SLADefinition.Query().All(ctx)
+	orgID, err := auth.GetOrganizationIDFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	// this is an internal lookup to default the due date, not a caller-requested view of SLA
+	// config, so bypass the caller's own view permissions but keep the query scoped to their org
+	slaConfig, err := m.Client().SLADefinition.Query().
+		Where(sladefinition.OwnerID(orgID)).
+		All(rule.WithInternalContext(ctx))
 	if err != nil {
 		return err
 	}

--- a/internal/graphapi/risk_test.go
+++ b/internal/graphapi/risk_test.go
@@ -298,6 +298,17 @@ func TestMutationCreateRisk(t *testing.T) {
 			expectedImpact: enums.RiskImpactLow,
 		},
 		{
+			name: "using api token with only risk read/write scope, missing sla_definition scope",
+			request: testclient.CreateRiskInput{
+				Name: "Risk",
+			},
+			// the group and program are specific to the risk query in CreateRisk
+			client:         setupAPIToken(sharedTestUser1.UserCtx, t, []string{"risk:write", "group:read", "program:read"}),
+			ctx:            context.Background(),
+			expectedStatus: enums.RiskIdentified,
+			expectedImpact: enums.RiskImpactLow,
+		},
+		{
 			name: "user not authorized, not enough permissions",
 			request: testclient.CreateRiskInput{
 				Name: "Risk",


### PR DESCRIPTION
Fixes issue where api token with `risk:edit` was unable to create a risk with only `name` because it needed the `can_view_sla_definition` scope. This is an internal operation to set the due date and it should be allowed to pull the data. 