### PR TITLE
Strip html and markdown before matching

### DIFF
--- a/internal/graphapi/search_context.go
+++ b/internal/graphapi/search_context.go
@@ -1,10 +1,17 @@
 package graphapi
 
 import (
+	"bytes"
 	"context"
 	"reflect"
 	"strings"
 	"sync"
+
+	"github.com/microcosm-cc/bluemonday"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
+	goldmarkparser "github.com/yuin/goldmark/parser"
+	goldmarkhtml "github.com/yuin/goldmark/renderer/html"
 
 	"github.com/theopenlane/core/common/models"
 	"github.com/theopenlane/core/internal/ent/generated"
@@ -14,6 +21,14 @@ import (
 const (
 	maxSnippetLength = 100
 )
+
+var snippetMarkdown = goldmark.New(
+	goldmark.WithExtensions(extension.Table),
+	goldmark.WithParserOptions(goldmarkparser.WithAutoHeadingID()),
+	goldmark.WithRendererOptions(goldmarkhtml.WithUnsafe()),
+)
+
+var searchSanitizer = bluemonday.StrictPolicy()
 
 type searchCtxTracker struct {
 	mu       sync.Mutex
@@ -74,29 +89,7 @@ func (t *searchCtxTracker) extractSnippets(entity any, matchedFields []string) [
 			continue
 		}
 
-		var text string
-
-		switch field.Kind() {
-
-		case reflect.String:
-			text = field.String()
-
-		case reflect.Slice:
-			if field.Type().Elem().Kind() == reflect.String {
-				// handle string slices (tags - a good example here)
-				strs := make([]string, 0, field.Len())
-				for i := 0; i < field.Len(); i++ {
-					strs = append(strs, field.Index(i).String())
-				}
-				text = strings.Join(strs, ", ")
-			}
-
-		case reflect.Pointer:
-			if !field.IsNil() && field.Elem().Kind() == reflect.String {
-				text = field.Elem().String()
-			}
-		}
-
+		text := sanitizeContent(retrieveFieldValue(field))
 		if text == "" {
 			continue
 		}
@@ -110,6 +103,50 @@ func (t *searchCtxTracker) extractSnippets(entity any, matchedFields []string) [
 	}
 
 	return snippets
+}
+
+func retrieveFieldValue(field reflect.Value) string {
+	switch field.Kind() {
+	case reflect.String:
+		return field.String()
+
+	case reflect.Slice:
+		// tags, mapped categories and aliases are []string
+		if field.Type().Elem().Kind() != reflect.String {
+			return ""
+		}
+
+		val := make([]string, 0, field.Len())
+		for i := 0; i < field.Len(); i++ {
+			val = append(val, field.Index(i).String())
+		}
+
+		return strings.Join(val, ", ")
+
+	case reflect.Pointer:
+		// handle nullable string values
+		if !field.IsNil() && field.Elem().Kind() == reflect.String {
+			return field.Elem().String()
+		}
+	}
+
+	return ""
+}
+
+func sanitizeContent(text string) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+
+	var b bytes.Buffer
+	if err := snippetMarkdown.Convert([]byte(text), &b); err != nil {
+		return text
+	}
+
+	sanitized := searchSanitizer.Sanitize(b.String())
+
+	return strings.Join(strings.Fields(sanitized), " ")
 }
 
 // createSnippet creates a snippet with highlighted match to improve the surrounding context
@@ -200,22 +237,9 @@ func (c *fieldMatchChecker) check(entity any, fieldNames []string) []string {
 		}
 
 		matched := false
-		switch field.Kind() {
-		case reflect.String:
-			matched = strings.Contains(strings.ToLower(field.String()), queryLower)
-		case reflect.Slice:
-			if field.Type().Elem().Kind() == reflect.String {
-				for i := 0; i < field.Len(); i++ {
-					if strings.Contains(strings.ToLower(field.Index(i).String()), queryLower) {
-						matched = true
-						break
-					}
-				}
-			}
-		case reflect.Pointer:
-			if !field.IsNil() && field.Elem().Kind() == reflect.String {
-				matched = strings.Contains(strings.ToLower(field.Elem().String()), queryLower)
-			}
+		text := sanitizeContent(retrieveFieldValue(field))
+		if text != "" {
+			matched = strings.Contains(strings.ToLower(text), queryLower)
 		}
 
 		if matched {

--- a/internal/graphapi/search_context_test.go
+++ b/internal/graphapi/search_context_test.go
@@ -2,11 +2,13 @@ package graphapi
 
 import (
 	"slices"
+	"strings"
 	"testing"
 
-	"github.com/theopenlane/core/internal/ent/generated"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
+
+	"github.com/theopenlane/core/internal/ent/generated"
 )
 
 func TestSearchContextTracker(t *testing.T) {
@@ -96,4 +98,64 @@ func TestExtractSnippets(t *testing.T) {
 
 	assert.Check(t, is.Equal(true, nameSnippetExists), "Should have snippet for Name field")
 	assert.Check(t, is.Equal(true, detailSnippetExists), "Should have snippet for Details field")
+}
+
+func TestSearchContextContentSanitization(t *testing.T) {
+	tt := []struct {
+		name         string
+		query        string
+		details      string
+		wantSnippet  string
+		wantMatch    bool
+		wantSanitize string
+	}{
+		{
+			name:  "html attributes ignored",
+			query: "slate",
+			details: `<span data-slate-node="text">` +
+				`<span data-slate-string="true">Visible objective</span></span>`,
+			wantMatch: false,
+		},
+		{
+			name:  "html stripped",
+			query: "objectives",
+			details: `<span class="slate-bold"><span data-slate-string="true">objectives</span></span>` +
+				`<span data-slate-node="text"> and responsibilities</span>`,
+			wantSnippet: "objectives and responsibilities",
+			wantMatch:   true,
+		},
+		{
+			name:         "markdown stripped",
+			details:      "## Recovery Objectives\n\n- [Objective owner](https://example.com)\n- **monitoring**",
+			wantSanitize: "Recovery Objectives Objective owner monitoring",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.wantSanitize != "" {
+				assert.Check(t, is.Equal(tc.wantSanitize, sanitizeContent(tc.details)))
+				return
+			}
+
+			entity := &generated.ActionPlan{
+				ID:      "plan-123",
+				Details: tc.details,
+			}
+
+			checker := fieldMatchChecker{query: tc.query}
+			matches := checker.check(entity, []string{"Details"})
+			assert.Check(t, is.Equal(tc.wantMatch, slices.Contains(matches, "Details")))
+
+			if tc.wantSnippet == "" {
+				return
+			}
+
+			snippets := newContextTracker(tc.query).extractSnippets(entity, []string{"Details"})
+			assert.Assert(t, is.Len(snippets, 1))
+			assert.Check(t, is.Equal(tc.wantSnippet, snippets[0].Text))
+			assert.Check(t, !strings.Contains(snippets[0].Text, "<span"))
+			assert.Check(t, !strings.Contains(snippets[0].Text, "data-slate"))
+		})
+	}
 }


### PR DESCRIPTION
long term, maybe we want to do a standalone search thing? but sanitizing the content should be fine for now 

<img width="1816" height="1590" alt="CleanShot 2026-07-30 at 19 36 12@2x" src="https://github.com/user-attachments/assets/0324f65e-76f1-475e-870a-610d34f6507b" />

### before

<img width="1292" height="1348" alt="CleanShot 2026-07-30 at 18 35 45@2x" src="https://github.com/user-attachments/assets/1b3232ed-8706-4f81-a7b9-ae1a63277531" />

