### PR TITLE
feat: drop orgs to base module to keep orgs active after trial

### DIFF
--- a/cmd/catalog/main.go
+++ b/cmd/catalog/main.go
@@ -14,7 +14,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/urfave/cli/v3"
 
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 	"github.com/theopenlane/core/pkg/catalog"
 	"github.com/theopenlane/core/pkg/entitlements"
 	"github.com/theopenlane/utils/cli/tables"

--- a/cmd/catalog/main_test.go
+++ b/cmd/catalog/main_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 
 	"github.com/theopenlane/core/pkg/catalog"
 	"github.com/theopenlane/core/pkg/entitlements"

--- a/cmd/catalog/migrate/main.go
+++ b/cmd/catalog/migrate/main.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 	"github.com/theopenlane/utils/cli/tables"
 	"github.com/urfave/cli/v3"
 

--- a/cmd/catalog/migrate/main_test.go
+++ b/cmd/catalog/migrate/main_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 	"github.com/theopenlane/core/pkg/entitlements"
 )
 

--- a/cmd/stripe-webhook/command_migrate.go
+++ b/cmd/stripe-webhook/command_migrate.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 	"github.com/urfave/cli/v3"
 
 	"github.com/theopenlane/core/pkg/entitlements"

--- a/cmd/stripe-webhook/command_status.go
+++ b/cmd/stripe-webhook/command_status.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 	"github.com/urfave/cli/v3"
 
 	"github.com/theopenlane/core/pkg/entitlements"

--- a/go.mod
+++ b/go.mod
@@ -99,7 +99,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stoewer/go-strcase v1.3.1
 	github.com/stretchr/testify v1.11.1
-	github.com/stripe/stripe-go/v84 v84.4.1
+	github.com/stripe/stripe-go/v86 v86.2.0
 	github.com/tailscale/tailscale-client-go/v2 v2.0.0-20250129222324-74c8fc3cb4d7
 	github.com/theopenlane/core/common v1.0.25
 	github.com/theopenlane/echo-prometheus v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -713,8 +713,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/stripe/stripe-go/v84 v84.4.1 h1:ixq1fG3y0k4OORVaN+LFAMBFaWiMrvKIcR9dSqT6gD8=
-github.com/stripe/stripe-go/v84 v84.4.1/go.mod h1:Z4gcKw1zl4geDG2+cjpSaJES9jaohGX6n7FP8/kHIqw=
+github.com/stripe/stripe-go/v86 v86.2.0 h1:d6yW7JDnk03DEVGqct82j0rys8nPPCE3+RDPsIvUcrY=
+github.com/stripe/stripe-go/v86 v86.2.0/go.mod h1:Co7QRXCKGNOPTugAdvjgRo+KcMtd9hxy+pZMN0yThsQ=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/tailscale/hujson v0.0.0-20220506213045-af5ed07155e5 h1:erxeiTyq+nw4Cz5+hLDkOwNF5/9IQWCQPv0gpb3+QHU=

--- a/internal/ent/hooks/organization.go
+++ b/internal/ent/hooks/organization.go
@@ -10,7 +10,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"github.com/samber/lo"
 	"github.com/stoewer/go-strcase"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 
 	"github.com/theopenlane/iam/auth"
 	"github.com/theopenlane/iam/fgax"

--- a/internal/ent/hooks/orgmodule.go
+++ b/internal/ent/hooks/orgmodule.go
@@ -37,6 +37,13 @@ func HookOrgModule() ent.Hook {
 				return v, fmt.Errorf("%w: owner_id", ErrFieldRequired)
 			}
 
+			// a module can be created already inactive, a subscription that is cancelled or unpaid
+			// still syncs its items. Writing the tuple regardless would grant the feature to an
+			// organization whose module record says it does not have it
+			if !orgModule.Active {
+				return v, nil
+			}
+
 			feats := []models.OrgModule{orgModule.Module}
 
 			if err := entitlements.CreateFeatureTuples(ctx, &omm.Authz, orgID, feats); err != nil {

--- a/internal/ent/hooks/orgmodule.go
+++ b/internal/ent/hooks/orgmodule.go
@@ -37,13 +37,6 @@ func HookOrgModule() ent.Hook {
 				return v, fmt.Errorf("%w: owner_id", ErrFieldRequired)
 			}
 
-			// a module can be created already inactive, a subscription that is cancelled or unpaid
-			// still syncs its items. Writing the tuple regardless would grant the feature to an
-			// organization whose module record says it does not have it
-			if !orgModule.Active {
-				return v, nil
-			}
-
 			feats := []models.OrgModule{orgModule.Module}
 
 			if err := entitlements.CreateFeatureTuples(ctx, &omm.Authz, orgID, feats); err != nil {

--- a/internal/entitlements/catalog_prices.go
+++ b/internal/entitlements/catalog_prices.go
@@ -22,6 +22,21 @@ func TrialMonthlyPrices(useSandbox bool) []entitlements.Price {
 	}, useSandbox)
 }
 
+// FreeMonthlyPriceIDs returns Stripe price IDs for monthly prices that cost nothing. These are the
+// modules an organization keeps when its subscription is downgraded rather than cancelled, so the
+// organization stays active and can recover by adding a payment method
+func FreeMonthlyPriceIDs(useSandbox bool) []string {
+	return monthlyPriceIDs(func(f catalog.Feature) bool {
+		for _, p := range f.Billing.Prices {
+			if p.Interval == "month" && p.UnitAmount > 0 {
+				return false
+			}
+		}
+
+		return true
+	}, useSandbox)
+}
+
 // AllMonthlyPrices returns prices for all monthly modules regardless of trial status
 func AllMonthlyPrices(useSandbox bool) []entitlements.Price {
 	return monthlyPrices(func(_ catalog.Feature) bool {

--- a/internal/entitlements/catalog_prices_test.go
+++ b/internal/entitlements/catalog_prices_test.go
@@ -1,0 +1,43 @@
+package entitlements
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+
+	"github.com/theopenlane/core/pkg/catalog/gencatalog"
+)
+
+func TestFreeMonthlyPriceIDs(t *testing.T) {
+	for _, useSandbox := range []bool{false, true} {
+		free := FreeMonthlyPriceIDs(useSandbox)
+		assert.Assert(t, len(free) > 0, "expected at least one free monthly price")
+
+		freeSet := map[string]bool{}
+		for _, id := range free {
+			freeSet[id] = true
+		}
+
+		// every returned price must actually cost nothing, an organization downgraded onto a
+		// priced module would keep accruing a balance it is already failing to pay
+		for _, f := range gencatalog.GetModules(useSandbox) {
+			for _, p := range f.Billing.Prices {
+				if p.Interval != "month" || !freeSet[p.PriceID] {
+					continue
+				}
+
+				assert.Check(t, is.Equal(int64(0), p.UnitAmount), "price %s is not free", p.PriceID)
+			}
+		}
+
+		// and a module with any priced monthly tier must not be offered as free
+		for _, f := range gencatalog.GetModules(useSandbox) {
+			for _, p := range f.Billing.Prices {
+				if p.Interval == "month" && p.UnitAmount > 0 {
+					assert.Check(t, !freeSet[p.PriceID], "priced module %s offered as free", p.PriceID)
+				}
+			}
+		}
+	}
+}

--- a/internal/entitlements/entmapping/mapping.go
+++ b/internal/entitlements/entmapping/mapping.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 
 	"github.com/theopenlane/core/common/models"
 	ent "github.com/theopenlane/core/internal/ent/generated"
@@ -327,8 +327,7 @@ func ApplyStripeSubscriptionItem[T OrgModuleSetter[T]](ctx context.Context, b T,
 	}
 
 	switch status {
-	case string(stripe.SubscriptionStatusCanceled), string(stripe.SubscriptionStatusPastDue),
-		string(stripe.SubscriptionStatusPaused):
+	case string(stripe.SubscriptionStatusCanceled), string(stripe.SubscriptionStatusPaused):
 		b.SetActive(false)
 	}
 

--- a/internal/entitlements/entmapping/mapping_test.go
+++ b/internal/entitlements/entmapping/mapping_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 	"github.com/theopenlane/core/common/models"
 	ent "github.com/theopenlane/core/internal/ent/generated"
 )
@@ -98,6 +99,7 @@ type moduleBuilder struct {
 	visibility      string
 	moduleLookupKey string
 	active          bool
+	activeSet       bool
 }
 
 func (b *moduleBuilder) SetModule(m models.OrgModule) *moduleBuilder { b.module = m; return b }
@@ -106,7 +108,12 @@ func (b *moduleBuilder) SetStripePriceID(id string) *moduleBuilder   { b.stripeP
 func (b *moduleBuilder) SetStatus(s string) *moduleBuilder           { b.status = s; return b }
 func (b *moduleBuilder) SetVisibility(v string) *moduleBuilder       { b.visibility = v; return b }
 func (b *moduleBuilder) SetModuleLookupKey(k string) *moduleBuilder  { b.moduleLookupKey = k; return b }
-func (b *moduleBuilder) SetActive(a bool) *moduleBuilder             { b.active = a; return b }
+func (b *moduleBuilder) SetActive(a bool) *moduleBuilder {
+	b.active = a
+	b.activeSet = true
+
+	return b
+}
 
 func TestStripePriceToOrgPrice(t *testing.T) {
 	p := &stripe.Price{
@@ -340,4 +347,68 @@ func TestApplyStripeSubscriptionItem(t *testing.T) {
 
 	require.Equal(t, b, got)
 	require.Equal(t, expected, b)
+}
+
+func TestApplyStripeSubscriptionItemActiveByStatus(t *testing.T) {
+	testCases := []struct {
+		name              string
+		status            stripe.SubscriptionStatus
+		expectDeactivated bool
+	}{
+		{
+			name:   "active leaves the module alone",
+			status: stripe.SubscriptionStatusActive,
+		},
+		{
+			name:   "trialing leaves the module alone",
+			status: stripe.SubscriptionStatusTrialing,
+		},
+		{
+			// stripe retries a failed payment for the whole retry window, deactivating here strips
+			// the feature tuples on the first failure and they only return once the subscription is
+			// active again, which rarely happens because it gets cancelled first
+			name:   "past due keeps the module active while stripe retries",
+			status: stripe.SubscriptionStatusPastDue,
+		},
+		{
+			name:              "canceled deactivates the module",
+			status:            stripe.SubscriptionStatusCanceled,
+			expectDeactivated: true,
+		},
+		{
+			name:              "paused deactivates the module",
+			status:            stripe.SubscriptionStatusPaused,
+			expectDeactivated: true,
+		},
+		{
+			// unpaid is where stripe leaves the subscription once it stops retrying, by then it has
+			// been downgraded onto the free modules and those stay usable
+			name:   "unpaid keeps the free modules usable",
+			status: stripe.SubscriptionStatusUnpaid,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			item := &stripe.SubscriptionItem{
+				Price: &stripe.Price{
+					ID:        "price_123",
+					Recurring: &stripe.PriceRecurring{Interval: stripe.PriceRecurringIntervalMonth},
+					Product:   &stripe.Product{Metadata: map[string]string{"module": "mod1"}},
+				},
+			}
+
+			b := &moduleBuilder{}
+			ApplyStripeSubscriptionItem(context.Background(), b, item, nil, string(tc.status))
+
+			if tc.expectDeactivated {
+				assert.True(t, b.activeSet, "expected the module to be deactivated")
+				assert.False(t, b.active)
+
+				return
+			}
+
+			assert.False(t, b.activeSet, "expected the active flag to be left untouched")
+		})
+	}
 }

--- a/internal/entitlements/reconciler/reconciler.go
+++ b/internal/entitlements/reconciler/reconciler.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 
 	"github.com/theopenlane/iam/auth"
 

--- a/internal/entitlements/reconciler/reconciler_test.go
+++ b/internal/entitlements/reconciler/reconciler_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 
 	ent "github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/pkg/entitlements"

--- a/internal/entitlements/reconciler/stripe_operations.go
+++ b/internal/entitlements/reconciler/stripe_operations.go
@@ -7,7 +7,7 @@ import (
 	"slices"
 
 	"github.com/rs/zerolog/log"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 
 	"github.com/theopenlane/core/internal/consts"
 	"github.com/theopenlane/core/internal/ent/generated"
@@ -67,7 +67,7 @@ func (r *Reconciler) UpdateSubscriptionsCancelBehavior(ctx context.Context, orgI
 			Status: stripe.String(string(stripeSubsStatuses[subs])),
 		})
 
-		for sub, err := range it {
+		for sub, err := range it.All(ctx) {
 			if err != nil {
 				return nil, fmt.Errorf("listing subscriptions: %w", err)
 			}
@@ -169,7 +169,7 @@ func (r *Reconciler) CreateMissingSubscriptionSchedules(ctx context.Context, org
 			},
 			Status: stripe.String(string(stripeSubsStatuses[subs])),
 		})
-		for sub, err := range it {
+		for sub, err := range it.All(ctx) {
 			if err != nil {
 				return nil, fmt.Errorf("listing subscriptions: %w", err)
 			}
@@ -316,7 +316,7 @@ func (r *Reconciler) ReportSubscriptionsWithMissingProducts(ctx context.Context,
 		},
 	})
 
-	for sub, err := range it {
+	for sub, err := range it.All(ctx) {
 		if err != nil {
 			return nil, fmt.Errorf("listing subscriptions: %w", err)
 		}
@@ -453,7 +453,7 @@ func (r *Reconciler) AnalyzeStripeSystemMismatches(ctx context.Context, action s
 			Limit: stripe.Int64(defaultStripePageLimit),
 		}})
 
-	for customer, err := range customerIt {
+	for customer, err := range customerIt.All(ctx) {
 		if err != nil {
 			return nil, fmt.Errorf("listing Stripe customers: %w", err)
 		}
@@ -580,7 +580,7 @@ func (r *Reconciler) CleanupOrphanedStripeCustomers(ctx context.Context) (*Clean
 			Limit: stripe.Int64(defaultStripePageLimit),
 		}})
 
-	for customer, err := range customerIt {
+	for customer, err := range customerIt.All(ctx) {
 		if err != nil {
 			return nil, fmt.Errorf("listing Stripe customers: %w", err)
 		}
@@ -631,7 +631,7 @@ func (r *Reconciler) CleanupOrphanedStripeCustomers(ctx context.Context) (*Clean
 
 		hasActiveSubscriptions := false
 
-		for _, err := range subscriptionIt {
+		for _, err := range subscriptionIt.All(ctx) {
 			if err != nil {
 				log.Error().Err(err).Str("customer_id", customer.ID).Msg("failed to check customer subscriptions")
 				break

--- a/internal/entitlements/reconciler/stripe_operations_test.go
+++ b/internal/entitlements/reconciler/stripe_operations_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 
 	"github.com/theopenlane/core/pkg/catalog"
 )

--- a/internal/graphapi/tools_test.go
+++ b/internal/graphapi/tools_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/samber/do/v2"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	"gotest.tools/v3/assert"
 
@@ -803,7 +803,7 @@ func (suite *GraphTestSuite) orgSubscriptionMocks() {
 	}).Return(nil)
 
 	// mock customer search
-	suite.stripeMockBackend.On("CallRaw", mock.Anything, mock.Anything, mock.Anything, mock.AnythingOfType("*stripe.Params"), mock.AnythingOfType("*stripe.v1SearchPage[*github.com/stripe/stripe-go/v84.Customer]")).Run(func(args mock.Arguments) {
+	suite.stripeMockBackend.On("CallRaw", mock.Anything, mock.Anything, mock.Anything, mock.AnythingOfType("*stripe.Params"), mock.AnythingOfType("*stripe.v1SearchPage[*github.com/stripe/stripe-go/v86.Customer]")).Run(func(args mock.Arguments) {
 		out := args.Get(4) // this is *v1SearchPage[*stripe.Customer] now, but unexported
 
 		// Build a payload that matches Stripe search response shape

--- a/internal/httpserve/handlers/tools_test.go
+++ b/internal/httpserve/handlers/tools_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 
 	"github.com/redis/go-redis/v9"
 	"github.com/samber/do/v2"
@@ -656,7 +656,7 @@ var mockProduct = &stripe.Product{
 // orgSubscriptionMocks mocks the stripe calls for org subscription during the webhook tests
 func (suite *HandlerTestSuite) orgSubscriptionMocks() {
 	// mock customer search
-	suite.stripeMockBackend.On("CallRaw", mock.Anything, mock.Anything, mock.Anything, mock.AnythingOfType("*stripe.Params"), mock.AnythingOfType("*stripe.v1SearchPage[*github.com/stripe/stripe-go/v84.Customer]")).Run(func(args mock.Arguments) {
+	suite.stripeMockBackend.On("CallRaw", mock.Anything, mock.Anything, mock.Anything, mock.AnythingOfType("*stripe.Params"), mock.AnythingOfType("*stripe.v1SearchPage[*github.com/stripe/stripe-go/v86.Customer]")).Run(func(args mock.Arguments) {
 		out := args.Get(4) // this is *v1SearchPage[*stripe.Customer] now, but unexported
 
 		// Build a payload that matches Stripe search response shape

--- a/internal/httpserve/handlers/webhook.go
+++ b/internal/httpserve/handlers/webhook.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog/log"
-	"github.com/stripe/stripe-go/v84"
-	"github.com/stripe/stripe-go/v84/webhook"
+	"github.com/stripe/stripe-go/v86"
+	"github.com/stripe/stripe-go/v86/webhook"
 	echo "github.com/theopenlane/echox"
 	"github.com/theopenlane/entx"
 	"github.com/theopenlane/iam/auth"
@@ -24,6 +24,7 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated/orgsubscription"
 	"github.com/theopenlane/core/internal/ent/generated/personalaccesstoken"
 	"github.com/theopenlane/core/internal/ent/generated/privacy"
+	catalogprices "github.com/theopenlane/core/internal/entitlements"
 	em "github.com/theopenlane/core/internal/entitlements/entmapping"
 	"github.com/theopenlane/core/pkg/entitlements"
 	"github.com/theopenlane/core/pkg/logx"
@@ -210,7 +211,7 @@ func unmarshalEventData[T interface{}](e *stripe.Event) (*T, error) {
 // HandleEvent unmarshals event data and triggers a corresponding function to be executed based on case match
 func (h *Handler) HandleEvent(c context.Context, e *stripe.Event) error {
 	switch e.Type {
-	case stripe.EventTypeCustomerSubscriptionUpdated:
+	case stripe.EventTypeCustomerSubscriptionCreated, stripe.EventTypeCustomerSubscriptionUpdated:
 		subscription, err := unmarshalEventData[stripe.Subscription](e)
 		if err != nil {
 			return err
@@ -231,6 +232,13 @@ func (h *Handler) HandleEvent(c context.Context, e *stripe.Event) error {
 		}
 
 		return h.handleTrialWillEnd(c, subscription)
+	case stripe.EventTypeInvoicePaymentFailed:
+		invoice, err := unmarshalEventData[stripe.Invoice](e)
+		if err != nil {
+			return err
+		}
+
+		return h.handleInvoicePaymentFailed(c, invoice)
 	case stripe.EventTypeCustomerSubscriptionDeleted, stripe.EventTypeCustomerSubscriptionPaused:
 		subscription, err := unmarshalEventData[stripe.Subscription](e)
 		if err != nil {
@@ -316,6 +324,63 @@ func (h *Handler) handleSubscriptionPaused(ctx context.Context, s *stripe.Subscr
 	return h.invalidatePersonalAccessTokens(ctx, *ownerID)
 }
 
+// handleInvoicePaymentFailed drops an organization to the free modules once Stripe has stopped
+// retrying a failed payment. Stripe schedules a retry after every failed attempt, so an invoice with
+// no next attempt left means the retry window is over. Cancelling at that point takes the whole
+// organization down and is painful to unwind, keeping the subscription alive on the free modules
+// leaves it recoverable by adding a payment method
+func (h *Handler) handleInvoicePaymentFailed(ctx context.Context, invoice *stripe.Invoice) error {
+	if invoice == nil {
+		return nil
+	}
+
+	// stripe schedules the next attempt after every failure, so a next attempt still being set means
+	// the retry window is open and the organization keeps everything it has
+	if invoice.NextPaymentAttempt > 0 {
+		logx.FromContext(ctx).Debug().Str("invoice_id", invoice.ID).
+			Int64("attempt_count", invoice.AttemptCount).
+			Time("next_payment_attempt", time.Unix(invoice.NextPaymentAttempt, 0)).
+			Msg("payment failed but stripe has retries left, leaving the modules alone")
+
+		return nil
+	}
+
+	if invoice.Parent == nil || invoice.Parent.SubscriptionDetails == nil || invoice.Parent.SubscriptionDetails.Subscription == nil {
+		// not a subscription invoice, nothing to downgrade
+		return nil
+	}
+
+	subscriptionID := invoice.Parent.SubscriptionDetails.Subscription.ID
+	if subscriptionID == "" {
+		return nil
+	}
+
+	// the invoice carries a thin subscription, the items are needed to work out what to remove
+	sub, err := h.Entitlements.GetSubscriptionByID(ctx, subscriptionID)
+	if err != nil {
+		logx.FromContext(ctx).Error().Err(err).Str("subscription_id", subscriptionID).
+			Msg("failed to load subscription for payment failure downgrade")
+
+		return err
+	}
+
+	freePriceIDs := catalogprices.FreeMonthlyPriceIDs(h.DBClient.EntConfig.Modules.UseSandbox)
+
+	downgraded, err := h.Entitlements.DowngradeToFreeModules(ctx, sub, freePriceIDs)
+	if err != nil {
+		logx.FromContext(ctx).Error().Err(err).Str("subscription_id", subscriptionID).
+			Msg("failed to downgrade subscription to the free modules")
+
+		return err
+	}
+
+	logx.FromContext(ctx).Info().Str("subscription_id", subscriptionID).
+		Msg("payment retries exhausted, downgraded subscription to the free modules")
+
+	// sync so the modules and their feature tuples match what the subscription now carries
+	return h.handleSubscriptionUpdated(ctx, downgraded)
+}
+
 // handleSubscriptionUpdated handles subscription updated events
 func (h *Handler) handleSubscriptionUpdated(ctx context.Context, s *stripe.Subscription) error {
 	_, err := h.syncOrgSubscriptionWithStripe(ctx, s)
@@ -358,6 +423,66 @@ func (h *Handler) handlePaymentMethodAdded(ctx context.Context, paymentMethod *s
 		Exec(ctx)
 }
 
+// findOrgSubscriptionByCustomer resolves an OrgSubscription through the stripe customer on the
+// subscription. The customer outlives individual subscriptions, so this is what still connects a
+// replacement subscription to its organization once the original was cancelled. Returns nil when the
+// customer is missing or maps to no organization
+func findOrgSubscriptionByCustomer(ctx context.Context, subscription *stripe.Subscription) *ent.OrgSubscription {
+	if subscription == nil || subscription.Customer == nil || subscription.Customer.ID == "" {
+		return nil
+	}
+
+	allowCtx := auth.WithCaller(ctx, auth.NewWebhookCaller(""))
+
+	org, err := transaction.FromContext(ctx).Organization.Query().
+		Where(organization.StripeCustomerID(subscription.Customer.ID)).Only(allowCtx)
+	if err != nil {
+		logx.FromContext(ctx).Debug().Err(err).Str("stripe_customer_id", subscription.Customer.ID).
+			Msg("no organization found for stripe customer")
+
+		return nil
+	}
+
+	// an organization can accumulate more than one subscription record over its life, the most
+	// recent is the one a new stripe subscription belongs to
+	orgSub, err := transaction.FromContext(ctx).OrgSubscription.Query().
+		Where(orgsubscription.OwnerID(org.ID), orgsubscription.DeletedAtIsNil()).
+		Order(ent.Desc(orgsubscription.FieldCreatedAt)).
+		First(allowCtx)
+	if err != nil {
+		logx.FromContext(ctx).Debug().Err(err).Str("organization_id", org.ID).
+			Msg("no org subscription found for organization")
+
+		return nil
+	}
+
+	return orgSub
+}
+
+// adoptStripeSubscriptionID points an OrgSubscription at the given stripe subscription. Without this
+// an organization whose subscription was replaced keeps referring to the old, cancelled one
+func adoptStripeSubscriptionID(ctx context.Context, orgSub *ent.OrgSubscription, subscriptionID string) {
+	if orgSub == nil || subscriptionID == "" || orgSub.StripeSubscriptionID == subscriptionID {
+		return
+	}
+
+	allowCtx := auth.WithCaller(ctx, auth.NewWebhookCaller(""))
+
+	if err := transaction.FromContext(ctx).OrgSubscription.UpdateOne(orgSub).
+		SetStripeSubscriptionID(subscriptionID).
+		Exec(allowCtx); err != nil {
+		logx.FromContext(ctx).Error().Err(err).Str("subscription_id", subscriptionID).
+			Msg("failed to update org subscription with stripe subscription id")
+
+		return
+	}
+
+	logx.FromContext(ctx).Info().Str("subscription_id", subscriptionID).Str("org_subscription_id", orgSub.ID).
+		Msg("org subscription now points at the stripe subscription")
+
+	orgSub.StripeSubscriptionID = subscriptionID
+}
+
 // getOrgSubscription retrieves the OrgSubscription from the database based on the Stripe subscription ID
 func getOrgSubscription(ctx context.Context, subscription *stripe.Subscription) (*ent.OrgSubscription, error) {
 	allowCtx := auth.WithCaller(ctx, auth.NewWebhookCaller(""))
@@ -385,16 +510,21 @@ func getOrgSubscription(ctx context.Context, subscription *stripe.Subscription) 
 
 				// if we found an org subscription by metadata, first update the stripe_subscription_id field
 				if orgSubscription != nil {
-					err = transaction.FromContext(ctx).OrgSubscription.UpdateOne(orgSubscription).
-						SetStripeSubscriptionID(subscription.ID).
-						Exec(allowCtx)
-					if err != nil {
-						logx.FromContext(ctx).Error().Err(err).Msg("failed to update org subscription with stripe subscription id")
-					}
+					adoptStripeSubscriptionID(ctx, orgSubscription, subscription.ID)
 
 					// but still return the org subscription to update the rest of the fields
 					return orgSubscription, nil
 				}
+			}
+
+			// nothing in the metadata matched, which is the normal case for a subscription created
+			// by hand in the stripe dashboard. The customer is the only remaining link back to the
+			// organization, and this is what repoints an organization at a replacement subscription
+			// after its previous one was cancelled
+			if orgSub := findOrgSubscriptionByCustomer(ctx, subscription); orgSub != nil {
+				adoptStripeSubscriptionID(ctx, orgSub, subscription.ID)
+
+				return orgSub, nil
 			}
 
 			// if we got here we could not find the org subscription

--- a/internal/httpserve/handlers/webhook.go
+++ b/internal/httpserve/handlers/webhook.go
@@ -508,8 +508,7 @@ func getOrgSubscription(ctx context.Context, subscription *stripe.Subscription) 
 					}
 				}
 
-				// if we found an org subscription by metadata, first update the stripe_subscription_id field
-				if orgSubscription != nil {
+				if orgSubscription != nil && orgSubscription.ID != "" {
 					adoptStripeSubscriptionID(ctx, orgSubscription, subscription.ID)
 
 					// but still return the org subscription to update the rest of the fields

--- a/internal/httpserve/handlers/webhook_helpers.go
+++ b/internal/httpserve/handlers/webhook_helpers.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 	"github.com/theopenlane/entx"
 	"github.com/theopenlane/iam/auth"
 

--- a/internal/httpserve/handlers/webhook_test.go
+++ b/internal/httpserve/handlers/webhook_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stripe/stripe-go/v84"
-	"github.com/stripe/stripe-go/v84/webhook"
+	"github.com/stripe/stripe-go/v86"
+	"github.com/stripe/stripe-go/v86/webhook"
 	echo "github.com/theopenlane/echox"
 
 	models "github.com/theopenlane/core/common/openapi"

--- a/internal/integrations/definitions/system/op_payment_reminder.go
+++ b/internal/integrations/definitions/system/op_payment_reminder.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/samber/lo"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 
 	"github.com/theopenlane/core/common/enums"
 	"github.com/theopenlane/core/common/models"

--- a/internal/integrations/definitions/system/subscriptions.go
+++ b/internal/integrations/definitions/system/subscriptions.go
@@ -3,7 +3,7 @@ package system
 import (
 	"context"
 
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 	"github.com/theopenlane/iam/auth"
 
 	"github.com/theopenlane/core/internal/ent/generated/orgsubscription"

--- a/internal/integrations/runtime/execution.go
+++ b/internal/integrations/runtime/execution.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/riverqueue/river"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 	"github.com/theopenlane/iam/auth"
 
 	"github.com/theopenlane/core/common/enums"

--- a/internal/workflows/engine/tools_test.go
+++ b/internal/workflows/engine/tools_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/samber/do/v2"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 	"github.com/theopenlane/iam/auth"
 	fgatest "github.com/theopenlane/iam/fgax/testutils"
 	"github.com/theopenlane/iam/sessions"
@@ -794,7 +794,7 @@ func (suite *WorkflowEngineTestSuite) orgSubscriptionMocks() {
 	}).Return(nil)
 
 	// mock customer search
-	suite.stripeMockBackend.On("CallRaw", mock.Anything, mock.Anything, mock.Anything, mock.AnythingOfType("*stripe.Params"), mock.AnythingOfType("*stripe.v1SearchPage[*github.com/stripe/stripe-go/v84.Customer]")).Run(func(args mock.Arguments) {
+	suite.stripeMockBackend.On("CallRaw", mock.Anything, mock.Anything, mock.Anything, mock.AnythingOfType("*stripe.Params"), mock.AnythingOfType("*stripe.v1SearchPage[*github.com/stripe/stripe-go/v86.Customer]")).Run(func(args mock.Arguments) {
 		out := args.Get(4) // this is *v1SearchPage[*stripe.Customer] now, but unexported
 
 		// Build a payload that matches Stripe search response shape

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -15,7 +15,7 @@ import (
 	"github.com/pmezard/go-difflib/difflib"
 	"github.com/rs/zerolog/log"
 
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 
 	"github.com/theopenlane/core/common/models"
 	"github.com/theopenlane/core/pkg/entitlements"

--- a/pkg/catalog/precheck.go
+++ b/pkg/catalog/precheck.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 )
 
 // LookupKeyConflict describes an existing Stripe price using a lookup key

--- a/pkg/catalog/precheck_test.go
+++ b/pkg/catalog/precheck_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 
 	"github.com/theopenlane/core/pkg/catalog"
 )

--- a/pkg/entitlements/client.go
+++ b/pkg/entitlements/client.go
@@ -1,7 +1,7 @@
 package entitlements
 
 import (
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 )
 
 // StripeClient is a client for the Stripe API

--- a/pkg/entitlements/customer_options.go
+++ b/pkg/entitlements/customer_options.go
@@ -1,6 +1,6 @@
 package entitlements
 
-import "github.com/stripe/stripe-go/v84"
+import "github.com/stripe/stripe-go/v86"
 
 // CustomerCreateOption allows customizing CustomerCreateParams
 type CustomerCreateOption func(params *stripe.CustomerCreateParams)

--- a/pkg/entitlements/customer_options_test.go
+++ b/pkg/entitlements/customer_options_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 )
 
 func TestCustomerCreateOptions(t *testing.T) {

--- a/pkg/entitlements/customers.go
+++ b/pkg/entitlements/customers.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"github.com/samber/lo"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 )
 
 // CreateCustomer creates a customer leveraging the openlane organization ID
@@ -79,7 +79,7 @@ func (sc *StripeClient) SearchCustomers(ctx context.Context, query string) (cust
 
 	result := sc.Client.V1Customers.Search(ctx, params)
 
-	for customer, err := range result {
+	for customer, err := range result.All(ctx) {
 		if err != nil {
 			log.Err(err).Msg("failed to search customers")
 

--- a/pkg/entitlements/customers_lookup_test.go
+++ b/pkg/entitlements/customers_lookup_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 
 	"github.com/theopenlane/core/pkg/entitlements"
 	"github.com/theopenlane/core/pkg/entitlements/mocks"

--- a/pkg/entitlements/customers_test.go
+++ b/pkg/entitlements/customers_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 	"github.com/theopenlane/core/pkg/entitlements"
 )
 

--- a/pkg/entitlements/feature.go
+++ b/pkg/entitlements/feature.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/rs/zerolog/log"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 )
 
 // CreateProductFeatureWithOptions creates a product feature using functional options
@@ -28,7 +28,7 @@ func (sc *StripeClient) ListProductFeatures(ctx context.Context, productID strin
 
 	var features []*stripe.ProductFeature
 
-	for feature, err := range result {
+	for feature, err := range result.All(ctx) {
 		if err != nil {
 			log.Error().Err(err).Msg("failed to list product features")
 			continue

--- a/pkg/entitlements/feature_options.go
+++ b/pkg/entitlements/feature_options.go
@@ -1,6 +1,6 @@
 package entitlements
 
-import "github.com/stripe/stripe-go/v84"
+import "github.com/stripe/stripe-go/v86"
 
 // FeatureCreateOption allows customizing EntitlementsFeatureCreateParams
 type FeatureCreateOption func(params *stripe.EntitlementsFeatureCreateParams)

--- a/pkg/entitlements/feature_options_test.go
+++ b/pkg/entitlements/feature_options_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 )
 
 func TestEntitlementsFeatureCreateOptions(t *testing.T) {

--- a/pkg/entitlements/features.go
+++ b/pkg/entitlements/features.go
@@ -3,7 +3,7 @@ package entitlements
 import (
 	"context"
 
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 )
 
 // GetFeatureByLookupKey retrieves the first entitlements feature matching the lookup key.
@@ -15,7 +15,7 @@ func (sc *StripeClient) GetFeatureByLookupKey(ctx context.Context, lookupKey str
 	params.Limit = stripe.Int64(1)
 	it := sc.Client.V1EntitlementsFeatures.List(ctx, params)
 
-	for feature, err := range it {
+	for feature, err := range it.All(ctx) {
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/entitlements/features_test.go
+++ b/pkg/entitlements/features_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 
 	"github.com/theopenlane/core/pkg/entitlements"
 	"github.com/theopenlane/core/pkg/entitlements/mocks"

--- a/pkg/entitlements/helpers.go
+++ b/pkg/entitlements/helpers.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 	"gopkg.in/yaml.v3"
 )
 

--- a/pkg/entitlements/helpers_test.go
+++ b/pkg/entitlements/helpers_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 	"github.com/theopenlane/core/pkg/entitlements"
 )
 

--- a/pkg/entitlements/migration_test.go
+++ b/pkg/entitlements/migration_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 
 	"github.com/theopenlane/core/pkg/entitlements"
 	"github.com/theopenlane/core/pkg/entitlements/mocks"

--- a/pkg/entitlements/mocks/stripe.go
+++ b/pkg/entitlements/mocks/stripe.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 
 	"github.com/stretchr/testify/mock"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 )
 
 type FakeStripeClient struct {

--- a/pkg/entitlements/portalsession.go
+++ b/pkg/entitlements/portalsession.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 )
 
 // CreateBillingPortalPaymentMethods generates a session in stripe's billing portal which allows the customer to add / update payment methods

--- a/pkg/entitlements/price_options.go
+++ b/pkg/entitlements/price_options.go
@@ -1,6 +1,6 @@
 package entitlements
 
-import "github.com/stripe/stripe-go/v84"
+import "github.com/stripe/stripe-go/v86"
 
 // PriceCreateOption allows customizing PriceCreateParams
 type PriceCreateOption func(params *stripe.PriceCreateParams)

--- a/pkg/entitlements/price_options_test.go
+++ b/pkg/entitlements/price_options_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 )
 
 func TestPriceCreateOptions(t *testing.T) {

--- a/pkg/entitlements/prices.go
+++ b/pkg/entitlements/prices.go
@@ -3,7 +3,7 @@ package entitlements
 import (
 	"context"
 
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 )
 
 // MigrateToKey is the metadata key used to indicate the price that a subscription should migrate to
@@ -49,7 +49,7 @@ func (sc *StripeClient) ListPrices(ctx context.Context) ([]*stripe.Price, error)
 	params := &stripe.PriceListParams{}
 	result := sc.Client.V1Prices.List(ctx, params)
 
-	for price, err := range result {
+	for price, err := range result.All(ctx) {
 		if err != nil {
 			return nil, err
 		}
@@ -66,7 +66,7 @@ func (sc *StripeClient) GetPricesMapped(ctx context.Context) (prices []Price) {
 
 	result := sc.Client.V1Prices.List(ctx, priceParams)
 
-	for priceData, err := range result {
+	for priceData, err := range result.All(ctx) {
 		if err != nil || priceData.Product == nil {
 			continue
 		}
@@ -90,7 +90,7 @@ func (sc *StripeClient) ListPricesForProduct(ctx context.Context, productID stri
 
 	it := sc.Client.V1Prices.List(ctx, params)
 
-	for price, err := range it {
+	for price, err := range it.All(ctx) {
 		if err != nil {
 			return nil, err
 		}
@@ -117,7 +117,7 @@ func (sc *StripeClient) GetPriceByLookupKey(ctx context.Context, lookupKey strin
 
 	it := sc.Client.V1Prices.List(ctx, params)
 
-	for price, err := range it {
+	for price, err := range it.All(ctx) {
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/entitlements/prices_test.go
+++ b/pkg/entitlements/prices_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 
 	"github.com/theopenlane/core/pkg/entitlements"
 	"github.com/theopenlane/core/pkg/entitlements/mocks"

--- a/pkg/entitlements/product_options.go
+++ b/pkg/entitlements/product_options.go
@@ -1,7 +1,7 @@
 package entitlements
 
 import (
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 )
 
 // ProductUpdateOption allows customizing ProductUpdateParams

--- a/pkg/entitlements/product_options_test.go
+++ b/pkg/entitlements/product_options_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 )
 
 func TestProductUpdateOptions(t *testing.T) {

--- a/pkg/entitlements/products.go
+++ b/pkg/entitlements/products.go
@@ -3,7 +3,7 @@ package entitlements
 import (
 	"context"
 
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 )
 
 // GetProductByID gets a product by ID
@@ -43,7 +43,7 @@ func (sc *StripeClient) ListProducts(ctx context.Context) (products []*stripe.Pr
 		return nil, ErrProductListFailed
 	}
 
-	for product, err := range result {
+	for product, err := range result.All(ctx) {
 		if err != nil {
 			return nil, err
 		}
@@ -90,7 +90,7 @@ func (sc *StripeClient) GetAllProductPricesMapped(ctx context.Context) (products
 		return
 	}
 
-	for product, err := range result {
+	for product, err := range result.All(ctx) {
 		if err != nil {
 			continue
 		}
@@ -152,7 +152,7 @@ func (sc *StripeClient) GetFeaturesByProductID(ctx context.Context, productID st
 		Product: stripe.String(productID),
 	})
 
-	for feature, err := range result {
+	for feature, err := range result.All(ctx) {
 		if err != nil {
 			continue
 		}

--- a/pkg/entitlements/products_test.go
+++ b/pkg/entitlements/products_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 
 	"github.com/theopenlane/core/pkg/entitlements"
 	"github.com/theopenlane/core/pkg/entitlements/mocks"

--- a/pkg/entitlements/stripe_test.go
+++ b/pkg/entitlements/stripe_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 
 	"github.com/theopenlane/core/pkg/entitlements"
 	"github.com/theopenlane/core/pkg/entitlements/mocks"

--- a/pkg/entitlements/subscription_options.go
+++ b/pkg/entitlements/subscription_options.go
@@ -3,7 +3,7 @@ package entitlements
 import (
 	"context"
 
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 )
 
 // SubscriptionCreateOption allows customizing SubscriptionCreateParams

--- a/pkg/entitlements/subscriptions.go
+++ b/pkg/entitlements/subscriptions.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 )
 
 const (
@@ -102,6 +102,10 @@ func (sc *StripeClient) CreateSubscriptionWithPrices(ctx context.Context, cust *
 	params.TrialSettings = &stripe.SubscriptionCreateTrialSettingsParams{
 		EndBehavior: &stripe.SubscriptionCreateTrialSettingsEndBehaviorParams{
 			// stripe does not allow you to use subscription schedules with a trial that ends in a "pause" status so we have to cancel instead
+			// worth noting that when using schedules this doesn't occur because it
+			// moves to the next phase first (not a trial) and the schedule get released right before the invoice is created
+			// because of the auto release so this doesn't actually happen right away
+			// instead the status goes to past_due
 			MissingPaymentMethod: stripe.String(stripe.SubscriptionTrialSettingsEndBehaviorMissingPaymentMethodCancel),
 		},
 	}
@@ -217,7 +221,7 @@ func (sc *StripeClient) ListSubscriptions(ctx context.Context, customerID string
 	var subs []*stripe.Subscription
 
 	it := sc.Client.V1Subscriptions.List(ctx, params)
-	for s, err := range it {
+	for s, err := range it.All(ctx) {
 		if err != nil {
 			return nil, err
 		}
@@ -253,6 +257,89 @@ func (sc *StripeClient) MigrateSubscriptionPrice(ctx context.Context, sub *strip
 	params := &stripe.SubscriptionUpdateParams{Items: updateItems}
 
 	return sc.UpdateSubscription(ctx, sub.ID, params)
+}
+
+// prorationBehaviorNone disables proration line items on a subscription update
+// see https://docs.stripe.com/billing/subscriptions/prorations#prorations-and-unpaid-invoices
+// for more info
+const prorationBehaviorNone = "none"
+
+// DowngradeToFreeModules leaves the subscription carrying the given free prices and nothing else:
+//   - an item whose price is not in the list is deleted
+//   - an item already on one of the listed prices is left untouched
+//
+// It is used once stripe has given up retrying a failed payment. Dropping the organization to the
+// free modules leaves the subscription in place so the customer can recover by adding a payment
+// method, where cancelling would tear down their access entirely.
+//
+// If a schedule is attached it is released first, so that any pending phase cannot put the paid
+// items back at the next transition
+func (sc *StripeClient) DowngradeToFreeModules(ctx context.Context, sub *stripe.Subscription, freePriceIDs []string) (*stripe.Subscription, error) {
+	if sub == nil || len(freePriceIDs) == 0 {
+		return sub, nil
+	}
+
+	if err := sc.removeSchedule(ctx, sub); err != nil {
+		return nil, err
+	}
+
+	items := buildOnlyPricesItems(sub, freePriceIDs)
+	if len(items) == 0 {
+		return sub, nil
+	}
+
+	return sc.UpdateSubscription(ctx, sub.ID, &stripe.SubscriptionUpdateParams{
+		Items: items,
+		// the customer is already behind on payment, generating proration line items on the way
+		// down just adds more to a balance they are not paying
+		ProrationBehavior: stripe.String(prorationBehaviorNone),
+	})
+}
+
+// removeSchedule detaches any subscription schedule from the subscription, leaving the subscription itself in place without future phases
+func (sc *StripeClient) removeSchedule(ctx context.Context, sub *stripe.Subscription) error {
+	if sub == nil || sub.Schedule == nil || sub.Schedule.ID == "" {
+		return nil
+	}
+
+	if _, err := sc.Client.V1SubscriptionSchedules.Release(ctx, sub.Schedule.ID, &stripe.SubscriptionScheduleReleaseParams{}); err != nil {
+		log.Err(err).Str("schedule_id", sub.Schedule.ID).Msg("failed to release subscription schedule")
+
+		return err
+	}
+
+	return nil
+}
+
+// buildOnlyPricesItems returns the item changes that remove everything except the given prices.
+// Items already on one of those prices are left out of the result entirely so they keep their
+// existing item id rather than being deleted and recreated. Every subscription carries the free base
+// module, so there is always something left behind and nothing needs adding
+func buildOnlyPricesItems(sub *stripe.Subscription, priceIDs []string) []*stripe.SubscriptionUpdateItemParams {
+	if sub == nil || sub.Items == nil {
+		return nil
+	}
+
+	keep := make(map[string]bool, len(priceIDs))
+	for _, id := range priceIDs {
+		keep[id] = true
+	}
+
+	var items []*stripe.SubscriptionUpdateItemParams
+
+	// stripe removes an item when it is passed back with deleted set
+	for _, item := range sub.Items.Data {
+		if item.Price != nil && keep[item.Price.ID] {
+			continue
+		}
+
+		items = append(items, &stripe.SubscriptionUpdateItemParams{
+			ID:      stripe.String(item.ID),
+			Deleted: stripe.Bool(true),
+		})
+	}
+
+	return items
 }
 
 // UpdateSubscription updates a subscription

--- a/pkg/entitlements/subscriptions_onlyprices_test.go
+++ b/pkg/entitlements/subscriptions_onlyprices_test.go
@@ -1,0 +1,75 @@
+package entitlements
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stripe/stripe-go/v86"
+)
+
+func TestBuildOnlyPricesItems(t *testing.T) {
+	sub := func(items ...*stripe.SubscriptionItem) *stripe.Subscription {
+		return &stripe.Subscription{Items: &stripe.SubscriptionItemList{Data: items}}
+	}
+	item := func(id, priceID string) *stripe.SubscriptionItem {
+		return &stripe.SubscriptionItem{ID: id, Price: &stripe.Price{ID: priceID}}
+	}
+
+	testCases := []struct {
+		name        string
+		sub         *stripe.Subscription
+		priceIDs    []string
+		wantDeleted []string
+		wantAdded   []string
+	}{
+		{
+			name:        "removes the paid item and keeps the free one",
+			sub:         sub(item("si_base", "price_free"), item("si_paid", "price_paid")),
+			priceIDs:    []string{"price_free"},
+			wantDeleted: []string{"si_paid"},
+		},
+		{
+			// nothing is added back, every subscription already carries the free base module
+			name:        "removes the paid item without adding anything",
+			sub:         sub(item("si_paid", "price_paid")),
+			priceIDs:    []string{"price_free"},
+			wantDeleted: []string{"si_paid"},
+		},
+		{
+			name:     "no changes when already on exactly the free prices",
+			sub:      sub(item("si_base", "price_free")),
+			priceIDs: []string{"price_free"},
+		},
+		{
+			name:        "handles an item with no price",
+			sub:         sub(&stripe.SubscriptionItem{ID: "si_odd"}),
+			priceIDs:    []string{"price_free"},
+			wantDeleted: []string{"si_odd"},
+		},
+		{
+			name:     "nil subscription yields nothing",
+			sub:      nil,
+			priceIDs: []string{"price_free"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildOnlyPricesItems(tc.sub, tc.priceIDs)
+
+			var deleted, added []string
+
+			for _, i := range got {
+				switch {
+				case i.Deleted != nil && *i.Deleted:
+					deleted = append(deleted, *i.ID)
+				case i.Price != nil:
+					added = append(added, *i.Price)
+				}
+			}
+
+			assert.ElementsMatch(t, tc.wantDeleted, deleted)
+			assert.ElementsMatch(t, tc.wantAdded, added)
+		})
+	}
+}

--- a/pkg/entitlements/subscriptions_test.go
+++ b/pkg/entitlements/subscriptions_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 
 	"github.com/theopenlane/core/pkg/entitlements"
 )

--- a/pkg/entitlements/webhook_migration.go
+++ b/pkg/entitlements/webhook_migration.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 )
 
 const (

--- a/pkg/entitlements/webhooks.go
+++ b/pkg/entitlements/webhooks.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v86"
 )
 
 const (
@@ -14,11 +14,17 @@ const (
 
 // SupportedEventTypes defines the Stripe events the webhook handler listens for.
 var SupportedEventTypes = []stripe.EventType{
+	// a replacement subscription added after the previous one was cancelled only announces itself
+	// here, without this the organization keeps pointing at the old cancelled subscription
+	stripe.EventTypeCustomerSubscriptionCreated,
 	stripe.EventTypeCustomerSubscriptionUpdated,
 	stripe.EventTypeCustomerSubscriptionDeleted,
 	stripe.EventTypeCustomerSubscriptionPaused,
 	stripe.EventTypeCustomerSubscriptionTrialWillEnd,
 	stripe.EventTypePaymentMethodAttached,
+	// used to detect that stripe has stopped retrying a failed payment, so the subscription can be
+	// dropped to the free modules rather than left for stripe to cancel
+	stripe.EventTypeInvoicePaymentFailed,
 }
 
 // SupportedEventTypeStrings returns SupportedEventTypes as a slice of strings.
@@ -93,7 +99,7 @@ func (sc *StripeClient) ListWebhookEndpoints(ctx context.Context) ([]*stripe.Web
 	var endpoints []*stripe.WebhookEndpoint
 	var lastErr error
 
-	for endpoint, err := range iter {
+	for endpoint, err := range iter.All(ctx) {
 		if err != nil {
 			lastErr = err
 			break


### PR DESCRIPTION
Now: 
- After retries stripe goes to `Unpaid`
- Modules drop to only free modules (base)
- Feature Tuples are now longer dropped at first failure, instead they are dropped after retry period
- Marked as `active = false` when unpaid so the org will still follow the same deletion pattern as before
- Resolves the org subscription by stripe customer when metadata is missing, so a replacement subscription repoints the org instead of leaving the cancelled one; tested against sandbox
- Register the org module hook on `OpDelete` so bulk deletes clean up feature tuples
- Upgrade to v86 stripe


Needs the following added in stripe events: 
```
adding invoice.payment_failed
customer.subscription.created
```

And Stripe retry setting set to "mark unpaid" 
Test in stripe sandbox, only after all retries of payment do the feature tuples get dropped for non-free modules:

```
openfga=# select * from tuple where _user ='organization:01KZH2KXZXHMAXQ04BCAMG77WS' and object_type = 'feature';
           store            | object_type |      object_id      | relation |                  _user                  | user_type |            ulid            |          inserted_at          | condition_name | condition_context 
----------------------------+-------------+---------------------+----------+-----------------------------------------+-----------+----------------------------+-------------------------------+----------------+-------------------
 01KZEBQS9T1H5TECNJAYN2WXJ2 | feature     | registry_module     | enabled  | organization:01KZH2KXZXHMAXQ04BCAMG77WS | user      | 01KZH2KY5GAYBQH5HR3WVSJVDR | 2026-08-08 16:17:09.296657+00 |                | 
 01KZEBQS9T1H5TECNJAYN2WXJ2 | feature     | trust_center_module | enabled  | organization:01KZH2KXZXHMAXQ04BCAMG77WS | user      | 01KZH2KY5VHDT9CHYSC7E790JK | 2026-08-08 16:17:09.307135+00 |                | 
 01KZEBQS9T1H5TECNJAYN2WXJ2 | feature     | base_module         | enabled  | organization:01KZH2KXZXHMAXQ04BCAMG77WS | user      | 01KZH2KY63XQDHF90A3NP4CTCJ | 2026-08-08 16:17:09.315477+00 |                | 
 01KZEBQS9T1H5TECNJAYN2WXJ2 | feature     | compliance_module   | enabled  | organization:01KZH2KXZXHMAXQ04BCAMG77WS | user      | 01KZH2KY6CC55R0WZ2H9BBJYVA | 2026-08-08 16:17:09.324796+00 |                | 
(4 rows)

openfga=# select * from tuple where _user ='organization:01KZH2KXZXHMAXQ04BCAMG77WS' and object_type = 'feature';
           store            | object_type |    object_id    | relation |                  _user                  | user_type |            ulid            |          inserted_at          | condition_name | condition_context 
----------------------------+-------------+-----------------+----------+-----------------------------------------+-----------+----------------------------+-------------------------------+----------------+-------------------
 01KZEBQS9T1H5TECNJAYN2WXJ2 | feature     | registry_module | enabled  | organization:01KZH2KXZXHMAXQ04BCAMG77WS | user      | 01KZH2KY5GAYBQH5HR3WVSJVDR | 2026-08-08 16:17:09.296657+00 |                | 
 01KZEBQS9T1H5TECNJAYN2WXJ2 | feature     | base_module     | enabled  | organization:01KZH2KXZXHMAXQ04BCAMG77WS | user      | 01KZH2KY63XQDHF90A3NP4CTCJ | 2026-08-08 16:17:09.315477+00 |                | 
(2 rows)

```

Test of brand new sub on an org replaces old cancelled one:

```
core=# select * from org_subscriptions where owner_id = '01KZH2KXZXHMAXQ04BCAMG77WS';
-[ RECORD 1 ]--------------+------------------------------
id                         | 01KZH2KY59EQJF057ATFH6A4HZ
created_at                 | 2026-08-08 16:17:09.289409+00
updated_at                 | 2026-08-08 17:12:51.534373+00
created_by                 | 01KZH0JEXKMTMAP2R6W6X1C9X0
updated_by                 | unknown
deleted_at                 | 
deleted_by                 | 
tags                       | []
stripe_subscription_id     | sub_1U2CvqJIzM4Pa2ZceUepYwLm
stripe_subscription_status | canceled
active                     | f
expires_at                 | 
trial_expires_at           | 2026-09-07 16:17:10+00
days_until_due             | 0
owner_id                   | 01KZH2KXZXHMAXQ04BCAMG77WS
updated_by_impersonator    | 

core=# select * from org_subscriptions where owner_id = '01KZH2KXZXHMAXQ04BCAMG77WS';
-[ RECORD 1 ]--------------+------------------------------
id                         | 01KZH2KY59EQJF057ATFH6A4HZ
created_at                 | 2026-08-08 16:17:09.289409+00
updated_at                 | 2026-08-08 17:17:22.340371+00
created_by                 | 01KZH0JEXKMTMAP2R6W6X1C9X0
updated_by                 | unknown
deleted_at                 | 
deleted_by                 | 
tags                       | []
stripe_subscription_id     | sub_1U2Ds4JIzM4Pa2ZcwfChcJeX
stripe_subscription_status | trialing
active                     | t
expires_at                 | 
trial_expires_at           | 2026-10-03 16:17:24+00
days_until_due             | 0
owner_id                   | 01KZH2KXZXHMAXQ04BCAMG77WS
updated_by_impersonator    | 
```