### PR TITLE
chore: update core v2 module tag

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -2,9 +2,6 @@ module github.com/theopenlane/core/cli
 
 go 1.26.6
 
-// temp fix while core/v2 is released and can be picked up by external deps
-replace github.com/theopenlane/core/v2 => ..
-
 require (
 	github.com/99designs/gqlgen v0.17.94
 	github.com/TylerBrock/colorjson v0.0.0-20200706003622-8a50f05110d2
@@ -21,7 +18,7 @@ require (
 	github.com/samber/lo v1.53.0
 	github.com/spf13/cobra v1.10.2
 	github.com/theopenlane/core/common v1.0.25
-	github.com/theopenlane/core/v2 v2.2.3
+	github.com/theopenlane/core/v2 v2.3.0
 	github.com/theopenlane/go-client v0.13.1
 	github.com/theopenlane/httpsling v0.3.0
 	github.com/theopenlane/iam v0.37.0

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -197,6 +197,8 @@ github.com/theopenlane/core v1.34.0 h1:2tJN64ppo3LQlky4q/5jy1JxCIbdWms23v6AGuoXM
 github.com/theopenlane/core v1.34.0/go.mod h1:cSpWnPDweResm75+snMKsJRx7j1hDa1QLOWqbTQWzy8=
 github.com/theopenlane/core/common v1.0.25 h1:HTsiNLJeCBPudPliSqALWz/BEuCrRhg5kr601pyYvOs=
 github.com/theopenlane/core/common v1.0.25/go.mod h1:HYQjD+iqJdxdM5x3kpD9lk7q/cs6KAnNv5U23KEYn+A=
+github.com/theopenlane/core/v2 v2.3.0 h1:C4BqyW1P/gkEGC+xtFyws6LLTB09U63lVmuBP/5BWzE=
+github.com/theopenlane/core/v2 v2.3.0/go.mod h1:VkcfF7fg9Qy1KsiRYeFdXKGQd9Ov4BQZz98utBzws9U=
 github.com/theopenlane/echox v0.3.0 h1:uwOKEw+r1utGQoOR6dZQqAVuY5j8TcasqnTwO5+rMsA=
 github.com/theopenlane/echox v0.3.0/go.mod h1:yTrXnj7s3VNIg0FCvB7Dut2Elr+LqJKU/nruxx1E1cM=
 github.com/theopenlane/go-client v0.13.1 h1:9n/LCMRqWn/dGxkM9dNpeVbh7MwF2GCACmvjraMJvxE=

--- a/common/go.mod
+++ b/common/go.mod
@@ -2,9 +2,6 @@ module github.com/theopenlane/core/common
 
 go 1.26.6
 
-// temp fix while core/v2 is released and can be picked up by external deps
-replace github.com/theopenlane/core/v2 => ..
-
 require (
 	entgo.io/ent v0.14.6
 	github.com/go-webauthn/webauthn v0.17.4
@@ -14,7 +11,7 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/stoewer/go-strcase v1.3.1
 	github.com/stretchr/testify v1.12.1
-	github.com/theopenlane/core/v2 v2.2.3
+	github.com/theopenlane/core/v2 v2.3.0
 	github.com/theopenlane/echox v0.3.0
 	github.com/theopenlane/entx v0.33.0
 	github.com/theopenlane/utils v0.7.1

--- a/common/go.sum
+++ b/common/go.sum
@@ -144,6 +144,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
+github.com/theopenlane/core/v2 v2.3.0 h1:C4BqyW1P/gkEGC+xtFyws6LLTB09U63lVmuBP/5BWzE=
+github.com/theopenlane/core/v2 v2.3.0/go.mod h1:VkcfF7fg9Qy1KsiRYeFdXKGQd9Ov4BQZz98utBzws9U=
 github.com/theopenlane/echox v0.3.0 h1:uwOKEw+r1utGQoOR6dZQqAVuY5j8TcasqnTwO5+rMsA=
 github.com/theopenlane/echox v0.3.0/go.mod h1:yTrXnj7s3VNIg0FCvB7Dut2Elr+LqJKU/nruxx1E1cM=
 github.com/theopenlane/entx v0.33.0 h1:3ojP4RF4T44ndlR/LKzU6ueq+GVZi0rwZIwQbIhjFHc=


### PR DESCRIPTION
bump cli and common go mod files to use new core/v2 tagged version instead of local