### PR TITLE
move generated deps out of pkg

### DIFF
--- a/internal/httpserve/handlers/webfinger.go
+++ b/internal/httpserve/handlers/webfinger.go
@@ -8,6 +8,7 @@ import (
 	models "github.com/theopenlane/core/common/openapi"
 	ent "github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
+	"github.com/theopenlane/core/internal/ssoenforcement"
 	"github.com/theopenlane/core/pkg/logx"
 	sso "github.com/theopenlane/core/pkg/ssoutils"
 	echo "github.com/theopenlane/echox"
@@ -86,7 +87,7 @@ type nonce string
 // user's owner, per-user, and per-domain exemptions, so callers and the webfinger acct lookup do not
 // route an exempt user through SSO. Provider, discovery URL, and TFA enforcement are always reported
 func (h *Handler) fetchSSOStatus(ctx context.Context, orgID, userID string) (models.SSOStatusResponse, error) {
-	in, setting, err := sso.LoadEnforcement(ctx, h.DBClient, orgID, userID, "")
+	in, setting, err := ssoenforcement.LoadEnforcement(ctx, h.DBClient, orgID, userID, "")
 	if err != nil {
 		return models.SSOStatusResponse{}, err
 	}

--- a/internal/ssoenforcement/load.go
+++ b/internal/ssoenforcement/load.go
@@ -1,4 +1,5 @@
-package ssoutils
+// Package ssoenforcement holds the db-aware loader
+package ssoenforcement
 
 import (
 	"context"
@@ -9,23 +10,24 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated/orgmembership"
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
 	"github.com/theopenlane/core/internal/ent/generated/user"
+	sso "github.com/theopenlane/core/pkg/ssoutils"
 )
 
 // LoadEnforcement loads the organization setting and, when a userID is provided, the subject's
 // membership and email, and returns the EnforcementInput plus the loaded setting. It is the single
 // db-aware source used by both the SSO handlers and the auth middleware to feed Evaluate, so the
 // membership query is projected to only the fields the decision needs
-func LoadEnforcement(ctx context.Context, db *ent.Client, orgID, userID, email string) (EnforcementInput, *ent.OrganizationSetting, error) {
+func LoadEnforcement(ctx context.Context, db *ent.Client, orgID, userID, email string) (sso.EnforcementInput, *ent.OrganizationSetting, error) {
 	allowCtx := privacy.DecisionContext(ctx, privacy.Allow)
 
 	setting, err := db.OrganizationSetting.Query().
 		Where(organizationsetting.OrganizationID(orgID)).
 		Only(allowCtx)
 	if err != nil {
-		return EnforcementInput{}, nil, err
+		return sso.EnforcementInput{}, nil, err
 	}
 
-	in := EnforcementInput{
+	in := sso.EnforcementInput{
 		SSOEnforced:   setting.IdentityProviderLoginEnforced,
 		TFAEnforced:   setting.MultifactorAuthEnforced,
 		ExemptDomains: setting.SSOExemptDomains,
@@ -43,7 +45,7 @@ func LoadEnforcement(ctx context.Context, db *ent.Client, orgID, userID, email s
 		Select(orgmembership.FieldRole, orgmembership.FieldSSOExempt).
 		Only(allowCtx)
 	if mErr != nil {
-		return EnforcementInput{}, nil, mErr
+		return sso.EnforcementInput{}, nil, mErr
 	}
 
 	in.IsMember = true
@@ -53,7 +55,7 @@ func LoadEnforcement(ctx context.Context, db *ent.Client, orgID, userID, email s
 	if in.Email == "" {
 		u, uErr := db.User.Query().Where(user.ID(userID)).Select(user.FieldEmail).Only(allowCtx)
 		if uErr != nil {
-			return EnforcementInput{}, nil, uErr
+			return sso.EnforcementInput{}, nil, uErr
 		}
 
 		in.Email = u.Email

--- a/pkg/middleware/auth/auth.go
+++ b/pkg/middleware/auth/auth.go
@@ -29,6 +29,7 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated/orgmembership"
 	"github.com/theopenlane/core/internal/ent/generated/personalaccesstoken"
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
+	"github.com/theopenlane/core/internal/ssoenforcement"
 	"github.com/theopenlane/core/pkg/logx"
 	"github.com/theopenlane/core/pkg/metrics"
 	"github.com/theopenlane/core/pkg/permissioncache"
@@ -617,7 +618,7 @@ func isSSOEnforced(ctx context.Context, db *ent.Client, orgID string) (bool, err
 // flow, taking owner, per-user, and per-domain exemptions into account. TFA enforcement is
 // evaluated separately and is not affected by SSO exemption
 func userMustSSO(ctx context.Context, db *ent.Client, orgID, userID string) (bool, error) {
-	in, _, err := sso.LoadEnforcement(ctx, db, orgID, userID, "")
+	in, _, err := ssoenforcement.LoadEnforcement(ctx, db, orgID, userID, "")
 	if err != nil {
 		if ent.IsNotFound(err) {
 			return false, nil


### PR DESCRIPTION
Moves the `generated` dep out of `pkg/ssoutils`. This was causing an import of all geneated packages into the `cli` build, blowing up the memory usage on a new build.

| Metric | Before | After | Change |
|---|---:|---:|---:|
| Cold build (wall) | 60.4s | **7.1s** | **−88%** |
| Cold build (CPU) | 365.9s | **55.5s** | −85% |
| Binary size | 77.66 MB | **47.65 MB** | **−30 MB** |
| Total dep packages | 1328 | **650** | −678 |
| `theopenlane/core` packages | 298 | **87** | −211 |
| ent generated packages | 195 | **0** | eliminated |