### PR TITLE
Establish .well-known/openid-configuration, Add Workload Identity Federation auth registration to gcpscc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -109,7 +109,7 @@ require (
 	github.com/theopenlane/go-client v0.13.0
 	github.com/theopenlane/gqlgen-plugins v0.14.7
 	github.com/theopenlane/httpsling v0.3.0
-	github.com/theopenlane/iam v0.35.8
+	github.com/theopenlane/iam v0.36.0
 	github.com/theopenlane/newman v0.4.2
 	github.com/theopenlane/riverboat v0.13.1
 	github.com/theopenlane/utils v0.7.1

--- a/go.mod
+++ b/go.mod
@@ -128,7 +128,7 @@ require (
 	golang.org/x/sync v0.22.0
 	golang.org/x/text v0.40.0
 	golang.org/x/tools v0.48.0
-	google.golang.org/api v0.291.0
+	google.golang.org/api v0.292.0
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.2
 )
@@ -412,6 +412,6 @@ require (
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260720211330-0afa2a65878a // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260803160001-6ac0973c030d // indirect
-	google.golang.org/grpc v1.82.1 // indirect
+	google.golang.org/grpc v1.83.0 // indirect
 	google.golang.org/protobuf v1.36.11
 )

--- a/go.sum
+++ b/go.sum
@@ -745,8 +745,8 @@ github.com/theopenlane/gqlgen-plugins v0.14.7 h1:B9I6tpgevch3xQfV3qqRTpxHIlJvwtX
 github.com/theopenlane/gqlgen-plugins v0.14.7/go.mod h1:fUjo1cVKEAPLhtRrH+iJtrfivCNp+GxVSB/UJgVBDuA=
 github.com/theopenlane/httpsling v0.3.0 h1:Bad0dGdqCqAB8UVDyVo+YCevzRvGHhmkK22F7T3pXtY=
 github.com/theopenlane/httpsling v0.3.0/go.mod h1:iJc3XRLYTFIpfCnPpLZVMBP0xsWIPAb7ozARtQoclAE=
-github.com/theopenlane/iam v0.35.8 h1:tRkO96NUfG57fgyTWFZwpyzXiKf/1Av/jx5gjFZlXZg=
-github.com/theopenlane/iam v0.35.8/go.mod h1:Va0pIutagrlfFUdXOcxg4IRMAkdvGemcDJmOLwo7qKg=
+github.com/theopenlane/iam v0.36.0 h1:Uoyxtw2b7TXQ3U1PhE+zl5k9mqN3zqoN2QNJB/EgEyw=
+github.com/theopenlane/iam v0.36.0/go.mod h1:Va0pIutagrlfFUdXOcxg4IRMAkdvGemcDJmOLwo7qKg=
 github.com/theopenlane/newman v0.4.2 h1:8hcZkPBZgPrROB9UXZSQv4xDUP7KDya2o8WfYokXCl0=
 github.com/theopenlane/newman v0.4.2/go.mod h1:tCDhl2yzEFNg387YdQK5ztgwgH0dYgDnTB8SPqPNRbY=
 github.com/theopenlane/oscalot v0.1.0 h1:ExYiMU4Q1ezbGq77sxkgahmfmc46L+2NqB39fg0HXjU=

--- a/go.sum
+++ b/go.sum
@@ -916,8 +916,8 @@ golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da h1:noIWHXmPHxILtqtCOPIhS
 golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=
 gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
 gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
-google.golang.org/api v0.291.0 h1:wfPbbY+mr9c7wZLqqzrHJLft/q8iFKREd6IgTBUene0=
-google.golang.org/api v0.291.0/go.mod h1:at7kwWbuonglBFEBoeMDAV1bguHqL3qf0BHFsv3coa0=
+google.golang.org/api v0.292.0 h1:Ewiwo/GTtiaPZSNAZQUcWLh8AYDEoPmIXyJfeoTSMHU=
+google.golang.org/api v0.292.0/go.mod h1:07kjmMnFGm2RQuCza2EZM/5N68G/fVvFb1xKjWqoFA0=
 google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 h1:XzmzkmB14QhVhgnawEVsOn6OFsnpyxNPRY9QV01dNB0=
 google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7/go.mod h1:L43LFes82YgSonw6iTXTxXUX1OlULt4AQtkik4ULL/I=
 google.golang.org/genproto/googleapis/api v0.0.0-20260720211330-0afa2a65878a h1:97PfJ4tCxY5C7NzzgGqQEMZmXbISdvSArNNEOoUGKBg=

--- a/go.sum
+++ b/go.sum
@@ -924,8 +924,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260720211330-0afa2a65878a h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260720211330-0afa2a65878a/go.mod h1:1brfde68Npq6+WA75c1EHWPijZEG1kMus61ygPZfn4A=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260803160001-6ac0973c030d h1:IL4hdHzcUv2l/gcg98/Rj3FbtE6axwqslOW8SW0C+S0=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260803160001-6ac0973c030d/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
-google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
+google.golang.org/grpc v1.83.0 h1:JeNZEKJFbQxArAMl+hiytHauacDNqJUllNfmIMmpqnQ=
+google.golang.org/grpc v1.83.0/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/httpserve/route/router.go
+++ b/internal/httpserve/route/router.go
@@ -426,6 +426,7 @@ func RegisterRoutes(router *Router) error {
 		registerRefreshHandler,
 		registerLogoutHandler,
 		registerJwksWellKnownHandler,
+		registerOpenIDConfigurationHandler,
 		registerInviteHandler,
 		registerGithubLoginHandler,
 		registerGithubCallbackHandler,

--- a/internal/httpserve/route/wellknown.go
+++ b/internal/httpserve/route/wellknown.go
@@ -7,6 +7,7 @@ import (
 	echo "github.com/theopenlane/echox"
 
 	"github.com/theopenlane/core/internal/httpserve/handlers"
+	"github.com/theopenlane/core/pkg/oidc"
 )
 
 //go:embed webauthn
@@ -53,6 +54,26 @@ func registerJwksWellKnownHandler(router *Router) (err error) {
 			}
 
 			return ctx.JSON(http.StatusOK, keys)
+		},
+	}
+
+	return router.AddUnversionedHandlerRoute(config)
+}
+
+// registerOpenIDConfigurationHandler supplies the OIDC discovery document
+func registerOpenIDConfigurationHandler(router *Router) (err error) {
+	config := Config{
+		Path:        "/.well-known/openid-configuration",
+		Method:      http.MethodGet,
+		Name:        "OpenIDConfiguration",
+		Description: "OpenID Connect discovery document for federated identity providers",
+		Tags:        []string{"well-known", "authentication"},
+		OperationID: "OpenIDConfiguration",
+		Security:    handlers.PublicSecurity,
+		Middlewares: *publicEndpoint,
+		RateLimit:   publicStaticRateLimit,
+		Handler: func(ctx echo.Context) error {
+			return ctx.JSON(http.StatusOK, oidc.DiscoveryDocument(router.Handler.TokenManager))
 		},
 	}
 

--- a/internal/httpserve/serveropts/integration_base.go
+++ b/internal/httpserve/serveropts/integration_base.go
@@ -39,8 +39,9 @@ func WithIntegrationsRuntime(ctx context.Context, dbClient *ent.Client) ServerOp
 			Gala:          galaInstance,
 			Keystore:      credStore,
 			RedisClient:   s.Config.Handler.RedisClient,
-			CatalogConfig: s.Config.Settings.Integrations,
-			DevMode:       s.Config.Settings.Server.Dev,
+			CatalogConfig:    s.Config.Settings.Integrations,
+			FederationIssuer: s.Config.Settings.Auth.Token.Issuer,
+			DevMode:          s.Config.Settings.Server.Dev,
 		})
 		if err != nil {
 			log.Panic().Err(err).Msg("failed to initialize integration runtime")

--- a/internal/httpserve/serveropts/integration_base.go
+++ b/internal/httpserve/serveropts/integration_base.go
@@ -35,10 +35,10 @@ func WithIntegrationsRuntime(ctx context.Context, dbClient *ent.Client) ServerOp
 
 		wf := s.Config.Handler.WorkflowEngine
 		rt, err := runtime.New(runtime.Config{
-			DB:            dbClient,
-			Gala:          galaInstance,
-			Keystore:      credStore,
-			RedisClient:   s.Config.Handler.RedisClient,
+			DB:               dbClient,
+			Gala:             galaInstance,
+			Keystore:         credStore,
+			RedisClient:      s.Config.Handler.RedisClient,
 			CatalogConfig:    s.Config.Settings.Integrations,
 			FederationIssuer: s.Config.Settings.Auth.Token.Issuer,
 			DevMode:          s.Config.Settings.Server.Dev,

--- a/internal/integrations/auth/federation.go
+++ b/internal/integrations/auth/federation.go
@@ -1,0 +1,36 @@
+package auth
+
+import (
+	"context"
+
+	"golang.org/x/oauth2"
+
+	"github.com/theopenlane/iam/tokens"
+
+	"github.com/theopenlane/core/internal/integrations/types"
+	"github.com/theopenlane/core/pkg/oidc"
+)
+
+// FederationSpec describes one identity federation exchange for an installation-scoped client
+type FederationSpec struct {
+	// Audience is the relying party identity the assertion is exchanged against
+	Audience string
+	// Scopes are the OAuth scopes requested during the exchange
+	Scopes []string
+	// Endpoint is the RFC 8693 token exchange endpoint
+	Endpoint string
+	// AssertionOptions customize the minted assertions
+	AssertionOptions []tokens.ConfigOpt
+}
+
+// FederatedTokenSource builds a caching token source authenticating the installation's organization via identity federation
+func FederatedTokenSource(ctx context.Context, req types.ClientBuildRequest, spec FederationSpec) (oauth2.TokenSource, error) {
+	return oidc.NewTokenSource(ctx, oidc.FederationSource{
+		Manager:          req.TokenManager,
+		OrganizationID:   req.Integration.OwnerID,
+		Audience:         spec.Audience,
+		Scopes:           spec.Scopes,
+		Endpoint:         spec.Endpoint,
+		AssertionOptions: spec.AssertionOptions,
+	})
+}

--- a/internal/integrations/auth/federation_test.go
+++ b/internal/integrations/auth/federation_test.go
@@ -1,0 +1,70 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/theopenlane/iam/tokens"
+
+	ent "github.com/theopenlane/core/internal/ent/generated"
+	"github.com/theopenlane/core/internal/integrations/types"
+	"github.com/theopenlane/core/pkg/oidc"
+)
+
+const (
+	// testFederationAudience is a representative workload identity pool provider resource name
+	testFederationAudience = "//iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/openlane/providers/openlane"
+	// testRSAKeySize is the smallest RSA key size the signing key loader accepts
+	testRSAKeySize = 2048
+)
+
+// testFederationBuildRequest builds a client build request with a signing token manager
+func testFederationBuildRequest(t *testing.T) types.ClientBuildRequest {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, testRSAKeySize)
+	require.NoError(t, err)
+
+	manager, err := tokens.NewWithKey(key, tokens.Config{
+		Audience:        "https://api.theopenlane.io",
+		Issuer:          "https://api.theopenlane.io",
+		AccessDuration:  time.Hour,
+		RefreshDuration: 2 * time.Hour,
+		RefreshOverlap:  -15 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	return types.ClientBuildRequest{
+		Integration:  &ent.Integration{OwnerID: "01JQZX9K8N7M6P5R4T3V2W1Y0Z"},
+		TokenManager: manager,
+	}
+}
+
+// TestFederatedTokenSource verifies the shared federation helper wiring and validation
+func TestFederatedTokenSource(t *testing.T) {
+	t.Run("builds a token source from the installation identity", func(t *testing.T) {
+		source, err := FederatedTokenSource(context.Background(), testFederationBuildRequest(t), FederationSpec{
+			Audience: testFederationAudience,
+			Endpoint: "https://sts.googleapis.com/v1/token",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, source)
+	})
+
+	t.Run("propagates validation errors at build time", func(t *testing.T) {
+		_, err := FederatedTokenSource(context.Background(), testFederationBuildRequest(t), FederationSpec{
+			Endpoint: "https://sts.googleapis.com/v1/token",
+		})
+		require.ErrorIs(t, err, oidc.ErrAudienceRequired)
+
+		_, err = FederatedTokenSource(context.Background(), testFederationBuildRequest(t), FederationSpec{
+			Audience: testFederationAudience,
+		})
+		require.ErrorIs(t, err, oidc.ErrEndpointRequired)
+	})
+}

--- a/internal/integrations/definitions/catalog/catalog.go
+++ b/internal/integrations/definitions/catalog/catalog.go
@@ -25,10 +25,11 @@ import (
 	"github.com/theopenlane/core/internal/integrations/registry"
 )
 
-// Builders returns the built-in reference definition builders. devMode is the
+// Builders returns the built-in reference definition builders. federationIssuer is
+// the issuer URI customer identity providers federate against. devMode is the
 // server-level development flag; when true, integrations that support it (e.g.
 // email) use local file-based senders instead of calling provider APIs
-func Builders(cfg Config, devMode bool) []registry.Builder {
+func Builders(cfg Config, federationIssuer string, devMode bool) []registry.Builder {
 	return []registry.Builder{
 		authentik.Builder(),
 		awssecurityhub.Builder(cfg.AWSSecurityHub),
@@ -36,7 +37,7 @@ func Builders(cfg Config, devMode bool) []registry.Builder {
 		azuresecuritycenter.Builder(),
 		cloudflare.Builder(&cfg.CloudflareRuntime),
 		email.Builder(&cfg.Email, devMode),
-		gcpscc.Builder(),
+		gcpscc.Builder(federationIssuer),
 		githubapp.Builder(cfg.GitHubApp),
 		googledrive.Builder(cfg.GoogleDrive),
 		googleworkspace.Builder(cfg.GoogleWorkspace),

--- a/internal/integrations/definitions/gcpscc/builder.go
+++ b/internal/integrations/definitions/gcpscc/builder.go
@@ -9,8 +9,8 @@ import (
 	"github.com/theopenlane/core/pkg/jsonx"
 )
 
-// Builder returns the GCP SCC definition builder
-func Builder() registry.Builder {
+// Builder returns the GCP SCC definition builder advertising the supplied federation issuer
+func Builder(federationIssuer string) registry.Builder {
 	return registry.Builder(func() (types.Definition, error) {
 		return types.Definition{
 			DefinitionSpec: types.DefinitionSpec{
@@ -29,6 +29,13 @@ func Builder() registry.Builder {
 			},
 			CredentialRegistrations: []types.CredentialRegistration{
 				{
+					Ref:         workloadIdentityCredential.ID(),
+					Name:        "GCP Workload Identity Federation",
+					Description: "Federated access to Security Command Center with no stored keys.",
+					Schema:      workloadIdentitySchema,
+					Recommended: true,
+				},
+				{
 					Ref:         sccCredential.ID(),
 					Name:        "GCP SCC Credential",
 					Description: "GCP service account key used to access Security Command Center.",
@@ -36,6 +43,25 @@ func Builder() registry.Builder {
 				},
 			},
 			Connections: []types.ConnectionRegistration{
+				{
+					CredentialRef: workloadIdentityCredential.ID(),
+					Name:          "GCP Workload Identity Federation",
+					Description:   "Configure Security Command Center access by trusting Openlane as an OIDC identity provider, so no service account key is ever stored.",
+					Meta: map[string]types.MetaInfo{
+						"Openlane Issuer URI": {
+							Value:     federationIssuer,
+							AllowCopy: true,
+						},
+					},
+					CredentialRefs:      []types.CredentialSlotID{workloadIdentityCredential.ID()},
+					ClientRefs:          []types.ClientID{sccClient.ID()},
+					ValidationOperation: healthCheckOperation.Name(),
+					Integration:         installation.Registration(),
+					Disconnect: &types.DisconnectRegistration{
+						CredentialRef: workloadIdentityCredential.ID(),
+						Description:   "Removes the stored workload identity configuration from Openlane. If the workload identity pool is no longer needed, delete the pool and its provider from your Google Cloud project.",
+					},
+				},
 				{
 					CredentialRef:       sccCredential.ID(),
 					Name:                "GCP Service Account",
@@ -53,7 +79,7 @@ func Builder() registry.Builder {
 			Clients: []types.ClientRegistration{
 				{
 					Ref:            sccClient.ID(),
-					CredentialRefs: []types.CredentialSlotID{sccCredential.ID()},
+					CredentialRefs: []types.CredentialSlotID{workloadIdentityCredential.ID(), sccCredential.ID()},
 					Description:    "Google Cloud Security Command Center v2 client",
 					Build:          Client{}.Build,
 				},

--- a/internal/integrations/definitions/gcpscc/client.go
+++ b/internal/integrations/definitions/gcpscc/client.go
@@ -10,7 +10,7 @@ import (
 	"github.com/theopenlane/core/internal/integrations/types"
 )
 
-// defaultScope is the GCP OAuth scope requested when no explicit scopes are provided
+// defaultScope is the GCP OAuth scope requested for every SCC credential
 const defaultScope = "https://www.googleapis.com/auth/cloud-platform"
 
 // Client builds GCP Security Command Center clients for one installation
@@ -18,19 +18,19 @@ type Client struct{}
 
 // Build constructs the GCP Security Command Center client for one installation
 func (Client) Build(ctx context.Context, req types.ClientBuildRequest) (any, error) {
-	meta, err := resolveCredential(req.Credentials)
+	scope, err := resolveScope(req.Credentials)
 	if err != nil {
 		return nil, err
 	}
 
-	clientOpts, err := clientOptions(ctx, meta)
+	clientOpts, err := clientOptions(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 
 	opts := append([]option.ClientOption{}, clientOpts...)
-	if meta.ProjectID != "" {
-		opts = append(opts, option.WithQuotaProject(meta.ProjectID))
+	if scope.ProjectID != "" {
+		opts = append(opts, option.WithQuotaProject(scope.ProjectID))
 	}
 
 	client, err := cloudscc.NewClient(ctx, opts...)
@@ -41,7 +41,7 @@ func (Client) Build(ctx context.Context, req types.ClientBuildRequest) (any, err
 	return client, nil
 }
 
-// resolveCredential decodes SCC credential metadata from the credential bindings
+// resolveCredential decodes SCC service account credential metadata from the credential bindings
 func resolveCredential(bindings types.CredentialBindings) (CredentialSchema, error) {
 	cred, ok, err := sccCredential.Resolve(bindings)
 	if err != nil {
@@ -52,16 +52,44 @@ func resolveCredential(bindings types.CredentialBindings) (CredentialSchema, err
 		return CredentialSchema{}, ErrCredentialMetadataRequired
 	}
 
-	return cred.applyDefaults(), nil
+	return cred, nil
 }
 
-// clientOptions builds client options based on available credentials
-func clientOptions(ctx context.Context, meta CredentialSchema) ([]option.ClientOption, error) {
+// resolveScope decodes the collection scope from whichever credential slot the installation bound
+func resolveScope(bindings types.CredentialBindings) (CollectionScope, error) {
+	federated, ok, err := workloadIdentityCredential.Resolve(bindings)
+	if err != nil {
+		return CollectionScope{}, ErrMetadataDecode
+	}
+
+	if ok {
+		return federated.CollectionScope, nil
+	}
+
+	meta, err := resolveCredential(bindings)
+	if err != nil {
+		return CollectionScope{}, err
+	}
+
+	return meta.CollectionScope, nil
+}
+
+// clientOptions builds client options for whichever credential slot the installation bound
+func clientOptions(ctx context.Context, req types.ClientBuildRequest) ([]option.ClientOption, error) {
+	if _, ok := req.Credentials.Resolve(workloadIdentityCredential.ID()); ok {
+		return workloadIdentityOptions(ctx, req)
+	}
+
+	meta, err := resolveCredential(req.Credentials)
+	if err != nil {
+		return nil, err
+	}
+
 	if meta.ServiceAccountKey == "" {
 		return nil, ErrServiceAccountKeyInvalid
 	}
 
-	creds, err := serviceAccountCredentials(ctx, meta.ServiceAccountKey, meta.Scopes)
+	creds, err := serviceAccountCredentials(ctx, meta.ServiceAccountKey)
 	if err != nil {
 		return nil, err
 	}
@@ -70,18 +98,13 @@ func clientOptions(ctx context.Context, meta CredentialSchema) ([]option.ClientO
 }
 
 // serviceAccountCredentials parses and validates a service account key
-func serviceAccountCredentials(ctx context.Context, rawKey string, scopes []string) (*google.Credentials, error) {
+func serviceAccountCredentials(ctx context.Context, rawKey string) (*google.Credentials, error) {
 	key := normalizeServiceAccountKey(rawKey)
 	if key == "" {
 		return nil, ErrServiceAccountKeyInvalid
 	}
 
-	scopeList := scopes
-	if len(scopeList) == 0 {
-		scopeList = []string{defaultScope}
-	}
-
-	creds, err := google.CredentialsFromJSONWithType(ctx, []byte(key), google.ServiceAccount, scopeList...)
+	creds, err := google.CredentialsFromJSONWithType(ctx, []byte(key), google.ServiceAccount, defaultScope)
 	if err != nil {
 		return nil, ErrServiceAccountKeyInvalid
 	}

--- a/internal/integrations/definitions/gcpscc/client_test.go
+++ b/internal/integrations/definitions/gcpscc/client_test.go
@@ -12,11 +12,13 @@ import (
 
 // TestResolveCredential verifies credential resolution from bindings and default application
 func TestResolveCredential(t *testing.T) {
-	t.Run("decodes into credential schema and applies defaults", func(t *testing.T) {
+	t.Run("decodes into credential schema", func(t *testing.T) {
 		raw, err := jsonx.ToRawMessage(CredentialSchema{
-			ProjectID:         "project-123",
-			OrganizationID:    "org-123",
 			ServiceAccountKey: "\"{\\n  \\\"type\\\":\\\"service_account\\\"\\n}\"",
+			CollectionScope: CollectionScope{
+				ProjectID:      "project-123",
+				OrganizationID: "org-123",
+			},
 		})
 		require.NoError(t, err)
 
@@ -29,8 +31,7 @@ func TestResolveCredential(t *testing.T) {
 
 		assert.Equal(t, "project-123", meta.ProjectID)
 		assert.Equal(t, "org-123", meta.OrganizationID)
-		assert.Equal(t, projectScopeAll, meta.ProjectScope)
-		assert.Equal(t, "{\n  \"type\":\"service_account\"\n}", meta.ServiceAccountKey)
+		assert.Equal(t, "{\n  \"type\":\"service_account\"\n}", normalizeServiceAccountKey(meta.ServiceAccountKey))
 	})
 
 	t.Run("returns decode error for invalid provider data", func(t *testing.T) {
@@ -44,6 +45,43 @@ func TestResolveCredential(t *testing.T) {
 
 	t.Run("returns required error when binding is missing", func(t *testing.T) {
 		_, err := resolveCredential(nil)
+		require.ErrorIs(t, err, ErrCredentialMetadataRequired)
+	})
+}
+
+// TestResolveScope verifies collection scope resolution from either credential slot
+func TestResolveScope(t *testing.T) {
+	t.Run("decodes collection scope from the workload identity slot", func(t *testing.T) {
+		raw, err := jsonx.ToRawMessage(WorkloadIdentityCredentialSchema{
+			ProjectNumber: "123456789",
+			CollectionScope: CollectionScope{
+				OrganizationID: "org-123",
+			},
+		})
+		require.NoError(t, err)
+
+		scope, err := resolveScope(types.CredentialBindings{
+			{Ref: workloadIdentityCredential.ID(), Credential: types.CredentialSet{Data: raw}},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "org-123", scope.OrganizationID)
+	})
+
+	t.Run("decodes collection scope from the service account slot", func(t *testing.T) {
+		raw, err := jsonx.ToRawMessage(CredentialSchema{
+			CollectionScope: CollectionScope{ProjectID: "project-123"},
+		})
+		require.NoError(t, err)
+
+		scope, err := resolveScope(types.CredentialBindings{
+			{Ref: sccCredential.ID(), Credential: types.CredentialSet{Data: raw}},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "project-123", scope.ProjectID)
+	})
+
+	t.Run("returns required error when no slot is bound", func(t *testing.T) {
+		_, err := resolveScope(nil)
 		require.ErrorIs(t, err, ErrCredentialMetadataRequired)
 	})
 }

--- a/internal/integrations/definitions/gcpscc/errors.go
+++ b/internal/integrations/definitions/gcpscc/errors.go
@@ -11,6 +11,8 @@ var (
 	ErrMetadataDecode = errors.New("gcpscc: failed to decode credential metadata")
 	// ErrProjectIDRequired indicates no project or organization ID was provided
 	ErrProjectIDRequired = errors.New("gcpscc: project or organization ID required")
+	// ErrProjectNumberRequired indicates no workload identity pool project number was provided
+	ErrProjectNumberRequired = errors.New("gcpscc: workload identity project number required")
 	// ErrServiceAccountKeyInvalid indicates the service account key JSON is invalid
 	ErrServiceAccountKeyInvalid = errors.New("gcpscc: service account key invalid")
 	// ErrSecurityCenterClientCreate indicates the SCC client could not be created

--- a/internal/integrations/definitions/gcpscc/federation.go
+++ b/internal/integrations/definitions/gcpscc/federation.go
@@ -1,0 +1,71 @@
+package gcpscc
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/oauth2"
+	"google.golang.org/api/impersonate"
+	"google.golang.org/api/option"
+
+	"github.com/theopenlane/core/internal/integrations/auth"
+	"github.com/theopenlane/core/internal/integrations/types"
+)
+
+const (
+	// googleSTSEndpoint is the Google Security Token Service RFC 8693 exchange endpoint
+	googleSTSEndpoint = "https://sts.googleapis.com/v1/token"
+	// workloadIdentityName is the fixed pool and provider ID customers create for Openlane federation
+	workloadIdentityName = "openlane"
+	// workloadIdentityAudienceFormat is the provider resource name Google STS expects as the exchange audience
+	workloadIdentityAudienceFormat = "//iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/providers/%s"
+)
+
+// workloadIdentityAudience builds the STS exchange audience for the pool-hosting project number
+func workloadIdentityAudience(projectNumber string) string {
+	return fmt.Sprintf(workloadIdentityAudienceFormat, projectNumber, workloadIdentityName, workloadIdentityName)
+}
+
+// workloadIdentityOptions builds client options that authenticate through workload identity federation
+func workloadIdentityOptions(ctx context.Context, req types.ClientBuildRequest) ([]option.ClientOption, error) {
+	cred, ok, err := workloadIdentityCredential.Resolve(req.Credentials)
+	if err != nil {
+		return nil, ErrMetadataDecode
+	}
+
+	if !ok {
+		return nil, ErrCredentialMetadataRequired
+	}
+
+	source, err := federationSource(ctx, req, cred)
+	if err != nil {
+		return nil, err
+	}
+
+	return []option.ClientOption{option.WithTokenSource(source)}, nil
+}
+
+// federationSource builds the token source, impersonating a service account when configured
+func federationSource(ctx context.Context, req types.ClientBuildRequest, cred WorkloadIdentityCredentialSchema) (oauth2.TokenSource, error) {
+	if cred.ProjectNumber == "" {
+		return nil, ErrProjectNumberRequired
+	}
+
+	federated, err := auth.FederatedTokenSource(ctx, req, auth.FederationSpec{
+		Audience: workloadIdentityAudience(cred.ProjectNumber),
+		Scopes:   []string{defaultScope},
+		Endpoint: googleSTSEndpoint,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if cred.ServiceAccountEmail == "" {
+		return federated, nil
+	}
+
+	return impersonate.CredentialsTokenSource(ctx, impersonate.CredentialsConfig{
+		TargetPrincipal: cred.ServiceAccountEmail,
+		Scopes:          []string{defaultScope},
+	}, option.WithTokenSource(federated))
+}

--- a/internal/integrations/definitions/gcpscc/federation_test.go
+++ b/internal/integrations/definitions/gcpscc/federation_test.go
@@ -1,0 +1,78 @@
+package gcpscc
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/theopenlane/iam/tokens"
+
+	ent "github.com/theopenlane/core/internal/ent/generated"
+	"github.com/theopenlane/core/internal/integrations/types"
+)
+
+const (
+	// testProjectNumber is a representative numeric GCP project number hosting the workload identity pool
+	testProjectNumber = "123456789"
+	// testRSAKeySize is the smallest RSA key size the signing key loader accepts
+	testRSAKeySize = 2048
+)
+
+// testBuildRequest builds a client build request with a signing token manager
+func testBuildRequest(t *testing.T) types.ClientBuildRequest {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, testRSAKeySize)
+	require.NoError(t, err)
+
+	manager, err := tokens.NewWithKey(key, tokens.Config{
+		Audience:        "https://api.theopenlane.io",
+		Issuer:          "https://api.theopenlane.io",
+		AccessDuration:  time.Hour,
+		RefreshDuration: 2 * time.Hour,
+		RefreshOverlap:  -15 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	return types.ClientBuildRequest{
+		Integration:  &ent.Integration{OwnerID: "01JQZX9K8N7M6P5R4T3V2W1Y0Z"},
+		TokenManager: manager,
+	}
+}
+
+// TestWorkloadIdentityAudience verifies the provider resource name construction
+func TestWorkloadIdentityAudience(t *testing.T) {
+	require.Equal(t,
+		"//iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/openlane/providers/openlane",
+		workloadIdentityAudience(testProjectNumber),
+	)
+}
+
+// TestFederationSource verifies the workload identity token source construction
+func TestFederationSource(t *testing.T) {
+	t.Run("builds a federated source without impersonation", func(t *testing.T) {
+		source, err := federationSource(context.Background(), testBuildRequest(t), WorkloadIdentityCredentialSchema{
+			ProjectNumber: testProjectNumber,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, source)
+	})
+
+	t.Run("builds an impersonated source when a service account is configured", func(t *testing.T) {
+		source, err := federationSource(context.Background(), testBuildRequest(t), WorkloadIdentityCredentialSchema{
+			ProjectNumber:       testProjectNumber,
+			ServiceAccountEmail: "collector@project-123.iam.gserviceaccount.com",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, source)
+	})
+
+	t.Run("requires a project number", func(t *testing.T) {
+		_, err := federationSource(context.Background(), testBuildRequest(t), WorkloadIdentityCredentialSchema{})
+		require.ErrorIs(t, err, ErrProjectNumberRequired)
+	})
+}

--- a/internal/integrations/definitions/gcpscc/installation.go
+++ b/internal/integrations/definitions/gcpscc/installation.go
@@ -15,26 +15,45 @@ type serviceAccountIdentity struct {
 
 // resolveInstallationMetadata derives GCP SCC installation metadata from the persisted credential
 func resolveInstallationMetadata(_ context.Context, req types.InstallationRequest) (InstallationMetadata, bool, error) {
-	meta, err := resolveCredential(req.Credentials)
+	scope, err := resolveScope(req.Credentials)
 	if err != nil {
 		return InstallationMetadata{}, false, err
 	}
 
-	if meta.OrganizationID == "" && meta.ProjectID == "" && len(meta.SourceIDs) == 0 {
+	if scope.OrganizationID == "" && scope.ProjectID == "" && len(scope.SourceIDs) == 0 {
 		return InstallationMetadata{}, false, nil
 	}
 
-	var serviceAccount serviceAccountIdentity
-	if key := normalizeServiceAccountKey(meta.ServiceAccountKey); key != "" {
-		_ = json.Unmarshal([]byte(key), &serviceAccount)
+	return InstallationMetadata{
+		OrganizationID:      scope.OrganizationID,
+		ProjectID:           scope.ProjectID,
+		ProjectScope:        scope.ProjectScope,
+		ProjectIDs:          scope.ProjectIDs,
+		SourceIDs:           scope.SourceIDs,
+		ServiceAccountEmail: serviceAccountEmail(req.Credentials),
+	}, true, nil
+}
+
+// serviceAccountEmail returns the service account the installation acts as
+func serviceAccountEmail(bindings types.CredentialBindings) string {
+	federated, ok, err := workloadIdentityCredential.Resolve(bindings)
+	if err == nil && ok {
+		return federated.ServiceAccountEmail
 	}
 
-	return InstallationMetadata{
-		OrganizationID:      meta.OrganizationID,
-		ProjectID:           meta.ProjectID,
-		ProjectScope:        meta.ProjectScope,
-		ProjectIDs:          meta.ProjectIDs,
-		SourceIDs:           meta.SourceIDs,
-		ServiceAccountEmail: serviceAccount.ClientEmail,
-	}, true, nil
+	cred, ok, err := sccCredential.Resolve(bindings)
+	if err != nil || !ok {
+		return ""
+	}
+
+	key := normalizeServiceAccountKey(cred.ServiceAccountKey)
+	if key == "" {
+		return ""
+	}
+
+	var identity serviceAccountIdentity
+
+	_ = json.Unmarshal([]byte(key), &identity)
+
+	return identity.ClientEmail
 }

--- a/internal/integrations/definitions/gcpscc/mappings_test.go
+++ b/internal/integrations/definitions/gcpscc/mappings_test.go
@@ -18,7 +18,7 @@ import (
 func testMappings(t *testing.T) []types.MappingRegistration {
 	t.Helper()
 
-	def, err := Builder()()
+	def, err := Builder("")()
 	require.NoError(t, err)
 
 	return def.Mappings

--- a/internal/integrations/definitions/gcpscc/operation_findings.go
+++ b/internal/integrations/definitions/gcpscc/operation_findings.go
@@ -45,12 +45,12 @@ func (f FindingsCollect) IngestHandle() types.IngestHandler {
 
 // Run collects GCP SCC findings from configured sources
 func (FindingsCollect) Run(ctx context.Context, credentials types.CredentialBindings, c *cloudscc.Client, cfg FindingsSync, lastRunAt *time.Time) ([]types.IngestPayloadSet, error) {
-	meta, err := resolveCredential(credentials)
+	scope, err := resolveScope(credentials)
 	if err != nil {
 		return nil, err
 	}
 
-	sources, err := resolveSources(meta)
+	sources, err := resolveSources(scope)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ func resolveFindingResource(sourceName string, finding *securitycenterpb.Finding
 }
 
 // resolveParents chooses the SCC parent resources used for health/settings checks
-func resolveParents(meta CredentialSchema) ([]string, error) {
+func resolveParents(meta CollectionScope) ([]string, error) {
 	if meta.OrganizationID != "" && meta.ProjectScope != projectScopeSpecific {
 		return []string{fmt.Sprintf("organizations/%s", meta.OrganizationID)}, nil
 	}
@@ -208,8 +208,8 @@ func resolveParents(meta CredentialSchema) ([]string, error) {
 	return nil, ErrProjectIDRequired
 }
 
-// resolveSources resolves source resource names from credential metadata
-func resolveSources(meta CredentialSchema) ([]string, error) {
+// resolveSources resolves source resource names from the collection scope
+func resolveSources(meta CollectionScope) ([]string, error) {
 	raw := make([]string, 0, len(meta.SourceIDs))
 
 	raw = append(raw, meta.SourceIDs...)

--- a/internal/integrations/definitions/gcpscc/operation_health.go
+++ b/internal/integrations/definitions/gcpscc/operation_health.go
@@ -29,13 +29,13 @@ func (h HealthCheck) Handle() types.OperationHandler {
 
 // Run executes the GCP SCC health check
 func (HealthCheck) Run(ctx context.Context, credentials types.CredentialBindings, c *cloudscc.Client) (json.RawMessage, error) {
-	meta, err := resolveCredential(credentials)
+	scope, err := resolveScope(credentials)
 	if err != nil {
 		logx.FromContext(ctx).Error().Err(err).Msg("gcpscc: error attempting to resolve credentials")
 		return nil, err
 	}
 
-	parents, err := resolveParents(meta)
+	parents, err := resolveParents(scope)
 	if err != nil {
 		logx.FromContext(ctx).Error().Err(err).Msg("gcpscc: error attempting to resolve parents")
 		return nil, err

--- a/internal/integrations/definitions/gcpscc/types.go
+++ b/internal/integrations/definitions/gcpscc/types.go
@@ -17,8 +17,10 @@ var (
 	installation = types.NewInstallationRef(resolveInstallationMetadata)
 	// sccClient is the client ref for the GCP Security Command Center client used by this definition
 	sccClient = types.NewClientRef[*cloudscc.Client]()
-	// sccSchema is the credential schema for GCP Security Command Center credentials
+	// sccSchema is the credential schema for GCP Security Command Center service account credentials
 	sccSchema, sccCredential = providerkit.CredentialSchema[CredentialSchema]()
+	// workloadIdentitySchema is the credential schema for GCP workload identity federation
+	workloadIdentitySchema, workloadIdentityCredential = providerkit.CredentialSchema[WorkloadIdentityCredentialSchema]()
 	// healthCheckSchema is the operation schema for the GCP Security Command Center health check operation
 	healthCheckSchema, healthCheckOperation = providerkit.OperationSchema[HealthCheck]()
 	// findingsCollectSchema is the operation schema for the GCP Security Command Center findings collection operation
@@ -26,8 +28,6 @@ var (
 )
 
 const (
-	// projectScopeAll indicates collection should target all GCP projects in the organization
-	projectScopeAll = "all"
 	// projectScopeSpecific indicates collection should target only the explicitly listed project IDs
 	projectScopeSpecific = "specific"
 )
@@ -35,7 +35,7 @@ const (
 // UserInput holds installation-specific configuration collected from the user
 type UserInput struct {
 	// FindingsSync includes the configuration for the findings collection operation
-	FindingsSync FindingsSyncConfig `json:"findingsSync,omitempty" jsonschema:"title=Findings Sync"`
+	FindingsSync FindingsSyncConfig `json:"findingsSync" jsonschema:"title=Findings Sync"`
 }
 
 type FindingsSyncConfig struct {
@@ -43,34 +43,38 @@ type FindingsSyncConfig struct {
 	FilterExpr string `json:"filterExpr,omitempty" jsonschema:"title=Filter Expression,description=Optional CEL expression to apply to records before ingesting (allows inclusion, exclusion, etc.),example=Example: payload.category != \"GKE_SECURITY_BULLETIN\""`
 }
 
-// CredentialSchema holds the GCP SCC credentials for one installation
-type CredentialSchema struct {
-	// ServiceAccountKey is the service account key JSON used for direct credentials
-	ServiceAccountKey string `json:"serviceAccountKey" jsonschema:"required,title=Service Account Key JSON,secret=true,description=Service Account JSON used to authenticate on your behalf to GCP SCC"`
+// CollectionScope holds the SCC collection targeting shared by both credential schemas
+type CollectionScope struct {
 	// OrganizationID is the GCP organization identifier
 	OrganizationID string `json:"organizationId,omitempty" jsonschema:"title=Organization ID,description=The ID of the organization to use as the parent - either organization ID or project ID are required"`
 	// ProjectID is the fallback GCP project identifier used for quota and parent resolution
 	ProjectID string `json:"projectId,omitempty" jsonschema:"title=Project ID,description=The ID of the project to use as the parent - either organization ID or project ID are required"`
 	// ProjectScope controls whether SCC collection targets all or specific projects
-	ProjectScope string `json:"projectScope,omitempty" jsonschema:"title=Project Scope,description=Filter project scope; only used if using an Organization ID as the initial filter,enum=all,enum=specific"`
+	ProjectScope string `json:"projectScope,omitempty" jsonschema:"title=Project Scope,description=Filter project scope; only used if using an Organization ID as the initial filter,enum=all,enum=specific,default=all"`
 	// ProjectIDs lists the specific GCP projects used when project scope is specific
 	ProjectIDs []string `json:"projectIds,omitempty" jsonschema:"title=Project IDs,description=List of project IDs to include if the project scope is set to specific"`
 	// SourceIDs lists the SCC source identifiers used for collection
 	SourceIDs []string `json:"sourceIds,omitempty" jsonschema:"title=SCC Source IDs,description=Limit sources to include in pulling in findings from SCC"`
-	// Scopes lists the OAuth scopes requested for service account credentials
-	Scopes []string `json:"scopes,omitempty" jsonschema:"title=OAuth Scopes,description=Limit what scopes are requested for the service account. default scope=https://www.googleapis.com/auth/cloud-platform"`
 }
 
-// applyDefaults fills in fallback values for missing optional fields
-func (m CredentialSchema) applyDefaults() CredentialSchema {
-	normalized := m
-	if normalized.ProjectScope == "" {
-		normalized.ProjectScope = projectScopeAll
-	}
+// CredentialSchema holds the GCP SCC service account credentials for one installation
+type CredentialSchema struct {
+	// ServiceAccountKey is the service account key JSON used for direct credentials
+	ServiceAccountKey string `json:"serviceAccountKey" jsonschema:"required,title=Service Account Key JSON,secret=true,description=Service Account JSON used to authenticate on your behalf to GCP SCC"`
+	// CollectionScope targets which GCP organization, projects, and sources to collect from
+	CollectionScope
+}
 
-	normalized.ServiceAccountKey = normalizeServiceAccountKey(normalized.ServiceAccountKey)
-
-	return normalized
+// WorkloadIdentityCredentialSchema holds the GCP workload identity federation inputs for
+// one installation. Openlane signs a short-lived assertion with its own keys and exchanges
+// it at Google STS, so nothing in this schema is secret
+type WorkloadIdentityCredentialSchema struct {
+	// ProjectNumber is the numeric project number of the GCP project hosting the openlane workload identity pool and provider
+	ProjectNumber string `json:"projectNumber" jsonschema:"required,title=GCP Project Number,pattern=^[0-9]+$,description=Numeric project number of the GCP project hosting the openlane workload identity pool and provider"`
+	// ServiceAccountEmail optionally impersonates a service account
+	ServiceAccountEmail string `json:"serviceAccountEmail,omitempty" jsonschema:"title=Service Account Email,description=Optional service account to impersonate"`
+	// CollectionScope targets which GCP organization, projects, and sources to collect from
+	CollectionScope
 }
 
 // normalizeServiceAccountKey trims and unwraps JSON-encoded service account keys

--- a/internal/integrations/runtime/credentials.go
+++ b/internal/integrations/runtime/credentials.go
@@ -151,6 +151,8 @@ func (r *Runtime) reconcileUserInput(ctx context.Context, installation *ent.Inte
 		return err
 	}
 
+	r.keystore().InvalidateClients(installation.ID)
+
 	systemCtx := privacy.DecisionContext(ctx, privacy.Allow)
 
 	state, err := def.ProviderState(installation.ProviderState)

--- a/internal/integrations/runtime/runtime.go
+++ b/internal/integrations/runtime/runtime.go
@@ -39,6 +39,8 @@ type Config struct {
 	RedisClient *redis.Client
 	// CatalogConfig supplies operator-level credentials for all built-in definitions
 	CatalogConfig catalog.Config
+	// FederationIssuer is the issuer URI customer identity providers federate against
+	FederationIssuer string
 	// DevMode is the server-level development flag; when true, integrations that
 	// support it use local file-based senders instead of calling provider APIs
 	DevMode bool
@@ -239,7 +241,7 @@ func New(config Config) (*Runtime, error) {
 
 		builders := config.DefinitionBuilders
 		if len(builders) == 0 && config.Registry == nil {
-			builders = catalog.Builders(config.CatalogConfig, config.DevMode)
+			builders = catalog.Builders(config.CatalogConfig, config.FederationIssuer, config.DevMode)
 		}
 
 		if len(builders) > 0 {

--- a/internal/integrations/types/client.go
+++ b/internal/integrations/types/client.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/theopenlane/iam/tokens"
+
 	generated "github.com/theopenlane/core/internal/ent/generated"
 )
 
@@ -15,6 +17,8 @@ type ClientBuildRequest struct {
 	Credentials CredentialBindings
 	// Config is the client-specific configuration payload
 	Config json.RawMessage
+	// TokenManager signs assertions for providers that authenticate via identity federation
+	TokenManager *tokens.TokenManager
 }
 
 // ClientBuilderFunc builds a client for one installation

--- a/internal/keystore/store.go
+++ b/internal/keystore/store.go
@@ -191,9 +191,10 @@ func (s *Store) BuildClient(ctx context.Context, installation *ent.Integration, 
 	}
 
 	client, err := registration.Build(ctx, types.ClientBuildRequest{
-		Integration: installation,
-		Credentials: cloneCredentialBindings(credentials),
-		Config:      jsonx.CloneRawMessage(config),
+		Integration:  installation,
+		Credentials:  cloneCredentialBindings(credentials),
+		Config:       jsonx.CloneRawMessage(config),
+		TokenManager: s.db.TokenManager,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/oidc/discovery.go
+++ b/pkg/oidc/discovery.go
@@ -1,0 +1,33 @@
+package oidc
+
+import (
+	"github.com/samber/lo"
+	zoidc "github.com/zitadel/oidc/v3/pkg/oidc"
+
+	"github.com/theopenlane/iam/tokens"
+)
+
+// DiscoveryDocument builds the OIDC discovery document for the issuer
+func DiscoveryDocument(manager *tokens.TokenManager) *zoidc.DiscoveryConfiguration {
+	cfg := manager.Config()
+
+	return &zoidc.DiscoveryConfiguration{
+		Issuer:                           cfg.Issuer,
+		JwksURI:                          cfg.JWKSEndpoint,
+		ResponseTypesSupported:           []string{string(zoidc.ResponseTypeIDTokenOnly)},
+		SubjectTypesSupported:            []string{"public"},
+		IDTokenSigningAlgValuesSupported: signingAlgorithms(manager),
+	}
+}
+
+// signingAlgorithms returns the deduplicated algorithms of the active signing keys
+func signingAlgorithms(manager *tokens.TokenManager) []string {
+	return lo.Uniq(lo.FilterMap(manager.ListActiveKeys(), func(kid string, _ int) (string, bool) {
+		metadata, err := manager.GetKeyMetadata(kid)
+		if err != nil {
+			return "", false
+		}
+
+		return metadata.Algorithm, true
+	}))
+}

--- a/pkg/oidc/discovery_test.go
+++ b/pkg/oidc/discovery_test.go
@@ -1,0 +1,34 @@
+package oidc
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/theopenlane/iam/tokens"
+)
+
+// TestDiscoveryDocument verifies the discovery document external providers resolve
+func TestDiscoveryDocument(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, testRSAKeySize)
+	require.NoError(t, err)
+
+	manager, err := tokens.NewWithKey(key, tokens.NewConfig(
+		tokens.WithIssuer(testIssuer),
+		tokens.WithAudience(testIssuer),
+		func(c *tokens.Config) { c.JWKSEndpoint = testJWKSEndpoint },
+	))
+	require.NoError(t, err)
+
+	doc := DiscoveryDocument(manager)
+
+	assert.Equal(t, testIssuer, doc.Issuer)
+	assert.Equal(t, testJWKSEndpoint, doc.JwksURI)
+	assert.Equal(t, []string{"id_token"}, doc.ResponseTypesSupported)
+	assert.Equal(t, []string{"public"}, doc.SubjectTypesSupported)
+	assert.Equal(t, []string{jwt.SigningMethodRS256.Alg()}, doc.IDTokenSigningAlgValuesSupported)
+}

--- a/pkg/oidc/doc.go
+++ b/pkg/oidc/doc.go
@@ -1,0 +1,3 @@
+// Package oidc publishes the OIDC discovery document and exchanges platform-signed
+// federation assertions over RFC 8693
+package oidc

--- a/pkg/oidc/errors.go
+++ b/pkg/oidc/errors.go
@@ -1,0 +1,14 @@
+package oidc
+
+import "errors"
+
+var (
+	// ErrOrganizationIDRequired indicates no organization was supplied to bind the assertion to
+	ErrOrganizationIDRequired = errors.New("oidc: organization ID required")
+	// ErrAudienceRequired indicates no federation audience was supplied
+	ErrAudienceRequired = errors.New("oidc: audience required")
+	// ErrEndpointRequired indicates no token exchange endpoint was supplied
+	ErrEndpointRequired = errors.New("oidc: token exchange endpoint required")
+	// ErrExchangeFailed indicates the RFC 8693 token exchange failed
+	ErrExchangeFailed = errors.New("oidc: token exchange failed")
+)

--- a/pkg/oidc/exchange.go
+++ b/pkg/oidc/exchange.go
@@ -1,0 +1,109 @@
+package oidc
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/zitadel/oidc/v3/pkg/client/tokenexchange"
+	zoidc "github.com/zitadel/oidc/v3/pkg/oidc"
+	"golang.org/x/oauth2"
+
+	"github.com/theopenlane/iam/tokens"
+)
+
+const defaultAssertionLifetime = 10 * time.Minute
+
+// FederationSource configures the assertion exchange against one RFC 8693 security token service
+type FederationSource struct {
+	// Manager signs the assertions with the platform signing keys
+	Manager *tokens.TokenManager
+	// OrganizationID is the organization bound into every assertion's identity claims
+	OrganizationID string
+	// Audience is the relying party identity the assertion is exchanged against
+	Audience string
+	// Scopes are the OAuth scopes requested during the exchange
+	Scopes []string
+	// Endpoint is the RFC 8693 token exchange endpoint
+	Endpoint string
+	// AssertionOptions customize the minted assertions; identity options always win
+	AssertionOptions []tokens.ConfigOpt
+}
+
+// NewTokenSource returns a caching token source that mints assertions and exchanges them at the configured endpoint
+func NewTokenSource(ctx context.Context, source FederationSource) (oauth2.TokenSource, error) {
+	if source.OrganizationID == "" {
+		return nil, ErrOrganizationIDRequired
+	}
+
+	if source.Audience == "" {
+		return nil, ErrAudienceRequired
+	}
+
+	if source.Endpoint == "" {
+		return nil, ErrEndpointRequired
+	}
+
+	metadata, err := source.Manager.GetKeyMetadata(source.Manager.CurrentKeyID())
+	if err != nil {
+		return nil, err
+	}
+
+	if metadata.Algorithm != jwt.SigningMethodRS256.Alg() {
+		return nil, tokens.ErrSigningAlgorithmMismatch
+	}
+
+	return oauth2.ReuseTokenSource(nil, &federationTokenSource{
+		// the token source outlives the request-scoped context in pooled clients
+		ctx:    context.WithoutCancel(ctx),
+		source: source,
+	}), nil
+}
+
+// federationTokenSource mints assertions and exchanges them for provider access tokens
+type federationTokenSource struct {
+	// ctx carries caller values without cancellation since Token takes no context
+	ctx context.Context
+	// source holds the organization, audience, scopes, and endpoint for the exchange
+	source FederationSource
+}
+
+// Token mints a fresh assertion and exchanges it for a provider access token
+func (s *federationTokenSource) Token() (*oauth2.Token, error) {
+	opts := append([]tokens.ConfigOpt{}, s.source.AssertionOptions...)
+	opts = append(opts,
+		tokens.WithSubject(s.source.OrganizationID),
+		tokens.WithAudience(s.source.Audience),
+		tokens.WithClaim("organization_id", s.source.OrganizationID),
+		tokens.WithAccessDuration(defaultAssertionLifetime),
+		tokens.WithRequiredAlgorithm(jwt.SigningMethodRS256.Alg()),
+	)
+
+	assertion, err := s.source.Manager.CreateSignedToken(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	exchanger, err := tokenexchange.NewTokenExchanger(s.ctx, "", tokenexchange.WithStaticTokenEndpoint("", s.source.Endpoint))
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrExchangeFailed, err)
+	}
+
+	resp, err := tokenexchange.ExchangeToken(s.ctx, exchanger, assertion, zoidc.JWTTokenType, "", "", nil, []string{s.source.Audience}, s.source.Scopes, zoidc.AccessTokenType)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrExchangeFailed, err)
+	}
+
+	expiresIn := resp.ExpiresIn
+	if expiresIn > math.MaxInt32 {
+		expiresIn = math.MaxInt32
+	}
+
+	return &oauth2.Token{
+		AccessToken: resp.AccessToken,
+		TokenType:   resp.TokenType,
+		Expiry:      time.Now().Add(time.Duration(expiresIn) * time.Second),
+	}, nil
+}

--- a/pkg/oidc/exchange_test.go
+++ b/pkg/oidc/exchange_test.go
@@ -1,0 +1,187 @@
+package oidc
+
+import (
+	"context"
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+
+	"github.com/theopenlane/iam/tokens"
+)
+
+const (
+	// testIssuer is the platform issuer external identity providers federate against
+	testIssuer = "https://api.theopenlane.io"
+	// testJWKSEndpoint is the JWKS location advertised by the discovery document
+	testJWKSEndpoint = "https://api.theopenlane.io/.well-known/jwks.json"
+	// testAudience is a representative GCP workload identity pool provider resource name
+	testAudience = "//iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/openlane/providers/openlane"
+	// testOrganizationID is the organization the assertions are requested for
+	testOrganizationID = "01JQZX9K8N7M6P5R4T3V2W1Y0Z"
+	// testScope is the OAuth scope requested during exchanges
+	testScope = "https://www.googleapis.com/auth/cloud-platform"
+	// testRSAKeySize is the smallest RSA key size the signing key loader accepts
+	testRSAKeySize = 2048
+)
+
+// testTokenManager builds a token manager signing with the supplied key
+func testTokenManager(t *testing.T, key crypto.Signer) *tokens.TokenManager {
+	t.Helper()
+
+	manager, err := tokens.NewWithKey(key, tokens.NewConfig(
+		tokens.WithIssuer(testIssuer),
+		tokens.WithAudience(testIssuer),
+	))
+	require.NoError(t, err)
+
+	return manager
+}
+
+// parseAssertion verifies the assertion signature and returns its claims
+func parseAssertion(t *testing.T, signed string, key crypto.Signer) jwt.MapClaims {
+	t.Helper()
+
+	claims := jwt.MapClaims{}
+
+	token, err := jwt.ParseWithClaims(signed, claims, func(*jwt.Token) (any, error) {
+		return key.Public(), nil
+	}, jwt.WithValidMethods([]string{jwt.SigningMethodRS256.Alg()}))
+	require.NoError(t, err)
+	require.True(t, token.Valid)
+
+	return claims
+}
+
+// testTokenSource builds a federation token source pointed at the supplied STS endpoint
+func testTokenSource(t *testing.T, key *rsa.PrivateKey, endpoint string) oauth2.TokenSource {
+	t.Helper()
+
+	source, err := NewTokenSource(context.Background(), FederationSource{
+		Manager:        testTokenManager(t, key),
+		OrganizationID: testOrganizationID,
+		Audience:       testAudience,
+		Scopes:         []string{testScope},
+		Endpoint:       endpoint,
+	})
+	require.NoError(t, err)
+
+	return source
+}
+
+// TestNewTokenSource verifies the token source constructor validation
+func TestNewTokenSource(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, testRSAKeySize)
+	require.NoError(t, err)
+
+	t.Run("requires an organization", func(t *testing.T) {
+		_, err := NewTokenSource(context.Background(), FederationSource{Audience: testAudience})
+		require.ErrorIs(t, err, ErrOrganizationIDRequired)
+	})
+
+	t.Run("requires an audience", func(t *testing.T) {
+		_, err := NewTokenSource(context.Background(), FederationSource{OrganizationID: testOrganizationID})
+		require.ErrorIs(t, err, ErrAudienceRequired)
+	})
+
+	t.Run("requires an endpoint", func(t *testing.T) {
+		_, err := NewTokenSource(context.Background(), FederationSource{
+			Manager:        testTokenManager(t, key),
+			OrganizationID: testOrganizationID,
+			Audience:       testAudience,
+		})
+		require.ErrorIs(t, err, ErrEndpointRequired)
+	})
+
+	t.Run("requires an RS256 signing key at build time", func(t *testing.T) {
+		_, edKey, keyErr := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, keyErr)
+
+		_, err := NewTokenSource(context.Background(), FederationSource{
+			Manager:        testTokenManager(t, edKey),
+			OrganizationID: testOrganizationID,
+			Audience:       testAudience,
+			Endpoint:       "https://sts.example.com/v1/token",
+		})
+		require.ErrorIs(t, err, tokens.ErrSigningAlgorithmMismatch)
+	})
+}
+
+// TestTokenExchange verifies the RFC 8693 request sent and the response parsed
+func TestTokenExchange(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, testRSAKeySize)
+	require.NoError(t, err)
+
+	t.Run("sends the exchange request and parses the granted token", func(t *testing.T) {
+		var form url.Values
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.NoError(t, r.ParseForm())
+
+			form = r.Form
+
+			w.Header().Set("Content-Type", "application/json")
+			_, err := w.Write([]byte(`{
+				"access_token": "ya29.test-granted-token",
+				"issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+				"token_type": "Bearer",
+				"expires_in": 3600
+			}`))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		token, err := testTokenSource(t, key, server.URL).Token()
+		require.NoError(t, err)
+
+		assert.Equal(t, "ya29.test-granted-token", token.AccessToken)
+		assert.Equal(t, "Bearer", token.TokenType)
+		assert.WithinDuration(t, time.Now().Add(time.Hour), token.Expiry, time.Minute)
+
+		// the exchange identifies the relying party with the assertion as subject token
+		assert.Equal(t, "urn:ietf:params:oauth:grant-type:token-exchange", form.Get("grant_type"))
+		assert.Equal(t, "urn:ietf:params:oauth:token-type:jwt", form.Get("subject_token_type"))
+		assert.Equal(t, "urn:ietf:params:oauth:token-type:access_token", form.Get("requested_token_type"))
+		assert.Equal(t, testAudience, form.Get("audience"))
+		assert.Equal(t, testScope, form.Get("scope"))
+
+		// pins zitadel's serialization of absent actor fields as empty parameters
+		assert.Contains(t, form, "actor_token")
+		assert.Empty(t, form.Get("actor_token"))
+
+		// the assertion carries server-derived identity claims, verifiable with the issuer's public key
+		claims := parseAssertion(t, form.Get("subject_token"), key)
+		assert.Equal(t, testIssuer, claims["iss"])
+		assert.Equal(t, testOrganizationID, claims["sub"])
+		assert.Equal(t, testAudience, claims["aud"])
+		assert.Equal(t, testOrganizationID, claims["organization_id"])
+
+		expiry, err := claims.GetExpirationTime()
+		require.NoError(t, err)
+		assert.WithinDuration(t, time.Now().Add(defaultAssertionLifetime), expiry.Time, time.Minute)
+	})
+
+	t.Run("returns the exchange error when the STS rejects the assertion", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, err := w.Write([]byte(`{"error":"invalid_request","error_description":"invalid audience"}`))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		_, err := testTokenSource(t, key, server.URL).Token()
+		require.ErrorIs(t, err, ErrExchangeFailed)
+		require.ErrorContains(t, err, "invalid audience")
+	})
+}


### PR DESCRIPTION
In order to keep this PR simple, there were a few key assumptions made: that the poolID + providerID used in the setup were both `openlane`, and that we require the assertion subject to contain the organization ID. It's hypothetically possible for someone with a GCP instance to misconfigure the pool allowing their GCP instance to accept any token minted by Openlane (for any of our tenants) so several of these were made in an attempt to minimize customer misconfiguration.

- Stood up the OIDC issuer surface, discovery and JWKS endpoints, signed federation assertions so external providers can validate and exchange openlane issued tokens
- Added workload identity federation as a keyless authentication method for gcpscc letting customers grant access by trusting Openlane as an OIDC identity provider in addition to the existing service account key method=
- Constructed the GCP token exchange using STS audience from collected project number against a fixed pool and provider naming convention, with optional service account impersonation
