### PR TITLE
fix: set completed for no assessment campaigns, fix not found bug

### DIFF
--- a/internal/ent/hooks/assessment_response.go
+++ b/internal/ent/hooks/assessment_response.go
@@ -315,7 +315,7 @@ func updateCampaignTargetFromAssessmentResponse(ctx context.Context, client *gen
 	return update.Exec(ctx)
 }
 
-// updateCampaignCompletionFromTargets marks campaigns complete when all targets are completed.
+// updateCampaignCompletionFromTargets marks campaigns complete when all targets are completed
 func updateCampaignCompletionFromTargets(ctx context.Context, client *generated.Client, campaignID string) error {
 	if campaignID == "" {
 		return nil

--- a/internal/ent/hooks/listeners_campaign_recurring.go
+++ b/internal/ent/hooks/listeners_campaign_recurring.go
@@ -12,7 +12,6 @@ import (
 	"github.com/theopenlane/iam/auth"
 
 	"github.com/theopenlane/core/internal/ent/eventqueue"
-	"github.com/theopenlane/core/internal/ent/generated"
 	entgen "github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/campaign"
 	"github.com/theopenlane/core/internal/integrations/operations"
@@ -86,7 +85,7 @@ func handleCampaignRecurringMutation(ctx gala.HandlerContext, payload eventqueue
 		).
 		Only(ctx.Context)
 	if err != nil {
-		if generated.IsNotFound(err) {
+		if entgen.IsNotFound(err) {
 			logx.FromContext(ctx.Context).Info().Msg("failed to find campaign, campaign may have been deleted before running")
 
 			// nothing to do if the campaign can no longer be found

--- a/internal/ent/hooks/listeners_campaign_recurring.go
+++ b/internal/ent/hooks/listeners_campaign_recurring.go
@@ -12,6 +12,7 @@ import (
 	"github.com/theopenlane/iam/auth"
 
 	"github.com/theopenlane/core/internal/ent/eventqueue"
+	"github.com/theopenlane/core/internal/ent/generated"
 	entgen "github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/campaign"
 	"github.com/theopenlane/core/internal/integrations/operations"
@@ -62,6 +63,12 @@ func handleCampaignRecurringMutation(ctx gala.HandlerContext, payload eventqueue
 		return nil
 	}
 
+	// set fields in the logger context
+	ctx.Context = withCampaignLogContext(ctx.Context, campaignID, caller.OrganizationID)
+
+	// ensure the caller can retrieve the campaign
+	ctx.Context = campaignScheduleContext(ctx.Context)
+
 	camp, err := client.Campaign.Query().
 		Where(
 			campaign.ID(campaignID),
@@ -74,11 +81,19 @@ func handleCampaignRecurringMutation(ctx gala.HandlerContext, payload eventqueue
 			campaign.FieldRecurrenceInterval,
 			campaign.FieldRecurrenceTimezone,
 			campaign.FieldNextRunAt,
+			campaign.FieldLastRunAt,
 			campaign.FieldStatus,
 		).
 		Only(ctx.Context)
 	if err != nil {
-		logx.FromContext(ctx.Context).Error().Err(err).Str("campaign_id", campaignID).Msg("failed loading campaign for recurring schedule sync")
+		if generated.IsNotFound(err) {
+			logx.FromContext(ctx.Context).Info().Msg("failed to find campaign, campaign may have been deleted before running")
+
+			// nothing to do if the campaign can no longer be found
+			return nil
+		}
+
+		logx.FromContext(ctx.Context).Error().Err(err).Msg("failed loading campaign for recurring schedule sync")
 
 		return err
 	}
@@ -113,11 +128,11 @@ func recomputeNextRunAt(ctx context.Context, client *entgen.Client, camp *entgen
 	if err := client.Campaign.UpdateOneID(camp.ID).
 		SetNextRunAt(models.DateTime(nextRun)).
 		Exec(ctx); err != nil {
-		logx.FromContext(ctx).Error().Err(err).Str("campaign_id", camp.ID).Msg("failed setting next_run_at on reactivation")
+		logx.FromContext(ctx).Error().Err(err).Msg("failed setting next_run_at on reactivation")
 		return err
 	}
 
-	logx.FromContext(ctx).Debug().Str("campaign_id", camp.ID).Time("next_run_at", nextRun).Msg("recurring campaign schedule recomputed")
+	logx.FromContext(ctx).Debug().Time("next_run_at", nextRun).Msg("recurring campaign schedule recomputed")
 
 	return nil
 }
@@ -127,11 +142,11 @@ func clearNextRunAt(ctx context.Context, client *entgen.Client, campaignID strin
 	if err := client.Campaign.UpdateOneID(campaignID).
 		ClearNextRunAt().
 		Exec(ctx); err != nil {
-		logx.FromContext(ctx).Error().Err(err).Str("campaign_id", campaignID).Msg("failed clearing next_run_at on deactivation")
+		logx.FromContext(ctx).Error().Err(err).Msg("failed clearing next_run_at on deactivation")
 		return err
 	}
 
-	logx.FromContext(ctx).Debug().Str("campaign_id", campaignID).Msg("recurring campaign schedule cleared")
+	logx.FromContext(ctx).Debug().Msg("recurring campaign schedule cleared")
 
 	return nil
 }
@@ -142,4 +157,23 @@ func isTerminalStatus(status enums.CampaignStatus) bool {
 		enums.CampaignStatusCompleted,
 		enums.CampaignStatusCanceled,
 	}, status)
+}
+
+// campaignScheduleContext grants the internal operation capability to the restored caller so the
+// recurrence schedule can be read and written without the caller's own object permissions
+func campaignScheduleContext(ctx context.Context) context.Context {
+	caller, ok := auth.CallerFromContext(ctx)
+	if !ok || caller == nil {
+		caller = &auth.Caller{}
+	}
+
+	return auth.WithCaller(ctx, caller.WithCapabilities(auth.CapInternalOperation))
+}
+
+// withCampaignLogContext sets the campaign and organization ID in the log context
+func withCampaignLogContext(ctx context.Context, campaignID, orgID string) context.Context {
+	return logx.WithFields(ctx, map[string]any{
+		"campaign_id":     campaignID,
+		"organization_id": orgID,
+	})
 }

--- a/internal/ent/hooks/listeners_campaign_recurring_test.go
+++ b/internal/ent/hooks/listeners_campaign_recurring_test.go
@@ -1,0 +1,130 @@
+//go:build test
+
+package hooks_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"entgo.io/ent"
+	"gotest.tools/v3/assert"
+
+	"github.com/theopenlane/core/common/enums"
+	"github.com/theopenlane/core/common/models"
+	"github.com/theopenlane/core/internal/ent/eventqueue"
+	"github.com/theopenlane/core/internal/ent/generated"
+	"github.com/theopenlane/core/internal/ent/generated/campaign"
+	"github.com/theopenlane/core/internal/ent/generated/privacy"
+	"github.com/theopenlane/core/pkg/entitlements"
+	"github.com/theopenlane/core/pkg/gala"
+	"github.com/theopenlane/iam/auth"
+)
+
+func (suite *HookTestSuite) TestCampaignRecurringListenerSchedulesNextRun() {
+	t := suite.T()
+
+	userCtx, allowCtx, orgID := suite.setupCampaignOrg(t)
+
+	camp, err := suite.newRecurringCampaign(orgID, "recurring schedule listener").
+		SetIsActive(true).
+		Save(allowCtx)
+	assert.NilError(t, err)
+	assert.Assert(t, camp.NextRunAt == nil)
+
+	envelope := suite.campaignMutationEnvelope(t, userCtx, camp.ID, campaign.FieldIsActive)
+
+	err = suite.galaRuntime.DispatchEnvelope(context.Background(), envelope)
+	assert.NilError(t, err)
+
+	updated, err := suite.client.Campaign.Get(allowCtx, camp.ID)
+	assert.NilError(t, err)
+	assert.Assert(t, updated.NextRunAt != nil)
+	assert.Assert(t, time.Time(*updated.NextRunAt).After(time.Now()))
+}
+
+func (suite *HookTestSuite) TestCampaignRecurringListenerClearsNextRunOnDeactivation() {
+	t := suite.T()
+
+	userCtx, allowCtx, orgID := suite.setupCampaignOrg(t)
+
+	camp, err := suite.newRecurringCampaign(orgID, "deactivated schedule listener").
+		SetIsActive(false).
+		SetNextRunAt(models.DateTime(time.Now().Add(time.Hour))).
+		Save(allowCtx)
+	assert.NilError(t, err)
+
+	envelope := suite.campaignMutationEnvelope(t, userCtx, camp.ID, campaign.FieldIsActive)
+
+	err = suite.galaRuntime.DispatchEnvelope(context.Background(), envelope)
+	assert.NilError(t, err)
+
+	updated, err := suite.client.Campaign.Get(allowCtx, camp.ID)
+	assert.NilError(t, err)
+	assert.Assert(t, updated.NextRunAt == nil)
+}
+
+func (suite *HookTestSuite) TestCampaignRecurringListenerSkipsDeletedCampaign() {
+	t := suite.T()
+
+	userCtx, allowCtx, orgID := suite.setupCampaignOrg(t)
+
+	camp, err := suite.newRecurringCampaign(orgID, "deleted schedule listener").
+		SetIsActive(true).
+		Save(allowCtx)
+	assert.NilError(t, err)
+
+	envelope := suite.campaignMutationEnvelope(t, userCtx, camp.ID, campaign.FieldIsActive)
+
+	err = suite.client.Campaign.DeleteOneID(camp.ID).Exec(allowCtx)
+	assert.NilError(t, err)
+
+	err = suite.galaRuntime.DispatchEnvelope(context.Background(), envelope)
+	assert.NilError(t, err)
+}
+
+func (suite *HookTestSuite) setupCampaignOrg(t *testing.T) (userCtx, allowCtx context.Context, orgID string) {
+	user := suite.seedUser()
+	orgID = user.Edges.OrgMemberships[0].OrganizationID
+
+	err := entitlements.CreateFeatureTuples(context.Background(), &suite.client.Authz, orgID,
+		[]models.OrgModule{models.CatalogBaseModule, models.CatalogComplianceModule})
+	assert.NilError(t, err)
+
+	userCtx = generated.NewContext(auth.NewTestContextWithOrgID(user.ID, orgID), suite.client)
+
+	return userCtx, privacy.DecisionContext(userCtx, privacy.Allow), orgID
+}
+
+func (suite *HookTestSuite) newRecurringCampaign(orgID, name string) *generated.CampaignCreate {
+	return suite.client.Campaign.Create().
+		SetName(name).
+		SetOwnerID(orgID).
+		SetIsRecurring(true).
+		SetStatus(enums.CampaignStatusActive).
+		SetRecurrenceFrequency(enums.FrequencyMonthly).
+		SetRecurrenceInterval(1)
+}
+
+func (suite *HookTestSuite) campaignMutationEnvelope(t *testing.T, ctx context.Context, campaignID string, changedFields ...string) gala.Envelope {
+	topic := eventqueue.MutationTopicName(eventqueue.MutationConcernDirect, generated.TypeCampaign)
+
+	encoded, err := suite.galaRuntime.Registry().EncodePayload(topic, eventqueue.MutationGalaPayload{
+		MutationType:  generated.TypeCampaign,
+		Operation:     ent.OpUpdateOne.String(),
+		EntityID:      campaignID,
+		ChangedFields: changedFields,
+	})
+	assert.NilError(t, err)
+
+	snapshot, err := suite.galaRuntime.ContextManager().Capture(ctx)
+	assert.NilError(t, err)
+
+	return gala.Envelope{
+		ID:              gala.NewEventID(),
+		Topic:           topic,
+		OccurredAt:      time.Now().UTC(),
+		Payload:         encoded,
+		ContextSnapshot: snapshot,
+	}
+}

--- a/internal/ent/hooks/listeners_campaign_recurring_test.go
+++ b/internal/ent/hooks/listeners_campaign_recurring_test.go
@@ -30,7 +30,7 @@ func (suite *HookTestSuite) TestCampaignRecurringListenerSchedulesNextRun() {
 		SetIsActive(true).
 		Save(allowCtx)
 	assert.NilError(t, err)
-	assert.Assert(t, camp.NextRunAt == nil)
+	assert.Check(t, camp.NextRunAt == nil)
 
 	envelope := suite.campaignMutationEnvelope(t, userCtx, camp.ID, campaign.FieldIsActive)
 
@@ -40,7 +40,7 @@ func (suite *HookTestSuite) TestCampaignRecurringListenerSchedulesNextRun() {
 	updated, err := suite.client.Campaign.Get(allowCtx, camp.ID)
 	assert.NilError(t, err)
 	assert.Assert(t, updated.NextRunAt != nil)
-	assert.Assert(t, time.Time(*updated.NextRunAt).After(time.Now()))
+	assert.Check(t, time.Time(*updated.NextRunAt).After(time.Now()))
 }
 
 func (suite *HookTestSuite) TestCampaignRecurringListenerClearsNextRunOnDeactivation() {
@@ -61,7 +61,7 @@ func (suite *HookTestSuite) TestCampaignRecurringListenerClearsNextRunOnDeactiva
 
 	updated, err := suite.client.Campaign.Get(allowCtx, camp.ID)
 	assert.NilError(t, err)
-	assert.Assert(t, updated.NextRunAt == nil)
+	assert.Check(t, updated.NextRunAt == nil)
 }
 
 func (suite *HookTestSuite) TestCampaignRecurringListenerSkipsDeletedCampaign() {

--- a/internal/ent/hooks/listeners_gala_registration_test.go
+++ b/internal/ent/hooks/listeners_gala_registration_test.go
@@ -171,6 +171,22 @@ func TestRegisterGalaDocumentAssociationListeners(t *testing.T) {
 	}
 }
 
+func TestRegisterGalaCampaignRecurringListeners(t *testing.T) {
+	t.Parallel()
+
+	registry := gala.NewRegistry()
+
+	ids, err := RegisterGalaCampaignRecurringListeners(registry)
+	require.NoError(t, err)
+	require.Len(t, ids, 1)
+
+	topic := eventqueue.MutationTopicName(eventqueue.MutationConcernDirect, entgen.TypeCampaign)
+	require.True(t, registry.InterestedIn(topic, ent.OpUpdate.String()))
+	require.True(t, registry.InterestedIn(topic, ent.OpUpdateOne.String()))
+	require.False(t, registry.InterestedIn(topic, ent.OpCreate.String()))
+	require.False(t, registry.InterestedIn(topic, ent.OpDelete.String()))
+}
+
 func TestRegisterGalaQuestionnaireTransformListeners(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ent/hooks/tools_test.go
+++ b/internal/ent/hooks/tools_test.go
@@ -146,6 +146,9 @@ func (suite *HookTestSuite) setupClient() *generated.Client {
 	_, err = hooks.RegisterGalaTaskRuleListeners(galaRuntime.Registry())
 	require.NoError(t, err)
 
+	_, err = hooks.RegisterGalaCampaignRecurringListeners(galaRuntime.Registry())
+	require.NoError(t, err)
+
 	do.ProvideValue(galaRuntime.Injector(), client)
 
 	client.Use(hooks.EmitGalaEventHook(func() *gala.Gala {

--- a/internal/ent/hooks/trustcentersetting.go
+++ b/internal/ent/hooks/trustcentersetting.go
@@ -2,6 +2,7 @@ package hooks
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"entgo.io/ent"
@@ -61,6 +62,12 @@ func HookTrustCenterSetting() ent.Hook {
 
 			if err := setDefaultCompanyName(ctx, m); err != nil {
 				return nil, err
+			}
+
+			// set email to lowercase if provided
+			email, ok := m.SecurityContact()
+			if ok {
+				m.SetSecurityContact(strings.ToLower(email))
 			}
 
 			initializeSubprocessorWatermark(ctx, m)

--- a/internal/graphapi/campaign_email_dispatch_test.go
+++ b/internal/graphapi/campaign_email_dispatch_test.go
@@ -28,7 +28,7 @@ func TestCampaignEmailDispatch(t *testing.T) {
 
 	// --- fixtures ---
 
-	emailTemplate := suite.client.db.EmailTemplate.Create().
+	emailTemplate, err := suite.client.db.EmailTemplate.Create().
 		SetName("Campaign Dispatch Test Template").
 		SetKey(email.BrandedMessageOp.Name()).
 		SetTemplateContext(enums.TemplateContextCampaignRecipient).
@@ -38,9 +38,10 @@ func TestCampaignEmailDispatch(t *testing.T) {
 			"intros":       []any{"Campaign: {{ .campaignName }}"},
 			"primaryColor": "#333333",
 		}).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
-	campaignObj := suite.client.db.Campaign.Create().
+	campaignObj, err := suite.client.db.Campaign.Create().
 		SetName("Dispatch Integration Test Campaign").
 		SetDescription("Testing email dispatch pipeline").
 		SetOwnerID(sharedTestUser1.OrganizationID).
@@ -49,23 +50,26 @@ func TestCampaignEmailDispatch(t *testing.T) {
 		SetMetadata(map[string]any{
 			"title": "Campaign Override",
 		}).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
-	targetAlice := suite.client.db.CampaignTarget.Create().
+	targetAlice, err := suite.client.db.CampaignTarget.Create().
 		SetCampaignID(campaignObj.ID).
 		SetEmail("alice@test.example").
 		SetFullName("Alice Smith").
 		SetOwnerID(sharedTestUser1.OrganizationID).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
-	targetBob := suite.client.db.CampaignTarget.Create().
+	targetBob, err := suite.client.db.CampaignTarget.Create().
 		SetCampaignID(campaignObj.ID).
 		SetEmail("bob@test.example").
 		SetFullName("Bob Jones").
 		SetOwnerID(sharedTestUser1.OrganizationID).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
-	defer func() {
+	t.Cleanup(func() {
 		(&Cleanup[*generated.CampaignTargetDeleteOne]{
 			client: suite.client.db.CampaignTarget,
 			IDs:    []string{targetAlice.ID, targetBob.ID},
@@ -78,7 +82,7 @@ func TestCampaignEmailDispatch(t *testing.T) {
 			client: suite.client.db.EmailTemplate,
 			ID:     emailTemplate.ID,
 		}).MustDelete(sharedTestUser1.UserCtx, t)
-	}()
+	})
 
 	// --- dispatch via SendBrandedCampaign operation ---
 
@@ -188,7 +192,7 @@ func TestCampaignEmailDispatch(t *testing.T) {
 func TestCampaignEmailDispatchSkipsSentTargets(t *testing.T) {
 	ctx := setContext(sharedTestUser1.UserCtx, suite.client.db)
 
-	emailTemplate := suite.client.db.EmailTemplate.Create().
+	emailTemplate, err := suite.client.db.EmailTemplate.Create().
 		SetName("Skip Sent Test Template").
 		SetKey(email.BrandedMessageOp.Name()).
 		SetTemplateContext(enums.TemplateContextCampaignRecipient).
@@ -197,35 +201,40 @@ func TestCampaignEmailDispatchSkipsSentTargets(t *testing.T) {
 			"title":   "Test",
 			"intros":  []any{"Test"},
 		}).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
-	campaignObj := suite.client.db.Campaign.Create().
+	campaignObj, err := suite.client.db.Campaign.Create().
 		SetName("Skip Sent Test Campaign").
 		SetOwnerID(sharedTestUser1.OrganizationID).
 		SetEmailTemplateID(emailTemplate.ID).
 		SetRecurrenceFrequency(enums.FrequencyNone).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
-	sentTarget := suite.client.db.CampaignTarget.Create().
+	sentTarget, err := suite.client.db.CampaignTarget.Create().
 		SetCampaignID(campaignObj.ID).
 		SetEmail("already-sent@test.example").
 		SetFullName("Already Sent").
 		SetOwnerID(sharedTestUser1.OrganizationID).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
 	sentAt := models.DateTime(time.Now())
-	suite.client.db.CampaignTarget.UpdateOneID(sentTarget.ID).
+	_, err = suite.client.db.CampaignTarget.UpdateOneID(sentTarget.ID).
 		SetSentAt(sentAt).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
-	unsentTarget := suite.client.db.CampaignTarget.Create().
+	unsentTarget, err := suite.client.db.CampaignTarget.Create().
 		SetCampaignID(campaignObj.ID).
 		SetEmail("unsent@test.example").
 		SetFullName("Unsent Target").
 		SetOwnerID(sharedTestUser1.OrganizationID).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
-	defer func() {
+	t.Cleanup(func() {
 		(&Cleanup[*generated.CampaignTargetDeleteOne]{
 			client: suite.client.db.CampaignTarget,
 			IDs:    []string{sentTarget.ID, unsentTarget.ID},
@@ -238,7 +247,7 @@ func TestCampaignEmailDispatchSkipsSentTargets(t *testing.T) {
 			client: suite.client.db.EmailTemplate,
 			ID:     emailTemplate.ID,
 		}).MustDelete(sharedTestUser1.UserCtx, t)
-	}()
+	})
 
 	mockSender, err := mock.New("")
 	assert.NilError(t, err)
@@ -275,7 +284,7 @@ func TestCampaignEmailDispatchSkipsSentTargets(t *testing.T) {
 func TestCampaignEmailDispatchNoBranding(t *testing.T) {
 	ctx := setContext(sharedTestUser1.UserCtx, suite.client.db)
 
-	emailTemplate := suite.client.db.EmailTemplate.Create().
+	emailTemplate, err := suite.client.db.EmailTemplate.Create().
 		SetName("No Branding Test Template").
 		SetKey(email.BrandedMessageOp.Name()).
 		SetTemplateContext(enums.TemplateContextCampaignRecipient).
@@ -284,23 +293,26 @@ func TestCampaignEmailDispatchNoBranding(t *testing.T) {
 			"title":   "Welcome {{ .firstName }}",
 			"intros":  []any{"Welcome {{ .firstName }}"},
 		}).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
-	campaignObj := suite.client.db.Campaign.Create().
+	campaignObj, err := suite.client.db.Campaign.Create().
 		SetName("No Branding Campaign").
 		SetOwnerID(sharedTestUser1.OrganizationID).
 		SetEmailTemplateID(emailTemplate.ID).
 		SetRecurrenceFrequency(enums.FrequencyNone).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
-	target := suite.client.db.CampaignTarget.Create().
+	target, err := suite.client.db.CampaignTarget.Create().
 		SetCampaignID(campaignObj.ID).
 		SetEmail("charlie@test.example").
 		SetFullName("Charlie Brown").
 		SetOwnerID(sharedTestUser1.OrganizationID).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
-	defer func() {
+	t.Cleanup(func() {
 		(&Cleanup[*generated.CampaignTargetDeleteOne]{
 			client: suite.client.db.CampaignTarget,
 			ID:     target.ID,
@@ -313,7 +325,7 @@ func TestCampaignEmailDispatchNoBranding(t *testing.T) {
 			client: suite.client.db.EmailTemplate,
 			ID:     emailTemplate.ID,
 		}).MustDelete(sharedTestUser1.UserCtx, t)
-	}()
+	})
 
 	mockSender, err := mock.New("")
 	assert.NilError(t, err)
@@ -351,20 +363,22 @@ func TestCampaignEmailDispatchNoBranding(t *testing.T) {
 func TestCampaignEmailDispatchNoTemplate(t *testing.T) {
 	ctx := setContext(sharedTestUser1.UserCtx, suite.client.db)
 
-	campaignObj := suite.client.db.Campaign.Create().
+	campaignObj, err := suite.client.db.Campaign.Create().
 		SetName("No Template Campaign").
 		SetOwnerID(sharedTestUser1.OrganizationID).
 		SetRecurrenceFrequency(enums.FrequencyNone).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
-	target := suite.client.db.CampaignTarget.Create().
+	target, err := suite.client.db.CampaignTarget.Create().
 		SetCampaignID(campaignObj.ID).
 		SetEmail("nobody@test.example").
 		SetFullName("No Body").
 		SetOwnerID(sharedTestUser1.OrganizationID).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
-	defer func() {
+	t.Cleanup(func() {
 		(&Cleanup[*generated.CampaignTargetDeleteOne]{
 			client: suite.client.db.CampaignTarget,
 			ID:     target.ID,
@@ -373,7 +387,7 @@ func TestCampaignEmailDispatchNoTemplate(t *testing.T) {
 			client: suite.client.db.Campaign,
 			ID:     campaignObj.ID,
 		}).MustDelete(sharedTestUser1.UserCtx, t)
-	}()
+	})
 
 	mockSender, err := mock.New("")
 	assert.NilError(t, err)
@@ -411,16 +425,17 @@ func TestQuestionnaireTestEmailDispatch(t *testing.T) {
 
 	assessmentObj := (&AssessmentBuilder{client: suite.client}).MustNew(sharedTestUser1.UserCtx, t)
 
-	campaignObj := suite.client.db.Campaign.Create().
+	campaignObj, err := suite.client.db.Campaign.Create().
 		SetName("Questionnaire Test Send Campaign").
 		SetOwnerID(sharedTestUser1.OrganizationID).
 		SetCampaignType(enums.CampaignTypeQuestionnaire).
 		SetAssessmentID(assessmentObj.ID).
 		SetRecurrenceFrequency(enums.FrequencyNone).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
 	var responseIDs []string
-	defer func() {
+	t.Cleanup(func() {
 		if len(responseIDs) > 0 {
 			(&Cleanup[*generated.AssessmentResponseDeleteOne]{
 				client: suite.client.db.AssessmentResponse,
@@ -439,7 +454,7 @@ func TestQuestionnaireTestEmailDispatch(t *testing.T) {
 			client: suite.client.db.Template,
 			ID:     assessmentObj.TemplateID,
 		}).MustDelete(sharedTestUser1.UserCtx, t)
-	}()
+	})
 
 	mockSender, err := mock.New("")
 	assert.NilError(t, err)
@@ -492,4 +507,144 @@ func TestQuestionnaireTestEmailDispatch(t *testing.T) {
 		).
 		IDs(ctx)
 	assert.NilError(t, err)
+}
+
+// TestCustomCampaignCompletesWhenAllSent verifies a custom campaign is marked completed
+// once every target has been emailed, and that other campaign types are left alone
+func TestCustomCampaignCompletesWhenAllSent(t *testing.T) {
+	ctx := setContext(sharedTestUser1.UserCtx, suite.client.db)
+
+	emailTemplate := (&EmailTemplateBuilder{client: suite.client}).MustNew(ctx, t)
+
+	t.Cleanup(func() {
+		(&Cleanup[*generated.EmailTemplateDeleteOne]{
+			client: suite.client.db.EmailTemplate,
+			ID:     emailTemplate.ID,
+		}).MustDelete(sharedTestUser1.UserCtx, t)
+	})
+
+	testCases := []struct {
+		name                string
+		campaignType        enums.CampaignType
+		isRecurring         bool
+		withAssessment      bool
+		skippedTargetStatus *enums.AssessmentResponseStatus
+		expectedStatus      enums.CampaignStatus
+	}{
+		{
+			name:           "custom campaign completes once all targets are sent",
+			campaignType:   enums.CampaignTypeCustom,
+			expectedStatus: enums.CampaignStatusCompleted,
+		},
+		{
+			name:                "custom campaign stays active while a target is unsent",
+			campaignType:        enums.CampaignTypeCustom,
+			skippedTargetStatus: &enums.AssessmentResponseStatusCompleted,
+			expectedStatus:      enums.CampaignStatusActive,
+		},
+		{
+			name:           "non custom campaign is not completed by sending",
+			campaignType:   enums.CampaignTypeTraining,
+			expectedStatus: enums.CampaignStatusActive,
+		},
+		{
+			name:           "recurring custom campaign is not completed by sending",
+			campaignType:   enums.CampaignTypeCustom,
+			isRecurring:    true,
+			expectedStatus: enums.CampaignStatusActive,
+		},
+		{
+			name:           "custom campaign with a linked assessment is not completed by sending",
+			campaignType:   enums.CampaignTypeCustom,
+			withAssessment: true,
+			expectedStatus: enums.CampaignStatusActive,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			create := suite.client.db.Campaign.Create().
+				SetName(randomName(t)).
+				SetOwnerID(sharedTestUser1.OrganizationID).
+				SetCampaignType(tc.campaignType).
+				SetStatus(enums.CampaignStatusActive).
+				SetIsActive(true).
+				SetIsRecurring(tc.isRecurring).
+				SetEmailTemplateID(emailTemplate.ID).
+				SetRecurrenceFrequency(enums.FrequencyNone)
+
+			if tc.withAssessment {
+				assessmentObj := (&AssessmentBuilder{client: suite.client}).MustNew(ctx, t)
+
+				t.Cleanup(func() {
+					(&Cleanup[*generated.AssessmentDeleteOne]{
+						client: suite.client.db.Assessment,
+						ID:     assessmentObj.ID,
+					}).MustDelete(sharedTestUser1.UserCtx, t)
+				})
+
+				create.SetAssessmentID(assessmentObj.ID)
+			}
+
+			campaignObj, err := create.Save(ctx)
+			requireNoError(t, err)
+
+			target, err := suite.client.db.CampaignTarget.Create().
+				SetCampaignID(campaignObj.ID).
+				SetEmail("target@test.example").
+				SetOwnerID(sharedTestUser1.OrganizationID).
+				Save(ctx)
+			requireNoError(t, err)
+
+			targetIDs := []string{target.ID}
+
+			if tc.skippedTargetStatus != nil {
+				skipped, err := suite.client.db.CampaignTarget.Create().
+					SetCampaignID(campaignObj.ID).
+					SetEmail("skipped@test.example").
+					SetOwnerID(sharedTestUser1.OrganizationID).
+					SetStatus(*tc.skippedTargetStatus).
+					Save(ctx)
+				requireNoError(t, err)
+
+				targetIDs = append(targetIDs, skipped.ID)
+			}
+
+			t.Cleanup(func() {
+				(&Cleanup[*generated.CampaignTargetDeleteOne]{
+					client: suite.client.db.CampaignTarget,
+					IDs:    targetIDs,
+				}).MustDelete(sharedTestUser1.UserCtx, t)
+				(&Cleanup[*generated.CampaignDeleteOne]{
+					client: suite.client.db.Campaign,
+					ID:     campaignObj.ID,
+				}).MustDelete(sharedTestUser1.UserCtx, t)
+			})
+
+			mockSender, err := mock.New("")
+			assert.NilError(t, err)
+
+			emailClient := &email.Client{
+				Sender: mockSender,
+				Config: email.RuntimeEmailConfig{
+					FromEmail:   "test@mail.example.com",
+					CompanyName: "TestCorp",
+					ProductURL:  "https://app.example.com",
+				},
+			}
+
+			cfg := email.SendBrandedCampaignRequest{CampaignDispatchInput: email.CampaignDispatchInput{CampaignID: campaignObj.ID}}
+
+			_, err = email.SendBrandedCampaign{}.Run(ctx, types.OperationRequest{Client: emailClient, DB: suite.client.db}, emailClient, cfg)
+			assert.NilError(t, err)
+
+			completed := tc.expectedStatus == enums.CampaignStatusCompleted
+
+			updated, err := suite.client.db.Campaign.Get(ctx, campaignObj.ID)
+			assert.NilError(t, err)
+			assert.Equal(t, updated.Status, tc.expectedStatus)
+			assert.Equal(t, updated.IsActive, !completed)
+			assert.Equal(t, updated.CompletedAt != nil, completed)
+		})
+	}
 }

--- a/internal/graphapi/query/trustcentersetting.graphql
+++ b/internal/graphapi/query/trustcentersetting.graphql
@@ -1,227 +1,248 @@
-mutation CreateTrustCenterSetting ($input: CreateTrustCenterSettingInput!, $logoFile: Upload, $logoFileMetadata: FileMetadataInput, $faviconFile: Upload, $faviconFileMetadata: FileMetadataInput) {
-	createTrustCenterSetting(input: $input, logoFile: $logoFile, logoFileMetadata: $logoFileMetadata, faviconFile: $faviconFile, faviconFileMetadata: $faviconFileMetadata) {
-		trustCenterSetting {
-			accentColor
-			backgroundColor
-			companyDescription
-			companyDomain
-			companyName
-			createdAt
-			createdBy
-			environment
-			faviconLocalFileID
-			faviconRemoteURL
-			font
-			foregroundColor
-			heroImageLocalFileID
-			id
-			logoLocalFileID
-			logoRemoteURL
-			ndaApprovalRequired
-			overview
-			primaryColor
-			removeBranding
-			secondaryBackgroundColor
-			secondaryForegroundColor
-			securityContact
-			statusPageURL
-			themeMode
-			title
-			trustCenterID
-			updatedAt
-			updatedBy
-			logoFile {
-				id
-				name
-				metadata
-				presignedURL
-			}
-			faviconFile {
-				id
-				name
-				metadata
-				presignedURL
-			}
-			heroImageFile {
-				presignedURL
-			}
-		}
-	}
+mutation CreateTrustCenterSetting($input: CreateTrustCenterSettingInput!, $logoFile: Upload, $logoFileMetadata: FileMetadataInput, $faviconFile: Upload, $faviconFileMetadata: FileMetadataInput) {
+  createTrustCenterSetting(
+    input: $input
+    logoFile: $logoFile
+    logoFileMetadata: $logoFileMetadata
+    faviconFile: $faviconFile
+    faviconFileMetadata: $faviconFileMetadata
+  ) {
+    trustCenterSetting {
+      accentColor
+      backgroundColor
+      companyDescription
+      companyDomain
+      companyName
+      createdAt
+      createdBy
+      environment
+      faviconLocalFileID
+      faviconRemoteURL
+      font
+      foregroundColor
+      heroImageLocalFileID
+      id
+      logoLocalFileID
+      logoRemoteURL
+      ndaApprovalRequired
+      overview
+      primaryColor
+      removeBranding
+      secondaryBackgroundColor
+      secondaryForegroundColor
+      securityContact
+      statusPageURL
+      themeMode
+      title
+      trustCenterID
+      updatedAt
+      updatedBy
+      logoFile {
+        id
+        name
+        metadata
+        presignedURL
+      }
+      faviconFile {
+        id
+        name
+        metadata
+        presignedURL
+      }
+      heroImageFile {
+        presignedURL
+      }
+    }
+  }
 }
-mutation DeleteTrustCenterSetting ($deleteTrustCenterSettingId: ID!) {
-	deleteTrustCenterSetting(id: $deleteTrustCenterSettingId) {
-		deletedID
-	}
+
+mutation DeleteTrustCenterSetting($deleteTrustCenterSettingId: ID!) {
+  deleteTrustCenterSetting(id: $deleteTrustCenterSettingId) {
+    deletedID
+  }
 }
+
 query GetAllTrustCenterSettings {
-	trustCenterSettings {
-		totalCount
-		pageInfo {
-			startCursor
-			endCursor
-			hasPreviousPage
-			hasNextPage
-		}
-		edges {
-			node {
-				createdAt
-				createdBy
-				id
-				overview
-				primaryColor
-				title
-				trustCenterID
-				updatedAt
-				updatedBy
-				logoFile {
-					presignedURL
-				}
-				logoRemoteURL
-				logoLocalFileID
-				faviconFile {
-					presignedURL
-				}
-				faviconRemoteURL
-				faviconLocalFileID
-				heroImageFile {
-					presignedURL
-				}
-				heroImageLocalFileID
-				themeMode
-				font
-				foregroundColor
-				backgroundColor
-				accentColor
-				environment
-			}
-		}
-	}
+  trustCenterSettings {
+    totalCount
+    pageInfo {
+      startCursor
+      endCursor
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      node {
+        createdAt
+        createdBy
+        id
+        overview
+        primaryColor
+        title
+        trustCenterID
+        updatedAt
+        updatedBy
+        logoFile {
+          presignedURL
+        }
+        logoRemoteURL
+        logoLocalFileID
+        faviconFile {
+          presignedURL
+        }
+        faviconRemoteURL
+        faviconLocalFileID
+        heroImageFile {
+          presignedURL
+        }
+        heroImageLocalFileID
+        themeMode
+        font
+        foregroundColor
+        backgroundColor
+        accentColor
+        environment
+      }
+    }
+  }
 }
-query GetTrustCenterSettingByID ($trustCenterSettingId: ID!) {
-	trustCenterSetting(id: $trustCenterSettingId) {
-		accentColor
-		allowSubscribers
-		backgroundColor
-		companyDescription
-		companyDomain
-		companyName
-		createdAt
-		createdBy
-		environment
-		faviconLocalFileID
-		faviconRemoteURL
-		font
-		foregroundColor
-		heroImageLocalFileID
-		id
-		logoLocalFileID
-		logoRemoteURL
-		ndaApprovalRequired
-		ndaApproverGroupID
-		notifySubscribersOnSubprocessorChange
-		overview
-		primaryColor
-		removeBranding
-		secondaryBackgroundColor
-		secondaryForegroundColor
-		securityContact
-		statusPageURL
-		subprocessorsNotifiedAt
-		themeMode
-		title
-		trustCenterID
-		updatedAt
-		updatedBy
-		updatedByImpersonator
-		logoFile {
-			presignedURL
-		}
-		faviconFile {
-			presignedURL
-		}
-		heroImageFile {
-			presignedURL
-		}
-	}
+
+query GetTrustCenterSettingByID($trustCenterSettingId: ID!) {
+  trustCenterSetting(id: $trustCenterSettingId) {
+    accentColor
+    allowSubscribers
+    backgroundColor
+    companyDescription
+    companyDomain
+    companyName
+    createdAt
+    createdBy
+    environment
+    faviconLocalFileID
+    faviconRemoteURL
+    font
+    foregroundColor
+    heroImageLocalFileID
+    id
+    logoLocalFileID
+    logoRemoteURL
+    ndaApprovalRequired
+    ndaApproverGroupID
+    notifySubscribersOnSubprocessorChange
+    overview
+    primaryColor
+    removeBranding
+    secondaryBackgroundColor
+    secondaryForegroundColor
+    securityContact
+    statusPageURL
+    subprocessorsNotifiedAt
+    themeMode
+    title
+    trustCenterID
+    updatedAt
+    updatedBy
+    updatedByImpersonator
+    logoFile {
+      presignedURL
+    }
+    faviconFile {
+      presignedURL
+    }
+    heroImageFile {
+      presignedURL
+    }
+  }
 }
-query GetTrustCenterSettings ($first: Int, $last: Int, $where: TrustCenterSettingWhereInput) {
-	trustCenterSettings(first: $first, last: $last, where: $where) {
-		totalCount
-		pageInfo {
-			startCursor
-			endCursor
-			hasPreviousPage
-			hasNextPage
-		}
-		edges {
-			node {
-				createdAt
-				createdBy
-				id
-				overview
-				primaryColor
-				title
-				trustCenterID
-				updatedAt
-				updatedBy
-				logoFile {
-					presignedURL
-				}
-				logoRemoteURL
-				logoLocalFileID
-				faviconFile {
-					presignedURL
-				}
-				faviconRemoteURL
-				faviconLocalFileID
-				heroImageFile {
-					presignedURL
-				}
-				heroImageLocalFileID
-				themeMode
-				font
-				foregroundColor
-				backgroundColor
-				accentColor
-				environment
-			}
-		}
-	}
+
+query GetTrustCenterSettings($first: Int, $last: Int, $where: TrustCenterSettingWhereInput) {
+  trustCenterSettings(first: $first, last: $last, where: $where) {
+    totalCount
+    pageInfo {
+      startCursor
+      endCursor
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      node {
+        createdAt
+        createdBy
+        id
+        overview
+        primaryColor
+        title
+        trustCenterID
+        updatedAt
+        updatedBy
+        logoFile {
+          presignedURL
+        }
+        logoRemoteURL
+        logoLocalFileID
+        faviconFile {
+          presignedURL
+        }
+        faviconRemoteURL
+        faviconLocalFileID
+        heroImageFile {
+          presignedURL
+        }
+        heroImageLocalFileID
+        themeMode
+        font
+        foregroundColor
+        backgroundColor
+        accentColor
+        environment
+      }
+    }
+  }
 }
-mutation UpdateTrustCenterSetting ($updateTrustCenterSettingId: ID!, $input: UpdateTrustCenterSettingInput!, $logoFile: Upload, $logoFileMetadata: FileMetadataInput, $faviconFile: Upload, $faviconFileMetadata: FileMetadataInput, $heroImageFile: Upload, $heroImageFileMetadata: FileMetadataInput) {
-	updateTrustCenterSetting(id: $updateTrustCenterSettingId, input: $input, logoFile: $logoFile, logoFileMetadata: $logoFileMetadata, faviconFile: $faviconFile, faviconFileMetadata: $faviconFileMetadata, heroImageFile: $heroImageFile, heroImageFileMetadata: $heroImageFileMetadata) {
-		trustCenterSetting {
-			createdAt
-			createdBy
-			id
-			overview
-			primaryColor
-			title
-			trustCenterID
-			updatedAt
-			updatedBy
-			logoFile {
-				id
-				name
-				metadata
-				presignedURL
-			}
-			logoRemoteURL
-			logoLocalFileID
-			faviconFile {
-				id
-				name
-				metadata
-				presignedURL
-			}
-			faviconRemoteURL
-			faviconLocalFileID
-			themeMode
-			font
-			foregroundColor
-			backgroundColor
-			accentColor
-			environment
-		}
-	}
+
+mutation UpdateTrustCenterSetting($updateTrustCenterSettingId: ID!, $input: UpdateTrustCenterSettingInput!, $logoFile: Upload, $logoFileMetadata: FileMetadataInput, $faviconFile: Upload, $faviconFileMetadata: FileMetadataInput, $heroImageFile: Upload, $heroImageFileMetadata: FileMetadataInput) {
+  updateTrustCenterSetting(
+    id: $updateTrustCenterSettingId
+    input: $input
+    logoFile: $logoFile
+    logoFileMetadata: $logoFileMetadata
+    faviconFile: $faviconFile
+    faviconFileMetadata: $faviconFileMetadata
+    heroImageFile: $heroImageFile
+    heroImageFileMetadata: $heroImageFileMetadata
+  ) {
+    trustCenterSetting {
+      createdAt
+      createdBy
+      id
+      overview
+      primaryColor
+      title
+      trustCenterID
+      updatedAt
+      updatedBy
+      logoFile {
+        id
+        name
+        metadata
+        presignedURL
+      }
+      logoRemoteURL
+      logoLocalFileID
+      faviconFile {
+        id
+        name
+        metadata
+        presignedURL
+      }
+      faviconRemoteURL
+      faviconLocalFileID
+      themeMode
+      font
+      foregroundColor
+      backgroundColor
+      accentColor
+      environment
+      securityContact
+    }
+  }
 }

--- a/internal/graphapi/testclient/graphclient.go
+++ b/internal/graphapi/testclient/graphclient.go
@@ -142389,6 +142389,7 @@ type UpdateTrustCenterSetting_UpdateTrustCenterSetting_TrustCenterSetting struct
 	LogoRemoteURL      *string                                                                           "json:\"logoRemoteURL,omitempty\" graphql:\"logoRemoteURL\""
 	Overview           *string                                                                           "json:\"overview,omitempty\" graphql:\"overview\""
 	PrimaryColor       *string                                                                           "json:\"primaryColor,omitempty\" graphql:\"primaryColor\""
+	SecurityContact    *string                                                                           "json:\"securityContact,omitempty\" graphql:\"securityContact\""
 	ThemeMode          *enums.TrustCenterThemeMode                                                       "json:\"themeMode,omitempty\" graphql:\"themeMode\""
 	Title              *string                                                                           "json:\"title,omitempty\" graphql:\"title\""
 	TrustCenterID      *string                                                                           "json:\"trustCenterID,omitempty\" graphql:\"trustCenterID\""
@@ -142491,6 +142492,12 @@ func (t *UpdateTrustCenterSetting_UpdateTrustCenterSetting_TrustCenterSetting) G
 		t = &UpdateTrustCenterSetting_UpdateTrustCenterSetting_TrustCenterSetting{}
 	}
 	return t.PrimaryColor
+}
+func (t *UpdateTrustCenterSetting_UpdateTrustCenterSetting_TrustCenterSetting) GetSecurityContact() *string {
+	if t == nil {
+		t = &UpdateTrustCenterSetting_UpdateTrustCenterSetting_TrustCenterSetting{}
+	}
+	return t.SecurityContact
 }
 func (t *UpdateTrustCenterSetting_UpdateTrustCenterSetting_TrustCenterSetting) GetThemeMode() *enums.TrustCenterThemeMode {
 	if t == nil {
@@ -212243,6 +212250,7 @@ const UpdateTrustCenterSettingDocument = `mutation UpdateTrustCenterSetting ($up
 			backgroundColor
 			accentColor
 			environment
+			securityContact
 		}
 	}
 }

--- a/internal/graphapi/trustcentersetting_test.go
+++ b/internal/graphapi/trustcentersetting_test.go
@@ -2,6 +2,7 @@ package graphapi_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -224,6 +225,7 @@ func TestUpdateTrustCenterSetting(t *testing.T) {
 				Overview:        lo.ToPtr("New Overview"),
 				PrimaryColor:    lo.ToPtr("#00FF00"),
 				ForegroundColor: lo.ToPtr("#111111"),
+				SecurityContact: lo.ToPtr("Security@example.com"),
 			},
 			client: suite.client.api,
 			ctx:    tcOrg.owner.UserCtx,
@@ -296,6 +298,10 @@ func TestUpdateTrustCenterSetting(t *testing.T) {
 
 			if tc.input.ThemeMode != nil {
 				assert.Check(t, is.Equal(*tc.input.ThemeMode, *resp.UpdateTrustCenterSetting.TrustCenterSetting.ThemeMode))
+			}
+
+			if tc.input.SecurityContact != nil {
+				assert.Check(t, is.Equal(strings.ToLower(*tc.input.SecurityContact), *resp.UpdateTrustCenterSetting.TrustCenterSetting.SecurityContact))
 			}
 
 			if tc.expectJob {

--- a/internal/integrations/definitions/email/compose.go
+++ b/internal/integrations/definitions/email/compose.go
@@ -75,6 +75,56 @@ func markCampaignTargetSent(ctx context.Context, db *generated.Client, targetID 
 	return nil
 }
 
+// completeCampaignWhenAllSent marks custom campaigns with nothing to respond to complete once every target has been sent a message.
+// Campaigns with a linked assessment (which include training, vendor intake, etc) complete when all responses are submitted, and recurring campaigns complete when their
+// recurrence is exhausted, so both are skipped here
+func completeCampaignWhenAllSent(ctx context.Context, db *generated.Client, camp *generated.Campaign) error {
+	if camp == nil || camp.CampaignType != enums.CampaignTypeCustom || camp.IsRecurring || camp.AssessmentID != "" {
+		return nil
+	}
+
+	if camp.Status == enums.CampaignStatusCompleted || camp.Status == enums.CampaignStatusCanceled {
+		return nil
+	}
+
+	systemCtx := privacy.DecisionContext(ctx, privacy.Allow)
+
+	total, err := db.CampaignTarget.Query().
+		Where(campaigntarget.CampaignIDEQ(camp.ID)).
+		Count(systemCtx)
+	if err != nil {
+		return err
+	}
+
+	if total == 0 {
+		return nil
+	}
+
+	pending, err := db.CampaignTarget.Query().
+		Where(
+			campaigntarget.CampaignIDEQ(camp.ID),
+			campaigntarget.SentAtIsNil(),
+		).
+		Count(systemCtx)
+	if err != nil {
+		return err
+	}
+
+	if pending > 0 {
+		return nil
+	}
+
+	update := db.Campaign.UpdateOneID(camp.ID).
+		SetStatus(enums.CampaignStatusCompleted).
+		SetIsActive(false)
+
+	if camp.CompletedAt == nil || camp.CompletedAt.IsZero() {
+		update.SetCompletedAt(models.DateTime(time.Now()))
+	}
+
+	return update.Exec(systemCtx)
+}
+
 // createAssessmentResponseForRecipient creates a new assessment response record for the campaign and recipient email
 func createAssessmentResponseForRecipient(ctx context.Context, db *generated.Client, camp *generated.Campaign, assessmentID string, email string, isTest bool) (*generated.AssessmentResponse, error) {
 	if strings.TrimSpace(email) == "" {

--- a/internal/integrations/definitions/email/operation_send_campaign.go
+++ b/internal/integrations/definitions/email/operation_send_campaign.go
@@ -112,6 +112,11 @@ func (SendBrandedCampaign) Run(ctx context.Context, req types.OperationRequest, 
 
 	sentCount, sendFailed := sendCampaignMessages(ctx, req.DB, client, messages, targetIDs, attachments)
 
+	// custom campaigns have no responses to wait on, they are done once every target has been emailed
+	if err := completeCampaignWhenAllSent(ctx, req.DB, camp); err != nil {
+		logx.FromContext(ctx).Error().Err(err).Str("campaign_id", camp.ID).Msg("failed updating campaign completion status")
+	}
+
 	result := CampaignDispatchResult{
 		SentCount:    sentCount,
 		SkippedCount: skipped,


### PR DESCRIPTION
- Fixes `not found` bug when authz filtered out the campaign
- No longer errors on not found, a deleted campaign shouldn't cause a listener failure
- Marks custom campaigns with no assessments as completed when all emails are sent
- Lowercases the security contact email for trust center settings