### PR TITLE
Audit: set user who approved NDA request

### DIFF
--- a/internal/ent/hooks/nda_attestation.go
+++ b/internal/ent/hooks/nda_attestation.go
@@ -23,6 +23,7 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated/trustcenter"
 	"github.com/theopenlane/core/internal/ent/interceptors"
 	"github.com/theopenlane/core/internal/objects"
+	"github.com/theopenlane/core/internal/objects/store"
 	"github.com/theopenlane/core/internal/objects/upload"
 	"github.com/theopenlane/core/pkg/jsonx"
 	"github.com/theopenlane/core/pkg/logx"
@@ -159,7 +160,11 @@ func uploadAttestedPDF(ctx context.Context, client *generated.Client, attestedPD
 		OriginalName:         fileName,
 		FieldName:            "documentDataFile",
 		CorrelatedObjectID:   docData.ID,
-		CorrelatedObjectType: "DocumentData",
+		CorrelatedObjectType: generated.TypeDocumentData,
+		Parent: pkgobjects.ParentObject{
+			ID:   docData.ID,
+			Type: generated.TypeDocumentData,
+		},
 		FileMetadata: pkgobjects.FileMetadata{
 			ContentType: "application/pdf",
 			Size:        int64(len(attestedPDF)),
@@ -167,7 +172,7 @@ func uploadAttestedPDF(ctx context.Context, client *generated.Client, attestedPD
 		},
 	}
 
-	_, uploadedFiles, err := upload.HandleUploads(ctx, client.ObjectManager, []pkgobjects.File{file})
+	uploadCtx, uploadedFiles, err := upload.HandleUploads(ctx, client.ObjectManager, []pkgobjects.File{file})
 	if err != nil {
 		logx.FromContext(ctx).Error().Err(err).Msg("failed to upload pdf")
 
@@ -178,6 +183,12 @@ func uploadAttestedPDF(ctx context.Context, client *generated.Client, attestedPD
 		logx.FromContext(ctx).Error().Msg("no files were uploaded")
 
 		return ErrNoUploadedFiles
+	}
+
+	if _, err := store.AddFilePermissions(uploadCtx); err != nil {
+		logx.FromContext(ctx).Error().Err(err).Msg("could not add fga permissions for attested file upload")
+
+		return err
 	}
 
 	data := docData.Data

--- a/internal/ent/hooks/trustcenterndarequest.go
+++ b/internal/ent/hooks/trustcenterndarequest.go
@@ -7,6 +7,7 @@ import (
 
 	"entgo.io/ent"
 	"github.com/samber/lo"
+	"github.com/theopenlane/iam/auth"
 	"github.com/theopenlane/iam/fgax"
 
 	"github.com/theopenlane/core/common/enums"
@@ -244,6 +245,14 @@ func HookTrustCenterNDARequestUpdate() ent.Hook {
 			}
 
 			m.SetApprovedAt(*now)
+			if _, ok := m.ApprovedByUserID(); !ok {
+				userID, err := auth.GetSubjectIDFromContext(ctx)
+				if err != nil || userID == "" {
+					return nil, auth.ErrNoAuthUser
+				}
+
+				m.SetApprovedByUserID(userID)
+			}
 
 			v, err := next.Mutate(ctx, m)
 			if err != nil {


### PR DESCRIPTION
- Set the user who approved the request for auditing 
- fix a bug where files permission are not added to the attested file upload since uploads are now done in gala and do not go through the upload middleware anymore that handles perms automatically which is the reason why `document.files` returns an empty array now

```

query($trustCenterNdaRequestId: ID!) {
  trustCenterNDARequest(id: $trustCenterNdaRequestId) {
    file {
      id
      name ## original file
      presignedURL
    }
     documentDataID
      document {
        files {
          edges {
            node {
              id
              presignedURL ## attested file
            }
          }
        }
      }
  }
}

```

