### PR TITLE
DirectorySync fixes, backfill / repair mangled data, log key name collision repairs

### DIFF
--- a/internal/graphapi/directory_externalid_repair_test.go
+++ b/internal/graphapi/directory_externalid_repair_test.go
@@ -1,0 +1,301 @@
+package graphapi_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"entgo.io/ent/dialect/sql"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+
+	"github.com/theopenlane/core/common/enums"
+	"github.com/theopenlane/core/internal/ent/entityops"
+	"github.com/theopenlane/core/internal/ent/generated"
+	"github.com/theopenlane/core/internal/ent/generated/directoryaccount"
+	"github.com/theopenlane/core/internal/ent/generated/directorygroup"
+	"github.com/theopenlane/core/internal/ent/generated/directorymembership"
+	"github.com/theopenlane/core/internal/integrations/definitions/githubapp"
+	"github.com/theopenlane/core/internal/integrations/operations"
+	"github.com/theopenlane/core/internal/integrations/registry"
+	"github.com/theopenlane/core/internal/integrations/types"
+)
+
+// TestDirectoryAccountExternalIDRepair runs the exact query and Modify update the backfill and
+// ingest adopt paths use to repair scientific notation external ids; external_id is immutable so
+// the write only works through the sql modifier, and this proves that against a real seeded row
+func TestDirectoryAccountExternalIDRepair(t *testing.T) {
+	ctx := setContext(sharedTestUser1.UserCtx, suite.client.db)
+
+	da := (&DirectoryAccountBuilder{
+		client:      suite.client,
+		DisplayName: "Notation Repair User",
+		OwnerID:     sharedTestUser1.OrganizationID,
+		ExternalID:  "1.47884153e+08",
+	}).MustNew(ctx, t)
+
+	matched, err := suite.client.db.DirectoryAccount.Query().
+		Where(directoryaccount.ExternalIDContains("e+"), directoryaccount.IDEQ(da.ID)).
+		Only(ctx)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal("1.47884153e+08", matched.ExternalID))
+
+	err = suite.client.db.DirectoryAccount.UpdateOneID(da.ID).
+		Modify(func(u *sql.UpdateBuilder) {
+			u.Set(directoryaccount.FieldExternalID, "147884153")
+		}).
+		Exec(ctx)
+	assert.NilError(t, err)
+
+	repaired, err := suite.client.db.DirectoryAccount.Get(ctx, da.ID)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal("147884153", repaired.ExternalID))
+
+	(&Cleanup[*generated.DirectoryAccountDeleteOne]{client: suite.client.db.DirectoryAccount, ID: da.ID}).MustDelete(ctx, t)
+}
+
+// TestDirectorySyncAdoptsLegacyScientificKeys seeds directory rows the way the broken CEL
+// conversion stored them, then runs a real DirectorySync ingest through ProcessPayloadSets with the
+// actual githubapp definition and mappings. The sync should adopt and repair the existing rows
+// instead of creating duplicates, and the membership should resolve against the repaired account
+func TestDirectorySyncAdoptsLegacyScientificKeys(t *testing.T) {
+	def, err := githubapp.Builder(githubapp.Config{})()
+	assert.NilError(t, err)
+
+	reg := registry.New()
+	assert.NilError(t, reg.Register(def))
+
+	orgUser := suite.userBuilder(context.Background(), t)
+	ctx := setContext(orgUser.UserCtx, suite.client.db)
+
+	integration, err := suite.client.db.Integration.Create().
+		SetName("GitHub Legacy Key Test").
+		SetKind("github").
+		SetDefinitionID(def.ID).
+		SetOwnerID(orgUser.OrganizationID).
+		Save(ctx)
+	assert.NilError(t, err)
+
+	// seed the rows exactly as a pre-fix sync stored them: scientific notation external ids
+	priorRun, err := suite.client.db.DirectorySyncRun.Create().
+		SetIntegrationID(integration.ID).
+		SetOwnerID(orgUser.OrganizationID).
+		SetStatus(enums.DirectorySyncRunStatusCompleted).
+		Save(ctx)
+	assert.NilError(t, err)
+
+	seededAccount, err := suite.client.db.DirectoryAccount.Create().
+		SetExternalID("1.47884153e+08").
+		SetDisplayName("sfunk").
+		SetOwnerID(orgUser.OrganizationID).
+		SetIntegrationID(integration.ID).
+		SetDirectoryInstanceID("sfunk-dev").
+		Save(ctx)
+	assert.NilError(t, err)
+
+	seededGroup, err := suite.client.db.DirectoryGroup.Create().
+		SetExternalID("1.7146926e+07").
+		SetDisplayName("meow").
+		SetOwnerID(orgUser.OrganizationID).
+		SetIntegrationID(integration.ID).
+		SetDirectoryInstanceID("sfunk-dev").
+		SetDirectorySyncRunID(priorRun.ID).
+		Save(ctx)
+	assert.NilError(t, err)
+
+	// the same member and team as the provider returns them on the next sync
+	memberPayload := `{"DatabaseID":147884153,"Login":"sfunk","Name":"Sarah Funkhouser","Email":"","AvatarURL":"https://avatars.githubusercontent.com/u/147884153","OrganizationVerifiedDomainEmails":[],"Org":"sfunk-dev","CanonicalEmail":"sfunk@example.com","EmailAliases":null,"GivenName":"","FamilyName":""}`
+	teamPayload := `{"DatabaseID":17146926,"Name":"meow","Slug":"meow","Description":"","Privacy":"","Org":"sfunk-dev"}`
+	membershipPayload := `{"Org":"sfunk-dev","Team":{"DatabaseID":17146926,"Slug":"meow"},"Member":{"DatabaseID":147884153,"Login":"sfunk"},"Role":"MAINTAINER"}`
+
+	ic := operations.IngestContext{
+		Registry:    reg,
+		DB:          suite.client.db,
+		Integration: integration,
+	}
+
+	contracts := []types.IngestContract{
+		{Schema: entityops.SchemaDirectoryAccount.Name},
+		{Schema: entityops.SchemaDirectoryGroup.Name},
+		{Schema: entityops.SchemaDirectoryMembership.Name},
+	}
+
+	payloadSets := []types.IngestPayloadSet{
+		{
+			Schema:    entityops.SchemaDirectoryAccount.Name,
+			Envelopes: []types.MappingEnvelope{{Resource: "sfunk-dev/sfunk", Payload: json.RawMessage(memberPayload)}},
+		},
+		{
+			Schema:    entityops.SchemaDirectoryGroup.Name,
+			Envelopes: []types.MappingEnvelope{{Resource: "sfunk-dev/meow", Payload: json.RawMessage(teamPayload)}},
+		},
+		{
+			Schema:    entityops.SchemaDirectoryMembership.Name,
+			Envelopes: []types.MappingEnvelope{{Resource: "sfunk-dev/meow", Payload: json.RawMessage(membershipPayload)}},
+		},
+	}
+
+	err = operations.ProcessPayloadSets(ctx, ic, "DirectorySync", contracts, payloadSets, operations.IngestOptions{})
+	assert.NilError(t, err)
+
+	// the seeded account was adopted and repaired in place, not duplicated
+	account, err := suite.client.db.DirectoryAccount.Get(ctx, seededAccount.ID)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal("147884153", account.ExternalID))
+
+	accountCount, err := suite.client.db.DirectoryAccount.Query().
+		Where(directoryaccount.OwnerID(orgUser.OrganizationID)).
+		Count(ctx)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(1, accountCount), "sync must not create a duplicate account")
+
+	// same for the group
+	group, err := suite.client.db.DirectoryGroup.Get(ctx, seededGroup.ID)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal("17146926", group.ExternalID))
+
+	groupCount, err := suite.client.db.DirectoryGroup.Query().
+		Where(directorygroup.OwnerID(orgUser.OrganizationID)).
+		Count(ctx)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(1, groupCount), "sync must not create a duplicate group")
+
+	// the membership resolved its refs against the repaired rows
+	membership, err := suite.client.db.DirectoryMembership.Query().
+		Where(directorymembership.IntegrationID(integration.ID)).
+		Only(ctx)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(seededAccount.ID, membership.DirectoryAccountID))
+	assert.Check(t, is.Equal(seededGroup.ID, membership.DirectoryGroupID))
+
+	(&Cleanup[*generated.DirectoryMembershipDeleteOne]{client: suite.client.db.DirectoryMembership, ID: membership.ID}).MustDelete(ctx, t)
+	(&Cleanup[*generated.DirectoryAccountDeleteOne]{client: suite.client.db.DirectoryAccount, ID: seededAccount.ID}).MustDelete(ctx, t)
+	(&Cleanup[*generated.DirectoryGroupDeleteOne]{client: suite.client.db.DirectoryGroup, ID: seededGroup.ID}).MustDelete(ctx, t)
+	(&Cleanup[*generated.IntegrationDeleteOne]{client: suite.client.db.Integration, ID: integration.ID}).MustDelete(ctx, t)
+}
+
+// TestDirectorySyncResolvesAccountsAcrossReinstall covers the reinstall scenario from production:
+// the account row belongs to a previous installation of the same definition, and the membership
+// resolver has to find it by owner + directory instance rather than the current integration id.
+// External ids are seeded in clean decimal form so this exercises only the scoping change
+func TestDirectorySyncResolvesAccountsAcrossReinstall(t *testing.T) {
+	def, err := githubapp.Builder(githubapp.Config{})()
+	assert.NilError(t, err)
+
+	reg := registry.New()
+	assert.NilError(t, reg.Register(def))
+
+	orgUser := suite.userBuilder(context.Background(), t)
+	ctx := setContext(orgUser.UserCtx, suite.client.db)
+
+	oldIntegration, err := suite.client.db.Integration.Create().
+		SetName("GitHub Old Install").
+		SetKind("github").
+		SetDefinitionID(def.ID).
+		SetOwnerID(orgUser.OrganizationID).
+		Save(ctx)
+	assert.NilError(t, err)
+
+	newIntegration, err := suite.client.db.Integration.Create().
+		SetName("GitHub New Install").
+		SetKind("github").
+		SetDefinitionID(def.ID).
+		SetOwnerID(orgUser.OrganizationID).
+		Save(ctx)
+	assert.NilError(t, err)
+
+	priorRun, err := suite.client.db.DirectorySyncRun.Create().
+		SetIntegrationID(oldIntegration.ID).
+		SetOwnerID(orgUser.OrganizationID).
+		SetStatus(enums.DirectorySyncRunStatusCompleted).
+		Save(ctx)
+	assert.NilError(t, err)
+
+	// the account survives from the old installation, keyed by owner + instance
+	seededAccount, err := suite.client.db.DirectoryAccount.Create().
+		SetExternalID("147884153").
+		SetDisplayName("sfunk").
+		SetOwnerID(orgUser.OrganizationID).
+		SetIntegrationID(oldIntegration.ID).
+		SetDirectoryInstanceID("sfunk-dev").
+		Save(ctx)
+	assert.NilError(t, err)
+
+	// the group upsert is integration scoped, so the old row stays behind and the new
+	// installation gets its own
+	oldGroup, err := suite.client.db.DirectoryGroup.Create().
+		SetExternalID("17146926").
+		SetDisplayName("meow").
+		SetOwnerID(orgUser.OrganizationID).
+		SetIntegrationID(oldIntegration.ID).
+		SetDirectoryInstanceID("sfunk-dev").
+		SetDirectorySyncRunID(priorRun.ID).
+		Save(ctx)
+	assert.NilError(t, err)
+
+	memberPayload := `{"DatabaseID":147884153,"Login":"sfunk","Name":"Sarah Funkhouser","Email":"","AvatarURL":"https://avatars.githubusercontent.com/u/147884153","OrganizationVerifiedDomainEmails":[],"Org":"sfunk-dev","CanonicalEmail":"sfunk@example.com","EmailAliases":null,"GivenName":"","FamilyName":""}`
+	teamPayload := `{"DatabaseID":17146926,"Name":"meow","Slug":"meow","Description":"","Privacy":"","Org":"sfunk-dev"}`
+	membershipPayload := `{"Org":"sfunk-dev","Team":{"DatabaseID":17146926,"Slug":"meow"},"Member":{"DatabaseID":147884153,"Login":"sfunk"},"Role":"MAINTAINER"}`
+
+	ic := operations.IngestContext{
+		Registry:    reg,
+		DB:          suite.client.db,
+		Integration: newIntegration,
+	}
+
+	contracts := []types.IngestContract{
+		{Schema: entityops.SchemaDirectoryAccount.Name},
+		{Schema: entityops.SchemaDirectoryGroup.Name},
+		{Schema: entityops.SchemaDirectoryMembership.Name},
+	}
+
+	payloadSets := []types.IngestPayloadSet{
+		{
+			Schema:    entityops.SchemaDirectoryAccount.Name,
+			Envelopes: []types.MappingEnvelope{{Resource: "sfunk-dev/sfunk", Payload: json.RawMessage(memberPayload)}},
+		},
+		{
+			Schema:    entityops.SchemaDirectoryGroup.Name,
+			Envelopes: []types.MappingEnvelope{{Resource: "sfunk-dev/meow", Payload: json.RawMessage(teamPayload)}},
+		},
+		{
+			Schema:    entityops.SchemaDirectoryMembership.Name,
+			Envelopes: []types.MappingEnvelope{{Resource: "sfunk-dev/meow", Payload: json.RawMessage(membershipPayload)}},
+		},
+	}
+
+	err = operations.ProcessPayloadSets(ctx, ic, "DirectorySync", contracts, payloadSets, operations.IngestOptions{})
+	assert.NilError(t, err)
+
+	// the old installation's account row was matched by owner + instance, not duplicated
+	accountCount, err := suite.client.db.DirectoryAccount.Query().
+		Where(directoryaccount.OwnerID(orgUser.OrganizationID)).
+		Count(ctx)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(1, accountCount), "reinstall must not duplicate the account")
+
+	account, err := suite.client.db.DirectoryAccount.Get(ctx, seededAccount.ID)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(oldIntegration.ID, account.IntegrationID), "adopted account keeps its original integration edge")
+
+	// the new installation created its own group row
+	newGroup, err := suite.client.db.DirectoryGroup.Query().
+		Where(directorygroup.IntegrationID(newIntegration.ID)).
+		Only(ctx)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal("17146926", newGroup.ExternalID))
+
+	// this membership fails with "unresolved directory account reference" if the resolver
+	// scopes by the current integration id instead of owner + instance
+	membership, err := suite.client.db.DirectoryMembership.Query().
+		Where(directorymembership.IntegrationID(newIntegration.ID)).
+		Only(ctx)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(seededAccount.ID, membership.DirectoryAccountID))
+	assert.Check(t, is.Equal(newGroup.ID, membership.DirectoryGroupID))
+
+	(&Cleanup[*generated.DirectoryMembershipDeleteOne]{client: suite.client.db.DirectoryMembership, ID: membership.ID}).MustDelete(ctx, t)
+	(&Cleanup[*generated.DirectoryAccountDeleteOne]{client: suite.client.db.DirectoryAccount, ID: seededAccount.ID}).MustDelete(ctx, t)
+	(&Cleanup[*generated.DirectoryGroupDeleteOne]{client: suite.client.db.DirectoryGroup, IDs: []string{oldGroup.ID, newGroup.ID}}).MustDelete(ctx, t)
+	(&Cleanup[*generated.IntegrationDeleteOne]{client: suite.client.db.Integration, IDs: []string{oldIntegration.ID, newIntegration.ID}}).MustDelete(ctx, t)
+}

--- a/internal/httpserve/serveropts/backfill.go
+++ b/internal/httpserve/serveropts/backfill.go
@@ -1,31 +1,31 @@
 package serveropts
 
 import (
-	"bytes"
 	"context"
+	"math"
+	"strconv"
 
+	"entgo.io/ent/dialect/sql"
 	"github.com/rs/zerolog/log"
-	"github.com/stoewer/go-strcase"
 
 	"github.com/theopenlane/iam/auth"
 
-	"github.com/theopenlane/core/common/enums"
 	ent "github.com/theopenlane/core/internal/ent/generated"
-	"github.com/theopenlane/core/internal/ent/generated/file"
-	"github.com/theopenlane/core/internal/ent/generated/organization"
-	"github.com/theopenlane/core/internal/ent/generated/orgmembership"
+	"github.com/theopenlane/core/internal/ent/generated/directoryaccount"
+	"github.com/theopenlane/core/internal/ent/generated/directorygroup"
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
-	"github.com/theopenlane/core/internal/ent/interceptors"
-	"github.com/theopenlane/core/internal/objects/upload"
-	"github.com/theopenlane/core/pkg/objects/storage"
 )
 
 // backfillBypassCaps lets the backfill write organizations and memberships without a request caller while
 // skipping the org-filter, FGA, and managed-group guards the membership hooks would otherwise apply
 const backfillBypassCaps = auth.CapBypassOrgFilter | auth.CapBypassFGA | auth.CapInternalOperation | auth.CapBypassManagedGroup
 
+// maxExactExternalID is the largest float64 that can still hold every integer exactly (2^53)
+const maxExactExternalID = float64(1 << 53)
+
 // WithBackfill runs one-time, idempotent startup backfills for data introduced by recent migrations:
-// organization slug names, owner SSO exemptions, trust center update templates, and file md5 hashes.
+// organization slug names, owner SSO exemptions, trust center update templates, file md5 hashes, and
+// directory external id notation repair.
 // It is gated by the Backfill.Enabled config flag and runs in the background so it never blocks
 // server startup
 func WithBackfill(ctx context.Context, dbClient *ent.Client) ServerOption {
@@ -38,144 +38,124 @@ func WithBackfill(ctx context.Context, dbClient *ent.Client) ServerOption {
 			backfillCtx := privacy.DecisionContext(ctx, privacy.Allow)
 			backfillCtx = auth.WithCaller(backfillCtx, &auth.Caller{Capabilities: backfillBypassCaps})
 
-			backfillOrganizationSlugs(backfillCtx, dbClient)
-			backfillOwnerSSOExemptions(backfillCtx, dbClient)
-			backfillFileMD5Hashes(backfillCtx, dbClient)
+			backfillDirectoryExternalIDs(backfillCtx, dbClient)
 		}()
 	})
 }
 
-// backfillOrganizationSlugs derives slug_name from the organization name for organizations that pre-date
-// the field, matching the kebab-case format applied to newly created organizations
-func backfillOrganizationSlugs(ctx context.Context, dbClient *ent.Client) {
-	orgs, err := dbClient.Organization.Query().
-		Where(organization.Or(organization.SlugNameIsNil(), organization.SlugNameEQ(""))).
+// backfillDirectoryExternalIDs rewrites directory account and group external ids that the CEL double
+// conversion stored in scientific notation (e.g. "1.47884153e+08" back to "147884153"); the "e+"
+// contains query is just a cheap prefilter, the strict parse in decimalExternalID decides what
+// actually gets touched, so values like emails that happen to contain "e+" are never rewritten
+func backfillDirectoryExternalIDs(ctx context.Context, dbClient *ent.Client) {
+	accounts, err := dbClient.DirectoryAccount.Query().
+		Where(directoryaccount.ExternalIDContains("e+")).
 		All(ctx)
 	if err != nil {
-		log.Error().Err(err).Msg("backfill: failed to query organizations missing a slug name")
+		log.Error().Err(err).Msg("backfill: failed to query directory accounts with scientific notation external ids")
 		return
 	}
 
-	updated := 0
+	accountsCorrected := 0
 
-	for _, org := range orgs {
-		if err := dbClient.Organization.UpdateOneID(org.ID).
-			SetSlugName(strcase.KebabCase(org.Name)).
-			Exec(ctx); err != nil {
-			log.Error().Err(err).Str("organization_id", org.ID).Msg("backfill: failed to set organization slug name")
+	for _, account := range accounts {
+		corrected, ok := decimalExternalID(account.ExternalID)
+		if !ok {
+			continue
+		}
+
+		conflict, err := dbClient.DirectoryAccount.Query().
+			Where(
+				directoryaccount.OwnerID(account.OwnerID),
+				directoryaccount.ExternalID(corrected),
+				directoryaccount.IDNEQ(account.ID),
+			).
+			Exist(ctx)
+		if err != nil {
+			log.Error().Err(err).Str("directory_account_id", account.ID).Msg("backfill: failed to check directory account external id conflict")
 
 			continue
 		}
 
-		updated++
+		if conflict {
+			log.Warn().Str("directory_account_id", account.ID).Str("external_id", corrected).Msg("backfill: corrected external id already held by another directory account, skipping")
+
+			continue
+		}
+
+		// external_id is immutable, so the fix has to go through the sql modifier
+		if err := dbClient.DirectoryAccount.UpdateOneID(account.ID).
+			Modify(func(u *sql.UpdateBuilder) {
+				u.Set(directoryaccount.FieldExternalID, corrected)
+			}).
+			Exec(ctx); err != nil {
+			log.Error().Err(err).Str("directory_account_id", account.ID).Msg("backfill: failed to correct directory account external id")
+
+			continue
+		}
+
+		accountsCorrected++
 	}
 
-	log.Info().Int("updated", updated).Int("candidates", len(orgs)).Msg("backfill: organization slug names populated")
-}
-
-// backfillOwnerSSOExemptions marks existing organization owners as SSO exempt so the exemption is explicit
-// on the membership record, matching how owners are seeded for newly created organizations
-func backfillOwnerSSOExemptions(ctx context.Context, dbClient *ent.Client) {
-	updated, err := dbClient.OrgMembership.Update().
-		Where(orgmembership.RoleEQ(enums.RoleOwner), orgmembership.SSOExempt(false)).
-		SetSSOExempt(true).
-		SetSSOExemptReason("organization owner").
-		Save(ctx)
+	groups, err := dbClient.DirectoryGroup.Query().
+		Where(directorygroup.ExternalIDContains("e+")).
+		All(ctx)
 	if err != nil {
-		log.Error().Err(err).Msg("backfill: failed to set owner SSO exemptions")
+		log.Error().Err(err).Msg("backfill: failed to query directory groups with scientific notation external ids")
 		return
 	}
 
-	log.Info().Int("updated", updated).Msg("backfill: owner SSO exemptions populated")
+	groupsCorrected := 0
+
+	for _, group := range groups {
+		corrected, ok := decimalExternalID(group.ExternalID)
+		if !ok {
+			continue
+		}
+
+		conflict, err := dbClient.DirectoryGroup.Query().
+			Where(
+				directorygroup.OwnerID(group.OwnerID),
+				directorygroup.ExternalID(corrected),
+				directorygroup.IDNEQ(group.ID),
+			).
+			Exist(ctx)
+		if err != nil {
+			log.Error().Err(err).Str("directory_group_id", group.ID).Msg("backfill: failed to check directory group external id conflict")
+
+			continue
+		}
+
+		if conflict {
+			log.Warn().Str("directory_group_id", group.ID).Str("external_id", corrected).Msg("backfill: corrected external id already held by another directory group, skipping")
+
+			continue
+		}
+
+		// external_id is immutable, so the fix has to go through the sql modifier
+		if err := dbClient.DirectoryGroup.UpdateOneID(group.ID).
+			Modify(func(u *sql.UpdateBuilder) {
+				u.Set(directorygroup.FieldExternalID, corrected)
+			}).
+			Exec(ctx); err != nil {
+			log.Error().Err(err).Str("directory_group_id", group.ID).Msg("backfill: failed to correct directory group external id")
+
+			continue
+		}
+
+		groupsCorrected++
+	}
+
+	log.Info().Int("accounts_corrected", accountsCorrected).Int("groups_corrected", groupsCorrected).Msg("backfill: directory external id notation corrected")
 }
 
-func backfillFileMD5Hashes(ctx context.Context, dbClient *ent.Client) {
-	if dbClient.ObjectManager == nil {
-		log.Warn().Msg("backfill: object manager is nil, skipping backfill for file md5 hashes")
-		return
+// decimalExternalID converts a scientific notation external id back to plain digits, refusing
+// anything that isn't a whole number float64 can represent exactly
+func decimalExternalID(externalID string) (string, bool) {
+	value, err := strconv.ParseFloat(externalID, 64)
+	if err != nil || value != math.Trunc(value) || math.Abs(value) >= maxExactExternalID {
+		return "", false
 	}
 
-	const batchSize = 100
-
-	totalFiles := 0
-	updatedCounter := 0
-	failedCounter := 0
-	lastKnownID := ""
-
-	for {
-		query := dbClient.File.Query().
-			Where(file.Or(file.Md5HashIsNil(), file.Md5HashEQ(""))).
-			Order(file.ByID()).
-			Limit(batchSize)
-
-		if lastKnownID != "" {
-			query = query.Where(file.IDGT(lastKnownID))
-		}
-
-		files, err := query.All(ctx)
-		if err != nil {
-			log.Error().Err(err).Msg("backfill: failed to query files missing md5 hash")
-			return
-		}
-
-		if len(files) == 0 {
-			break
-		}
-
-		totalFiles += len(files)
-
-		for _, f := range files {
-			lastKnownID = f.ID
-
-			file := interceptors.StorageFileFromEnt(f)
-
-			if file == nil || file.ProviderHints == nil || file.ProviderHints.KnownProvider == "" {
-				failedCounter++
-				log.Error().Str("file_id", f.ID).
-					Msg("backfill: file storage provider is missing, skipping md5 hash")
-
-				continue
-			}
-
-			downloaded, err := dbClient.ObjectManager.Download(ctx, nil, file, &storage.DownloadOptions{})
-			if err != nil {
-				failedCounter++
-				log.Error().Err(err).Str("file_id", f.ID).
-					Str("storage_key", f.StoreKey).
-					Str("storage_path", f.StoragePath).
-					Msg("backfill: failed to download file for md5 hash")
-
-				continue
-			}
-
-			if downloaded == nil {
-				failedCounter++
-				log.Error().Str("file_id", f.ID).Msg("backfill: downloaded file is nil")
-
-				continue
-			}
-
-			computedHash, err := upload.ComputeMD5Hash(bytes.NewReader(downloaded.File))
-			if err != nil {
-				failedCounter++
-				log.Error().Err(err).Str("file_id", f.ID).Msg("backfill: failed to calculate md5 hash")
-
-				continue
-			}
-
-			if err := dbClient.File.UpdateOneID(f.ID).SetMd5Hash(string(computedHash)).Exec(ctx); err != nil {
-				failedCounter++
-				log.Error().Err(err).Str("file_id", f.ID).Msg("backfill: failed to set file md5 hash")
-
-				continue
-			}
-
-			updatedCounter++
-		}
-	}
-
-	log.Info().Int("updated_files", updatedCounter).
-		Int("failed_files", failedCounter).
-		Int("total_files_without_hash", totalFiles).
-		Msg("backfill: file md5 hashes populated in database")
+	return strconv.FormatFloat(value, 'f', -1, 64), true
 }

--- a/internal/httpserve/serveropts/backfill.go
+++ b/internal/httpserve/serveropts/backfill.go
@@ -23,11 +23,8 @@ const backfillBypassCaps = auth.CapBypassOrgFilter | auth.CapBypassFGA | auth.Ca
 // maxExactExternalID is the largest float64 that can still hold every integer exactly (2^53)
 const maxExactExternalID = float64(1 << 53)
 
-// WithBackfill runs one-time, idempotent startup backfills for data introduced by recent migrations:
-// organization slug names, owner SSO exemptions, trust center update templates, file md5 hashes, and
-// directory external id notation repair.
-// It is gated by the Backfill.Enabled config flag and runs in the background so it never blocks
-// server startup
+// WithBackfill runs a one-time, non-blocking, config-gated, idempotent startup backfills
+// use-cases for this are things a db migration can't easily handle, computed data or fields, or repairs
 func WithBackfill(ctx context.Context, dbClient *ent.Client) ServerOption {
 	return newApplyFunc(func(s *ServerOptions) {
 		if dbClient == nil || !s.Config.Settings.Backfill.Enabled {

--- a/internal/integrations/definitions/githubapp/mappings_directory_test.go
+++ b/internal/integrations/definitions/githubapp/mappings_directory_test.go
@@ -41,6 +41,18 @@ func TestGitHubDirectoryMembershipMapping(t *testing.T) {
 	assert.NilError(t, err)
 
 	assert.Check(t, is.Equal("MEMBER", noRoleMapped["role"]))
+
+	largeIDRaw, err := providerkit.EvalMap(context.Background(), spec.MapExpr, types.MappingEnvelope{
+		Resource: "acme/security",
+		Payload:  json.RawMessage(`{"Org":"acme","Team":{"DatabaseID":17146926,"Slug":"security"},"Member":{"DatabaseID":147884153,"Login":"bigid"},"Role":"MEMBER"}`),
+	})
+	assert.NilError(t, err)
+
+	largeIDMapped, err := jsonx.ToMap(largeIDRaw)
+	assert.NilError(t, err)
+
+	assert.Check(t, is.Equal("147884153", largeIDMapped["directory_account_id"]), "large ids must not render in scientific notation")
+	assert.Check(t, is.Equal("17146926", largeIDMapped["directory_group_id"]))
 }
 
 // TestGitHubDirectoryAccountMapping verifies confirmed email aliases flow into the mapped account document

--- a/internal/integrations/observability/context.go
+++ b/internal/integrations/observability/context.go
@@ -16,8 +16,10 @@ const (
 	FieldIntegrationID = "integration_id"
 	// FieldDefinitionID is the log field key for the integration definition identifier
 	FieldDefinitionID = "definition_id"
-	// FieldOperation is the log field key for the operation name
-	FieldOperation = "operation"
+	// FieldOperation is the log field key for the integration operation name (DirectorySync,
+	// HealthCheck, etc); named integration_operation so it can't collide with entityops' generic
+	// "operation" key on the same log line
+	FieldOperation = "integration_operation"
 	// FieldRunID is the log field key for the run identifier
 	FieldRunID = "run_id"
 )

--- a/internal/integrations/operations/dispatcher.go
+++ b/internal/integrations/operations/dispatcher.go
@@ -9,6 +9,7 @@ import (
 	"github.com/theopenlane/core/common/enums"
 	ent "github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/integration"
+	intobvs "github.com/theopenlane/core/internal/integrations/observability"
 	"github.com/theopenlane/core/internal/integrations/registry"
 	"github.com/theopenlane/core/internal/integrations/types"
 	"github.com/theopenlane/core/pkg/gala"
@@ -50,7 +51,7 @@ func Dispatch(ctx context.Context, reg *registry.Registry, db *ent.Client, runti
 	}
 
 	if operation.DisabledForAll {
-		logx.FromContext(ctx).Debug().Str("operation", req.Operation).Msg("operation is disabled, skipping dispatch")
+		logx.FromContext(ctx).Debug().Str(intobvs.FieldOperation, req.Operation).Msg("operation is disabled, skipping dispatch")
 
 		return types.DispatchResult{Status: enums.IntegrationRunStatusCancelled}, nil
 	}

--- a/internal/integrations/operations/ingest_directoryaccount_persist.go
+++ b/internal/integrations/operations/ingest_directoryaccount_persist.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"entgo.io/ent/dialect/sql"
+
 	ent "github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/directoryaccount"
 	"github.com/theopenlane/core/internal/ent/generated/predicate"
@@ -23,26 +25,41 @@ func persistDirectoryAccountInput(ctx context.Context, db *ent.Client, integrati
 
 	now := time.Now()
 
-	where := []predicate.DirectoryAccount{
-		directoryaccount.OwnerID(*createInput.OwnerID),
-		directoryaccount.ExternalID(createInput.ExternalID),
-	}
-
 	// prefer directory instance so recreating integrations does
 	// not create a new directory account record, fall back to integration id
-	if createInput.DirectoryInstanceID != nil && *createInput.DirectoryInstanceID != "" {
-		where = append(where, directoryaccount.DirectoryInstanceID(*createInput.DirectoryInstanceID))
-	} else {
-		where = append(where, directoryaccount.IntegrationID(*createInput.IntegrationID))
+	lookup := func(externalID string) []predicate.DirectoryAccount {
+		where := []predicate.DirectoryAccount{
+			directoryaccount.OwnerID(*createInput.OwnerID),
+			directoryaccount.ExternalID(externalID),
+		}
+
+		if createInput.DirectoryInstanceID != nil && *createInput.DirectoryInstanceID != "" {
+			return append(where, directoryaccount.DirectoryInstanceID(*createInput.DirectoryInstanceID))
+		}
+
+		return append(where, directoryaccount.IntegrationID(*createInput.IntegrationID))
 	}
 
 	return persistRoundTripUpsert(
 		ctx,
 		createInput,
 		func(ctx context.Context) (*ent.DirectoryAccount, error) {
-			return db.DirectoryAccount.Query().
-				Where(where...).
-				Only(ctx)
+			return findWithLegacyKeyAdoption(ctx, createInput.ExternalID,
+				func(ctx context.Context, externalID string) (*ent.DirectoryAccount, error) {
+					return db.DirectoryAccount.Query().
+						Where(lookup(externalID)...).
+						Only(ctx)
+				},
+				// the row still carries the old scientific notation key, so fix it in place
+				// before the update proceeds (Modify because external_id is immutable)
+				func(ctx context.Context, account *ent.DirectoryAccount) error {
+					return db.DirectoryAccount.UpdateOneID(account.ID).
+						Modify(func(u *sql.UpdateBuilder) {
+							u.Set(directoryaccount.FieldExternalID, createInput.ExternalID)
+						}).
+						Exec(ctx)
+				},
+			)
 		},
 		func(ctx context.Context, input ent.CreateDirectoryAccountInput) (string, error) {
 			input.FirstSeenAt = &now

--- a/internal/integrations/operations/ingest_directorygroup_persist.go
+++ b/internal/integrations/operations/ingest_directorygroup_persist.go
@@ -3,6 +3,8 @@ package operations
 import (
 	"context"
 
+	"entgo.io/ent/dialect/sql"
+
 	ent "github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/directorygroup"
 )
@@ -21,10 +23,23 @@ func persistDirectoryGroupInput(ctx context.Context, db *ent.Client, integration
 		ctx,
 		createInput,
 		func(ctx context.Context) (*ent.DirectoryGroup, error) {
-			return db.DirectoryGroup.Query().
-				Where(directorygroup.IntegrationID(integration.ID)).
-				Where(directorygroup.ExternalID(createInput.ExternalID)).
-				Only(ctx)
+			return findWithLegacyKeyAdoption(ctx, createInput.ExternalID,
+				func(ctx context.Context, externalID string) (*ent.DirectoryGroup, error) {
+					return db.DirectoryGroup.Query().
+						Where(directorygroup.IntegrationID(integration.ID)).
+						Where(directorygroup.ExternalID(externalID)).
+						Only(ctx)
+				},
+				// the row still carries the old scientific notation key, so fix it in place
+				// before the update proceeds (Modify because external_id is immutable)
+				func(ctx context.Context, group *ent.DirectoryGroup) error {
+					return db.DirectoryGroup.UpdateOneID(group.ID).
+						Modify(func(u *sql.UpdateBuilder) {
+							u.Set(directorygroup.FieldExternalID, createInput.ExternalID)
+						}).
+						Exec(ctx)
+				},
+			)
 		},
 		func(ctx context.Context, input ent.CreateDirectoryGroupInput) (string, error) {
 			dg, err := db.DirectoryGroup.Create().SetInput(input).Save(ctx)

--- a/internal/integrations/operations/ingest_directorymembership_persist.go
+++ b/internal/integrations/operations/ingest_directorymembership_persist.go
@@ -7,11 +7,13 @@ import (
 	"time"
 
 	"entgo.io/ent/dialect/sql"
+	"github.com/samber/lo"
 
 	ent "github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/directoryaccount"
 	"github.com/theopenlane/core/internal/ent/generated/directorygroup"
 	"github.com/theopenlane/core/internal/ent/generated/directorymembership"
+	"github.com/theopenlane/core/internal/ent/generated/predicate"
 	"github.com/theopenlane/core/pkg/logx"
 )
 
@@ -69,7 +71,7 @@ func persistDirectoryMembershipInput(ctx context.Context, db *ent.Client, integr
 
 // resolveDirectoryMembershipInput normalizes provider lookup values into internal record IDs before persistence
 func resolveDirectoryMembershipInput(ctx context.Context, db *ent.Client, integration *ent.Integration, input ent.CreateDirectoryMembershipInput) (ent.CreateDirectoryMembershipInput, error) {
-	accountID, err := resolveDirectoryAccountID(ctx, db, integration, input.DirectoryAccountID)
+	accountID, err := resolveDirectoryAccountID(ctx, db, integration, lo.FromPtr(input.DirectoryInstanceID), input.DirectoryAccountID)
 	if err != nil {
 		logx.FromContext(ctx).Error().Err(err).Str("account_ref", input.DirectoryAccountID).Str("group_ref", input.DirectoryGroupID).Msg("unresolved directory account for membership")
 
@@ -94,14 +96,21 @@ func resolveDirectoryMembershipInput(ctx context.Context, db *ent.Client, integr
 }
 
 // resolveDirectoryAccountID resolves a directory account reference to its internal ID by checking primary key, external ID, and canonical email
-func resolveDirectoryAccountID(ctx context.Context, db *ent.Client, integration *ent.Integration, value string) (string, error) {
+// Lookups are scoped the same way the account upsert is (owner + directory instance when the
+// membership carries one, integration otherwise) so accounts that survived a reinstall still resolve
+func resolveDirectoryAccountID(ctx context.Context, db *ent.Client, integration *ent.Integration, instanceID string, value string) (string, error) {
 	value = strings.TrimSpace(value)
 	if value == "" {
 		return "", ErrIngestUpsertKeyMissing
 	}
 
+	scope := directoryaccount.IntegrationID(integration.ID)
+	if instanceID != "" {
+		scope = directoryaccount.DirectoryInstanceID(instanceID)
+	}
+
 	account, err := db.DirectoryAccount.Query().
-		Where(directoryaccount.ID(value), directoryaccount.IntegrationID(integration.ID)).
+		Where(directoryaccount.ID(value), directoryaccount.OwnerID(integration.OwnerID)).
 		Only(ctx)
 	switch {
 	case err == nil:
@@ -110,12 +119,19 @@ func resolveDirectoryAccountID(ctx context.Context, db *ent.Client, integration 
 		return "", err
 	}
 
+	refs := []predicate.DirectoryAccount{
+		directoryaccount.ExternalID(value),
+		directoryaccount.CanonicalEmail(value),
+	}
+
+	// older rows may still hold the scientific notation form of the same key
+	if legacy, ok := legacyScientificKey(value); ok {
+		refs = append(refs, directoryaccount.ExternalID(legacy))
+	}
+
 	account, err = db.DirectoryAccount.Query().
-		Where(directoryaccount.IntegrationID(integration.ID)).
-		Where(directoryaccount.Or(
-			directoryaccount.ExternalID(value),
-			directoryaccount.CanonicalEmail(value),
-		)).
+		Where(directoryaccount.OwnerID(integration.OwnerID), scope).
+		Where(directoryaccount.Or(refs...)).
 		Order(directoryaccount.ByCreatedAt(sql.OrderDesc())).
 		First(ctx)
 	if err != nil {
@@ -146,12 +162,19 @@ func resolveDirectoryGroupID(ctx context.Context, db *ent.Client, integration *e
 		return "", err
 	}
 
+	refs := []predicate.DirectoryGroup{
+		directorygroup.ExternalID(value),
+		directorygroup.Email(value),
+	}
+
+	// older rows may still hold the scientific notation form of the same key
+	if legacy, ok := legacyScientificKey(value); ok {
+		refs = append(refs, directorygroup.ExternalID(legacy))
+	}
+
 	group, err = db.DirectoryGroup.Query().
 		Where(directorygroup.IntegrationID(integration.ID)).
-		Where(directorygroup.Or(
-			directorygroup.ExternalID(value),
-			directorygroup.Email(value),
-		)).
+		Where(directorygroup.Or(refs...)).
 		Order(directorygroup.ByCreatedAt(sql.OrderDesc())).
 		First(ctx)
 	if err != nil {

--- a/internal/integrations/operations/reconcile.go
+++ b/internal/integrations/operations/reconcile.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	ent "github.com/theopenlane/core/internal/ent/generated"
+	intobvs "github.com/theopenlane/core/internal/integrations/observability"
 	"github.com/theopenlane/core/internal/integrations/registry"
 	"github.com/theopenlane/core/internal/integrations/types"
 	"github.com/theopenlane/core/pkg/gala"
@@ -68,12 +69,12 @@ func RegisterReconcileListener(runtime *gala.Gala, reg *registry.Registry, handl
 			}
 
 			if errors.Is(err, registry.ErrDefinitionNotFound) || errors.Is(err, registry.ErrOperationNotFound) {
-				logx.FromContext(ctx).Error().Err(err).Str("definition_id", src.DefinitionID).Str("operation", e.Operation).Msg("operation no longer registered, stopping cycle")
+				logx.FromContext(ctx).Error().Err(err).Str("definition_id", src.DefinitionID).Str(intobvs.FieldOperation, e.Operation).Msg("operation no longer registered, stopping cycle")
 				return true
 			}
 
 			if errors.Is(err, ErrOperationDisabled) {
-				logx.FromContext(ctx).Info().Str("integration_id", src.IntegrationID).Str("operation", e.Operation).Msg("operation disabled, stopping cycle")
+				logx.FromContext(ctx).Info().Str("integration_id", src.IntegrationID).Str(intobvs.FieldOperation, e.Operation).Msg("operation disabled, stopping cycle")
 				return true
 			}
 

--- a/internal/integrations/operations/upsert.go
+++ b/internal/integrations/operations/upsert.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/rs/zerolog/log"
 
@@ -12,6 +13,53 @@ import (
 	ent "github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/pkg/jsonx"
 )
+
+// legacyScientificKey converts a numeric key like "147884153" into the "1.47884153e+08" form the
+// old CEL double conversion stored, so we can still find rows written before the fix; returns false
+// for non-numeric keys and for numbers small enough that the two forms are identical
+func legacyScientificKey(value string) (string, bool) {
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return "", false
+	}
+
+	legacy := strconv.FormatFloat(parsed, 'g', -1, 64)
+	if legacy == value {
+		return "", false
+	}
+
+	return legacy, true
+}
+
+// findWithLegacyKeyAdoption runs the upsert lookup for one external id, retrying with the legacy
+// scientific notation form when the canonical form misses; a row found under the legacy key gets
+// its key repaired via the repair callback before it is returned, so the update path sees a row
+// that already carries the canonical key
+func findWithLegacyKeyAdoption[T any](ctx context.Context, externalID string, find func(context.Context, string) (T, error), repair func(context.Context, T) error) (T, error) {
+	existing, err := find(ctx, externalID)
+	if err == nil || !ent.IsNotFound(err) {
+		return existing, err
+	}
+
+	legacy, ok := legacyScientificKey(externalID)
+	if !ok {
+		return existing, err
+	}
+
+	adopted, legacyErr := find(ctx, legacy)
+	switch {
+	case ent.IsNotFound(legacyErr):
+		return existing, err
+	case legacyErr != nil:
+		return existing, legacyErr
+	}
+
+	if repairErr := repair(ctx, adopted); repairErr != nil {
+		return existing, repairErr
+	}
+
+	return adopted, nil
+}
 
 // persistCatalogUpsert marshals one prepared create input and persists it through the schema's
 // catalog-driven entityops upsert, mapping the entityops sentinels onto the ingest error classes.

--- a/internal/integrations/providerkit/cel.go
+++ b/internal/integrations/providerkit/cel.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -35,6 +36,9 @@ const (
 	celVarAction = "action"
 	// celVarPayload is the CEL variable name bound to the envelope payload field
 	celVarPayload = "payload"
+
+	// maxSafeInteger is the largest float64 that can still hold every integer exactly (2^53)
+	maxSafeInteger = float64(1 << 53)
 )
 
 var (
@@ -83,6 +87,33 @@ func buildEnvelopeEnv() (*cel.Env, error) {
 	))
 }
 
+// normalizeIntegralNumbers walks a JSON-decoded value and converts whole-number float64s to int64;
+// without this, CEL string() renders big IDs like 147884153 as "1.47884153e+08"
+func normalizeIntegralNumbers(value any) any {
+	switch v := value.(type) {
+	case map[string]any:
+		for key, item := range v {
+			v[key] = normalizeIntegralNumbers(item)
+		}
+
+		return v
+	case []any:
+		for i, item := range v {
+			v[i] = normalizeIntegralNumbers(item)
+		}
+
+		return v
+	case float64:
+		if v == math.Trunc(v) && math.Abs(v) < maxSafeInteger {
+			return int64(v)
+		}
+
+		return v
+	default:
+		return value
+	}
+}
+
 // envelopeToVars converts a MappingEnvelope into the CEL variable map
 func envelopeToVars(envelope types.MappingEnvelope) map[string]any {
 	var payload any
@@ -90,6 +121,8 @@ func envelopeToVars(envelope types.MappingEnvelope) map[string]any {
 	if len(envelope.Payload) > 0 {
 		if err := json.Unmarshal(envelope.Payload, &payload); err != nil {
 			payload = string(envelope.Payload)
+		} else {
+			payload = normalizeIntegralNumbers(payload)
 		}
 	}
 

--- a/internal/integrations/runtime/execution.go
+++ b/internal/integrations/runtime/execution.go
@@ -41,7 +41,7 @@ func (r *Runtime) reconcileOperations(ctx context.Context, integration *ent.Inte
 		}
 
 		if op.Disabled != nil && op.Disabled(integration.Config.ClientConfig) {
-			logx.FromContext(ctx).Debug().Str("operation", op.Name).Msg("operation is disabled, skipping reconcile")
+			logx.FromContext(ctx).Debug().Str(intobvs.FieldOperation, op.Name).Msg("operation is disabled, skipping reconcile")
 
 			continue
 		}
@@ -59,13 +59,13 @@ func (r *Runtime) reconcileOperations(ctx context.Context, integration *ent.Inte
 		})
 
 		if receipt.Err != nil {
-			logx.FromContext(ctx).Error().Err(receipt.Err).Str("operation", op.Name).Msg("failed to emit reconcile envelope")
+			logx.FromContext(ctx).Error().Err(receipt.Err).Str(intobvs.FieldOperation, op.Name).Msg("failed to emit reconcile envelope")
 			errs = append(errs, receipt.Err)
 
 			continue
 		}
 
-		logx.FromContext(ctx).Info().Str("operation", op.Name).Msg("reconcile envelope emitted")
+		logx.FromContext(ctx).Info().Str(intobvs.FieldOperation, op.Name).Msg("reconcile envelope emitted")
 	}
 
 	return errors.Join(errs...)
@@ -546,17 +546,17 @@ func (r *Runtime) seedReconcileJobsForInstallation(ctx context.Context, inst *en
 
 		active, err := r.Gala().HasActiveJobWithMetadata(ctx, fragment)
 		if err != nil {
-			logx.FromContext(ctx).Error().Err(err).Str("integration_id", inst.ID).Str("operation", op.Name).Msg("failed to check for active reconcile job")
+			logx.FromContext(ctx).Error().Err(err).Str("integration_id", inst.ID).Str(intobvs.FieldOperation, op.Name).Msg("failed to check for active reconcile job")
 			errs = append(errs, err)
 			continue
 		}
 
 		if active {
-			logx.FromContext(ctx).Debug().Str("integration_id", inst.ID).Str("operation", op.Name).Msg("reconcile job already active, skipping seed")
+			logx.FromContext(ctx).Debug().Str("integration_id", inst.ID).Str(intobvs.FieldOperation, op.Name).Msg("reconcile job already active, skipping seed")
 			continue
 		}
 
-		logx.FromContext(ctx).Info().Str("integration_id", inst.ID).Str("operation", op.Name).Msg("seeding missing reconcile job")
+		logx.FromContext(ctx).Info().Str("integration_id", inst.ID).Str(intobvs.FieldOperation, op.Name).Msg("seeding missing reconcile job")
 
 		oc := types.NewOperationContext(inst.OwnerID, op.Name, types.IntegrationSource{
 			IntegrationID: inst.ID,
@@ -571,7 +571,7 @@ func (r *Runtime) seedReconcileJobsForInstallation(ctx context.Context, inst *en
 			gala.Headers{Properties: oc.Properties()},
 		)
 		if receipt.Err != nil {
-			logx.FromContext(ctx).Error().Err(receipt.Err).Str("integration_id", inst.ID).Str("operation", op.Name).Msg("failed to seed reconcile job")
+			logx.FromContext(ctx).Error().Err(receipt.Err).Str("integration_id", inst.ID).Str(intobvs.FieldOperation, op.Name).Msg("failed to seed reconcile job")
 			errs = append(errs, receipt.Err)
 		}
 	}

--- a/internal/integrations/runtime/ratelimit.go
+++ b/internal/integrations/runtime/ratelimit.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/theopenlane/iam/auth"
 
+	intobvs "github.com/theopenlane/core/internal/integrations/observability"
 	"github.com/theopenlane/core/internal/integrations/types"
 	"github.com/theopenlane/core/pkg/logx"
 )
@@ -31,7 +32,7 @@ func (r *Runtime) checkRateLimit(ctx context.Context, operation types.OperationR
 	}
 
 	if caller.Has(auth.CapInternalOperation) {
-		logx.FromContext(ctx).Debug().Str("operation", operation.Name).Msg("internal operation caller, bypassing rate limit")
+		logx.FromContext(ctx).Debug().Str(intobvs.FieldOperation, operation.Name).Msg("internal operation caller, bypassing rate limit")
 
 		return true, nil
 	}

--- a/internal/integrations/runtime/scheduled_operations.go
+++ b/internal/integrations/runtime/scheduled_operations.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	"github.com/theopenlane/core/common/enums"
+	intobvs "github.com/theopenlane/core/internal/integrations/observability"
 	"github.com/theopenlane/core/internal/integrations/operations"
 	"github.com/theopenlane/core/internal/integrations/types"
 	"github.com/theopenlane/core/pkg/gala"
@@ -61,7 +62,7 @@ func (r *Runtime) SeedScheduledOperations(ctx context.Context) error {
 			}
 
 			if op.DisabledForAll || (op.Disabled != nil && op.Disabled(nil)) {
-				logx.FromContext(ctx).Info().Str("definition_id", def.ID).Str("operation", op.Name).Msg("scheduled operation disabled, skipping seed")
+				logx.FromContext(ctx).Info().Str("definition_id", def.ID).Str(intobvs.FieldOperation, op.Name).Msg("scheduled operation disabled, skipping seed")
 
 				continue
 			}
@@ -92,18 +93,18 @@ func (r *Runtime) seedScheduledOperation(ctx context.Context, oc gala.OperationC
 
 	active, err := r.Gala().HasActiveJobWithMetadata(ctx, fragment)
 	if err != nil {
-		logx.FromContext(ctx).Error().Err(err).Str("definition_id", src.DefinitionID).Str("operation", oc.Operation).Msg("failed to check for active scheduled operation job")
+		logx.FromContext(ctx).Error().Err(err).Str("definition_id", src.DefinitionID).Str(intobvs.FieldOperation, oc.Operation).Msg("failed to check for active scheduled operation job")
 
 		return err
 	}
 
 	if active {
-		logx.FromContext(ctx).Debug().Str("definition_id", src.DefinitionID).Str("operation", oc.Operation).Msg("scheduled operation already active, skipping seed")
+		logx.FromContext(ctx).Debug().Str("definition_id", src.DefinitionID).Str(intobvs.FieldOperation, oc.Operation).Msg("scheduled operation already active, skipping seed")
 
 		return nil
 	}
 
-	logx.FromContext(ctx).Info().Str("definition_id", src.DefinitionID).Str("operation", oc.Operation).Msg("seeding scheduled operation")
+	logx.FromContext(ctx).Info().Str("definition_id", src.DefinitionID).Str(intobvs.FieldOperation, oc.Operation).Msg("seeding scheduled operation")
 
 	receipt := r.Gala().EmitWithHeaders(
 		gala.WithOperationContext(ctx, oc),


### PR DESCRIPTION
- Directory sync memberships no longer fail when GitHub's numeric IDs exceed one million - integer IDs now map to their plain decimal form instead of scientific notation
- Reinstalling an integration no longer breaks membership resolution; directory accounts carried over from a prior installation are matched by owner and directory instance rather than the current installation alone
- Existing records stored with corrupted scientific-notation keys are updated through backfill and a defensive check, so syncs already in flight adopt and repair them in place, and the startup backfill cleans up whatever no sync ever touches, so the fix can ship without ordering concerns or duplicate records
- Fixed production log name key collision where the integration operation name and the entity mutation verb no longer fight over the same structured log key, eliminating garbled values like "createorySync"
- Added integration tests demonstrating the externalID key update (given the field is immutable, needed to confirm the behavior exactly)
