### PR TITLE
fix: pass email domain context when listing users

### DIFF
--- a/internal/ent/interceptors/user.go
+++ b/internal/ent/interceptors/user.go
@@ -129,11 +129,13 @@ func filterUsingFGA(ctx context.Context, q *generated.UserQuery) error {
 	orgIDs := caller.OrgIDs()
 
 	userIDs := []string{}
+	conditionContext := emailDomainConditionContext(caller.SubjectEmail)
 
 	for _, orgID := range orgIDs {
 		req := fgax.ListRequest{
-			ObjectID:   orgID,
-			ObjectType: generated.TypeOrganization,
+			ObjectID:         orgID,
+			ObjectType:       generated.TypeOrganization,
+			ConditionContext: conditionContext,
 		}
 
 		listUserResp, err := q.Authz.ListUserRequest(ctx, req)
@@ -148,9 +150,10 @@ func filterUsingFGA(ctx context.Context, q *generated.UserQuery) error {
 		// auditors do not have can_view on the org, so they must be listed separately
 		// auditor inherits from parent via "auditor from parent" in the FGA model
 		auditorReq := fgax.ListRequest{
-			ObjectID:   orgID,
-			ObjectType: generated.TypeOrganization,
-			Relation:   fgax.AuditorRelation,
+			ObjectID:         orgID,
+			ObjectType:       generated.TypeOrganization,
+			Relation:         fgax.AuditorRelation,
+			ConditionContext: conditionContext,
 		}
 
 		listAuditorResp, err := q.Authz.ListUserRequest(ctx, auditorReq)
@@ -166,4 +169,18 @@ func filterUsingFGA(ctx context.Context, q *generated.UserQuery) error {
 	q.Where(user.IDIn(userIDs...))
 
 	return nil
+}
+
+func emailDomainConditionContext(email string) *map[string]any {
+	at := strings.LastIndex(email, "@")
+	if at < 0 || at+1 >= len(email) {
+		return nil
+	}
+
+	domain := strings.ToLower(strings.TrimSpace(email[at+1:]))
+	if domain == "" {
+		return nil
+	}
+
+	return &map[string]any{"email_domain": domain}
 }

--- a/internal/ent/interceptors/user_test.go
+++ b/internal/ent/interceptors/user_test.go
@@ -126,3 +126,39 @@ func TestFilterType(t *testing.T) {
 		})
 	}
 }
+
+func TestEmailDomainConditionContext(t *testing.T) {
+	tests := []struct {
+		name  string
+		email string
+		want  *map[string]any
+	}{
+		{
+			name:  "valid email",
+			email: "person@example.com",
+			want:  &map[string]any{"email_domain": "example.com"},
+		},
+		{
+			name:  "normalizes domain",
+			email: "person@ EXAMPLE.COM ",
+			want:  &map[string]any{"email_domain": "example.com"},
+		},
+		{
+			name:  "missing separator",
+			email: "person.example.com",
+		},
+		{
+			name:  "missing domain",
+			email: "person@",
+		},
+		{
+			name: "empty email",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, emailDomainConditionContext(tt.email))
+		})
+	}
+}


### PR DESCRIPTION
## Problem

When an organization uses the `email_domains_allowed` relationship condition, user-filtered GraphQL queries fail because `filterUsingFGA` calls OpenFGA `ListUsers` without the required `email_domain` context.

OpenFGA returns:

`failed to evaluate relationship condition: 'email_domains_allowed' ... is missing context parameters '[email_domain]'`

This prevents queries involving organization users from resolving and can also leave dependent views, such as Programs, empty.

## Fix

- Derive and normalize the authenticated caller's email domain.
- Pass it through `fgax.ListRequest.ConditionContext`.
- Apply the context to both member and auditor `ListUsers` requests.
- Return no condition context when the caller has no valid email domain.

## Validation

- Added table-driven coverage for valid, normalized, missing, and empty domains.
- `gofmt` and `git diff --check` pass.
- Full repository validation is delegated to CI.