### PR TITLE
fix: panic on null map due to null filter - ISS-2668

### DIFF
--- a/internal/ent/hooks/export.go
+++ b/internal/ent/hooks/export.go
@@ -113,14 +113,16 @@ func getFinalFilters(filters string, m *generated.ExportMutation, ownerID string
 		return filters, nil
 	}
 
-	if filters == "" {
-		filters = "{}"
-	}
-
 	var filterMap map[string]any
 
-	if err := json.Unmarshal([]byte(filters), &filterMap); err != nil {
-		return "", err
+	if filters != "" {
+		if err := json.Unmarshal([]byte(filters), &filterMap); err != nil {
+			return "", err
+		}
+	}
+
+	if filterMap == nil {
+		filterMap = map[string]any{}
 	}
 
 	// filter by owner ID

--- a/internal/ent/hooks/export_test.go
+++ b/internal/ent/hooks/export_test.go
@@ -50,6 +50,13 @@ func TestGetFinalFilters(t *testing.T) {
 			ownerID:         "owner-123",
 			expectedFilters: map[string]any{"ownerID": "owner-123", "systemOwned": false},
 		},
+		{
+			name:            "null string filters provided, should add ownerID and systemOwned",
+			exportType:      enums.ExportTypeRemediation,
+			filters:         "null",
+			ownerID:         "owner-123",
+			expectedFilters: map[string]any{"ownerID": "owner-123", "systemOwned": false},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Fixes issue where filter was:

```
"filters": "null",
```

Which unmarshals valid, but ends up with a nil map. 
Adds test case to cover path. 