### PR TITLE
fix: long gala shutdown, more gracefully handle errors and retry 

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -29,8 +29,8 @@ import (
 	pkgobjects "github.com/theopenlane/core/pkg/objects"
 )
 
-// galaShutdownTimeout is the maximum time to wait for gala workers to stop gracefully.
-const galaShutdownTimeout = 10 * time.Second
+// galaShutdownTimeout is the maximum time to wait for gala workers to stop gracefully
+const galaShutdownTimeout = 30 * time.Second
 
 var serveCmd = &cobra.Command{
 	Use:   "serve",

--- a/internal/entdb/errors.go
+++ b/internal/entdb/errors.go
@@ -2,11 +2,13 @@ package entdb
 
 import (
 	"errors"
+
+	"github.com/theopenlane/core/internal/shutdown"
 )
 
 var (
 	// ErrDriverLackingBeginTx is returned when the driver does not support BeginTx
 	ErrDriverLackingBeginTx = errors.New("driver does not support BeginTx")
 	// ErrShuttingDown is returned when operations are attempted during shutdown
-	ErrShuttingDown = errors.New("database shutting down")
+	ErrShuttingDown = shutdown.ErrShuttingDown
 )

--- a/internal/entdb/shutdown.go
+++ b/internal/entdb/shutdown.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	stdsql "database/sql"
 	"fmt"
-	"sync/atomic"
 	"time"
 
 	"ariga.io/entcache"
@@ -12,57 +11,37 @@ import (
 	entsql "entgo.io/ent/dialect/sql"
 
 	ent "github.com/theopenlane/core/internal/ent/generated"
+	"github.com/theopenlane/core/internal/shutdown"
 	"github.com/theopenlane/core/internal/ent/generated/intercept"
 	"github.com/theopenlane/core/internal/ent/historygenerated"
 	hintercept "github.com/theopenlane/core/internal/ent/historygenerated/intercept"
 )
 
-// ShutdownFlag tracks whether a shutdown is in progress
-type ShutdownFlag struct {
-	// flag is an atomic boolean that indicates if a shutdown is in progress
-	// atomic.Bool is used to ensure thread-safe access to the flag
-	// without the need for explicit locks
-	// this is important in a concurrent environment where multiple goroutines
-	// may be checking or setting the flag at the same time
-	flag atomic.Bool
-}
-
-// Begin sets the shutdown flag to true, indicating that a shutdown is in progress
-func (s *ShutdownFlag) Begin() {
-	s.flag.Store(true)
-}
-
-// Reset clears the shutdown flag, indicating that a shutdown is no longer in progress
-func (s *ShutdownFlag) Reset() {
-	s.flag.Store(false)
-}
-
-// IsSet checks if the shutdown flag is set to true
-func (s *ShutdownFlag) IsSet() bool {
-	return s.flag.Load()
-}
+// ShutdownFlag tracks whether a shutdown is in progress. It lives in the shutdown package so
+// packages this one depends on can check it without an import cycle
+type ShutdownFlag = shutdown.Flag
 
 // newShutdownFlag creates a new instance of ShutdownFlag
 func newShutdownFlag() *ShutdownFlag {
-	return &ShutdownFlag{}
+	return shutdown.New()
 }
 
-// / defaultShutdown is the default shutdown flag used throughout the package
-var defaultShutdown = newShutdownFlag()
+// defaultShutdown is the default shutdown flag used throughout the package
+var defaultShutdown = shutdown.Default
 
 // BeginShutdown marks the system as shutting down. It is safe to call multiple times
 func BeginShutdown() {
-	defaultShutdown.Begin()
+	shutdown.Begin()
 }
 
 // ResetShutdown clears the shutdown flag. It is intended for tests
 func ResetShutdown() {
-	defaultShutdown.Reset()
+	shutdown.Reset()
 }
 
 // IsShuttingDown reports whether GracefulClose was invoked
 func IsShuttingDown() bool {
-	return defaultShutdown.IsSet()
+	return shutdown.InProgress()
 }
 
 type dbClientWithDriver interface {

--- a/internal/entdb/shutdown.go
+++ b/internal/entdb/shutdown.go
@@ -11,20 +11,15 @@ import (
 	entsql "entgo.io/ent/dialect/sql"
 
 	ent "github.com/theopenlane/core/internal/ent/generated"
-	"github.com/theopenlane/core/internal/shutdown"
 	"github.com/theopenlane/core/internal/ent/generated/intercept"
 	"github.com/theopenlane/core/internal/ent/historygenerated"
 	hintercept "github.com/theopenlane/core/internal/ent/historygenerated/intercept"
+	"github.com/theopenlane/core/internal/shutdown"
 )
 
 // ShutdownFlag tracks whether a shutdown is in progress. It lives in the shutdown package so
 // packages this one depends on can check it without an import cycle
 type ShutdownFlag = shutdown.Flag
-
-// newShutdownFlag creates a new instance of ShutdownFlag
-func newShutdownFlag() *ShutdownFlag {
-	return shutdown.New()
-}
 
 // defaultShutdown is the default shutdown flag used throughout the package
 var defaultShutdown = shutdown.Default

--- a/internal/entdb/shutdown_test.go
+++ b/internal/entdb/shutdown_test.go
@@ -12,13 +12,14 @@ import (
 
 	ent "github.com/theopenlane/core/internal/ent/generated"
 	"github.com/theopenlane/core/internal/ent/generated/enttest"
+	"github.com/theopenlane/core/internal/shutdown"
 	"github.com/theopenlane/utils/testutils"
 )
 
 // TestGracefulCloseWaits verifies that GracefulClose waits for in-flight
 // queries before closing the database connection
 func TestGracefulCloseWaits(t *testing.T) {
-	flag := newShutdownFlag()
+	flag := shutdown.New()
 	t.Cleanup(flag.Reset)
 	tf := NewTestFixture()
 	defer testutils.TeardownFixture(tf)
@@ -73,7 +74,7 @@ func TestGracefulCloseWaits(t *testing.T) {
 
 // TestBlockNewQueries verifies that new operations are rejected after shutdown begins
 func TestBlockNewQueries(t *testing.T) {
-	flag := newShutdownFlag()
+	flag := shutdown.New()
 	t.Cleanup(flag.Reset)
 	tf := NewTestFixture()
 	defer testutils.TeardownFixture(tf)
@@ -105,7 +106,7 @@ func TestBlockNewQueries(t *testing.T) {
 
 // TestGracefulCloseContextCancel verifies that GracefulClose returns when the context is canceled
 func TestGracefulCloseContextCancel(t *testing.T) {
-	flag := newShutdownFlag()
+	flag := shutdown.New()
 	t.Cleanup(flag.Reset)
 	tf := NewTestFixture()
 	defer testutils.TeardownFixture(tf)

--- a/internal/integrations/operations/errors.go
+++ b/internal/integrations/operations/errors.go
@@ -41,6 +41,9 @@ var (
 	ErrIngestUnsupportedSchema = errors.New("integrations/operations: ingest schema unsupported")
 	// ErrIngestPersistFailed indicates the mapped record could not be persisted
 	ErrIngestPersistFailed = errors.New("integrations/operations: ingest persistence failed")
+	// ErrIngestInterrupted indicates the ingest stopped because the process began shutting down;
+	// nothing is wrong with the data and the job resumes on the next process
+	ErrIngestInterrupted = errors.New("integrations/operations: ingest interrupted by shutdown")
 	// ErrIngestIntegrationUnresolved indicates the integration record could not be resolved for an ingest operation
 	ErrIngestIntegrationUnresolved = errors.New("integrations/operations: ingest integration unresolved")
 	// ErrOperationDisabled indicates the operation is disabled for this installation and the reconcile cycle should stop

--- a/internal/integrations/operations/ingest.go
+++ b/internal/integrations/operations/ingest.go
@@ -16,6 +16,7 @@ import (
 	"github.com/theopenlane/core/internal/ent/generated/directorysyncrun"
 	"github.com/theopenlane/core/internal/integrations/providerkit"
 	"github.com/theopenlane/core/internal/integrations/types"
+	"github.com/theopenlane/core/internal/shutdown"
 	"github.com/theopenlane/core/pkg/gala"
 	"github.com/theopenlane/core/pkg/jsonx"
 	"github.com/theopenlane/core/pkg/logx"
@@ -235,6 +236,19 @@ func applyPayloadSets(ctx context.Context, ic IngestContext, operationName strin
 			}
 
 			if handleErr := handle(envCtx, record); handleErr != nil {
+				// a write refused because the process is shutting down is not a bad record, and
+				// every remaining record would fail the same way. abort so the job is retried on
+				// the next process rather than recording the whole batch as skipped
+				if shutdown.IsError(handleErr) {
+					logx.FromContext(envCtx).Info().Msg("ingest interrupted by shutdown, job will be retried")
+
+					result.Attempted = attempted
+					result.Failed = failed
+					result.Failures = recordFailures
+
+					return result, fmt.Errorf("%w: %w", ErrIngestInterrupted, handleErr)
+				}
+
 				logx.FromContext(envCtx).Error().Err(handleErr).Msg("ingest persist failed")
 
 				failed++

--- a/internal/shutdown/shutdown.go
+++ b/internal/shutdown/shutdown.go
@@ -1,0 +1,65 @@
+// Package shutdown holds the process-wide shutdown flag
+package shutdown
+
+import (
+	"errors"
+	"sync/atomic"
+)
+
+// ErrShuttingDown is returned when operations are attempted during shutdown
+var ErrShuttingDown = errors.New("database client shutting down")
+
+// Flag tracks whether a shutdown is in progress
+type Flag struct {
+	// flag is an atomic boolean that indicates if a shutdown is in progress
+	// atomic.Bool is used to ensure thread-safe access to the flag
+	// without the need for explicit locks
+	// this is important in a concurrent environment where multiple goroutines
+	// may be checking or setting the flag at the same time
+	flag atomic.Bool
+}
+
+// Begin sets the shutdown flag to true, indicating that a shutdown is in progress
+func (s *Flag) Begin() {
+	s.flag.Store(true)
+}
+
+// Reset clears the shutdown flag, indicating that a shutdown is no longer in progress
+func (s *Flag) Reset() {
+	s.flag.Store(false)
+}
+
+// IsSet checks if the shutdown flag is set to true
+func (s *Flag) IsSet() bool {
+	return s.flag.Load()
+}
+
+// New creates a new instance of Flag
+func New() *Flag {
+	return &Flag{}
+}
+
+// Default is the shutdown flag used throughout the application
+var Default = New()
+
+// Begin marks the system as shutting down. It is safe to call multiple times
+func Begin() {
+	Default.Begin()
+}
+
+// Reset clears the shutdown flag. It is intended for tests
+func Reset() {
+	Default.Reset()
+}
+
+// InProgress reports whether shutdown has begun
+func InProgress() bool {
+	return Default.IsSet()
+}
+
+// IsError reports whether the error came from an operation refused because the process is
+// shutting down. These are expected during a deploy or restart and should be retried rather
+// than logged as failures
+func IsError(err error) bool {
+	return errors.Is(err, ErrShuttingDown)
+}


### PR DESCRIPTION
- increases the wait for gala jobs to shutdown to 30 seconds to help prevent job interruptions
- updates the package to retry database client shutdown (and make the log more clear its the _client_ not the database)
- `shutdown` leaf package created to prevent import errors 