### PR TITLE
fix: buildkite agent v4 has reversed post command hooks, trivy has to come first

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -812,6 +812,13 @@ steps:
               username: openlane-bender
               password-env: SECRET_GHCR_PUBLISH_TOKEN
               server: ghcr.io
+          # this needs to be before the container build because post-command hooks are reversed in order
+          - equinixmetal-buildkite/trivy#v1.19.0:
+              severity: CRITICAL,HIGH
+              ignore-unfixed: true
+              scanners: misconfig,secret,vuln
+              skip-files: "cosign.key,Dockerfile.dev,internal/graphapi/generated/*,internal/ent/generated/*,internal/ent/historygenerated/*"
+              trivy-version: "0.74.0"
           - theopenlane/docker-metadata#v1.0.1:
               images:
                 - "${IMAGE_REPO}"
@@ -822,12 +829,6 @@ steps:
               push: false
               build-args:
                 - NAME=${APP_NAME}
-          - equinixmetal-buildkite/trivy#v1.19.0:
-              severity: CRITICAL,HIGH
-              ignore-unfixed: true
-              scanners: misconfig,secret,vuln
-              skip-files: "cosign.key,Dockerfile.dev,internal/graphapi/generated/*,internal/ent/generated/*,internal/ent/historygenerated/*"
-              trivy-version: "0.74.0"
       - label: ":docker: docker build and publish"
         key: "docker-build-and-tag"
         cancel_on_build_failing: true


### PR DESCRIPTION
only works on buildkite-agent v4