### PR TITLE
fix: add tz package because our base image doesn't include by default

### DIFF
--- a/internal/graphapi/campaign_scheduled_test.go
+++ b/internal/graphapi/campaign_scheduled_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/theopenlane/core/common/models"
 	"github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/campaign"
+	"github.com/theopenlane/core/internal/graphapi/testclient"
 	"github.com/theopenlane/core/internal/integrations/definitions/email"
 	"github.com/theopenlane/core/internal/integrations/operations"
 	"github.com/theopenlane/core/internal/integrations/types"
@@ -28,7 +29,7 @@ import (
 func TestRecurringCampaignDispatchAdvancesSchedule(t *testing.T) {
 	ctx := setContext(sharedTestUser1.UserCtx, suite.client.db)
 
-	emailTemplate := suite.client.db.EmailTemplate.Create().
+	emailTemplate, err := suite.client.db.EmailTemplate.Create().
 		SetName("Recurring Schedule Test Template").
 		SetKey(email.BrandedMessageOp.Name()).
 		SetTemplateContext(enums.TemplateContextCampaignRecipient).
@@ -37,31 +38,44 @@ func TestRecurringCampaignDispatchAdvancesSchedule(t *testing.T) {
 			"title":   "Recurring Title",
 			"intros":  []any{"Recurring body"},
 		}).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
 	now := time.Now().UTC()
 	pastRun := models.DateTime(now.Add(-time.Hour))
 
-	campaignObj := suite.client.db.Campaign.Create().
-		SetName("Recurring Schedule Test").
-		SetOwnerID(sharedTestUser1.OrganizationID).
-		SetEmailTemplateID(emailTemplate.ID).
-		SetIsRecurring(true).
-		SetIsActive(true).
-		SetStatus(enums.CampaignStatusActive).
-		SetRecurrenceFrequency(enums.FrequencyMonthly).
-		SetRecurrenceInterval(1).
-		SetNextRunAt(pastRun).
-		SaveX(ctx)
+	input := testclient.CreateCampaignInput{
+		Name:            "Recurring Schedule Test",
+		EmailTemplateID: lo.ToPtr(emailTemplate.ID),
+		IsActive:        lo.ToPtr(true),
+		Status:          &enums.CampaignStatusActive,
+		NextRunAt:       &pastRun,
+	}
+	campResp, err := suite.client.api.CreateCampaign(ctx, input)
+	requireNoError(t, err)
 
-	target := suite.client.db.CampaignTarget.Create().
+	campaignObj := campResp.CreateCampaign.Campaign
+
+	updateInput := testclient.UpdateCampaignInput{
+		RecurrenceFrequency:  &enums.FrequencyYearly,
+		RecurrenceTimezone:   lo.ToPtr("America/Denver"),
+		RecurrenceInterval:   lo.ToPtr(int64(1)),
+		ClearRecurrenceEndAt: lo.ToPtr(true),
+		IsRecurring:          lo.ToPtr(true),
+	}
+
+	_, err = suite.client.api.UpdateCampaign(ctx, campaignObj.ID, updateInput)
+	requireNoError(t, err)
+
+	target, err := suite.client.db.CampaignTarget.Create().
 		SetCampaignID(campaignObj.ID).
 		SetEmail("recurring@test.example").
 		SetFullName("Recurring User").
 		SetOwnerID(sharedTestUser1.OrganizationID).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
-	defer func() {
+	t.Cleanup(func() {
 		(&Cleanup[*generated.CampaignTargetDeleteOne]{
 			client: suite.client.db.CampaignTarget,
 			ID:     target.ID,
@@ -74,7 +88,7 @@ func TestRecurringCampaignDispatchAdvancesSchedule(t *testing.T) {
 			client: suite.client.db.EmailTemplate,
 			ID:     emailTemplate.ID,
 		}).MustDelete(sharedTestUser1.UserCtx, t)
-	}()
+	})
 
 	mockSender, err := mock.New("")
 	assert.NilError(t, err)
@@ -153,7 +167,7 @@ func TestRecurringCampaignExhaustion(t *testing.T) {
 		SetOwnerID(sharedTestUser1.OrganizationID).
 		SaveX(ctx)
 
-	defer func() {
+	t.Cleanup(func() {
 		(&Cleanup[*generated.CampaignTargetDeleteOne]{
 			client: suite.client.db.CampaignTarget,
 			ID:     target.ID,
@@ -166,7 +180,7 @@ func TestRecurringCampaignExhaustion(t *testing.T) {
 			client: suite.client.db.EmailTemplate,
 			ID:     emailTemplate.ID,
 		}).MustDelete(sharedTestUser1.UserCtx, t)
-	}()
+	})
 
 	mockSender, err := mock.New("")
 	assert.NilError(t, err)

--- a/internal/graphapi/campaign_scheduled_test.go
+++ b/internal/graphapi/campaign_scheduled_test.go
@@ -132,7 +132,7 @@ func TestRecurringCampaignDispatchAdvancesSchedule(t *testing.T) {
 func TestRecurringCampaignExhaustion(t *testing.T) {
 	ctx := setContext(sharedTestUser1.UserCtx, suite.client.db)
 
-	emailTemplate := suite.client.db.EmailTemplate.Create().
+	emailTemplate, err := suite.client.db.EmailTemplate.Create().
 		SetName("Exhaustion Test Template").
 		SetKey(email.BrandedMessageOp.Name()).
 		SetTemplateContext(enums.TemplateContextCampaignRecipient).
@@ -141,13 +141,14 @@ func TestRecurringCampaignExhaustion(t *testing.T) {
 			"title":   "Exhaustion",
 			"intros":  []any{"Final run"},
 		}).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
 	now := time.Now().UTC()
 	pastRun := models.DateTime(now.Add(-time.Hour))
 	endAt := models.DateTime(now.Add(24 * time.Hour))
 
-	campaignObj := suite.client.db.Campaign.Create().
+	campaignObj, err := suite.client.db.Campaign.Create().
 		SetName("Exhaustion Test Campaign").
 		SetOwnerID(sharedTestUser1.OrganizationID).
 		SetEmailTemplateID(emailTemplate.ID).
@@ -158,14 +159,16 @@ func TestRecurringCampaignExhaustion(t *testing.T) {
 		SetRecurrenceInterval(1).
 		SetNextRunAt(pastRun).
 		SetRecurrenceEndAt(endAt).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
-	target := suite.client.db.CampaignTarget.Create().
+	target, err := suite.client.db.CampaignTarget.Create().
 		SetCampaignID(campaignObj.ID).
 		SetEmail("exhaust@test.example").
 		SetFullName("Exhaust User").
 		SetOwnerID(sharedTestUser1.OrganizationID).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
 	t.Cleanup(func() {
 		(&Cleanup[*generated.CampaignTargetDeleteOne]{
@@ -322,7 +325,7 @@ func TestDueCampaignPredicatesFiltering(t *testing.T) {
 	pastEnd := models.DateTime(now.Add(-30 * time.Minute))
 	futureEnd := models.DateTime(now.Add(24 * time.Hour))
 
-	dueActive := suite.client.db.Campaign.Create().
+	dueActive, err := suite.client.db.Campaign.Create().
 		SetName("Due Active Campaign").
 		SetOwnerID(sharedTestUser1.OrganizationID).
 		SetIsRecurring(true).
@@ -330,9 +333,10 @@ func TestDueCampaignPredicatesFiltering(t *testing.T) {
 		SetStatus(enums.CampaignStatusActive).
 		SetRecurrenceFrequency(enums.FrequencyMonthly).
 		SetNextRunAt(pastRun).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
-	notYetDue := suite.client.db.Campaign.Create().
+	notYetDue, err := suite.client.db.Campaign.Create().
 		SetName("Not Yet Due Campaign").
 		SetOwnerID(sharedTestUser1.OrganizationID).
 		SetIsRecurring(true).
@@ -340,9 +344,10 @@ func TestDueCampaignPredicatesFiltering(t *testing.T) {
 		SetStatus(enums.CampaignStatusActive).
 		SetRecurrenceFrequency(enums.FrequencyMonthly).
 		SetNextRunAt(futureRun).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
-	notRecurring := suite.client.db.Campaign.Create().
+	notRecurring, err := suite.client.db.Campaign.Create().
 		SetName("Non-Recurring Campaign").
 		SetOwnerID(sharedTestUser1.OrganizationID).
 		SetIsRecurring(false).
@@ -350,9 +355,10 @@ func TestDueCampaignPredicatesFiltering(t *testing.T) {
 		SetStatus(enums.CampaignStatusActive).
 		SetRecurrenceFrequency(enums.FrequencyMonthly).
 		SetNextRunAt(pastRun).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
-	inactive := suite.client.db.Campaign.Create().
+	inactive, err := suite.client.db.Campaign.Create().
 		SetName("Inactive Campaign").
 		SetOwnerID(sharedTestUser1.OrganizationID).
 		SetIsRecurring(true).
@@ -360,9 +366,10 @@ func TestDueCampaignPredicatesFiltering(t *testing.T) {
 		SetStatus(enums.CampaignStatusActive).
 		SetRecurrenceFrequency(enums.FrequencyMonthly).
 		SetNextRunAt(pastRun).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
-	completed := suite.client.db.Campaign.Create().
+	completed, err := suite.client.db.Campaign.Create().
 		SetName("Completed Campaign").
 		SetOwnerID(sharedTestUser1.OrganizationID).
 		SetIsRecurring(true).
@@ -370,9 +377,10 @@ func TestDueCampaignPredicatesFiltering(t *testing.T) {
 		SetStatus(enums.CampaignStatusCompleted).
 		SetRecurrenceFrequency(enums.FrequencyMonthly).
 		SetNextRunAt(pastRun).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
-	pastEndAt := suite.client.db.Campaign.Create().
+	pastEndAt, err := suite.client.db.Campaign.Create().
 		SetName("Past End At Campaign").
 		SetOwnerID(sharedTestUser1.OrganizationID).
 		SetIsRecurring(true).
@@ -381,9 +389,10 @@ func TestDueCampaignPredicatesFiltering(t *testing.T) {
 		SetRecurrenceFrequency(enums.FrequencyMonthly).
 		SetNextRunAt(pastRun).
 		SetRecurrenceEndAt(pastEnd).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
-	futureEndAt := suite.client.db.Campaign.Create().
+	futureEndAt, err := suite.client.db.Campaign.Create().
 		SetName("Future End At Campaign").
 		SetOwnerID(sharedTestUser1.OrganizationID).
 		SetIsRecurring(true).
@@ -392,9 +401,10 @@ func TestDueCampaignPredicatesFiltering(t *testing.T) {
 		SetRecurrenceFrequency(enums.FrequencyMonthly).
 		SetNextRunAt(pastRun).
 		SetRecurrenceEndAt(futureEnd).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
-	draftCampaign := suite.client.db.Campaign.Create().
+	draftCampaign, err := suite.client.db.Campaign.Create().
 		SetName("Draft Campaign").
 		SetOwnerID(sharedTestUser1.OrganizationID).
 		SetIsRecurring(true).
@@ -402,7 +412,8 @@ func TestDueCampaignPredicatesFiltering(t *testing.T) {
 		SetStatus(enums.CampaignStatusDraft).
 		SetRecurrenceFrequency(enums.FrequencyMonthly).
 		SetNextRunAt(pastRun).
-		SaveX(ctx)
+		Save(ctx)
+	requireNoError(t, err)
 
 	allIDs := []string{
 		dueActive.ID, notYetDue.ID, notRecurring.ID, inactive.ID,

--- a/main.go
+++ b/main.go
@@ -2,6 +2,8 @@
 package main
 
 import (
+	_ "time/tzdata"
+
 	"github.com/theopenlane/core/cmd"
 	_ "github.com/theopenlane/core/internal/ent/generated/runtime"
 	_ "github.com/theopenlane/core/internal/ent/historygenerated/runtime"


### PR DESCRIPTION
In production we get an error:
```
      "message": "validator failed for field \"Campaign.recurrence_timezone\": unknown time zone America/Denver",
```

I update the tests to make sure we had the same update pattern, still worked. Which makes sense because `America/Denver` is a valid timezone. 

Turns out the issue is because we use `cgr.dev/chainguard/bash:latest`, which does not include the timezones so only `UTC` worked. I figured adding it as an import will mean it will always work, but we could alternatively add it to the dockerfile instead. 

The test changes are just to make sure we are using `Save` + checking error instead of panicing and had upated one test to use the `api` instead of `db` to make sure we weren't bypassing validation but still passes the same. 